### PR TITLE
fix(sdk): forward hasPerRequestStream so modern cancellation aborts t…

### DIFF
--- a/.changeset/modern-cancellation-aborts-the-stream.md
+++ b/.changeset/modern-cancellation-aborts-the-stream.md
@@ -1,0 +1,43 @@
+---
+"@mcpjam/sdk": patch
+---
+
+Modern-era cancellation aborts the per-request stream instead of POSTing `notifications/cancelled`
+
+MCP `2026-07-28` moved cancellation onto the transport for Streamable HTTP:
+
+> Closing the SSE response stream is the cancellation signal. The server MUST treat a client disconnect as cancellation of that request. No `notifications/cancelled` message is required or expected.
+
+The client package already forks on exactly this. Its protocol layer aborts the
+per-request stream when the negotiated era is modern **and** the transport
+reports `hasPerRequestStream === true`, and only falls back to POSTing
+`notifications/cancelled` — the 2025-era and stdio signal — when it does not.
+`StreamableHTTPClientTransport` sets the flag; the fork was never reaching it.
+
+Every transport we hand to a client is wrapped first, and the wrappers forwarded
+`sessionId` and `setProtocolVersion` but not `hasPerRequestStream`. The flag read
+`undefined`, so the fork took the legacy branch on *every* connection. This was
+not limited to debug configurations: `wrapTransportForTaskResults` is applied
+unconditionally at every HTTP transport site, so a plain 2026-07-28 connection
+with no logger and no simulated-client options was already downgraded.
+
+Both halves of the resulting behavior were wrong. We sent a `notifications/cancelled`
+a modern server neither requires nor expects, and — because that notification is
+its own POST while the cancelled call is a *different* in-flight request — the
+server holding the tool call never learned anything. It kept running the tool
+until it finished, on a stateless transport where the abandoned response stream
+was the only signal that would have reached it.
+
+All five wrappers now forward the flag: the four in `transport-utils`
+(`LoggingTransport`, `DroppedListChangedTransport`, `TaskResultTransport`,
+`FirstPageOnlyTransport`) and the widget runtime's `LoggingTransport`. It is
+forwarded, never defaulted — a wrapper around a stdio transport must keep
+reporting no per-request stream, because there the notification IS the spec
+signal.
+
+The suite already had a test asserting no `notifications/cancelled` on a modern
+abort, and it passed throughout. The legacy branch POSTs fire-and-forget, so
+asserting the instant the call rejects reads `exchanges` before the notification
+lands. The test now waits for that window to settle and additionally asserts the
+positive half — that the aborted `tools/call` exchange actually terminates, which
+a client that only rejects locally never does.

--- a/.changeset/tool-cancellation-host-knob.md
+++ b/.changeset/tool-cancellation-host-knob.md
@@ -32,6 +32,13 @@ nothing and keeps its canonical hash; only an explicit `false` is stored. The
 field is validated by the same `canonicalBooleanCapabilityRecord` its sibling
 `toolListChanged` already uses, on both sides of the wire.
 
+Which leaf governs a connection is resolved where its protocol version is
+already known — `cancellationLeafForVersion(pin)` — and a single flag reaches the
+client, which simply obeys it. The client is never asked what era it negotiated:
+`getProtocolEra()` is optional on the managed-client interface, so on adapters
+that cannot report one the era reads as unknown and the suppression would
+silently never apply.
+
 A `false` leaf is enforced by withholding the caller's abort signal from the
 request and racing the caller against it locally instead. The signal is the only
 thing that reaches the wire, so withholding it withholds whichever mechanism that

--- a/.changeset/tool-cancellation-host-knob.md
+++ b/.changeset/tool-cancellation-host-knob.md
@@ -3,75 +3,54 @@
 "@mcpjam/inspector": patch
 ---
 
-Model tool cancellation as a host behavior: a Protocol-tab knob and a caniuse row
+Model tool cancellation per era: two Protocol-tab switches and two caniuse rows
 
 A server author has no way to answer the question that decides whether a stopped
 turn costs them anything: **when the user hits stop, does the host tell me?** If
-it does not, the tool runs to completion on the server — side effects, tokens and
-all — while the host has already moved on. Hosts genuinely differ here, and
-nothing in the host config recorded it, so it could not be simulated, compared,
-or published.
+it does not, the tool runs to completion server-side — side effects, tokens and
+all — while the host has already moved on.
 
-`mcpProfile.toolCallCancellation` now does, as a sibling of `paginationTraversal`
-and `mrtrSupport` and with the same delete-on-default discipline: `"full"` is
-absence, so a host that never touches the control keeps its canonical hash, and
-only the degraded `"none"` is ever stored.
+`mcpProfile.toolCallCancellation` now answers it, as
+`{ legacy?: boolean; modern?: boolean }` — one leaf per era.
 
-**One knob, not one per era.** Which signal a conforming client sends is fixed by
-the negotiated revision and transport, never chosen by the host: closing the
-response stream on `2026-07-28` Streamable HTTP, `notifications/cancelled`
-everywhere else — all of 2025, and stdio on any revision. (`2025-03-26` and
-`2025-06-18` are identical here; `2025-11-25` differs only in routing
-task-augmented requests through `tasks/cancel`.) Two fields would imply a host
-could answer them independently, which the spec does not allow. So the era
-changes the row's LABEL — "Tool cancellation (2026)", "(2025)", or "(2025 +
-2026)" when the version is unpinned and could negotiate either — while the
-comparison matrix and caniuse.dev keep the plain label, because adjacent columns
-there are hosts pinned to different revisions and a single suffix would be wrong
-for half the row.
+**Two leaves, not one boolean.** A host can be right on one era and wrong on the
+other, and the proof is this package's own history: MCPJam sent
+`notifications/cancelled` correctly on 2025 while never aborting the stream on
+2026. Through the 2026 migration that split is common, and collapsing it hides
+exactly the defect the prober exists to find. `legacy` covers every 2025 revision
+(they are identical here; `2025-11-25` differs only in routing task-augmented
+requests through `tasks/cancel`); `modern` covers `2026-07-28`.
 
-Cancellation is deliberately NOT modeled as a capability. The spec declares none:
-it is a *pattern*, not something a client advertises. But `HOST_CONFIG_FIELDS`
-already carries observed behaviors — `paginationTraversal`, `mrtrSupport`,
-`toolListChanged` — and this is one of them.
+The era selects the leaf, not the transport: a 2026 stdio connection reads
+`modern` even though its mechanism is `notifications/cancelled`. What is modeled
+is whether the host cancels on that era's connections, not which message carries
+it. Users never see `legacy`/`modern` — the UI and caniuse say "Tool cancellation
+(2025)" and "(2026)".
 
-`false` is enforced by withholding the caller's abort signal from the request
-and racing the caller against it locally instead (`awaitWithAbort`). The signal
-is the only thing that reaches the wire, so withholding it withholds whichever
-mechanism the negotiated revision would have used, while the turn still ends
-promptly for the user. It is deliberately not implemented by hiding the
-transport's `hasPerRequestStream`: that would make a modern connection fall back
-to POSTing `notifications/cancelled`, a message no conforming client sends on
-`2026-07-28`. The simulated host must be silent, not wrong.
+Absent per leaf is the conforming answer, so a fully cancelling client writes
+nothing and keeps its canonical hash; only an explicit `false` is stored. The
+field is validated by the same `canonicalBooleanCapabilityRecord` its sibling
+`toolListChanged` already uses, on both sides of the wire.
 
-**Public rows now appear with their data.** caniuse.dev hides any field no
-published host has been measured for yet, rather than showing a row of "Not yet
-tested" — a question dressed as an answer. The row appears on its own the moment
-the first real host value lands, with the hosts still queued behind it reading
-"Not yet tested" rather than being published as silently abandoning every
-cancelled call. No allowlist to maintain: the data decides. The internal matrix
-still shows every field, because that is where a value gets filled in, and a row
-you cannot see is a row you cannot populate.
+A `false` leaf is enforced by withholding the caller's abort signal from the
+request and racing the caller against it locally instead. The signal is the only
+thing that reaches the wire, so withholding it withholds whichever mechanism that
+era would have used, while the turn still ends promptly for the user. It is
+deliberately not implemented by hiding the transport's `hasPerRequestStream`:
+that would make a modern connection fall back to POSTing
+`notifications/cancelled`, a message no conforming client sends on `2026-07-28`.
+The simulated host must be silent, not wrong.
 
-ChatGPT's measurement is unparked in the same change set: stopping a tool call
-ends its turn without telling the server, which keeps running the tool. That one
-value is what makes the row appear — every other host reads "Not yet tested"
-until it is probed.
+Two fixes fall out of wiring it up:
 
-**Plumbing, which is where this originally failed.** The SDK enforces the knob,
-but nothing carried it to the SDK. `MCPServerConfig.suppressRequestCancellation`
-is only reachable if every layer between the stored `mcpProfile` and the
-connection copies it by hand, and each one had to learn the field: the shared
-`ConnectionDefaults`, the local resolver (both stdio and HTTP branches, plus its
-body parser), the hosted `initializePins` extractor and all four of its inline
-pin types, the host-config overlay in `effective-auth`, and the client senders in
-`App.tsx`, `use-server-state`, `mcp-api`, `use-hosted-api-context`, the web
-`context` and `servers-api`. Miss one and the UI saves the knob, the host
-persists it, and the connection silently ignores it — which is exactly what
-happened: a host set to "Not supported" still cancelled normally against a live
-server.
+- `toolCallCancellation` was missing from `CONFORMANCE_PROFILE_KEYS`, so the
+  public `HostMcp` ⇄ `mcpProfile` round-trip silently dropped it in both
+  directions.
+- `isMcpProfileEmpty` did not know the field, so turning an era off on a host
+  with nothing else configured collapsed the profile and wrote nothing at all.
 
-The overlay follows the same security rule as its siblings: a host that cancels
-normally REMOVES a body-supplied `suppressRequestCancellation`, so a share-link
-body cannot degrade a conforming host into one that abandons every cancelled
-call and leaves servers running tools nobody wants.
+**Public rows appear with their data.** caniuse.dev hides any field no published
+host has been measured for, rather than showing a column of "Not yet tested" — a
+question dressed as an answer. The two eras gate independently, so a 2025-only
+measurement never publishes a 2026 row nobody has probed. No host values ship
+here, so neither row is visible yet.

--- a/.changeset/tool-cancellation-host-knob.md
+++ b/.changeset/tool-cancellation-host-knob.md
@@ -57,3 +57,21 @@ ChatGPT's measurement is unparked in the same change set: stopping a tool call
 ends its turn without telling the server, which keeps running the tool. That one
 value is what makes the row appear — every other host reads "Not yet tested"
 until it is probed.
+
+**Plumbing, which is where this originally failed.** The SDK enforces the knob,
+but nothing carried it to the SDK. `MCPServerConfig.suppressRequestCancellation`
+is only reachable if every layer between the stored `mcpProfile` and the
+connection copies it by hand, and each one had to learn the field: the shared
+`ConnectionDefaults`, the local resolver (both stdio and HTTP branches, plus its
+body parser), the hosted `initializePins` extractor and all four of its inline
+pin types, the host-config overlay in `effective-auth`, and the client senders in
+`App.tsx`, `use-server-state`, `mcp-api`, `use-hosted-api-context`, the web
+`context` and `servers-api`. Miss one and the UI saves the knob, the host
+persists it, and the connection silently ignores it — which is exactly what
+happened: a host set to "Not supported" still cancelled normally against a live
+server.
+
+The overlay follows the same security rule as its siblings: a host that cancels
+normally REMOVES a body-supplied `suppressRequestCancellation`, so a share-link
+body cannot degrade a conforming host into one that abandons every cancelled
+call and leaves servers running tools nobody wants.

--- a/.changeset/tool-cancellation-host-knob.md
+++ b/.changeset/tool-cancellation-host-knob.md
@@ -61,3 +61,11 @@ host has been measured for, rather than showing a column of "Not yet tested" —
 question dressed as an answer. The two eras gate independently, so a 2025-only
 measurement never publishes a 2026 row nobody has probed. No host values ship
 here, so neither row is visible yet.
+
+Saving the toggle also reconnects the host's connected servers, because the
+setting is read from a connection's config when it connects — without this a
+saved change sat inert until the user happened to reconnect, which reads as the
+switch doing nothing. Same reason the per-server protocol pin reconnects after
+its save. Narrow by construction: only when the setting actually changed, only
+for servers that are already connected, never interactive (a save must not open
+an OAuth prompt), and a failed reconnect warns rather than failing the save.

--- a/.changeset/tool-cancellation-host-knob.md
+++ b/.changeset/tool-cancellation-host-knob.md
@@ -32,12 +32,12 @@ nothing and keeps its canonical hash; only an explicit `false` is stored. The
 field is validated by the same `canonicalBooleanCapabilityRecord` its sibling
 `toolListChanged` already uses, on both sides of the wire.
 
-Which leaf governs a connection is resolved where its protocol version is
-already known — `cancellationLeafForVersion(pin)` — and a single flag reaches the
-client, which simply obeys it. The client is never asked what era it negotiated:
-`getProtocolEra()` is optional on the managed-client interface, so on adapters
-that cannot report one the era reads as unknown and the suppression would
-silently never apply.
+Both leaves travel to the connection, and the leaf that governs is resolved
+AFTER the handshake from `getNegotiatedProtocolVersion()` — the same value the
+UI reports — falling back to the configured pin before the handshake lands.
+Resolving at config-build time cannot work for an unpinned (`"auto"`) host: the
+era does not exist yet, so picking one there makes the other era's toggle
+unreachable.
 
 A `false` leaf is enforced by withholding the caller's abort signal from the
 request and racing the caller against it locally instead. The signal is the only

--- a/.changeset/tool-cancellation-host-knob.md
+++ b/.changeset/tool-cancellation-host-knob.md
@@ -62,10 +62,29 @@ question dressed as an answer. The two eras gate independently, so a 2025-only
 measurement never publishes a 2026 row nobody has probed. No host values ship
 here, so neither row is visible yet.
 
-Saving the toggle also reconnects the host's connected servers, because the
-setting is read from a connection's config when it connects — without this a
-saved change sat inert until the user happened to reconnect, which reads as the
-switch doing nothing. Same reason the per-server protocol pin reconnects after
-its save. Narrow by construction: only when the setting actually changed, only
-for servers that are already connected, never interactive (a save must not open
-an OAuth prompt), and a failed reconnect warns rather than failing the save.
+The saved value has to reach a connection that is already up, and it does so
+twice over:
+
+- **Per turn.** The chat routes (local and hosted) resolve the host config
+  server-side on every turn and pass its cancellation record to
+  `getToolsForAiSdk` as a per-turn override that takes precedence over the
+  connection's connect-time copy. It is authoritative whenever a host config
+  resolved: a host that cancels normally sends an *empty* record, not nothing,
+  because `undefined` would fall through to the stale connection copy and a
+  toggle switched back on would keep suppressing.
+- **On save.** The host's connected servers are reconnected so the connection's
+  own copy is refreshed too — the same reason the per-server protocol pin
+  reconnects after its save. The reconnect is deferred until the app's view of
+  the host shows the just-saved config: it builds its connection defaults from
+  the active host's profile, and right after the mutation resolves that
+  subscription still holds the previous config, so an immediate reconnect
+  applied the value the user had just replaced — one save behind, every time.
+  Narrow by construction: only when the setting actually changed, only for
+  servers already connected, never interactive, and a failed reconnect warns
+  rather than failing the save.
+
+A suppressed call also outlives the default request timeout. The protocol layer
+runs the same cancellation on a timeout as on an abort — closing the stream on a
+modern connection — so with the 60s timer left in place a host configured never
+to cancel still cancelled, a minute later, which read as the knob being flaky
+rather than off. Suppressed requests now carry a long bounded timeout instead.

--- a/.changeset/tool-cancellation-host-knob.md
+++ b/.changeset/tool-cancellation-host-knob.md
@@ -1,0 +1,59 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/inspector": patch
+---
+
+Model tool cancellation as a host behavior: a Protocol-tab knob and a caniuse row
+
+A server author has no way to answer the question that decides whether a stopped
+turn costs them anything: **when the user hits stop, does the host tell me?** If
+it does not, the tool runs to completion on the server — side effects, tokens and
+all — while the host has already moved on. Hosts genuinely differ here, and
+nothing in the host config recorded it, so it could not be simulated, compared,
+or published.
+
+`mcpProfile.toolCallCancellation` now does, as a sibling of `paginationTraversal`
+and `mrtrSupport` and with the same delete-on-default discipline: `"full"` is
+absence, so a host that never touches the control keeps its canonical hash, and
+only the degraded `"none"` is ever stored.
+
+**One knob, not one per era.** Which signal a conforming client sends is fixed by
+the negotiated revision and transport, never chosen by the host: closing the
+response stream on `2026-07-28` Streamable HTTP, `notifications/cancelled`
+everywhere else — all of 2025, and stdio on any revision. (`2025-03-26` and
+`2025-06-18` are identical here; `2025-11-25` differs only in routing
+task-augmented requests through `tasks/cancel`.) Two fields would imply a host
+could answer them independently, which the spec does not allow. So the era
+changes the row's LABEL — "Tool cancellation (2026)", "(2025)", or "(2025 +
+2026)" when the version is unpinned and could negotiate either — while the
+comparison matrix and caniuse.dev keep the plain label, because adjacent columns
+there are hosts pinned to different revisions and a single suffix would be wrong
+for half the row.
+
+Cancellation is deliberately NOT modeled as a capability. The spec declares none:
+it is a *pattern*, not something a client advertises. But `HOST_CONFIG_FIELDS`
+already carries observed behaviors — `paginationTraversal`, `mrtrSupport`,
+`toolListChanged` — and this is one of them.
+
+`false` is enforced by withholding the caller's abort signal from the request
+and racing the caller against it locally instead (`awaitWithAbort`). The signal
+is the only thing that reaches the wire, so withholding it withholds whichever
+mechanism the negotiated revision would have used, while the turn still ends
+promptly for the user. It is deliberately not implemented by hiding the
+transport's `hasPerRequestStream`: that would make a modern connection fall back
+to POSTing `notifications/cancelled`, a message no conforming client sends on
+`2026-07-28`. The simulated host must be silent, not wrong.
+
+**Public rows now appear with their data.** caniuse.dev hides any field no
+published host has been measured for yet, rather than showing a row of "Not yet
+tested" — a question dressed as an answer. The row appears on its own the moment
+the first real host value lands, with the hosts still queued behind it reading
+"Not yet tested" rather than being published as silently abandoning every
+cancelled call. No allowlist to maintain: the data decides. The internal matrix
+still shows every field, because that is where a value gets filled in, and a row
+you cannot see is a row you cannot populate.
+
+ChatGPT's measurement is unparked in the same change set: stopping a tool call
+ends its turn without telling the server, which keeps running the tool. That one
+value is what makes the row appear — every other host reads "Not yet tested"
+until it is probed.

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -256,7 +256,6 @@ import {
   readXaaEnterprisePolicy,
   taskModeForSurface,
   type McpProtocolVersion,
-  cancellationLeafForVersion,
 } from "@mcpjam/sdk/browser";
 import {
   cloneHostTemplateInput,
@@ -3614,13 +3613,16 @@ export default function App() {
       activeMcpProfile?.toolListChanged?.refetches === false
         ? (true as const)
         : undefined;
-    // Host-level pin resolves which era these connections speak, so one flag
-    // travels rather than both leaves.
-    const suppressRequestCancellation =
-      activeMcpProfile?.toolCallCancellation?.[
-        cancellationLeafForVersion(activeMcpProfile?.mcpProtocolVersion)
-      ] === false
-        ? (true as const)
+    // Forward the degraded leaves; the SDK picks the one matching the era each
+    // connection negotiates, which an unpinned host only learns at connect.
+    const cancellationLeaves = Object.fromEntries(
+      (["legacy", "modern"] as const)
+        .filter((key) => activeMcpProfile?.toolCallCancellation?.[key] === false)
+        .map((key) => [key, false])
+    );
+    const toolCallCancellation =
+      Object.keys(cancellationLeaves).length > 0
+        ? cancellationLeaves
         : undefined;
 
     return {
@@ -3635,7 +3637,7 @@ export default function App() {
       supportsMrtr,
       suppressListenChannel,
       dropToolListChanged,
-      suppressRequestCancellation,
+      toolCallCancellation,
       xaaPolicy,
     };
   }, [

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -3665,6 +3665,7 @@ export default function App() {
     mirrorToolParamHeaders: hostedMcpProfilePins.mirrorToolParamHeaders,
     firstPageOnly: hostedMcpProfilePins.firstPageOnly,
     supportsMrtr: hostedMcpProfilePins.supportsMrtr,
+    toolCallCancellation: hostedMcpProfilePins.toolCallCancellation,
     xaaPolicy: hostedMcpProfilePins.xaaPolicy,
     clientConfigSyncPending:
       isClientConfigSyncPending || isProjectServerConfigLoading,

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -652,7 +652,8 @@ function ActiveBillingUpsellGate() {
 }
 
 export function ServersRoute() {
-  const { convexProjectId, isAuthenticated } = useAppRouteContext();
+  const { convexProjectId, isAuthenticated, handleReconnect } =
+    useAppRouteContext();
   const [previewedHostId] = usePreviewedHostId(convexProjectId);
   const navigate = useAppNavigate();
   // `/servers/:serverId` and `/servers/plugins/:pluginId` — the exact
@@ -725,6 +726,7 @@ export function ServersRoute() {
       isAuthenticated={isAuthenticated}
       selectedHostId={null}
       onSelectHost={handleSelectHost}
+      onReconnect={handleReconnect}
       serversTabElement={
         <ServersTabBody
           routeServerId={routeParams.serverId ?? null}
@@ -800,6 +802,7 @@ export function HostsRoute() {
     hostsTabSelectedHostId,
     isAuthenticated,
     setHostsTabSelectedHostId,
+    handleReconnect,
   } = useAppRouteContext();
   const [previewedHostId, setPreviewedHostId] =
     usePreviewedHostId(convexProjectId);
@@ -976,6 +979,7 @@ export function HostsRoute() {
       isAuthenticated={isAuthenticated}
       selectedHostId={openableHostId ?? previewedHostId}
       onSelectHost={handleSelectHost}
+      onReconnect={handleReconnect}
       serversTabElement={<ServersTabBody />}
     />
   );

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -3613,8 +3613,12 @@ export default function App() {
       activeMcpProfile?.toolListChanged?.refetches === false
         ? (true as const)
         : undefined;
-    const suppressRequestCancellation =
-      activeMcpProfile?.toolCallCancellation === false
+    const suppressLegacyRequestCancellation =
+      activeMcpProfile?.toolCallCancellation?.legacy === false
+        ? (true as const)
+        : undefined;
+    const suppressModernRequestCancellation =
+      activeMcpProfile?.toolCallCancellation?.modern === false
         ? (true as const)
         : undefined;
 
@@ -3630,7 +3634,8 @@ export default function App() {
       supportsMrtr,
       suppressListenChannel,
       dropToolListChanged,
-      suppressRequestCancellation,
+      suppressLegacyRequestCancellation,
+      suppressModernRequestCancellation,
       xaaPolicy,
     };
   }, [

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -256,6 +256,7 @@ import {
   readXaaEnterprisePolicy,
   taskModeForSurface,
   type McpProtocolVersion,
+  cancellationLeafForVersion,
 } from "@mcpjam/sdk/browser";
 import {
   cloneHostTemplateInput,
@@ -3613,12 +3614,12 @@ export default function App() {
       activeMcpProfile?.toolListChanged?.refetches === false
         ? (true as const)
         : undefined;
-    const suppressLegacyRequestCancellation =
-      activeMcpProfile?.toolCallCancellation?.legacy === false
-        ? (true as const)
-        : undefined;
-    const suppressModernRequestCancellation =
-      activeMcpProfile?.toolCallCancellation?.modern === false
+    // Host-level pin resolves which era these connections speak, so one flag
+    // travels rather than both leaves.
+    const suppressRequestCancellation =
+      activeMcpProfile?.toolCallCancellation?.[
+        cancellationLeafForVersion(activeMcpProfile?.mcpProtocolVersion)
+      ] === false
         ? (true as const)
         : undefined;
 
@@ -3634,8 +3635,7 @@ export default function App() {
       supportsMrtr,
       suppressListenChannel,
       dropToolListChanged,
-      suppressLegacyRequestCancellation,
-      suppressModernRequestCancellation,
+      suppressRequestCancellation,
       xaaPolicy,
     };
   }, [

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -3613,6 +3613,10 @@ export default function App() {
       activeMcpProfile?.toolListChanged?.refetches === false
         ? (true as const)
         : undefined;
+    const suppressRequestCancellation =
+      activeMcpProfile?.toolCallCancellation === false
+        ? (true as const)
+        : undefined;
 
     return {
       clientInfo,
@@ -3626,6 +3630,7 @@ export default function App() {
       supportsMrtr,
       suppressListenChannel,
       dropToolListChanged,
+      suppressRequestCancellation,
       xaaPolicy,
     };
   }, [

--- a/mcpjam-inspector/client/src/components/HostsTab.tsx
+++ b/mcpjam-inspector/client/src/components/HostsTab.tsx
@@ -39,6 +39,15 @@ interface HostsTabProps {
   selectedHostId: string | null;
   onSelectHost: (hostId: string | null) => void;
   serversTabElement: ReactNode;
+  /**
+   * Reconnects one server by name. Threaded from `App` (which owns it) so a
+   * saved setting that only takes effect at connect time can be applied to the
+   * live connection — see the cancellation hook in `handleSave`.
+   */
+  onReconnect?: (
+    serverName: string,
+    options?: { forceOAuthFlow?: boolean; allowInteractiveOAuthFlow?: boolean }
+  ) => Promise<unknown> | void;
 }
 
 /**
@@ -55,6 +64,7 @@ export function HostsTab({
   selectedHostId,
   onSelectHost,
   serversTabElement,
+  onReconnect,
 }: HostsTabProps) {
   const navigate = useAppNavigate();
   const [previewedHostId, setPreviewedHostId] = usePreviewedHostId(projectId);
@@ -455,6 +465,7 @@ export function HostsTab({
                   <HostBuilderView
                     hostId={selectedHostId}
                     projectId={projectId}
+                    onReconnect={onReconnect}
                   />
                 </div>
               </motion.div>

--- a/mcpjam-inspector/client/src/components/hosts/HostBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostBuilderView.tsx
@@ -3,6 +3,15 @@ import { HostBuilderViewRedesigned } from "./redesigned/HostBuilderViewRedesigne
 interface HostBuilderViewProps {
   hostId: string;
   projectId: string;
+  /**
+   * Reconnects one server by name. Threaded from `App` (which owns it) so a
+   * saved setting that only takes effect at connect time can be applied to the
+   * live connection — see the cancellation hook in `handleSave`.
+   */
+  onReconnect?: (
+    serverName: string,
+    options?: { forceOAuthFlow?: boolean; allowInteractiveOAuthFlow?: boolean }
+  ) => Promise<unknown> | void;
 }
 
 export function HostBuilderView(props: HostBuilderViewProps) {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/CaniuseCapabilityPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/CaniuseCapabilityPage.tsx
@@ -15,6 +15,7 @@ import {
   buildCaniuseCapabilityPath,
   getCaniuseCapabilityBySlug,
   getCaniuseSupportLabel,
+  caniuseFieldHasPresetData,
   getCaniuseSupportLevel,
   sortCaniusePresetHosts,
 } from "./caniuse-capability-catalog";
@@ -29,7 +30,7 @@ interface CaniuseCapabilityPageProps {
 export function CaniuseCapabilityPage({
   capabilitySlug,
 }: CaniuseCapabilityPageProps) {
-  const capability = getCaniuseCapabilityBySlug(capabilitySlug);
+  const resolvedCapability = getCaniuseCapabilityBySlug(capabilitySlug);
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const catalogState = useHostCatalog();
   const compareCatalog = catalogState.catalog ?? bundledHostCompatCatalog();
@@ -46,6 +47,19 @@ export function CaniuseCapabilityPage({
   const hosts = useMemo(
     () => sortCaniusePresetHosts(presets.hosts),
     [presets.hosts]
+  );
+  // A capability nobody has measured has no page: every column would read
+  // "Not yet tested", which is a question rather than an answer, and a
+  // permalink to it would outlive the reason it was empty. Treated as an
+  // unknown slug so the not-found branch below handles it — the page appears
+  // by itself once the first host value lands.
+  const capability = useMemo(
+    () =>
+      resolvedCapability &&
+      caniuseFieldHasPresetData(resolvedCapability.field, presets.subjects)
+        ? resolvedCapability
+        : null,
+    [resolvedCapability, presets.subjects]
   );
 
   // Agent bridge: SNAPSHOT-ONLY (no tools). This is the `host-compare` surface

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -69,9 +69,9 @@ import {
 } from "./host-compare-selection";
 import { buildPresetCompareEntries } from "./host-compare-presets";
 import {
-  PUBLIC_CAN_I_USE_FIELDS,
   getCaniuseCapabilityBySlug,
   getCaniuseCapabilityForField,
+  publicCaniuseFieldsWithData,
   sortCaniusePresetHosts,
 } from "./caniuse-capability-catalog";
 import { HostConfigComparisonMatrix } from "./host-config-comparison-matrix";
@@ -318,9 +318,16 @@ export function HostConfigCompareView({
   // Every selectable id (real + preset). URL / stored selections reconcile
   // against this so a chosen preset column survives a reload.
   const knownHostIds = useMemo(() => hosts.map((host) => host.hostId), [hosts]);
+  // The public surface hides rows no published host has been measured for
+  // yet — a column of "Not yet tested" answers nothing. The internal matrix
+  // shows every field regardless, because that is where a value gets filled
+  // in, and a row you cannot see is a row you cannot populate.
   const compareFields = useMemo(
-    () => (presetOnly ? PUBLIC_CAN_I_USE_FIELDS : HOST_CONFIG_FIELDS),
-    [presetOnly]
+    () =>
+      presetOnly
+        ? publicCaniuseFieldsWithData(presets.subjects)
+        : HOST_CONFIG_FIELDS,
+    [presetOnly, presets.subjects]
   );
   // Base for the per-column "Verify against your server" deep-link. In dev the
   // caniuse surface and the hosted app share an origin, so stay on it (localhost)

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/caniuse-capability-catalog.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/caniuse-capability-catalog.test.ts
@@ -8,9 +8,14 @@ import {
   getCaniuseCapabilityBySlug,
   getCaniuseSupportLabel,
   getCaniuseSupportLevel,
+  caniuseFieldHasPresetData,
+  publicCaniuseFieldsWithData,
 } from "../caniuse-capability-catalog";
 import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
-import { hostConfigField } from "@/lib/host-config-field-schema";
+import {
+  hostConfigField,
+  type HostComparisonSubject,
+} from "@/lib/host-config-field-schema";
 
 describe("caniuse capability catalog", () => {
   it("includes stable public capability slugs", () => {
@@ -120,5 +125,48 @@ describe("caniuse capability catalog", () => {
 
   it("uses a static latest verification date for v1", () => {
     expect(CANIUSE_LAST_VERIFIED_DATE).toBe("2026-08-14");
+  });
+});
+
+describe("unmeasured rows stay off the public surface", () => {
+  const field = hostConfigField("toolCallCancellation");
+
+  const subjectWith = (
+    toolCallCancellation?: boolean
+  ): Record<string, HostComparisonSubject> => ({
+    "preset:claude": {
+      hostName: "Claude",
+      config: {
+        ...emptyHostConfigInputV2(),
+        id: "preset:claude",
+        schemaVersion: 2,
+        mcpProfile: {
+          profileVersion: 1,
+          ...(toolCallCancellation !== undefined
+            ? { toolCallCancellation }
+            : {}),
+        },
+      },
+    } as HostComparisonSubject,
+  });
+
+  it("hides a field no published host carries a value for", () => {
+    expect(caniuseFieldHasPresetData(field, subjectWith())).toBe(false);
+    expect(publicCaniuseFieldsWithData(subjectWith())).not.toContain(field);
+  });
+
+  it("shows it as soon as one host has a value", () => {
+    // One real host is the whole bar — the row exists to be compared, and a
+    // single measured column already answers the question for that host.
+    expect(caniuseFieldHasPresetData(field, subjectWith(false))).toBe(true);
+    expect(publicCaniuseFieldsWithData(subjectWith(false))).toContain(field);
+  });
+
+  it("reads an unmeasured host as not-yet-tested rather than unsupported", () => {
+    // The enum would otherwise resolve to "neutral", which renders as "Not
+    // supported" — publishing a claim about a host nobody probed.
+    const config = subjectWith()["preset:claude"]!.config;
+    expect(getCaniuseSupportLevel(field, config)).toBe("unknown");
+    expect(getCaniuseSupportLabel("unknown")).toBe("Not yet tested");
   });
 });

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/caniuse-capability-catalog.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/caniuse-capability-catalog.test.ts
@@ -129,10 +129,11 @@ describe("caniuse capability catalog", () => {
 });
 
 describe("unmeasured rows stay off the public surface", () => {
-  const field = hostConfigField("toolCallCancellation");
+  const legacyField = hostConfigField("toolCallCancellation.legacy");
+  const modernField = hostConfigField("toolCallCancellation.modern");
 
   const subjectWith = (
-    toolCallCancellation?: boolean
+    toolCallCancellation?: { legacy?: boolean; modern?: boolean }
   ): Record<string, HostComparisonSubject> => ({
     "preset:claude": {
       hostName: "Claude",
@@ -151,22 +152,35 @@ describe("unmeasured rows stay off the public surface", () => {
   });
 
   it("hides a field no published host carries a value for", () => {
-    expect(caniuseFieldHasPresetData(field, subjectWith())).toBe(false);
-    expect(publicCaniuseFieldsWithData(subjectWith())).not.toContain(field);
+    for (const field of [legacyField, modernField]) {
+      expect(caniuseFieldHasPresetData(field, subjectWith())).toBe(false);
+      expect(publicCaniuseFieldsWithData(subjectWith())).not.toContain(field);
+    }
   });
 
   it("shows it as soon as one host has a value", () => {
     // One real host is the whole bar — the row exists to be compared, and a
     // single measured column already answers the question for that host.
-    expect(caniuseFieldHasPresetData(field, subjectWith(false))).toBe(true);
-    expect(publicCaniuseFieldsWithData(subjectWith(false))).toContain(field);
+    const measured = subjectWith({ legacy: false });
+    expect(caniuseFieldHasPresetData(legacyField, measured)).toBe(true);
+    expect(publicCaniuseFieldsWithData(measured)).toContain(legacyField);
+  });
+
+  it("gates the two eras independently", () => {
+    // A 2025-only measurement must not publish a 2026 row nobody has probed:
+    // the eras are separate questions with separate evidence.
+    const legacyOnly = subjectWith({ legacy: false });
+    expect(caniuseFieldHasPresetData(modernField, legacyOnly)).toBe(false);
+    expect(publicCaniuseFieldsWithData(legacyOnly)).not.toContain(modernField);
   });
 
   it("reads an unmeasured host as not-yet-tested rather than unsupported", () => {
     // The enum would otherwise resolve to "neutral", which renders as "Not
     // supported" — publishing a claim about a host nobody probed.
     const config = subjectWith()["preset:claude"]!.config;
-    expect(getCaniuseSupportLevel(field, config)).toBe("unknown");
+    for (const field of [legacyField, modernField]) {
+      expect(getCaniuseSupportLevel(field, config)).toBe("unknown");
+    }
     expect(getCaniuseSupportLabel("unknown")).toBe("Not yet tested");
   });
 });

--- a/mcpjam-inspector/client/src/components/hosts/comparison/caniuse-capability-catalog.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/caniuse-capability-catalog.ts
@@ -1,5 +1,6 @@
 import {
   HOST_CONFIG_FIELDS,
+  type HostComparisonSubject,
   type HostConfigFieldDef,
   type SupportLevel,
 } from "@/lib/host-config-field-schema";
@@ -106,6 +107,37 @@ export function isPublicCaniuseCapabilityField(
 export const PUBLIC_CAN_I_USE_FIELDS: ReadonlyArray<HostConfigFieldDef> =
   HOST_CONFIG_FIELDS.filter(isPublicCaniuseCapabilityField);
 
+/**
+ * Whether any published host actually carries a value for this field.
+ *
+ * A row whose every column reads "Not yet tested" answers nothing — it
+ * advertises a question we have not asked yet. Fields added ahead of their
+ * measurements therefore stay hidden until the first real host value lands,
+ * and appear on their own the moment one does. No allowlist to maintain: the
+ * data decides.
+ *
+ * Only public presets (Claude, ChatGPT, Copilot, Cursor, Slack, VS Code) reach
+ * these surfaces, so "a host that is not MCPJam" holds by construction — the
+ * emulator's own defaults can never light a row on their own.
+ */
+export function caniuseFieldHasPresetData(
+  field: HostConfigFieldDef,
+  subjects: Record<string, HostComparisonSubject>,
+): boolean {
+  return Object.values(subjects).some(
+    (subject) => field.read(subject.config) !== undefined,
+  );
+}
+
+/** {@link PUBLIC_CAN_I_USE_FIELDS} minus the rows nobody has measured yet. */
+export function publicCaniuseFieldsWithData(
+  subjects: Record<string, HostComparisonSubject>,
+): ReadonlyArray<HostConfigFieldDef> {
+  return PUBLIC_CAN_I_USE_FIELDS.filter((field) =>
+    caniuseFieldHasPresetData(field, subjects),
+  );
+}
+
 export const CANIUSE_CAPABILITIES: ReadonlyArray<CaniuseCapability> =
   PUBLIC_CAN_I_USE_FIELDS.map((field) => ({
     slug: slugForField(field),
@@ -170,7 +202,11 @@ export function getCaniuseSupportLevel(
       // Enum rather than boolean, so it resolves to "neutral" rather than
       // undefined when unset — and "neutral" renders as "Not supported".
       // Without this an unprobed host publicly claims it cannot paginate.
-      field.id === "paginationTraversal") &&
+      field.id === "paginationTraversal" ||
+      // Same reasoning: once one host is measured the row appears, and the
+      // hosts still queued behind it must read "Not yet tested" rather than
+      // be published as silently abandoning every cancelled call.
+      field.id === "toolCallCancellation") &&
     field.read(config) === undefined
   ) {
     return "unknown";

--- a/mcpjam-inspector/client/src/components/hosts/comparison/caniuse-capability-catalog.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/caniuse-capability-catalog.ts
@@ -205,8 +205,9 @@ export function getCaniuseSupportLevel(
       field.id === "paginationTraversal" ||
       // Same reasoning: once one host is measured the row appears, and the
       // hosts still queued behind it must read "Not yet tested" rather than
-      // be published as silently abandoning every cancelled call.
-      field.id === "toolCallCancellation") &&
+      // be published as silently abandoning every cancelled call. Per era,
+      // because the two are measured independently.
+      field.id.startsWith("toolCallCancellation.")) &&
     field.read(config) === undefined
   ) {
     return "unknown";

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -61,6 +61,49 @@ import {
 interface HostBuilderViewRedesignedProps {
   hostId: string;
   projectId: string;
+  /**
+   * Reconnects one server by name. Threaded from `App` (which owns it) so a
+   * saved setting that only takes effect at connect time can be applied to the
+   * live connection — see the cancellation hook in `handleSave`.
+   */
+  onReconnect?: (
+    serverName: string,
+    options?: { forceOAuthFlow?: boolean; allowInteractiveOAuthFlow?: boolean }
+  ) => Promise<unknown> | void;
+}
+
+/**
+ * Whether a save changed the tool-cancellation setting.
+ *
+ * Compared as canonical JSON rather than by reference, matching how
+ * `handleSave` diffs the rest of the draft: the record is rebuilt on every
+ * keystroke, so identity always differs and would reconnect on every save.
+ */
+export function toolCallCancellationChanged(
+  saved: HostConfigInputV2 | null | undefined,
+  draft: HostConfigInputV2
+): boolean {
+  return (
+    JSON.stringify(saved?.mcpProfile?.toolCallCancellation) !==
+    JSON.stringify(draft.mcpProfile?.toolCallCancellation)
+  );
+}
+
+/**
+ * The servers a cancellation change must be applied to: this host's own
+ * servers that are currently CONNECTED.
+ *
+ * Disconnected ones are deliberately excluded — they read the setting when
+ * they next connect, and reconnecting them from a config save would be a
+ * surprise the user did not ask for.
+ */
+export function serversNeedingCancellationReconnect(
+  hostServerNames: ReadonlyArray<string>,
+  connectionStatusByName: Record<string, { connectionStatus?: string } | undefined>
+): string[] {
+  return hostServerNames.filter(
+    (name) => connectionStatusByName[name]?.connectionStatus === "connected"
+  );
 }
 
 const CLOSED_FOCUS: HostFocusState = {
@@ -72,6 +115,7 @@ const CLOSED_FOCUS: HostFocusState = {
 export function HostBuilderViewRedesigned({
   hostId,
   projectId,
+  onReconnect,
 }: HostBuilderViewRedesignedProps) {
   const navigate = useAppNavigate();
   const location = useLocation();
@@ -364,6 +408,12 @@ export function HostBuilderViewRedesigned({
               JSON.stringify(savedConfig[key])
           )
         : [];
+      // Reuse the same draft-vs-saved comparison the telemetry diff uses,
+      // rather than introducing a second notion of "changed".
+      const cancellationChanged = toolCallCancellationChanged(
+        savedConfig,
+        draftConfig
+      );
       const { hostConfigId } = await updateHost({
         hostId,
         name: draftName,
@@ -373,6 +423,35 @@ export function HostBuilderViewRedesigned({
       // subscription on the next tick; don't include it in this toast
       // because `host?.config?.id` is still the *previous* saved config here.
       toast.success("Client saved");
+      // Tool cancellation is read from the connection's config at CONNECT
+      // time, so a saved toggle would otherwise sit inert until the user
+      // happened to reconnect — which reads as the switch doing nothing.
+      // Reconnect the host's live servers so the just-saved value governs
+      // them, the same reason the per-server protocol pin reconnects after
+      // its save (`ServersTab`).
+      //
+      // Deliberately narrow: only when this setting actually changed, and
+      // only for servers that are currently connected. A disconnected server
+      // picks the value up on its next connect, and reconnecting it here
+      // would be a surprise. Never interactive — a save must not open an
+      // OAuth prompt.
+      if (cancellationChanged && onReconnect) {
+        const connectedNames = serversNeedingCancellationReconnect(
+          requiredServerNames,
+          connectionStatusByName
+        );
+        // Best-effort, like the telemetry below: the config is already
+        // persisted, so a failed reconnect is a warning, never a failed save.
+        for (const name of connectedNames) {
+          try {
+            await onReconnect(name, { allowInteractiveOAuthFlow: false });
+          } catch {
+            toast.warning(
+              `Saved, but "${name}" did not reconnect — its tool-cancellation setting still reflects the previous connection.`
+            );
+          }
+        }
+      }
       // Telemetry is best-effort: a posthog throw must not bubble into the
       // shared catch and surface "Failed to save host" after the config
       // has already been persisted.
@@ -392,7 +471,16 @@ export function HostBuilderViewRedesigned({
     } finally {
       setIsSaving(false);
     }
-  }, [hostId, draftName, draftConfig, savedConfig, updateHost]);
+  }, [
+    hostId,
+    draftName,
+    draftConfig,
+    savedConfig,
+    updateHost,
+    onReconnect,
+    requiredServerNames,
+    connectionStatusByName,
+  ]);
 
   const handleAddServer = useCallback(
     async (formData: ServerFormData) => {

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -338,6 +338,42 @@ export function HostBuilderViewRedesigned({
   if (liveSnapshotId) lastSnapshotIdRef.current = liveSnapshotId;
   const savedSnapshotId = liveSnapshotId || lastSnapshotIdRef.current;
 
+  // Runs the save-triggered cancellation reconnect once the app's view of the
+  // host has caught up with the save — see `handleSave`. Deliberately narrow:
+  // only connected servers, never interactive (a save must not open an OAuth
+  // prompt), and best-effort (the config is already persisted, so a failed
+  // reconnect is a warning, never a failed save).
+  const [pendingCancellationReconnect, setPendingCancellationReconnect] =
+    useState<string | null>(null);
+  useEffect(() => {
+    if (!pendingCancellationReconnect || !onReconnect) return;
+    if (liveSnapshotId !== pendingCancellationReconnect) return;
+    setPendingCancellationReconnect(null);
+    // Every connected server, not just `serverIds`: under the "all project
+    // servers attach" rule a server the host actually talks to need not
+    // appear in that list.
+    const connectedNames = serversNeedingCancellationReconnect(
+      Object.keys(connectionStatusByName),
+      connectionStatusByName
+    );
+    void (async () => {
+      for (const name of connectedNames) {
+        try {
+          await onReconnect(name, { allowInteractiveOAuthFlow: false });
+        } catch {
+          toast.warning(
+            `Saved, but "${name}" did not reconnect — its tool-cancellation setting still reflects the previous connection.`
+          );
+        }
+      }
+    })();
+  }, [
+    pendingCancellationReconnect,
+    liveSnapshotId,
+    onReconnect,
+    connectionStatusByName,
+  ]);
+
   const viewModel = useMemo(() => {
     const draft = draftConfig ?? emptyHostConfigInputV2();
     return buildRedesignedHostCanvas(
@@ -430,27 +466,14 @@ export function HostBuilderViewRedesigned({
       // them, the same reason the per-server protocol pin reconnects after
       // its save (`ServersTab`).
       //
-      // Deliberately narrow: only when this setting actually changed, and
-      // only for servers that are currently connected. A disconnected server
-      // picks the value up on its next connect, and reconnecting it here
-      // would be a surprise. Never interactive — a save must not open an
-      // OAuth prompt.
+      // DEFERRED, not run here. The reconnect builds its connection defaults
+      // from the active host's profile as the app currently sees it, and at
+      // this point the Convex subscription still holds the PREVIOUS config
+      // (see the toast note above). Reconnecting now would apply the value
+      // the user just replaced — one save behind, every time. The effect
+      // below waits until the saved config id is the one the app is showing.
       if (cancellationChanged && onReconnect) {
-        const connectedNames = serversNeedingCancellationReconnect(
-          requiredServerNames,
-          connectionStatusByName
-        );
-        // Best-effort, like the telemetry below: the config is already
-        // persisted, so a failed reconnect is a warning, never a failed save.
-        for (const name of connectedNames) {
-          try {
-            await onReconnect(name, { allowInteractiveOAuthFlow: false });
-          } catch {
-            toast.warning(
-              `Saved, but "${name}" did not reconnect — its tool-cancellation setting still reflects the previous connection.`
-            );
-          }
-        }
+        setPendingCancellationReconnect(hostConfigId);
       }
       // Telemetry is best-effort: a posthog throw must not bubble into the
       // shared catch and surface "Failed to save host" after the config
@@ -477,9 +500,6 @@ export function HostBuilderViewRedesigned({
     draftConfig,
     savedConfig,
     updateHost,
-    onReconnect,
-    requiredServerNames,
-    connectionStatusByName,
   ]);
 
   const handleAddServer = useCallback(

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/HostBuilderViewRedesigned.cancellationReconnect.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/HostBuilderViewRedesigned.cancellationReconnect.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
+import type { HostConfigInputV2 } from "@/lib/client-config-v2";
+import {
+  serversNeedingCancellationReconnect,
+  toolCallCancellationChanged,
+} from "../HostBuilderViewRedesigned";
+
+const withCancellation = (
+  toolCallCancellation?: Record<string, boolean>,
+): HostConfigInputV2 =>
+  ({
+    ...emptyHostConfigInputV2(),
+    mcpProfile: {
+      profileVersion: 1,
+      ...(toolCallCancellation ? { toolCallCancellation } : {}),
+    },
+  }) as HostConfigInputV2;
+
+/**
+ * The knob is read from the connection's config at CONNECT time, so a saved
+ * change has to be pushed onto live connections or the switch reads as inert.
+ * These guard the two things that keep that from becoming a reconnect storm:
+ * only when the setting actually changed, and only for connected servers.
+ */
+describe("cancellation change detection", () => {
+  it("is true when a leaf is turned off, and when one is turned back on", () => {
+    expect(
+      toolCallCancellationChanged(
+        withCancellation(),
+        withCancellation({ modern: false }),
+      ),
+    ).toBe(true);
+    expect(
+      toolCallCancellationChanged(
+        withCancellation({ modern: false }),
+        withCancellation(),
+      ),
+    ).toBe(true);
+  });
+
+  it("is true when only one era changed", () => {
+    expect(
+      toolCallCancellationChanged(
+        withCancellation({ legacy: false }),
+        withCancellation({ legacy: false, modern: false }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for an unrelated save", () => {
+    // Compared by value, not identity: the draft rebuilds this record on every
+    // keystroke, so an identity check would reconnect on every save.
+    const saved = withCancellation({ modern: false });
+    const draft = {
+      ...withCancellation({ modern: false }),
+      modelId: "anthropic/claude-sonnet-4-6",
+    } as HostConfigInputV2;
+    expect(toolCallCancellationChanged(saved, draft)).toBe(false);
+  });
+
+  it("is false when the host never had the setting", () => {
+    expect(
+      toolCallCancellationChanged(withCancellation(), withCancellation()),
+    ).toBe(false);
+  });
+
+  it("treats a first save (no saved config) as a change only when set", () => {
+    expect(toolCallCancellationChanged(null, withCancellation())).toBe(false);
+    expect(
+      toolCallCancellationChanged(null, withCancellation({ legacy: false })),
+    ).toBe(true);
+  });
+});
+
+describe("which servers get reconnected", () => {
+  const status = {
+    live: { connectionStatus: "connected" },
+    sleeping: { connectionStatus: "disconnected" },
+    failing: { connectionStatus: "failed" },
+  };
+
+  it("reconnects only the connected ones", () => {
+    expect(
+      serversNeedingCancellationReconnect(
+        ["live", "sleeping", "failing"],
+        status,
+      ),
+    ).toEqual(["live"]);
+  });
+
+  it("ignores servers this host does not use", () => {
+    expect(serversNeedingCancellationReconnect([], status)).toEqual([]);
+  });
+
+  it("ignores a server with no runtime state at all", () => {
+    expect(
+      serversNeedingCancellationReconnect(["never-connected"], status),
+    ).toEqual([]);
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/HostBuilderViewRedesigned.cancellationReconnect.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/HostBuilderViewRedesigned.cancellationReconnect.test.ts
@@ -89,8 +89,13 @@ describe("which servers get reconnected", () => {
     ).toEqual(["live"]);
   });
 
-  it("ignores servers this host does not use", () => {
-    expect(serversNeedingCancellationReconnect([], status)).toEqual([]);
+  it("covers every connected server, not just a host's serverIds list", () => {
+    // Under the "all project servers attach" rule a server the host talks to
+    // need not appear in `serverIds`. Filtering by that list skipped the
+    // reconnect entirely, so a saved toggle kept being ignored.
+    expect(
+      serversNeedingCancellationReconnect(Object.keys(status), status)
+    ).toEqual(["live"]);
   });
 
   it("ignores a server with no runtime state at all", () => {

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -231,7 +231,7 @@ type ProtocolDoc = {
    */
   paginationTraversal?: PaginationTraversalMode;
   mrtrSupport?: MrtrSupport;
-  toolCallCancellation?: boolean;
+  toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   /**
    * How the client handles `notifications/tools/list_changed`. `listens` is
    * whether it opens the server→client channel at all; `refetches` is whether
@@ -565,9 +565,21 @@ export function applyJsonToDraft(
   const rawMrtr = parsed.mrtrSupport;
   const mrtrSupport: MrtrSupport | undefined =
     rawMrtr === "full" || rawMrtr === "none" ? rawMrtr : undefined;
+  // Same closed-shape collapse as `toolListChanged`: an unknown leaf or a
+  // non-boolean must not reach the canonicalizer, which throws and rejects the
+  // whole save.
   const rawCancellation = parsed.toolCallCancellation;
-  const toolCallCancellation =
-    typeof rawCancellation === "boolean" ? rawCancellation : undefined;
+  let toolCallCancellation: HostConfigMcpProfileV1["toolCallCancellation"];
+  if (rawCancellation && typeof rawCancellation === "object") {
+    const parsedCancellation: { legacy?: boolean; modern?: boolean } = {};
+    for (const key of ["legacy", "modern"] as const) {
+      const value = (rawCancellation as Record<string, unknown>)[key];
+      if (typeof value === "boolean") parsedCancellation[key] = value;
+    }
+    if (Object.keys(parsedCancellation).length > 0) {
+      toolCallCancellation = parsedCancellation;
+    }
+  }
 
   let toolListChangedParsed: HostConfigMcpProfileV1["toolListChanged"];
   if (isPlainObject(parsed.toolListChanged)) {
@@ -822,33 +834,34 @@ export function ProtocolTab({
   const storedPagination = draft.mcpProfile?.paginationTraversal;
   const storedMrtrSupport = draft.mcpProfile?.mrtrSupport;
   const storedToolCallCancellation = draft.mcpProfile?.toolCallCancellation;
-  // Cancellation is ONE knob whose label names the era, because the era picks
-  // the mechanism and nothing else: closing the response stream on 2026-07-28
-  // Streamable HTTP, `notifications/cancelled` on every 2025 revision (all
-  // three are identical here) and on stdio. Auto negotiates at connect time
-  // and can land on either, so it names both rather than guessing one.
-  const pinnedVersion = draft.mcpProfile?.mcpProtocolVersion;
-  const cancellationEra =
-    pinnedVersion === undefined || pinnedVersion === "auto"
-      ? "both"
-      : isStatelessProtocolVersion(pinnedVersion)
-        ? "modern"
-        : "legacy";
-  const cancellationLabel =
-    cancellationEra === "modern"
-      ? "Tool cancellation (2026)"
-      : cancellationEra === "legacy"
-        ? "Tool cancellation (2025)"
-        : "Tool cancellation (2025 + 2026)";
-  const cancellationMechanism =
-    cancellationEra === "modern"
-      ? "closing the response stream for that request"
-      : cancellationEra === "legacy"
-        ? "sending notifications/cancelled"
-        : "closing the response stream on 2026-07-28, or sending notifications/cancelled on 2025";
-  const setConformanceKnob = <
-    K extends "paginationTraversal" | "mrtrSupport" | "toolCallCancellation",
-  >(
+  // Delete-on-default per leaf, exactly like `toolListChanged`: absent is the
+  // conforming answer (the client cancels), so re-enabling a switch must leave
+  // no trace rather than write `true`.
+  const setToolCallCancellationPart = (
+    key: "legacy" | "modern",
+    enabled: boolean
+  ) => {
+    onDraftChange((prev) => {
+      const base: HostConfigMcpProfileV1 = prev.mcpProfile ?? {
+        profileVersion: 1,
+      };
+      const toolCallCancellation = { ...(base.toolCallCancellation ?? {}) };
+      if (enabled) delete toolCallCancellation[key];
+      else toolCallCancellation[key] = false;
+      const updated: HostConfigMcpProfileV1 = { ...base };
+      if (Object.keys(toolCallCancellation).length > 0) {
+        updated.toolCallCancellation = toolCallCancellation;
+      } else {
+        delete updated.toolCallCancellation;
+      }
+      return {
+        ...prev,
+        mcpProfile: isMcpProfileEmpty(updated) ? undefined : updated,
+      };
+    });
+  };
+
+  const setConformanceKnob = <K extends "paginationTraversal" | "mrtrSupport">(
     key: K,
     next: HostConfigMcpProfileV1[K] | undefined
   ) => {
@@ -1150,38 +1163,45 @@ export function ProtocolTab({
             </SelectContent>
           </Select>
         </div>
-        <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">
+        <div className="mt-2.5 border-t border-border/50 pt-2.5">
           <div className="min-w-0">
-            <span className="text-[12px] font-medium">{cancellationLabel}</span>
+            <span className="text-[12px] font-medium">Tool cancellation</span>
             <p className="text-[11px] leading-snug text-muted-foreground">
-              {storedToolCallCancellation === false
-                ? `Stopping a tool call ends the turn here and tells the server nothing — it keeps running the tool to completion, side effects and cost included. Real hosts behave this way, which is why a server cannot assume a vanished client means a cancelled call.`
-                : `Stopping a tool call reaches the server by ${cancellationMechanism}. Switch to Not supported to see what your server does when a host abandons the call without saying so.`}
+              Whether stopping an in-flight tool call reaches the server, or
+              only ends the turn here while the server runs the tool to
+              completion. Measured per era because a client can be right on one
+              and wrong on the other; each connection reads only the era it
+              negotiated.
             </p>
           </div>
-          <Select
-            value={storedToolCallCancellation === false ? "none" : "full"}
-            onValueChange={(next) => {
-              // Absence is the conforming answer, so only `false` is stored —
-              // an untouched host must keep hashing as it did before the field.
-              setConformanceKnob(
-                "toolCallCancellation",
-                next === "none" ? false : undefined
-              );
-            }}
-            disabled={readOnly}
-          >
-            <SelectTrigger
-              aria-label={cancellationLabel}
-              className="h-9 w-[220px] flex-shrink-0 text-xs"
-            >
-              <SelectValue placeholder="Supported" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="full">Supported (default)</SelectItem>
-              <SelectItem value="none">Not supported</SelectItem>
-            </SelectContent>
-          </Select>
+          <div className="mt-2 flex flex-col divide-y divide-border/50 rounded-md border border-border/50">
+            <div className="flex items-center justify-between gap-3 px-3 py-2">
+              <span className="text-[12px]">
+                Cancels on 2025 (notifications/cancelled)
+              </span>
+              <Switch
+                checked={storedToolCallCancellation?.legacy !== false}
+                onCheckedChange={(checked) =>
+                  setToolCallCancellationPart("legacy", checked)
+                }
+                disabled={readOnly}
+                aria-label="Tool cancellation (2025)"
+              />
+            </div>
+            <div className="flex items-center justify-between gap-3 px-3 py-2">
+              <span className="text-[12px]">
+                Cancels on 2026 (closes the response stream)
+              </span>
+              <Switch
+                checked={storedToolCallCancellation?.modern !== false}
+                onCheckedChange={(checked) =>
+                  setToolCallCancellationPart("modern", checked)
+                }
+                disabled={readOnly}
+                aria-label="Tool cancellation (2026)"
+              />
+            </div>
+          </div>
         </div>
         <div className="mt-2.5 border-t border-border/50 pt-2.5">
           <div className="min-w-0">

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -227,10 +227,11 @@ type ProtocolDoc = {
    * back as absence for the same hash reason as the mirroring knob above:
    * a host that never touches the control must keep hashing exactly as it
    * did before the field existed. Map onto `mcpProfile.paginationTraversal`
-   * / `mcpProfile.mrtrSupport`.
+   * / `mcpProfile.mrtrSupport` / `mcpProfile.toolCallCancellation`.
    */
   paginationTraversal?: PaginationTraversalMode;
   mrtrSupport?: MrtrSupport;
+  toolCallCancellation?: boolean;
   /**
    * How the client handles `notifications/tools/list_changed`. `listens` is
    * whether it opens the server→client channel at all; `refetches` is whether
@@ -311,6 +312,9 @@ export function protocolToJson(draft: HostConfigInputV2): ProtocolDoc {
   }
   if (draft.mcpProfile?.mrtrSupport !== undefined) {
     doc.mrtrSupport = draft.mcpProfile.mrtrSupport;
+  }
+  if (draft.mcpProfile?.toolCallCancellation !== undefined) {
+    doc.toolCallCancellation = draft.mcpProfile.toolCallCancellation;
   }
 
   const toolListChanged = draft.mcpProfile?.toolListChanged;
@@ -561,6 +565,9 @@ export function applyJsonToDraft(
   const rawMrtr = parsed.mrtrSupport;
   const mrtrSupport: MrtrSupport | undefined =
     rawMrtr === "full" || rawMrtr === "none" ? rawMrtr : undefined;
+  const rawCancellation = parsed.toolCallCancellation;
+  const toolCallCancellation =
+    typeof rawCancellation === "boolean" ? rawCancellation : undefined;
 
   let toolListChangedParsed: HostConfigMcpProfileV1["toolListChanged"];
   if (isPlainObject(parsed.toolListChanged)) {
@@ -643,6 +650,7 @@ export function applyJsonToDraft(
       toolParamHeaderMirroring,
       paginationTraversal,
       mrtrSupport,
+      toolCallCancellation,
       toolListChanged: toolListChangedParsed,
       extensions: profileExtensions,
       // `apps` is owned by the Apps tab (including the widget tool-result
@@ -808,12 +816,39 @@ export function ProtocolTab({
     });
   };
 
-  // Client-conformance knobs (siblings of the mirroring control above). Both
+  // Client-conformance knobs (siblings of the mirroring control above). All
   // model how REAL hosts differ, so the default is written back as ABSENCE
   // and only the degraded value is stored.
   const storedPagination = draft.mcpProfile?.paginationTraversal;
   const storedMrtrSupport = draft.mcpProfile?.mrtrSupport;
-  const setConformanceKnob = <K extends "paginationTraversal" | "mrtrSupport">(
+  const storedToolCallCancellation = draft.mcpProfile?.toolCallCancellation;
+  // Cancellation is ONE knob whose label names the era, because the era picks
+  // the mechanism and nothing else: closing the response stream on 2026-07-28
+  // Streamable HTTP, `notifications/cancelled` on every 2025 revision (all
+  // three are identical here) and on stdio. Auto negotiates at connect time
+  // and can land on either, so it names both rather than guessing one.
+  const pinnedVersion = draft.mcpProfile?.mcpProtocolVersion;
+  const cancellationEra =
+    pinnedVersion === undefined || pinnedVersion === "auto"
+      ? "both"
+      : isStatelessProtocolVersion(pinnedVersion)
+        ? "modern"
+        : "legacy";
+  const cancellationLabel =
+    cancellationEra === "modern"
+      ? "Tool cancellation (2026)"
+      : cancellationEra === "legacy"
+        ? "Tool cancellation (2025)"
+        : "Tool cancellation (2025 + 2026)";
+  const cancellationMechanism =
+    cancellationEra === "modern"
+      ? "closing the response stream for that request"
+      : cancellationEra === "legacy"
+        ? "sending notifications/cancelled"
+        : "closing the response stream on 2026-07-28, or sending notifications/cancelled on 2025";
+  const setConformanceKnob = <
+    K extends "paginationTraversal" | "mrtrSupport" | "toolCallCancellation",
+  >(
     key: K,
     next: HostConfigMcpProfileV1[K] | undefined
   ) => {
@@ -1105,6 +1140,39 @@ export function ProtocolTab({
           >
             <SelectTrigger
               aria-label="Multi-round tool results"
+              className="h-9 w-[220px] flex-shrink-0 text-xs"
+            >
+              <SelectValue placeholder="Supported" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="full">Supported (default)</SelectItem>
+              <SelectItem value="none">Not supported</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">
+          <div className="min-w-0">
+            <span className="text-[12px] font-medium">{cancellationLabel}</span>
+            <p className="text-[11px] leading-snug text-muted-foreground">
+              {storedToolCallCancellation === false
+                ? `Stopping a tool call ends the turn here and tells the server nothing — it keeps running the tool to completion, side effects and cost included. Real hosts behave this way, which is why a server cannot assume a vanished client means a cancelled call.`
+                : `Stopping a tool call reaches the server by ${cancellationMechanism}. Switch to Not supported to see what your server does when a host abandons the call without saying so.`}
+            </p>
+          </div>
+          <Select
+            value={storedToolCallCancellation === false ? "none" : "full"}
+            onValueChange={(next) => {
+              // Absence is the conforming answer, so only `false` is stored —
+              // an untouched host must keep hashing as it did before the field.
+              setConformanceKnob(
+                "toolCallCancellation",
+                next === "none" ? false : undefined
+              );
+            }}
+            disabled={readOnly}
+          >
+            <SelectTrigger
+              aria-label={cancellationLabel}
               className="h-9 w-[220px] flex-shrink-0 text-xs"
             >
               <SelectValue placeholder="Supported" />

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.cancellation.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.cancellation.test.tsx
@@ -30,7 +30,9 @@ function Harness({ initial }: { initial: HostConfigInputV2 }) {
   return (
     <div>
       <div data-testid="cancellation">
-        {String(draft.mcpProfile?.toolCallCancellation ?? "<undefined>")}
+        {draft.mcpProfile?.toolCallCancellation === undefined
+          ? "<undefined>"
+          : JSON.stringify(draft.mcpProfile.toolCallCancellation)}
       </div>
       <ProtocolTab
         draft={draft}
@@ -41,79 +43,67 @@ function Harness({ initial }: { initial: HostConfigInputV2 }) {
   );
 }
 
-function draftPinnedTo(version: string | undefined): HostConfigInputV2 {
-  return {
+const legacySwitch = () =>
+  screen.getByRole("switch", { name: "Tool cancellation (2025)" });
+const modernSwitch = () =>
+  screen.getByRole("switch", { name: "Tool cancellation (2026)" });
+
+const withProfile = (
+  toolCallCancellation: Record<string, boolean>,
+): HostConfigInputV2 =>
+  ({
     ...emptyHostConfigInputV2(),
-    mcpProfile: {
-      profileVersion: 1,
-      ...(version ? { mcpProtocolVersion: version } : {}),
-    },
-  } as HostConfigInputV2;
-}
+    mcpProfile: { profileVersion: 1, toolCallCancellation },
+  }) as HostConfigInputV2;
 
 /**
- * The row is ONE knob whose label names the era, because the era picks the
- * mechanism and nothing else: closing the response stream on 2026-07-28
- * Streamable HTTP, `notifications/cancelled` on 2025 and on stdio. Splitting
- * it into two fields would imply a host could answer them differently, which
- * the spec does not allow — the negotiated revision decides.
+ * Two switches rather than one, because a host can cancel correctly on 2025
+ * and not at all on 2026 — MCPJam itself did. The eras are separate questions
+ * with separate evidence, so neither control may move the other.
  */
-describe("ProtocolTab tool-cancellation control", () => {
-  it("names the 2026 era when the host is pinned to a 2026 revision", () => {
-    render(<Harness initial={draftPinnedTo("2026-07-28")} />);
-    expect(
-      screen.getByRole("combobox", { name: "Tool cancellation (2026)" })
-    ).toBeInTheDocument();
-  });
-
-  it("names the 2025 era when the host is pinned to a 2025 revision", () => {
-    render(<Harness initial={draftPinnedTo("2025-11-25")} />);
-    expect(
-      screen.getByRole("combobox", { name: "Tool cancellation (2025)" })
-    ).toBeInTheDocument();
-  });
-
-  it("names both eras when the version is unpinned", () => {
-    // Auto negotiates at connect time and can land on either, so the label
-    // states both rather than guessing one and being wrong half the time.
+describe("ProtocolTab tool-cancellation controls", () => {
+  it("shows both eras as cancelling for a host that never configured it", () => {
     render(<Harness initial={emptyHostConfigInputV2()} />);
+    expect(legacySwitch()).toBeChecked();
+    expect(modernSwitch()).toBeChecked();
+    expect(screen.getByTestId("cancellation").textContent).toBe("<undefined>");
+  });
+
+  it("stores only the era that was turned off", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial={emptyHostConfigInputV2()} />);
+
+    await user.click(modernSwitch());
+
+    // The 2025 leaf must stay absent — absent means "cancels", and writing
+    // `legacy: true` would claim a measurement nobody made.
+    expect(screen.getByTestId("cancellation").textContent).toBe(
+      '{"modern":false}',
+    );
+    expect(legacySwitch()).toBeChecked();
+  });
+
+  it("keeps the two eras independent", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial={withProfile({ modern: false })} />);
+    expect(modernSwitch()).not.toBeChecked();
+    expect(legacySwitch()).toBeChecked();
+
+    await user.click(legacySwitch());
+
     expect(
-      screen.getByRole("combobox", { name: "Tool cancellation (2025 + 2026)" })
-    ).toBeInTheDocument();
+      JSON.parse(screen.getByTestId("cancellation").textContent ?? "{}"),
+    ).toEqual({ legacy: false, modern: false });
   });
 
-  it("stores 'none' for a host that never tells the server", async () => {
+  it("writes ABSENCE when the last era is switched back on", async () => {
+    // Delete-on-default, collapsing the whole record: an untouched host must
+    // keep hashing exactly as it did before the field existed.
     const user = userEvent.setup();
-    render(<Harness initial={draftPinnedTo("2026-07-28")} />);
+    render(<Harness initial={withProfile({ legacy: false })} />);
+    expect(legacySwitch()).not.toBeChecked();
 
-    await user.click(
-      screen.getByRole("combobox", { name: "Tool cancellation (2026)" })
-    );
-    await user.click(await screen.findByRole("option", { name: "Not supported" }));
-
-    expect(screen.getByTestId("cancellation").textContent).toBe("false");
-  });
-
-  it("writes ABSENCE when switched back, so an untouched host keeps its hash", async () => {
-    const user = userEvent.setup();
-    render(
-      <Harness
-        initial={
-          {
-            ...emptyHostConfigInputV2(),
-            mcpProfile: { profileVersion: 1, toolCallCancellation: false },
-          } as HostConfigInputV2
-        }
-      />
-    );
-    expect(screen.getByTestId("cancellation").textContent).toBe("false");
-
-    await user.click(
-      screen.getByRole("combobox", { name: "Tool cancellation (2025 + 2026)" })
-    );
-    await user.click(
-      await screen.findByRole("option", { name: "Supported (default)" })
-    );
+    await user.click(legacySwitch());
 
     expect(screen.getByTestId("cancellation").textContent).toBe("<undefined>");
   });

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.cancellation.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.cancellation.test.tsx
@@ -1,0 +1,120 @@
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  emptyHostConfigInputV2,
+  type HostConfigInputV2,
+} from "@/lib/client-config-v2";
+
+vi.mock("@/components/ui/json-editor", () => ({
+  JsonEditor: ({
+    rawContent,
+    onRawChange,
+  }: {
+    rawContent: string;
+    onRawChange: (next: string) => void;
+  }) => (
+    <textarea
+      aria-label="json"
+      value={rawContent}
+      onChange={(e) => onRawChange(e.target.value)}
+    />
+  ),
+}));
+
+import { ProtocolTab } from "../ProtocolTab";
+
+function Harness({ initial }: { initial: HostConfigInputV2 }) {
+  const [draft, setDraft] = useState(initial);
+  return (
+    <div>
+      <div data-testid="cancellation">
+        {String(draft.mcpProfile?.toolCallCancellation ?? "<undefined>")}
+      </div>
+      <ProtocolTab
+        draft={draft}
+        onDraftChange={(updater) => setDraft((prev) => updater(prev))}
+        attention={[]}
+      />
+    </div>
+  );
+}
+
+function draftPinnedTo(version: string | undefined): HostConfigInputV2 {
+  return {
+    ...emptyHostConfigInputV2(),
+    mcpProfile: {
+      profileVersion: 1,
+      ...(version ? { mcpProtocolVersion: version } : {}),
+    },
+  } as HostConfigInputV2;
+}
+
+/**
+ * The row is ONE knob whose label names the era, because the era picks the
+ * mechanism and nothing else: closing the response stream on 2026-07-28
+ * Streamable HTTP, `notifications/cancelled` on 2025 and on stdio. Splitting
+ * it into two fields would imply a host could answer them differently, which
+ * the spec does not allow — the negotiated revision decides.
+ */
+describe("ProtocolTab tool-cancellation control", () => {
+  it("names the 2026 era when the host is pinned to a 2026 revision", () => {
+    render(<Harness initial={draftPinnedTo("2026-07-28")} />);
+    expect(
+      screen.getByRole("combobox", { name: "Tool cancellation (2026)" })
+    ).toBeInTheDocument();
+  });
+
+  it("names the 2025 era when the host is pinned to a 2025 revision", () => {
+    render(<Harness initial={draftPinnedTo("2025-11-25")} />);
+    expect(
+      screen.getByRole("combobox", { name: "Tool cancellation (2025)" })
+    ).toBeInTheDocument();
+  });
+
+  it("names both eras when the version is unpinned", () => {
+    // Auto negotiates at connect time and can land on either, so the label
+    // states both rather than guessing one and being wrong half the time.
+    render(<Harness initial={emptyHostConfigInputV2()} />);
+    expect(
+      screen.getByRole("combobox", { name: "Tool cancellation (2025 + 2026)" })
+    ).toBeInTheDocument();
+  });
+
+  it("stores 'none' for a host that never tells the server", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial={draftPinnedTo("2026-07-28")} />);
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Tool cancellation (2026)" })
+    );
+    await user.click(await screen.findByRole("option", { name: "Not supported" }));
+
+    expect(screen.getByTestId("cancellation").textContent).toBe("false");
+  });
+
+  it("writes ABSENCE when switched back, so an untouched host keeps its hash", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initial={
+          {
+            ...emptyHostConfigInputV2(),
+            mcpProfile: { profileVersion: 1, toolCallCancellation: false },
+          } as HostConfigInputV2
+        }
+      />
+    );
+    expect(screen.getByTestId("cancellation").textContent).toBe("false");
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Tool cancellation (2025 + 2026)" })
+    );
+    await user.click(
+      await screen.findByRole("option", { name: "Supported (default)" })
+    );
+
+    expect(screen.getByTestId("cancellation").textContent).toBe("<undefined>");
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
@@ -20,8 +20,7 @@ interface UseApiContextOptions {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressLegacyRequestCancellation?: true;
-  suppressModernRequestCancellation?: true;
+  suppressRequestCancellation?: true;
   // Active host's enterprise-managed authorization policy (validated `on`
   // value only) — rides ad-hoc chat/eval request bodies.
   xaaPolicy?: XaaEnterprisePolicy;
@@ -49,8 +48,7 @@ export function useApiContext({
   supportsMrtr,
   suppressListenChannel,
   dropToolListChanged,
-  suppressLegacyRequestCancellation,
-  suppressModernRequestCancellation,
+  suppressRequestCancellation,
   xaaPolicy,
   clientConfigSyncPending,
   getAccessToken,
@@ -83,8 +81,7 @@ export function useApiContext({
       supportsMrtr,
       suppressListenChannel,
       dropToolListChanged,
-      suppressLegacyRequestCancellation,
-      suppressModernRequestCancellation,
+      suppressRequestCancellation,
       xaaPolicy,
       clientConfigSyncPending,
       getAccessToken,
@@ -111,8 +108,7 @@ export function useApiContext({
     supportsMrtr,
     suppressListenChannel,
     dropToolListChanged,
-    suppressLegacyRequestCancellation,
-    suppressModernRequestCancellation,
+    suppressRequestCancellation,
     xaaPolicy,
     clientConfigSyncPending,
     getAccessToken,

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
@@ -20,6 +20,7 @@ interface UseApiContextOptions {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
+  suppressRequestCancellation?: true;
   // Active host's enterprise-managed authorization policy (validated `on`
   // value only) — rides ad-hoc chat/eval request bodies.
   xaaPolicy?: XaaEnterprisePolicy;
@@ -47,6 +48,7 @@ export function useApiContext({
   supportsMrtr,
   suppressListenChannel,
   dropToolListChanged,
+  suppressRequestCancellation,
   xaaPolicy,
   clientConfigSyncPending,
   getAccessToken,
@@ -79,6 +81,7 @@ export function useApiContext({
       supportsMrtr,
       suppressListenChannel,
       dropToolListChanged,
+      suppressRequestCancellation,
       xaaPolicy,
       clientConfigSyncPending,
       getAccessToken,
@@ -105,6 +108,7 @@ export function useApiContext({
     supportsMrtr,
     suppressListenChannel,
     dropToolListChanged,
+    suppressRequestCancellation,
     xaaPolicy,
     clientConfigSyncPending,
     getAccessToken,

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
@@ -20,7 +20,7 @@ interface UseApiContextOptions {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressRequestCancellation?: true;
+  toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   // Active host's enterprise-managed authorization policy (validated `on`
   // value only) — rides ad-hoc chat/eval request bodies.
   xaaPolicy?: XaaEnterprisePolicy;
@@ -48,7 +48,7 @@ export function useApiContext({
   supportsMrtr,
   suppressListenChannel,
   dropToolListChanged,
-  suppressRequestCancellation,
+  toolCallCancellation,
   xaaPolicy,
   clientConfigSyncPending,
   getAccessToken,
@@ -81,7 +81,7 @@ export function useApiContext({
       supportsMrtr,
       suppressListenChannel,
       dropToolListChanged,
-      suppressRequestCancellation,
+      toolCallCancellation,
       xaaPolicy,
       clientConfigSyncPending,
       getAccessToken,
@@ -108,7 +108,7 @@ export function useApiContext({
     supportsMrtr,
     suppressListenChannel,
     dropToolListChanged,
-    suppressRequestCancellation,
+    toolCallCancellation,
     xaaPolicy,
     clientConfigSyncPending,
     getAccessToken,

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
@@ -20,7 +20,8 @@ interface UseApiContextOptions {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressRequestCancellation?: true;
+  suppressLegacyRequestCancellation?: true;
+  suppressModernRequestCancellation?: true;
   // Active host's enterprise-managed authorization policy (validated `on`
   // value only) — rides ad-hoc chat/eval request bodies.
   xaaPolicy?: XaaEnterprisePolicy;
@@ -48,7 +49,8 @@ export function useApiContext({
   supportsMrtr,
   suppressListenChannel,
   dropToolListChanged,
-  suppressRequestCancellation,
+  suppressLegacyRequestCancellation,
+  suppressModernRequestCancellation,
   xaaPolicy,
   clientConfigSyncPending,
   getAccessToken,
@@ -81,7 +83,8 @@ export function useApiContext({
       supportsMrtr,
       suppressListenChannel,
       dropToolListChanged,
-      suppressRequestCancellation,
+      suppressLegacyRequestCancellation,
+      suppressModernRequestCancellation,
       xaaPolicy,
       clientConfigSyncPending,
       getAccessToken,
@@ -108,7 +111,8 @@ export function useApiContext({
     supportsMrtr,
     suppressListenChannel,
     dropToolListChanged,
-    suppressRequestCancellation,
+    suppressLegacyRequestCancellation,
+    suppressModernRequestCancellation,
     xaaPolicy,
     clientConfigSyncPending,
     getAccessToken,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1455,6 +1455,11 @@ export function useServerState({
       if (mcpProfile?.toolListChanged?.refetches === false) {
         defaults.dropToolListChanged = true;
       }
+      // Tool cancellation: only an explicit stored `false` (the host never
+      // signals the server) travels, as `suppressRequestCancellation: true`.
+      if (mcpProfile?.toolCallCancellation === false) {
+        defaults.suppressRequestCancellation = true;
+      }
       // Enterprise-managed authorization policy from the active host's
       // mcpProfile. Sent only when validly ON; an `invalid` stored policy
       // fails the connect client-side with an actionable message instead of

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -10,6 +10,7 @@ import {
   isKnownProtocolVersion,
   isStatelessProtocolVersion,
   readXaaEnterprisePolicy,
+  cancellationLeafForVersion,
 } from "@mcpjam/sdk/browser";
 import { normalizeRegistrationMode } from "@/shared/xaa.js";
 import type {
@@ -1455,13 +1456,15 @@ export function useServerState({
       if (mcpProfile?.toolListChanged?.refetches === false) {
         defaults.dropToolListChanged = true;
       }
-      // Tool cancellation, per era: only an explicit stored `false` leaf (the
-      // host never signals the server on that era) travels.
-      if (mcpProfile?.toolCallCancellation?.legacy === false) {
-        defaults.suppressLegacyRequestCancellation = true;
-      }
-      if (mcpProfile?.toolCallCancellation?.modern === false) {
-        defaults.suppressModernRequestCancellation = true;
+      // Tool cancellation is measured per era, but THIS connection speaks one
+      // — and `resolvedProtocolVersion` above is exactly that version — so the
+      // leaf is picked here and a single flag travels.
+      if (
+        mcpProfile?.toolCallCancellation?.[
+          cancellationLeafForVersion(resolvedProtocolVersion)
+        ] === false
+      ) {
+        defaults.suppressRequestCancellation = true;
       }
       // Enterprise-managed authorization policy from the active host's
       // mcpProfile. Sent only when validly ON; an `invalid` stored policy

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -10,7 +10,6 @@ import {
   isKnownProtocolVersion,
   isStatelessProtocolVersion,
   readXaaEnterprisePolicy,
-  cancellationLeafForVersion,
 } from "@mcpjam/sdk/browser";
 import { normalizeRegistrationMode } from "@/shared/xaa.js";
 import type {
@@ -1456,15 +1455,16 @@ export function useServerState({
       if (mcpProfile?.toolListChanged?.refetches === false) {
         defaults.dropToolListChanged = true;
       }
-      // Tool cancellation is measured per era, but THIS connection speaks one
-      // — and `resolvedProtocolVersion` above is exactly that version — so the
-      // leaf is picked here and a single flag travels.
-      if (
-        mcpProfile?.toolCallCancellation?.[
-          cancellationLeafForVersion(resolvedProtocolVersion)
-        ] === false
-      ) {
-        defaults.suppressRequestCancellation = true;
+      // Tool cancellation: forward the degraded leaves and let the SDK pick
+      // which one applies once the connection has negotiated. Resolving here
+      // cannot work for an unpinned host — the era does not exist yet.
+      const cancellationLeaves = Object.fromEntries(
+        (["legacy", "modern"] as const)
+          .filter((key) => mcpProfile?.toolCallCancellation?.[key] === false)
+          .map((key) => [key, false])
+      );
+      if (Object.keys(cancellationLeaves).length > 0) {
+        defaults.toolCallCancellation = cancellationLeaves;
       }
       // Enterprise-managed authorization policy from the active host's
       // mcpProfile. Sent only when validly ON; an `invalid` stored policy

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1455,10 +1455,13 @@ export function useServerState({
       if (mcpProfile?.toolListChanged?.refetches === false) {
         defaults.dropToolListChanged = true;
       }
-      // Tool cancellation: only an explicit stored `false` (the host never
-      // signals the server) travels, as `suppressRequestCancellation: true`.
-      if (mcpProfile?.toolCallCancellation === false) {
-        defaults.suppressRequestCancellation = true;
+      // Tool cancellation, per era: only an explicit stored `false` leaf (the
+      // host never signals the server on that era) travels.
+      if (mcpProfile?.toolCallCancellation?.legacy === false) {
+        defaults.suppressLegacyRequestCancellation = true;
+      }
+      if (mcpProfile?.toolCallCancellation?.modern === false) {
+        defaults.suppressModernRequestCancellation = true;
       }
       // Enterprise-managed authorization policy from the active host's
       // mcpProfile. Sent only when validly ON; an `invalid` stored policy

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -50,6 +50,7 @@ export interface ApiContext {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
+  suppressRequestCancellation?: true;
   /**
    * The active host's enterprise-managed authorization policy (validated
    * `on` value only). Rides ad-hoc chat/eval bodies; ignored server-side
@@ -448,6 +449,7 @@ function conformanceWireFields(apiContext: ApiContext): {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
+  suppressRequestCancellation?: true;
 } {
   return {
     ...(apiContext.mirrorToolParamHeaders === false
@@ -461,6 +463,9 @@ function conformanceWireFields(apiContext: ApiContext): {
       : {}),
     ...(apiContext.dropToolListChanged === true
       ? { dropToolListChanged: true as const }
+      : {}),
+    ...(apiContext.suppressRequestCancellation === true
+      ? { suppressRequestCancellation: true as const }
       : {}),
     ...(apiContext.supportsMrtr === false
       ? { supportsMrtr: false as const }
@@ -534,6 +539,7 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
+  suppressRequestCancellation?: true;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -613,6 +619,7 @@ export function buildResolvedServerBatchRequest(input: {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
+  suppressRequestCancellation?: true;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -660,6 +667,7 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
+  suppressRequestCancellation?: true;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -50,8 +50,7 @@ export interface ApiContext {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressLegacyRequestCancellation?: true;
-  suppressModernRequestCancellation?: true;
+  suppressRequestCancellation?: true;
   /**
    * The active host's enterprise-managed authorization policy (validated
    * `on` value only). Rides ad-hoc chat/eval bodies; ignored server-side
@@ -450,8 +449,7 @@ function conformanceWireFields(apiContext: ApiContext): {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressLegacyRequestCancellation?: true;
-  suppressModernRequestCancellation?: true;
+  suppressRequestCancellation?: true;
 } {
   return {
     ...(apiContext.mirrorToolParamHeaders === false
@@ -466,11 +464,8 @@ function conformanceWireFields(apiContext: ApiContext): {
     ...(apiContext.dropToolListChanged === true
       ? { dropToolListChanged: true as const }
       : {}),
-    ...(apiContext.suppressLegacyRequestCancellation === true
-      ? { suppressLegacyRequestCancellation: true as const }
-      : {}),
-    ...(apiContext.suppressModernRequestCancellation === true
-      ? { suppressModernRequestCancellation: true as const }
+    ...(apiContext.suppressRequestCancellation === true
+      ? { suppressRequestCancellation: true as const }
       : {}),
     ...(apiContext.supportsMrtr === false
       ? { supportsMrtr: false as const }
@@ -544,8 +539,7 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressLegacyRequestCancellation?: true;
-  suppressModernRequestCancellation?: true;
+  suppressRequestCancellation?: true;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -625,8 +619,7 @@ export function buildResolvedServerBatchRequest(input: {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressLegacyRequestCancellation?: true;
-  suppressModernRequestCancellation?: true;
+  suppressRequestCancellation?: true;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -674,8 +667,7 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressLegacyRequestCancellation?: true;
-  suppressModernRequestCancellation?: true;
+  suppressRequestCancellation?: true;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -50,7 +50,8 @@ export interface ApiContext {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressRequestCancellation?: true;
+  suppressLegacyRequestCancellation?: true;
+  suppressModernRequestCancellation?: true;
   /**
    * The active host's enterprise-managed authorization policy (validated
    * `on` value only). Rides ad-hoc chat/eval bodies; ignored server-side
@@ -449,7 +450,8 @@ function conformanceWireFields(apiContext: ApiContext): {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressRequestCancellation?: true;
+  suppressLegacyRequestCancellation?: true;
+  suppressModernRequestCancellation?: true;
 } {
   return {
     ...(apiContext.mirrorToolParamHeaders === false
@@ -464,8 +466,11 @@ function conformanceWireFields(apiContext: ApiContext): {
     ...(apiContext.dropToolListChanged === true
       ? { dropToolListChanged: true as const }
       : {}),
-    ...(apiContext.suppressRequestCancellation === true
-      ? { suppressRequestCancellation: true as const }
+    ...(apiContext.suppressLegacyRequestCancellation === true
+      ? { suppressLegacyRequestCancellation: true as const }
+      : {}),
+    ...(apiContext.suppressModernRequestCancellation === true
+      ? { suppressModernRequestCancellation: true as const }
       : {}),
     ...(apiContext.supportsMrtr === false
       ? { supportsMrtr: false as const }
@@ -539,7 +544,8 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressRequestCancellation?: true;
+  suppressLegacyRequestCancellation?: true;
+  suppressModernRequestCancellation?: true;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -619,7 +625,8 @@ export function buildResolvedServerBatchRequest(input: {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressRequestCancellation?: true;
+  suppressLegacyRequestCancellation?: true;
+  suppressModernRequestCancellation?: true;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -667,7 +674,8 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressRequestCancellation?: true;
+  suppressLegacyRequestCancellation?: true;
+  suppressModernRequestCancellation?: true;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -50,7 +50,7 @@ export interface ApiContext {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressRequestCancellation?: true;
+  toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   /**
    * The active host's enterprise-managed authorization policy (validated
    * `on` value only). Rides ad-hoc chat/eval bodies; ignored server-side
@@ -449,7 +449,7 @@ function conformanceWireFields(apiContext: ApiContext): {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressRequestCancellation?: true;
+  toolCallCancellation?: { legacy?: boolean; modern?: boolean };
 } {
   return {
     ...(apiContext.mirrorToolParamHeaders === false
@@ -464,8 +464,8 @@ function conformanceWireFields(apiContext: ApiContext): {
     ...(apiContext.dropToolListChanged === true
       ? { dropToolListChanged: true as const }
       : {}),
-    ...(apiContext.suppressRequestCancellation === true
-      ? { suppressRequestCancellation: true as const }
+    ...(apiContext.toolCallCancellation
+      ? { toolCallCancellation: apiContext.toolCallCancellation }
       : {}),
     ...(apiContext.supportsMrtr === false
       ? { supportsMrtr: false as const }
@@ -539,7 +539,7 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressRequestCancellation?: true;
+  toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -619,7 +619,7 @@ export function buildResolvedServerBatchRequest(input: {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressRequestCancellation?: true;
+  toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -667,7 +667,7 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressRequestCancellation?: true;
+  toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;

--- a/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
@@ -57,7 +57,7 @@ export type HostedServerValidateContext = {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressRequestCancellation?: true;
+  toolCallCancellation?: { legacy?: boolean; modern?: boolean };
 };
 
 export interface HostedServerValidateResponse {
@@ -150,8 +150,8 @@ export async function validateHostedServer(
         ...(hostedContext.dropToolListChanged === true
           ? { dropToolListChanged: true }
           : {}),
-        ...(hostedContext.suppressRequestCancellation === true
-          ? { suppressRequestCancellation: true }
+        ...(hostedContext.toolCallCancellation
+          ? { toolCallCancellation: hostedContext.toolCallCancellation }
           : {}),
       }
     : buildServerRequest(serverNameOrId);

--- a/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
@@ -57,8 +57,7 @@ export type HostedServerValidateContext = {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressLegacyRequestCancellation?: true;
-  suppressModernRequestCancellation?: true;
+  suppressRequestCancellation?: true;
 };
 
 export interface HostedServerValidateResponse {
@@ -151,11 +150,8 @@ export async function validateHostedServer(
         ...(hostedContext.dropToolListChanged === true
           ? { dropToolListChanged: true }
           : {}),
-        ...(hostedContext.suppressLegacyRequestCancellation === true
-          ? { suppressLegacyRequestCancellation: true }
-          : {}),
-        ...(hostedContext.suppressModernRequestCancellation === true
-          ? { suppressModernRequestCancellation: true }
+        ...(hostedContext.suppressRequestCancellation === true
+          ? { suppressRequestCancellation: true }
           : {}),
       }
     : buildServerRequest(serverNameOrId);

--- a/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
@@ -57,6 +57,7 @@ export type HostedServerValidateContext = {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
+  suppressRequestCancellation?: true;
 };
 
 export interface HostedServerValidateResponse {
@@ -148,6 +149,9 @@ export async function validateHostedServer(
           : {}),
         ...(hostedContext.dropToolListChanged === true
           ? { dropToolListChanged: true }
+          : {}),
+        ...(hostedContext.suppressRequestCancellation === true
+          ? { suppressRequestCancellation: true }
           : {}),
       }
     : buildServerRequest(serverNameOrId);

--- a/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
@@ -57,7 +57,8 @@ export type HostedServerValidateContext = {
   supportsMrtr?: false;
   suppressListenChannel?: true;
   dropToolListChanged?: true;
-  suppressRequestCancellation?: true;
+  suppressLegacyRequestCancellation?: true;
+  suppressModernRequestCancellation?: true;
 };
 
 export interface HostedServerValidateResponse {
@@ -150,8 +151,11 @@ export async function validateHostedServer(
         ...(hostedContext.dropToolListChanged === true
           ? { dropToolListChanged: true }
           : {}),
-        ...(hostedContext.suppressRequestCancellation === true
-          ? { suppressRequestCancellation: true }
+        ...(hostedContext.suppressLegacyRequestCancellation === true
+          ? { suppressLegacyRequestCancellation: true }
+          : {}),
+        ...(hostedContext.suppressModernRequestCancellation === true
+          ? { suppressModernRequestCancellation: true }
           : {}),
       }
     : buildServerRequest(serverNameOrId);

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -850,6 +850,13 @@ export function isMcpProfileEmpty(profile: HostConfigMcpProfileV1): boolean {
       Object.values(profile.toolListChanged).every(
         (value) => value === undefined
       )) &&
+    // Same per-leaf emptiness as `toolListChanged`. Omitting this collapsed
+    // the whole profile the moment cancellation was the ONLY thing set, so
+    // turning an era off silently wrote nothing.
+    (profile.toolCallCancellation === undefined ||
+      Object.values(profile.toolCallCancellation).every(
+        (value) => value === undefined
+      )) &&
     !profile.apps &&
     !profile.extensions
   );

--- a/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
@@ -745,25 +745,37 @@ const PAGINATION_FIELD: HostConfigFieldDef = {
  * `mcpProfile.toolCallCancellation` — whether stopping an in-flight tool call
  * reaches the server, or only ends the turn inside the host.
  *
- * The label carries no era here, unlike the editor in `ProtocolTab`. This one
- * feeds the comparison matrix and caniuse.dev, where adjacent columns are hosts
- * pinned to DIFFERENT revisions, and a single "(2026)" over that row would be
- * wrong for half of it. The era decides the mechanism — closing the response
- * stream on 2026-07-28 Streamable HTTP, `notifications/cancelled` on 2025 and
- * on stdio — never the answer, so the question still compares across eras even
- * though its wire form does not.
+ * Two independently-measured facts, one per era, because a host can be right
+ * on one and wrong on the other: MCPJam cancelled correctly on 2025 while
+ * never aborting the stream on 2026. Named by era rather than by mechanism —
+ * the reader wants to know "will my server hear the stop on the revision I
+ * speak", not which message carries it.
  */
-const TOOL_CALL_CANCELLATION_FIELD: HostConfigFieldDef = {
-  id: "toolCallCancellation",
-  section: "protocol",
-  subsection: "Cancellation",
-  label: "Tool cancellation",
-  path: "mcpProfile.toolCallCancellation",
-  description:
-    "Client tells the server when the user stops an in-flight tool call, instead of ending the turn locally and leaving the server to run it to completion.",
-  kind: { kind: "boolean" },
-  read: (cfg) => mcpProfile(cfg)?.toolCallCancellation,
-};
+const TOOL_CALL_CANCELLATION_FIELDS: ReadonlyArray<HostConfigFieldDef> = (
+  [
+    [
+      "legacy",
+      "Tool cancellation (2025)",
+      "Client tells the server when the user stops an in-flight tool call on a 2025 connection, by sending notifications/cancelled.",
+    ],
+    [
+      "modern",
+      "Tool cancellation (2026)",
+      "Client tells the server when the user stops an in-flight tool call on a 2026-07-28 connection, by closing that request's response stream.",
+    ],
+  ] as const
+).map(
+  ([key, label, description]): HostConfigFieldDef => ({
+    id: `toolCallCancellation.${key}`,
+    section: "protocol",
+    subsection: "Cancellation",
+    label,
+    path: `mcpProfile.toolCallCancellation.${key}`,
+    description,
+    kind: { kind: "boolean" },
+    read: (cfg) => mcpProfile(cfg)?.toolCallCancellation?.[key],
+  })
+);
 
 export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   // ============================================================
@@ -1174,7 +1186,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   ...TOOL_RESULT_WIDGET_FIELDS,
   ...TOOL_LIST_CHANGED_FIELDS,
   PAGINATION_FIELD,
-  TOOL_CALL_CANCELLATION_FIELD,
+  ...TOOL_CALL_CANCELLATION_FIELDS,
   {
     id: "sandbox.sandboxAttrs",
     section: "apps",

--- a/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
@@ -741,6 +741,30 @@ const PAGINATION_FIELD: HostConfigFieldDef = {
   read: (cfg) => mcpProfile(cfg)?.paginationTraversal,
 };
 
+/**
+ * `mcpProfile.toolCallCancellation` — whether stopping an in-flight tool call
+ * reaches the server, or only ends the turn inside the host.
+ *
+ * The label carries no era here, unlike the editor in `ProtocolTab`. This one
+ * feeds the comparison matrix and caniuse.dev, where adjacent columns are hosts
+ * pinned to DIFFERENT revisions, and a single "(2026)" over that row would be
+ * wrong for half of it. The era decides the mechanism — closing the response
+ * stream on 2026-07-28 Streamable HTTP, `notifications/cancelled` on 2025 and
+ * on stdio — never the answer, so the question still compares across eras even
+ * though its wire form does not.
+ */
+const TOOL_CALL_CANCELLATION_FIELD: HostConfigFieldDef = {
+  id: "toolCallCancellation",
+  section: "protocol",
+  subsection: "Cancellation",
+  label: "Tool cancellation",
+  path: "mcpProfile.toolCallCancellation",
+  description:
+    "Client tells the server when the user stops an in-flight tool call, instead of ending the turn locally and leaving the server to run it to completion.",
+  kind: { kind: "boolean" },
+  read: (cfg) => mcpProfile(cfg)?.toolCallCancellation,
+};
+
 export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   // ============================================================
   // Agent · Agent tooling
@@ -1150,6 +1174,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   ...TOOL_RESULT_WIDGET_FIELDS,
   ...TOOL_LIST_CHANGED_FIELDS,
   PAGINATION_FIELD,
+  TOOL_CALL_CANCELLATION_FIELD,
   {
     id: "sandbox.sandboxAttrs",
     section: "apps",

--- a/mcpjam-inspector/client/src/state/mcp-api.ts
+++ b/mcpjam-inspector/client/src/state/mcp-api.ts
@@ -118,8 +118,11 @@ function buildHostedValidationContext(
     ...(options.connectionDefaults?.dropToolListChanged === true
       ? { dropToolListChanged: true }
       : {}),
-    ...(options.connectionDefaults?.suppressRequestCancellation === true
-      ? { suppressRequestCancellation: true }
+    ...(options.connectionDefaults?.suppressLegacyRequestCancellation === true
+      ? { suppressLegacyRequestCancellation: true }
+      : {}),
+    ...(options.connectionDefaults?.suppressModernRequestCancellation === true
+      ? { suppressModernRequestCancellation: true }
       : {}),
   };
 }

--- a/mcpjam-inspector/client/src/state/mcp-api.ts
+++ b/mcpjam-inspector/client/src/state/mcp-api.ts
@@ -118,6 +118,9 @@ function buildHostedValidationContext(
     ...(options.connectionDefaults?.dropToolListChanged === true
       ? { dropToolListChanged: true }
       : {}),
+    ...(options.connectionDefaults?.suppressRequestCancellation === true
+      ? { suppressRequestCancellation: true }
+      : {}),
   };
 }
 

--- a/mcpjam-inspector/client/src/state/mcp-api.ts
+++ b/mcpjam-inspector/client/src/state/mcp-api.ts
@@ -118,8 +118,8 @@ function buildHostedValidationContext(
     ...(options.connectionDefaults?.dropToolListChanged === true
       ? { dropToolListChanged: true }
       : {}),
-    ...(options.connectionDefaults?.suppressRequestCancellation === true
-      ? { suppressRequestCancellation: true }
+    ...(options.connectionDefaults?.toolCallCancellation
+      ? { toolCallCancellation: options.connectionDefaults.toolCallCancellation }
       : {}),
   };
 }

--- a/mcpjam-inspector/client/src/state/mcp-api.ts
+++ b/mcpjam-inspector/client/src/state/mcp-api.ts
@@ -118,11 +118,8 @@ function buildHostedValidationContext(
     ...(options.connectionDefaults?.dropToolListChanged === true
       ? { dropToolListChanged: true }
       : {}),
-    ...(options.connectionDefaults?.suppressLegacyRequestCancellation === true
-      ? { suppressLegacyRequestCancellation: true }
-      : {}),
-    ...(options.connectionDefaults?.suppressModernRequestCancellation === true
-      ? { suppressModernRequestCancellation: true }
+    ...(options.connectionDefaults?.suppressRequestCancellation === true
+      ? { suppressRequestCancellation: true }
       : {}),
   };
 }

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -18,6 +18,7 @@ import { getCanonicalModelId } from "@/shared/types";
 import type { ModelProvider } from "@/shared/types";
 import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
 import { getClientIp } from "../../utils/client-ip.js";
+import { toolCallCancellationFromMcpProfile } from "../../utils/effective-auth.js";
 import { getProductionGuestAuthHeader } from "../../utils/guest-auth.js";
 import { logger } from "../../utils/logger";
 import { WEBMCP_INSPECTOR_ENABLED } from "../../config";
@@ -1326,6 +1327,24 @@ chatV2.post("/", async (c) => {
       prepared = await prepareChatV2({
         mcpClientManager,
         selectedServers,
+        // Read from the SERVER-resolved host config, never the body, and per
+        // turn rather than per connection: the connection's copy is captured
+        // when it connects, so a toggle saved mid-session would not reach it
+        // until something reconnected.
+        //
+        // Authoritative whenever a host config resolved: a host that cancels
+        // normally must send an EMPTY record, not nothing. `undefined` would
+        // fall through to the connection's connect-time copy — which is the
+        // stale value this exists to override — so switching the toggle back
+        // on would keep suppressing.
+        ...(hostRuntimeConfig
+          ? {
+              toolCallCancellation:
+                toolCallCancellationFromMcpProfile(
+                  (hostRuntimeConfig as { mcpProfile?: unknown }).mcpProfile
+                ) ?? {},
+            }
+          : {}),
         modelDefinition,
         systemPrompt: effectiveSystemPrompt,
         temperature,

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -825,8 +825,7 @@ export function toHttpConfig(
      */
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
-    suppressLegacyRequestCancellation?: boolean;
-    suppressModernRequestCancellation?: boolean;
+    suppressRequestCancellation?: boolean;
   },
   /**
    * A plugin stdio component that IS reachable: a live shim, recorded in
@@ -876,11 +875,8 @@ export function toHttpConfig(
         ...(initializePins?.supportsMrtr === false
           ? { supportsMrtr: false }
           : {}),
-        ...(initializePins?.suppressLegacyRequestCancellation === true
-          ? { suppressLegacyRequestCancellation: true }
-          : {}),
-        ...(initializePins?.suppressModernRequestCancellation === true
-          ? { suppressModernRequestCancellation: true }
+        ...(initializePins?.suppressRequestCancellation === true
+          ? { suppressRequestCancellation: true }
           : {}),
       };
     }
@@ -963,11 +959,8 @@ export function toHttpConfig(
     // resolve against.
     ...(initializePins?.firstPageOnly === true ? { firstPageOnly: true } : {}),
     ...(initializePins?.supportsMrtr === false ? { supportsMrtr: false } : {}),
-    ...(initializePins?.suppressLegacyRequestCancellation === true
-      ? { suppressLegacyRequestCancellation: true }
-      : {}),
-    ...(initializePins?.suppressModernRequestCancellation === true
-      ? { suppressModernRequestCancellation: true }
+    ...(initializePins?.suppressRequestCancellation === true
+      ? { suppressRequestCancellation: true }
       : {}),
   };
 }
@@ -989,8 +982,7 @@ function resolveEffectiveInitializePinsForServer(
     mirrorToolParamHeaders?: boolean;
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
-    suppressLegacyRequestCancellation?: boolean;
-    suppressModernRequestCancellation?: boolean;
+    suppressRequestCancellation?: boolean;
   },
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>
 ):
@@ -1004,8 +996,7 @@ function resolveEffectiveInitializePinsForServer(
       mirrorToolParamHeaders?: boolean;
       firstPageOnly?: boolean;
       supportsMrtr?: boolean;
-      suppressLegacyRequestCancellation?: boolean;
-      suppressModernRequestCancellation?: boolean;
+      suppressRequestCancellation?: boolean;
     }
   | undefined {
   const perServerPin = mcpProtocolVersionsByServerId?.[serverId];
@@ -1039,11 +1030,8 @@ function resolveEffectiveInitializePinsForServer(
     // resolve against.
     ...(initializePins?.firstPageOnly === true ? { firstPageOnly: true } : {}),
     ...(initializePins?.supportsMrtr === false ? { supportsMrtr: false } : {}),
-    ...(initializePins?.suppressLegacyRequestCancellation === true
-      ? { suppressLegacyRequestCancellation: true }
-      : {}),
-    ...(initializePins?.suppressModernRequestCancellation === true
-      ? { suppressModernRequestCancellation: true }
+    ...(initializePins?.suppressRequestCancellation === true
+      ? { suppressRequestCancellation: true }
       : {}),
   };
 
@@ -1113,8 +1101,7 @@ export async function createAuthorizedManager(
       /** Client-conformance knobs; host-level, so batch-uniform. */
       firstPageOnly?: boolean;
       supportsMrtr?: boolean;
-      suppressLegacyRequestCancellation?: boolean;
-      suppressModernRequestCancellation?: boolean;
+      suppressRequestCancellation?: boolean;
     };
     /**
      * Per-server `mcpProtocolVersion` overrides keyed by serverId.
@@ -1982,8 +1969,7 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
     mirrorToolParamHeaders?: boolean;
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
-    suppressLegacyRequestCancellation?: boolean;
-    suppressModernRequestCancellation?: boolean;
+    suppressRequestCancellation?: boolean;
   };
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
 } {
@@ -2019,10 +2005,7 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
   // Same one-explicit-value rule for the sibling knobs.
   const truncatePagination = raw.firstPageOnly === true;
   const disableMrtr = raw.supportsMrtr === false;
-  const disableLegacyCancellation =
-    raw.suppressLegacyRequestCancellation === true;
-  const disableModernCancellation =
-    raw.suppressModernRequestCancellation === true;
+  const disableCancellation = raw.suppressRequestCancellation === true;
   const initializePins =
     initializeClientInfo ||
     initializeSupportedVersions ||
@@ -2030,8 +2013,7 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
     suppressParamMirroring ||
     truncatePagination ||
     disableMrtr ||
-    disableLegacyCancellation ||
-    disableModernCancellation
+    disableCancellation
       ? {
           ...(initializeClientInfo ? { clientInfo: initializeClientInfo } : {}),
           ...(initializeSupportedVersions
@@ -2042,11 +2024,8 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
             : {}),
           ...(truncatePagination ? { firstPageOnly: true } : {}),
           ...(disableMrtr ? { supportsMrtr: false } : {}),
-          ...(disableLegacyCancellation
-            ? { suppressLegacyRequestCancellation: true }
-            : {}),
-          ...(disableModernCancellation
-            ? { suppressModernRequestCancellation: true }
+          ...(disableCancellation
+            ? { suppressRequestCancellation: true }
             : {}),
           ...(suppressParamMirroring ? { mirrorToolParamHeaders: false } : {}),
         }

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -825,7 +825,8 @@ export function toHttpConfig(
      */
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
-    suppressRequestCancellation?: boolean;
+    suppressLegacyRequestCancellation?: boolean;
+    suppressModernRequestCancellation?: boolean;
   },
   /**
    * A plugin stdio component that IS reachable: a live shim, recorded in
@@ -875,8 +876,11 @@ export function toHttpConfig(
         ...(initializePins?.supportsMrtr === false
           ? { supportsMrtr: false }
           : {}),
-        ...(initializePins?.suppressRequestCancellation === true
-          ? { suppressRequestCancellation: true }
+        ...(initializePins?.suppressLegacyRequestCancellation === true
+          ? { suppressLegacyRequestCancellation: true }
+          : {}),
+        ...(initializePins?.suppressModernRequestCancellation === true
+          ? { suppressModernRequestCancellation: true }
           : {}),
       };
     }
@@ -959,8 +963,11 @@ export function toHttpConfig(
     // resolve against.
     ...(initializePins?.firstPageOnly === true ? { firstPageOnly: true } : {}),
     ...(initializePins?.supportsMrtr === false ? { supportsMrtr: false } : {}),
-    ...(initializePins?.suppressRequestCancellation === true
-      ? { suppressRequestCancellation: true }
+    ...(initializePins?.suppressLegacyRequestCancellation === true
+      ? { suppressLegacyRequestCancellation: true }
+      : {}),
+    ...(initializePins?.suppressModernRequestCancellation === true
+      ? { suppressModernRequestCancellation: true }
       : {}),
   };
 }
@@ -982,7 +989,8 @@ function resolveEffectiveInitializePinsForServer(
     mirrorToolParamHeaders?: boolean;
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
-    suppressRequestCancellation?: boolean;
+    suppressLegacyRequestCancellation?: boolean;
+    suppressModernRequestCancellation?: boolean;
   },
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>
 ):
@@ -996,7 +1004,8 @@ function resolveEffectiveInitializePinsForServer(
       mirrorToolParamHeaders?: boolean;
       firstPageOnly?: boolean;
       supportsMrtr?: boolean;
-      suppressRequestCancellation?: boolean;
+      suppressLegacyRequestCancellation?: boolean;
+      suppressModernRequestCancellation?: boolean;
     }
   | undefined {
   const perServerPin = mcpProtocolVersionsByServerId?.[serverId];
@@ -1030,8 +1039,11 @@ function resolveEffectiveInitializePinsForServer(
     // resolve against.
     ...(initializePins?.firstPageOnly === true ? { firstPageOnly: true } : {}),
     ...(initializePins?.supportsMrtr === false ? { supportsMrtr: false } : {}),
-    ...(initializePins?.suppressRequestCancellation === true
-      ? { suppressRequestCancellation: true }
+    ...(initializePins?.suppressLegacyRequestCancellation === true
+      ? { suppressLegacyRequestCancellation: true }
+      : {}),
+    ...(initializePins?.suppressModernRequestCancellation === true
+      ? { suppressModernRequestCancellation: true }
       : {}),
   };
 
@@ -1101,7 +1113,8 @@ export async function createAuthorizedManager(
       /** Client-conformance knobs; host-level, so batch-uniform. */
       firstPageOnly?: boolean;
       supportsMrtr?: boolean;
-      suppressRequestCancellation?: boolean;
+      suppressLegacyRequestCancellation?: boolean;
+      suppressModernRequestCancellation?: boolean;
     };
     /**
      * Per-server `mcpProtocolVersion` overrides keyed by serverId.
@@ -1969,7 +1982,8 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
     mirrorToolParamHeaders?: boolean;
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
-    suppressRequestCancellation?: boolean;
+    suppressLegacyRequestCancellation?: boolean;
+    suppressModernRequestCancellation?: boolean;
   };
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
 } {
@@ -2005,7 +2019,10 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
   // Same one-explicit-value rule for the sibling knobs.
   const truncatePagination = raw.firstPageOnly === true;
   const disableMrtr = raw.supportsMrtr === false;
-  const disableCancellation = raw.suppressRequestCancellation === true;
+  const disableLegacyCancellation =
+    raw.suppressLegacyRequestCancellation === true;
+  const disableModernCancellation =
+    raw.suppressModernRequestCancellation === true;
   const initializePins =
     initializeClientInfo ||
     initializeSupportedVersions ||
@@ -2013,7 +2030,8 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
     suppressParamMirroring ||
     truncatePagination ||
     disableMrtr ||
-    disableCancellation
+    disableLegacyCancellation ||
+    disableModernCancellation
       ? {
           ...(initializeClientInfo ? { clientInfo: initializeClientInfo } : {}),
           ...(initializeSupportedVersions
@@ -2024,8 +2042,11 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
             : {}),
           ...(truncatePagination ? { firstPageOnly: true } : {}),
           ...(disableMrtr ? { supportsMrtr: false } : {}),
-          ...(disableCancellation
-            ? { suppressRequestCancellation: true }
+          ...(disableLegacyCancellation
+            ? { suppressLegacyRequestCancellation: true }
+            : {}),
+          ...(disableModernCancellation
+            ? { suppressModernRequestCancellation: true }
             : {}),
           ...(suppressParamMirroring ? { mirrorToolParamHeaders: false } : {}),
         }

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -825,6 +825,7 @@ export function toHttpConfig(
      */
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
+    suppressRequestCancellation?: boolean;
   },
   /**
    * A plugin stdio component that IS reachable: a live shim, recorded in
@@ -873,6 +874,9 @@ export function toHttpConfig(
           : {}),
         ...(initializePins?.supportsMrtr === false
           ? { supportsMrtr: false }
+          : {}),
+        ...(initializePins?.suppressRequestCancellation === true
+          ? { suppressRequestCancellation: true }
           : {}),
       };
     }
@@ -955,6 +959,9 @@ export function toHttpConfig(
     // resolve against.
     ...(initializePins?.firstPageOnly === true ? { firstPageOnly: true } : {}),
     ...(initializePins?.supportsMrtr === false ? { supportsMrtr: false } : {}),
+    ...(initializePins?.suppressRequestCancellation === true
+      ? { suppressRequestCancellation: true }
+      : {}),
   };
 }
 
@@ -975,6 +982,7 @@ function resolveEffectiveInitializePinsForServer(
     mirrorToolParamHeaders?: boolean;
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
+    suppressRequestCancellation?: boolean;
   },
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>
 ):
@@ -988,6 +996,7 @@ function resolveEffectiveInitializePinsForServer(
       mirrorToolParamHeaders?: boolean;
       firstPageOnly?: boolean;
       supportsMrtr?: boolean;
+      suppressRequestCancellation?: boolean;
     }
   | undefined {
   const perServerPin = mcpProtocolVersionsByServerId?.[serverId];
@@ -1021,6 +1030,9 @@ function resolveEffectiveInitializePinsForServer(
     // resolve against.
     ...(initializePins?.firstPageOnly === true ? { firstPageOnly: true } : {}),
     ...(initializePins?.supportsMrtr === false ? { supportsMrtr: false } : {}),
+    ...(initializePins?.suppressRequestCancellation === true
+      ? { suppressRequestCancellation: true }
+      : {}),
   };
 
   return Object.keys(resolved).length > 0 ? resolved : undefined;
@@ -1089,6 +1101,7 @@ export async function createAuthorizedManager(
       /** Client-conformance knobs; host-level, so batch-uniform. */
       firstPageOnly?: boolean;
       supportsMrtr?: boolean;
+      suppressRequestCancellation?: boolean;
     };
     /**
      * Per-server `mcpProtocolVersion` overrides keyed by serverId.
@@ -1956,6 +1969,7 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
     mirrorToolParamHeaders?: boolean;
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
+    suppressRequestCancellation?: boolean;
   };
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
 } {
@@ -1991,13 +2005,15 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
   // Same one-explicit-value rule for the sibling knobs.
   const truncatePagination = raw.firstPageOnly === true;
   const disableMrtr = raw.supportsMrtr === false;
+  const disableCancellation = raw.suppressRequestCancellation === true;
   const initializePins =
     initializeClientInfo ||
     initializeSupportedVersions ||
     initializeWireMode ||
     suppressParamMirroring ||
     truncatePagination ||
-    disableMrtr
+    disableMrtr ||
+    disableCancellation
       ? {
           ...(initializeClientInfo ? { clientInfo: initializeClientInfo } : {}),
           ...(initializeSupportedVersions
@@ -2008,6 +2024,9 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
             : {}),
           ...(truncatePagination ? { firstPageOnly: true } : {}),
           ...(disableMrtr ? { supportsMrtr: false } : {}),
+          ...(disableCancellation
+            ? { suppressRequestCancellation: true }
+            : {}),
           ...(suppressParamMirroring ? { mirrorToolParamHeaders: false } : {}),
         }
       : undefined;

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -825,7 +825,7 @@ export function toHttpConfig(
      */
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
-    suppressRequestCancellation?: boolean;
+    toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   },
   /**
    * A plugin stdio component that IS reachable: a live shim, recorded in
@@ -875,8 +875,8 @@ export function toHttpConfig(
         ...(initializePins?.supportsMrtr === false
           ? { supportsMrtr: false }
           : {}),
-        ...(initializePins?.suppressRequestCancellation === true
-          ? { suppressRequestCancellation: true }
+        ...(initializePins?.toolCallCancellation
+          ? { toolCallCancellation: initializePins.toolCallCancellation }
           : {}),
       };
     }
@@ -959,8 +959,8 @@ export function toHttpConfig(
     // resolve against.
     ...(initializePins?.firstPageOnly === true ? { firstPageOnly: true } : {}),
     ...(initializePins?.supportsMrtr === false ? { supportsMrtr: false } : {}),
-    ...(initializePins?.suppressRequestCancellation === true
-      ? { suppressRequestCancellation: true }
+    ...(initializePins?.toolCallCancellation
+      ? { toolCallCancellation: initializePins.toolCallCancellation }
       : {}),
   };
 }
@@ -982,7 +982,7 @@ function resolveEffectiveInitializePinsForServer(
     mirrorToolParamHeaders?: boolean;
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
-    suppressRequestCancellation?: boolean;
+    toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   },
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>
 ):
@@ -996,7 +996,7 @@ function resolveEffectiveInitializePinsForServer(
       mirrorToolParamHeaders?: boolean;
       firstPageOnly?: boolean;
       supportsMrtr?: boolean;
-      suppressRequestCancellation?: boolean;
+      toolCallCancellation?: { legacy?: boolean; modern?: boolean };
     }
   | undefined {
   const perServerPin = mcpProtocolVersionsByServerId?.[serverId];
@@ -1030,8 +1030,8 @@ function resolveEffectiveInitializePinsForServer(
     // resolve against.
     ...(initializePins?.firstPageOnly === true ? { firstPageOnly: true } : {}),
     ...(initializePins?.supportsMrtr === false ? { supportsMrtr: false } : {}),
-    ...(initializePins?.suppressRequestCancellation === true
-      ? { suppressRequestCancellation: true }
+    ...(initializePins?.toolCallCancellation
+      ? { toolCallCancellation: initializePins.toolCallCancellation }
       : {}),
   };
 
@@ -1101,7 +1101,7 @@ export async function createAuthorizedManager(
       /** Client-conformance knobs; host-level, so batch-uniform. */
       firstPageOnly?: boolean;
       supportsMrtr?: boolean;
-      suppressRequestCancellation?: boolean;
+      toolCallCancellation?: { legacy?: boolean; modern?: boolean };
     };
     /**
      * Per-server `mcpProtocolVersion` overrides keyed by serverId.
@@ -1969,7 +1969,7 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
     mirrorToolParamHeaders?: boolean;
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
-    suppressRequestCancellation?: boolean;
+    toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   };
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
 } {
@@ -2005,7 +2005,14 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
   // Same one-explicit-value rule for the sibling knobs.
   const truncatePagination = raw.firstPageOnly === true;
   const disableMrtr = raw.supportsMrtr === false;
-  const disableCancellation = raw.suppressRequestCancellation === true;
+  const rawCancellation =
+    raw.toolCallCancellation && typeof raw.toolCallCancellation === "object"
+      ? (raw.toolCallCancellation as { legacy?: unknown; modern?: unknown })
+      : undefined;
+  const cancellationLeaves: { legacy?: boolean; modern?: boolean } = {};
+  if (rawCancellation?.legacy === false) cancellationLeaves.legacy = false;
+  if (rawCancellation?.modern === false) cancellationLeaves.modern = false;
+  const disableCancellation = Object.keys(cancellationLeaves).length > 0;
   const initializePins =
     initializeClientInfo ||
     initializeSupportedVersions ||
@@ -2025,7 +2032,7 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
           ...(truncatePagination ? { firstPageOnly: true } : {}),
           ...(disableMrtr ? { supportsMrtr: false } : {}),
           ...(disableCancellation
-            ? { suppressRequestCancellation: true }
+            ? { toolCallCancellation: cancellationLeaves }
             : {}),
           ...(suppressParamMirroring ? { mirrorToolParamHeaders: false } : {}),
         }

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -77,6 +77,7 @@ import {
   parseXaaPolicyValue,
   conformanceKnobsFromMcpProfile,
   mirrorToolParamHeadersFromMcpProfile,
+  toolCallCancellationFromMcpProfile,
   xaaPolicyFromMcpProfile,
 } from "../../utils/effective-auth.js";
 import { resolveXaaIssuer } from "../../services/xaa-mint.js";
@@ -1489,6 +1490,18 @@ chatV2.post("/", async (c) => {
           requireToolApproval,
           respectToolVisibility,
           modelVisibleMcpToolResults,
+          // Server-resolved, never from the body, and authoritative whenever a
+          // host config resolved: an EMPTY record means "cancels normally" and
+          // must still be sent, or the connection's stale connect-time copy
+          // would win and a toggle switched back on would keep suppressing.
+          ...(hostRuntimeConfig
+            ? {
+                toolCallCancellation:
+                  toolCallCancellationFromMcpProfile(
+                    (hostRuntimeConfig as { mcpProfile?: unknown }).mcpProfile
+                  ) ?? {},
+              }
+            : {}),
           customProviders: body.customProviders,
           uiMessages: messages,
           ...(resolvedExecution.harness

--- a/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
@@ -264,7 +264,7 @@ describe("applyHostConformanceKnobs — toolListChanged", () => {
     supportsMrtr: undefined,
     suppressListenChannel: undefined,
     dropToolListChanged: undefined,
-    suppressRequestCancellation: undefined,
+    toolCallCancellation: undefined,
   } as const;
 
   it("adds the host's knobs to a body that carried none", () => {
@@ -300,7 +300,7 @@ describe("conformanceKnobsFromMcpProfile", () => {
       supportsMrtr: false,
       suppressListenChannel: undefined,
       dropToolListChanged: undefined,
-      suppressRequestCancellation: undefined,
+      toolCallCancellation: undefined,
     });
   });
 
@@ -319,37 +319,27 @@ describe("conformanceKnobsFromMcpProfile", () => {
         supportsMrtr: undefined,
         suppressListenChannel: undefined,
         dropToolListChanged: undefined,
-        suppressRequestCancellation: undefined,
+        toolCallCancellation: undefined,
       });
     }
   });
 });
 
 describe("conformanceKnobsFromMcpProfile — toolCallCancellation", () => {
-  it("picks the leaf named by the host's version pin", () => {
-    // The host config measures both eras; the pin says which one its
-    // connections speak, so exactly one flag comes out.
+  it("forwards only the degraded leaves", () => {
+    // Both eras travel; the SDK picks which one applies once the connection
+    // has negotiated. Resolving here cannot work for an unpinned host.
     expect(
       conformanceKnobsFromMcpProfile({
-        mcpProtocolVersion: "2025-11-25",
         toolCallCancellation: { legacy: false },
-      }).suppressRequestCancellation
-    ).toBe(true);
-
-    // The other era's leaf must be ignored, not leak through.
-    expect(
-      conformanceKnobsFromMcpProfile({
-        mcpProtocolVersion: "2025-11-25",
-        toolCallCancellation: { modern: false },
-      }).suppressRequestCancellation
-    ).toBeUndefined();
+      }).toolCallCancellation
+    ).toEqual({ legacy: false });
 
     expect(
       conformanceKnobsFromMcpProfile({
-        mcpProtocolVersion: "2026-07-28",
-        toolCallCancellation: { modern: false },
-      }).suppressRequestCancellation
-    ).toBe(true);
+        toolCallCancellation: { legacy: true, modern: false },
+      }).toolCallCancellation
+    ).toEqual({ modern: false });
   });
 
   it("treats `true`, junk and a non-record as the conforming client", () => {
@@ -363,7 +353,7 @@ describe("conformanceKnobsFromMcpProfile — toolCallCancellation", () => {
     ]) {
       expect(
         conformanceKnobsFromMcpProfile({ toolCallCancellation: value })
-          .suppressRequestCancellation
+          .toolCallCancellation
       ).toBeUndefined();
     }
   });
@@ -375,25 +365,25 @@ describe("applyHostConformanceKnobs — toolCallCancellation", () => {
     supportsMrtr: undefined,
     suppressListenChannel: undefined,
     dropToolListChanged: undefined,
-    suppressRequestCancellation: undefined,
+    toolCallCancellation: undefined,
   } as const;
 
-  it("adds the host's suppression to a body that carried none", () => {
+  it("adds the host's leaves to a body that carried none", () => {
     expect(
       applyHostConformanceKnobs(undefined, {
         ...conforming,
-        suppressRequestCancellation: true,
+        toolCallCancellation: { modern: false },
       })
-    ).toEqual({ suppressRequestCancellation: true });
+    ).toEqual({ toolCallCancellation: { modern: false } });
   });
 
-  it("REMOVES body-supplied suppression when the host cancels normally", () => {
+  it("REMOVES body-supplied leaves when the host cancels normally", () => {
     // Same security property as the sibling knobs: a share-link body must not
     // be able to make a conforming host silently abandon cancelled calls,
     // leaving servers running tools nobody wants.
     expect(
       applyHostConformanceKnobs(
-        { suppressRequestCancellation: true },
+        { toolCallCancellation: { legacy: false } },
         conforming
       )
     ).toEqual({});

--- a/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
@@ -264,7 +264,8 @@ describe("applyHostConformanceKnobs — toolListChanged", () => {
     supportsMrtr: undefined,
     suppressListenChannel: undefined,
     dropToolListChanged: undefined,
-    suppressRequestCancellation: undefined,
+    suppressLegacyRequestCancellation: undefined,
+    suppressModernRequestCancellation: undefined,
   } as const;
 
   it("adds the host's knobs to a body that carried none", () => {
@@ -300,7 +301,8 @@ describe("conformanceKnobsFromMcpProfile", () => {
       supportsMrtr: false,
       suppressListenChannel: undefined,
       dropToolListChanged: undefined,
-      suppressRequestCancellation: undefined,
+      suppressLegacyRequestCancellation: undefined,
+    suppressModernRequestCancellation: undefined,
     });
   });
 
@@ -319,25 +321,44 @@ describe("conformanceKnobsFromMcpProfile", () => {
         supportsMrtr: undefined,
         suppressListenChannel: undefined,
         dropToolListChanged: undefined,
-        suppressRequestCancellation: undefined,
+        suppressLegacyRequestCancellation: undefined,
+    suppressModernRequestCancellation: undefined,
       });
     }
   });
 });
 
 describe("conformanceKnobsFromMcpProfile — toolCallCancellation", () => {
-  it("reads only an explicit stored false as the suppression", () => {
-    expect(
-      conformanceKnobsFromMcpProfile({ toolCallCancellation: false })
-        .suppressRequestCancellation
-    ).toBe(true);
-    // `true`, junk and absence are all the conforming client — the knob is a
-    // suppression switch with no positive state, like its siblings.
-    for (const value of [true, "false", 0, null, undefined]) {
-      expect(
-        conformanceKnobsFromMcpProfile({ toolCallCancellation: value })
-          .suppressRequestCancellation
-      ).toBeUndefined();
+  it("reads each era's leaf independently", () => {
+    // The point of the record: a host measured as broken on 2026 must leave
+    // 2025 untouched, and vice versa.
+    const legacyBroken = conformanceKnobsFromMcpProfile({
+      toolCallCancellation: { legacy: false },
+    });
+    expect(legacyBroken.suppressLegacyRequestCancellation).toBe(true);
+    expect(legacyBroken.suppressModernRequestCancellation).toBeUndefined();
+
+    const modernBroken = conformanceKnobsFromMcpProfile({
+      toolCallCancellation: { modern: false },
+    });
+    expect(modernBroken.suppressModernRequestCancellation).toBe(true);
+    expect(modernBroken.suppressLegacyRequestCancellation).toBeUndefined();
+  });
+
+  it("treats `true`, junk and a non-record as the conforming client", () => {
+    for (const value of [
+      { legacy: true, modern: true },
+      { legacy: "false" },
+      {},
+      "nope",
+      null,
+      undefined,
+    ]) {
+      const knobs = conformanceKnobsFromMcpProfile({
+        toolCallCancellation: value,
+      });
+      expect(knobs.suppressLegacyRequestCancellation).toBeUndefined();
+      expect(knobs.suppressModernRequestCancellation).toBeUndefined();
     }
   });
 });
@@ -348,86 +369,31 @@ describe("applyHostConformanceKnobs — toolCallCancellation", () => {
     supportsMrtr: undefined,
     suppressListenChannel: undefined,
     dropToolListChanged: undefined,
-    suppressRequestCancellation: undefined,
+    suppressLegacyRequestCancellation: undefined,
+    suppressModernRequestCancellation: undefined,
   } as const;
 
-  it("adds the host's suppression to a body that carried none", () => {
+  it("adds only the era the host actually suppresses", () => {
     expect(
       applyHostConformanceKnobs(undefined, {
         ...conforming,
-        suppressRequestCancellation: true,
+        suppressModernRequestCancellation: true,
       })
-    ).toEqual({ suppressRequestCancellation: true });
+    ).toEqual({ suppressModernRequestCancellation: true });
   });
 
-  it("REMOVES a body-supplied suppression when the host cancels normally", () => {
+  it("REMOVES body-supplied suppression when the host cancels normally", () => {
     // Same security property as the sibling knobs: a share-link body must not
-    // be able to make a conforming host silently abandon every cancelled
-    // call, leaving servers running tools nobody wants.
-    expect(
-      applyHostConformanceKnobs(
-        { suppressRequestCancellation: true },
-        conforming
-      )
-    ).toEqual({});
-  });
-});
-
-describe("applyHostConformanceKnobs", () => {
-  // Every knob is required on the host argument on purpose: adding one must
-  // break every call site rather than silently default to "conforming".
-  const off = {
-    firstPageOnly: undefined,
-    supportsMrtr: undefined,
-    suppressListenChannel: undefined,
-    dropToolListChanged: undefined,
-    suppressRequestCancellation: undefined,
-  } as const;
-
-  it("forces the pins on when the host asks for the degraded client", () => {
-    expect(
-      applyHostConformanceKnobs(undefined, {
-        ...off,
-        firstPageOnly: true,
-        supportsMrtr: false,
-      })
-    ).toEqual({ firstPageOnly: true, supportsMrtr: false });
-    expect(
-      applyHostConformanceKnobs(
-        { protocolVersion: "2026-07-28" } as Record<string, unknown>,
-        { ...off, firstPageOnly: true }
-      )
-    ).toEqual({ protocolVersion: "2026-07-28", firstPageOnly: true });
-  });
-
-  it("strips caller pins when the host wants the full behavior", () => {
-    // The security-relevant direction: a share-link body must not be able to
-    // degrade a conforming host into one that hides tools from the model or
-    // silently drops MRTR rounds.
+    // be able to make a conforming host silently abandon cancelled calls,
+    // leaving servers running tools nobody wants.
     expect(
       applyHostConformanceKnobs(
         {
-          protocolVersion: "2026-07-28",
-          firstPageOnly: true,
-          supportsMrtr: false,
-        } as Record<string, unknown>,
-        off
+          suppressLegacyRequestCancellation: true,
+          suppressModernRequestCancellation: true,
+        },
+        conforming
       )
-    ).toEqual({ protocolVersion: "2026-07-28" });
-  });
-
-  it("strips only the knob the host reclaims, keeping the other", () => {
-    expect(
-      applyHostConformanceKnobs(
-        { firstPageOnly: true, supportsMrtr: false } as Record<string, unknown>,
-        { ...off, supportsMrtr: false }
-      )
-    ).toEqual({ supportsMrtr: false });
-  });
-
-  it("leaves untouched pins alone", () => {
-    const pins = { protocolVersion: "2026-07-28" };
-    expect(applyHostConformanceKnobs(pins, off)).toBe(pins);
-    expect(applyHostConformanceKnobs(undefined, off)).toBeUndefined();
+    ).toEqual({});
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
@@ -264,8 +264,7 @@ describe("applyHostConformanceKnobs — toolListChanged", () => {
     supportsMrtr: undefined,
     suppressListenChannel: undefined,
     dropToolListChanged: undefined,
-    suppressLegacyRequestCancellation: undefined,
-    suppressModernRequestCancellation: undefined,
+    suppressRequestCancellation: undefined,
   } as const;
 
   it("adds the host's knobs to a body that carried none", () => {
@@ -301,8 +300,7 @@ describe("conformanceKnobsFromMcpProfile", () => {
       supportsMrtr: false,
       suppressListenChannel: undefined,
       dropToolListChanged: undefined,
-      suppressLegacyRequestCancellation: undefined,
-    suppressModernRequestCancellation: undefined,
+      suppressRequestCancellation: undefined,
     });
   });
 
@@ -321,44 +319,52 @@ describe("conformanceKnobsFromMcpProfile", () => {
         supportsMrtr: undefined,
         suppressListenChannel: undefined,
         dropToolListChanged: undefined,
-        suppressLegacyRequestCancellation: undefined,
-    suppressModernRequestCancellation: undefined,
+        suppressRequestCancellation: undefined,
       });
     }
   });
 });
 
 describe("conformanceKnobsFromMcpProfile — toolCallCancellation", () => {
-  it("reads each era's leaf independently", () => {
-    // The point of the record: a host measured as broken on 2026 must leave
-    // 2025 untouched, and vice versa.
-    const legacyBroken = conformanceKnobsFromMcpProfile({
-      toolCallCancellation: { legacy: false },
-    });
-    expect(legacyBroken.suppressLegacyRequestCancellation).toBe(true);
-    expect(legacyBroken.suppressModernRequestCancellation).toBeUndefined();
+  it("picks the leaf named by the host's version pin", () => {
+    // The host config measures both eras; the pin says which one its
+    // connections speak, so exactly one flag comes out.
+    expect(
+      conformanceKnobsFromMcpProfile({
+        mcpProtocolVersion: "2025-11-25",
+        toolCallCancellation: { legacy: false },
+      }).suppressRequestCancellation
+    ).toBe(true);
 
-    const modernBroken = conformanceKnobsFromMcpProfile({
-      toolCallCancellation: { modern: false },
-    });
-    expect(modernBroken.suppressModernRequestCancellation).toBe(true);
-    expect(modernBroken.suppressLegacyRequestCancellation).toBeUndefined();
+    // The other era's leaf must be ignored, not leak through.
+    expect(
+      conformanceKnobsFromMcpProfile({
+        mcpProtocolVersion: "2025-11-25",
+        toolCallCancellation: { modern: false },
+      }).suppressRequestCancellation
+    ).toBeUndefined();
+
+    expect(
+      conformanceKnobsFromMcpProfile({
+        mcpProtocolVersion: "2026-07-28",
+        toolCallCancellation: { modern: false },
+      }).suppressRequestCancellation
+    ).toBe(true);
   });
 
   it("treats `true`, junk and a non-record as the conforming client", () => {
     for (const value of [
       { legacy: true, modern: true },
-      { legacy: "false" },
+      { modern: "false" },
       {},
       "nope",
       null,
       undefined,
     ]) {
-      const knobs = conformanceKnobsFromMcpProfile({
-        toolCallCancellation: value,
-      });
-      expect(knobs.suppressLegacyRequestCancellation).toBeUndefined();
-      expect(knobs.suppressModernRequestCancellation).toBeUndefined();
+      expect(
+        conformanceKnobsFromMcpProfile({ toolCallCancellation: value })
+          .suppressRequestCancellation
+      ).toBeUndefined();
     }
   });
 });
@@ -369,17 +375,16 @@ describe("applyHostConformanceKnobs — toolCallCancellation", () => {
     supportsMrtr: undefined,
     suppressListenChannel: undefined,
     dropToolListChanged: undefined,
-    suppressLegacyRequestCancellation: undefined,
-    suppressModernRequestCancellation: undefined,
+    suppressRequestCancellation: undefined,
   } as const;
 
-  it("adds only the era the host actually suppresses", () => {
+  it("adds the host's suppression to a body that carried none", () => {
     expect(
       applyHostConformanceKnobs(undefined, {
         ...conforming,
-        suppressModernRequestCancellation: true,
+        suppressRequestCancellation: true,
       })
-    ).toEqual({ suppressModernRequestCancellation: true });
+    ).toEqual({ suppressRequestCancellation: true });
   });
 
   it("REMOVES body-supplied suppression when the host cancels normally", () => {
@@ -388,10 +393,7 @@ describe("applyHostConformanceKnobs — toolCallCancellation", () => {
     // leaving servers running tools nobody wants.
     expect(
       applyHostConformanceKnobs(
-        {
-          suppressLegacyRequestCancellation: true,
-          suppressModernRequestCancellation: true,
-        },
+        { suppressRequestCancellation: true },
         conforming
       )
     ).toEqual({});

--- a/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
@@ -264,6 +264,7 @@ describe("applyHostConformanceKnobs — toolListChanged", () => {
     supportsMrtr: undefined,
     suppressListenChannel: undefined,
     dropToolListChanged: undefined,
+    suppressRequestCancellation: undefined,
   } as const;
 
   it("adds the host's knobs to a body that carried none", () => {
@@ -299,6 +300,7 @@ describe("conformanceKnobsFromMcpProfile", () => {
       supportsMrtr: false,
       suppressListenChannel: undefined,
       dropToolListChanged: undefined,
+      suppressRequestCancellation: undefined,
     });
   });
 
@@ -317,17 +319,75 @@ describe("conformanceKnobsFromMcpProfile", () => {
         supportsMrtr: undefined,
         suppressListenChannel: undefined,
         dropToolListChanged: undefined,
+        suppressRequestCancellation: undefined,
       });
     }
   });
 });
 
+describe("conformanceKnobsFromMcpProfile — toolCallCancellation", () => {
+  it("reads only an explicit stored false as the suppression", () => {
+    expect(
+      conformanceKnobsFromMcpProfile({ toolCallCancellation: false })
+        .suppressRequestCancellation
+    ).toBe(true);
+    // `true`, junk and absence are all the conforming client — the knob is a
+    // suppression switch with no positive state, like its siblings.
+    for (const value of [true, "false", 0, null, undefined]) {
+      expect(
+        conformanceKnobsFromMcpProfile({ toolCallCancellation: value })
+          .suppressRequestCancellation
+      ).toBeUndefined();
+    }
+  });
+});
+
+describe("applyHostConformanceKnobs — toolCallCancellation", () => {
+  const conforming = {
+    firstPageOnly: undefined,
+    supportsMrtr: undefined,
+    suppressListenChannel: undefined,
+    dropToolListChanged: undefined,
+    suppressRequestCancellation: undefined,
+  } as const;
+
+  it("adds the host's suppression to a body that carried none", () => {
+    expect(
+      applyHostConformanceKnobs(undefined, {
+        ...conforming,
+        suppressRequestCancellation: true,
+      })
+    ).toEqual({ suppressRequestCancellation: true });
+  });
+
+  it("REMOVES a body-supplied suppression when the host cancels normally", () => {
+    // Same security property as the sibling knobs: a share-link body must not
+    // be able to make a conforming host silently abandon every cancelled
+    // call, leaving servers running tools nobody wants.
+    expect(
+      applyHostConformanceKnobs(
+        { suppressRequestCancellation: true },
+        conforming
+      )
+    ).toEqual({});
+  });
+});
+
 describe("applyHostConformanceKnobs", () => {
-  const off = { firstPageOnly: undefined, supportsMrtr: undefined } as const;
+  // Every knob is required on the host argument on purpose: adding one must
+  // break every call site rather than silently default to "conforming".
+  const off = {
+    firstPageOnly: undefined,
+    supportsMrtr: undefined,
+    suppressListenChannel: undefined,
+    dropToolListChanged: undefined,
+    suppressRequestCancellation: undefined,
+  } as const;
 
   it("forces the pins on when the host asks for the degraded client", () => {
     expect(
       applyHostConformanceKnobs(undefined, {
+        ...off,
         firstPageOnly: true,
         supportsMrtr: false,
       })
@@ -335,7 +395,7 @@ describe("applyHostConformanceKnobs", () => {
     expect(
       applyHostConformanceKnobs(
         { protocolVersion: "2026-07-28" } as Record<string, unknown>,
-        { firstPageOnly: true, supportsMrtr: undefined }
+        { ...off, firstPageOnly: true }
       )
     ).toEqual({ protocolVersion: "2026-07-28", firstPageOnly: true });
   });
@@ -360,7 +420,7 @@ describe("applyHostConformanceKnobs", () => {
     expect(
       applyHostConformanceKnobs(
         { firstPageOnly: true, supportsMrtr: false } as Record<string, unknown>,
-        { firstPageOnly: undefined, supportsMrtr: false }
+        { ...off, supportsMrtr: false }
       )
     ).toEqual({ supportsMrtr: false });
   });

--- a/mcpjam-inspector/server/utils/__tests__/local-server-resolver.cancellation.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/local-server-resolver.cancellation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { parseConnectionDefaults, toMCPServerConfig } from "../local-server-resolver.js";
+
+describe("local connect: defaults -> MCPServerConfig", () => {
+  it("lands toolCallCancellation on the http config", () => {
+    const defaults = parseConnectionDefaults({
+      toolCallCancellation: { legacy: false, modern: false },
+    });
+    expect(defaults?.toolCallCancellation).toBeTruthy();
+
+    const config = toMCPServerConfig(
+      {
+        serverConfig: {
+          transportType: "http",
+          url: "https://example.test/mcp",
+          headers: {},
+          timeout: 30000,
+        },
+      } as never,
+      { toolCallCancellation: defaults?.toolCallCancellation },
+    );
+    expect(
+      (config as { toolCallCancellation?: unknown }).toolCallCancellation,
+    ).toEqual({ legacy: false, modern: false });
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/mcp-tool-options.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-tool-options.test.ts
@@ -1,7 +1,7 @@
 /**
  * The ONE builder for `getToolsForAiSdk`'s host-derived options.
  *
- * These assertions pin the property that four call sites depend on and that a
+ * These assertions pin the property that every call site depends on and that a
  * fifth (the harness host-executed projection) silently violated by building
  * nothing at all: absent-everything answers `undefined`, so a default turn
  * takes the no-options overload and produces byte-identical tools.
@@ -50,9 +50,43 @@ describe("mcpToolOptionsFor", () => {
     expect(mcpToolOptionsFor({ tasks: seam })).toEqual({ tasks: seam });
   });
 
-  it("reproduces the emulated engine's four-field object", () => {
+  /**
+   * `toolCallCancellation` is the ONE field here where absent and empty are
+   * different instructions, so it gets its own case rather than riding along
+   * with the policy-object one.
+   *
+   * `applyCancellationPolicy` reads `override ?? config?.toolCallCancellation`.
+   * Absent therefore falls through to the connection's connect-time copy — the
+   * stale value the per-turn override exists to beat — while `{}` overrides it
+   * with "no era is suppressed". Both chat routes send `{}` whenever a host
+   * config resolved, so if this builder ever dropped the empty record (which
+   * the `Object.keys` rule would do the moment the field stopped being
+   * counted) a host toggled back ON would keep suppressing. That was the bug.
+   */
+  it("keeps an EMPTY cancellation record, which is not the same as absent", () => {
+    expect(mcpToolOptionsFor({ toolCallCancellation: {} })).toEqual({
+      toolCallCancellation: {},
+    });
+    // ...and absent still answers undefined, so a default turn keeps taking
+    // the no-options overload.
+    expect(
+      mcpToolOptionsFor({ toolCallCancellation: undefined })
+    ).toBeUndefined();
+  });
+
+  it("carries a cancellation record through unchanged", () => {
+    const leaves = { legacy: false, modern: false };
+    expect(mcpToolOptionsFor({ toolCallCancellation: leaves })).toEqual({
+      toolCallCancellation: leaves,
+    });
+    expect(
+      mcpToolOptionsFor({ toolCallCancellation: { modern: false } })
+    ).toEqual({ toolCallCancellation: { modern: false } });
+  });
+
+  it("reproduces the emulated engine's full object", () => {
     // The shape `chat-v2-orchestration` built by hand before this helper
-    // existed, from the same four host-derived inputs.
+    // existed, from the same host-derived inputs.
     const policy = { directContent: { image: false } } as never;
     const seam = { mode: "detach" } as never;
     expect(
@@ -61,12 +95,14 @@ describe("mcpToolOptionsFor", () => {
         includeAppOnly: true,
         modelVisibleMcpToolResults: policy,
         tasks: seam,
+        toolCallCancellation: { modern: false },
       })
     ).toEqual({
       needsApproval: true,
       includeAppOnly: true,
       modelVisibleMcpToolResults: policy,
       tasks: seam,
+      toolCallCancellation: { modern: false },
     });
   });
 });

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -671,6 +671,12 @@ export interface PrepareChatV2Options {
    * missing label falls back to the server id — uglier, still safe.
    */
   serverLabels?: Record<string, string>;
+  /**
+   * The host's tool-cancellation setting for this turn, resolved server-side
+   * from the host config. Passed per turn because the connection's own copy
+   * is captured at connect time and goes stale the moment the user saves.
+   */
+  toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   modelDefinition: ModelDefinition;
   systemPrompt?: string;
   temperature?: number;
@@ -1152,6 +1158,7 @@ export async function prepareChatV2(
     harness,
     tasks,
     serverLabels,
+    toolCallCancellation,
   } = options;
 
   // Drop ids the manager hasn't registered (server disabled/disconnected, or
@@ -1168,6 +1175,7 @@ export async function prepareChatV2(
     includeAppOnly: respectToolVisibility === false,
     modelVisibleMcpToolResults,
     tasks,
+    toolCallCancellation,
   });
 
   // 1. Get MCP + skill tools

--- a/mcpjam-inspector/server/utils/effective-auth.ts
+++ b/mcpjam-inspector/server/utils/effective-auth.ts
@@ -240,7 +240,8 @@ export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
   supportsMrtr: false | undefined;
   suppressListenChannel: true | undefined;
   dropToolListChanged: true | undefined;
-  suppressRequestCancellation: true | undefined;
+  suppressLegacyRequestCancellation: true | undefined;
+  suppressModernRequestCancellation: true | undefined;
 } {
   const profile =
     mcpProfile !== null && typeof mcpProfile === "object"
@@ -261,6 +262,16 @@ export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
           refetches?: unknown;
         })
       : undefined;
+  // Same narrowing for the sibling per-era record; a non-object reads as
+  // conforming rather than throwing.
+  const toolCallCancellation =
+    profile?.toolCallCancellation !== null &&
+    typeof profile?.toolCallCancellation === "object"
+      ? (profile.toolCallCancellation as {
+          legacy?: unknown;
+          modern?: unknown;
+        })
+      : undefined;
   return {
     firstPageOnly:
       profile?.paginationTraversal === "firstPageOnly" ? true : undefined,
@@ -269,8 +280,10 @@ export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
       toolListChanged?.listens === false ? true : undefined,
     dropToolListChanged:
       toolListChanged?.refetches === false ? true : undefined,
-    suppressRequestCancellation:
-      profile?.toolCallCancellation === false ? true : undefined,
+    suppressLegacyRequestCancellation:
+      toolCallCancellation?.legacy === false ? true : undefined,
+    suppressModernRequestCancellation:
+      toolCallCancellation?.modern === false ? true : undefined,
   };
 }
 
@@ -297,7 +310,8 @@ export function applyHostConformanceKnobs<
     supportsMrtr?: boolean;
     suppressListenChannel?: boolean;
     dropToolListChanged?: boolean;
-    suppressRequestCancellation?: boolean;
+    suppressLegacyRequestCancellation?: boolean;
+    suppressModernRequestCancellation?: boolean;
   }
 >(
   pins: T | undefined,
@@ -306,7 +320,8 @@ export function applyHostConformanceKnobs<
     supportsMrtr: false | undefined;
     suppressListenChannel: true | undefined;
     dropToolListChanged: true | undefined;
-    suppressRequestCancellation: true | undefined;
+    suppressLegacyRequestCancellation: true | undefined;
+  suppressModernRequestCancellation: true | undefined;
   }
 ): T | undefined {
   let next = pins;
@@ -334,10 +349,16 @@ export function applyHostConformanceKnobs<
     const { dropToolListChanged: _hostOverrides, ...rest } = next;
     next = rest as T;
   }
-  if (host.suppressRequestCancellation === true) {
-    next = { ...((next ?? {}) as T), suppressRequestCancellation: true };
-  } else if (next?.suppressRequestCancellation !== undefined) {
-    const { suppressRequestCancellation: _hostOverrides, ...rest } = next;
+  if (host.suppressLegacyRequestCancellation === true) {
+    next = { ...((next ?? {}) as T), suppressLegacyRequestCancellation: true };
+  } else if (next?.suppressLegacyRequestCancellation !== undefined) {
+    const { suppressLegacyRequestCancellation: _hostOverrides, ...rest } = next;
+    next = rest as T;
+  }
+  if (host.suppressModernRequestCancellation === true) {
+    next = { ...((next ?? {}) as T), suppressModernRequestCancellation: true };
+  } else if (next?.suppressModernRequestCancellation !== undefined) {
+    const { suppressModernRequestCancellation: _hostOverrides, ...rest } = next;
     next = rest as T;
   }
   return next;

--- a/mcpjam-inspector/server/utils/effective-auth.ts
+++ b/mcpjam-inspector/server/utils/effective-auth.ts
@@ -24,6 +24,7 @@
  */
 
 import {
+  cancellationLeafForVersion,
   readXaaEnterprisePolicy,
   XAA_ENTERPRISE_POLICY_IDPS,
   XAA_MCP_EXTENSION,
@@ -240,8 +241,7 @@ export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
   supportsMrtr: false | undefined;
   suppressListenChannel: true | undefined;
   dropToolListChanged: true | undefined;
-  suppressLegacyRequestCancellation: true | undefined;
-  suppressModernRequestCancellation: true | undefined;
+  suppressRequestCancellation: true | undefined;
 } {
   const profile =
     mcpProfile !== null && typeof mcpProfile === "object"
@@ -250,6 +250,7 @@ export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
           mrtrSupport?: unknown;
           toolListChanged?: unknown;
           toolCallCancellation?: unknown;
+          mcpProtocolVersion?: unknown;
         })
       : undefined;
   // Nested record, so it is narrowed separately; an unreadable value falls
@@ -280,10 +281,18 @@ export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
       toolListChanged?.listens === false ? true : undefined,
     dropToolListChanged:
       toolListChanged?.refetches === false ? true : undefined,
-    suppressLegacyRequestCancellation:
-      toolCallCancellation?.legacy === false ? true : undefined,
-    suppressModernRequestCancellation:
-      toolCallCancellation?.modern === false ? true : undefined,
+    // One flag: the host's own version pin says which era its connections
+    // speak, so the leaf is resolved here rather than at request time.
+    suppressRequestCancellation:
+      toolCallCancellation?.[
+        cancellationLeafForVersion(
+          typeof profile?.mcpProtocolVersion === "string"
+            ? profile.mcpProtocolVersion
+            : undefined
+        )
+      ] === false
+        ? true
+        : undefined,
   };
 }
 
@@ -310,8 +319,7 @@ export function applyHostConformanceKnobs<
     supportsMrtr?: boolean;
     suppressListenChannel?: boolean;
     dropToolListChanged?: boolean;
-    suppressLegacyRequestCancellation?: boolean;
-    suppressModernRequestCancellation?: boolean;
+    suppressRequestCancellation?: boolean;
   }
 >(
   pins: T | undefined,
@@ -320,8 +328,7 @@ export function applyHostConformanceKnobs<
     supportsMrtr: false | undefined;
     suppressListenChannel: true | undefined;
     dropToolListChanged: true | undefined;
-    suppressLegacyRequestCancellation: true | undefined;
-  suppressModernRequestCancellation: true | undefined;
+    suppressRequestCancellation: true | undefined;
   }
 ): T | undefined {
   let next = pins;
@@ -349,16 +356,10 @@ export function applyHostConformanceKnobs<
     const { dropToolListChanged: _hostOverrides, ...rest } = next;
     next = rest as T;
   }
-  if (host.suppressLegacyRequestCancellation === true) {
-    next = { ...((next ?? {}) as T), suppressLegacyRequestCancellation: true };
-  } else if (next?.suppressLegacyRequestCancellation !== undefined) {
-    const { suppressLegacyRequestCancellation: _hostOverrides, ...rest } = next;
-    next = rest as T;
-  }
-  if (host.suppressModernRequestCancellation === true) {
-    next = { ...((next ?? {}) as T), suppressModernRequestCancellation: true };
-  } else if (next?.suppressModernRequestCancellation !== undefined) {
-    const { suppressModernRequestCancellation: _hostOverrides, ...rest } = next;
+  if (host.suppressRequestCancellation === true) {
+    next = { ...((next ?? {}) as T), suppressRequestCancellation: true };
+  } else if (next?.suppressRequestCancellation !== undefined) {
+    const { suppressRequestCancellation: _hostOverrides, ...rest } = next;
     next = rest as T;
   }
   return next;

--- a/mcpjam-inspector/server/utils/effective-auth.ts
+++ b/mcpjam-inspector/server/utils/effective-auth.ts
@@ -240,6 +240,26 @@ export function applyHostParamMirroring<
  * cancels normally on both eras. Absent leaves are the conforming answer, so a
  * fully cancelling host must contribute no field at all.
  */
+/**
+ * The host's tool-cancellation setting as a TURN carries it: only the degraded
+ * (`false`) leaves, or `undefined` when the profile is missing or conforming.
+ *
+ * Callers that resolved a host config should treat `undefined` as an EMPTY
+ * record (`?? {}`) so the turn's value stays authoritative over the
+ * connection's connect-time copy — that copy is exactly the stale value a
+ * mid-session save has to override.
+ */
+export function toolCallCancellationFromMcpProfile(
+  mcpProfile: unknown
+): { legacy?: boolean; modern?: boolean } | undefined {
+  if (!mcpProfile || typeof mcpProfile !== "object") return undefined;
+  const raw = (mcpProfile as { toolCallCancellation?: unknown })
+    .toolCallCancellation;
+  return raw && typeof raw === "object"
+    ? degradedCancellationLeaves(raw as { legacy?: unknown; modern?: unknown })
+    : undefined;
+}
+
 function degradedCancellationLeaves(
   raw: { legacy?: unknown; modern?: unknown } | undefined
 ): { legacy?: boolean; modern?: boolean } | undefined {

--- a/mcpjam-inspector/server/utils/effective-auth.ts
+++ b/mcpjam-inspector/server/utils/effective-auth.ts
@@ -24,7 +24,6 @@
  */
 
 import {
-  cancellationLeafForVersion,
   readXaaEnterprisePolicy,
   XAA_ENTERPRISE_POLICY_IDPS,
   XAA_MCP_EXTENSION,
@@ -236,12 +235,27 @@ export function applyHostParamMirroring<
  * Like the mirroring reader, this cannot fail closed into an error: an
  * unreadable value means "behave conformantly", which is always safe.
  */
+/**
+ * The degraded (`false`) cancellation leaves only, or `undefined` when the host
+ * cancels normally on both eras. Absent leaves are the conforming answer, so a
+ * fully cancelling host must contribute no field at all.
+ */
+function degradedCancellationLeaves(
+  raw: { legacy?: unknown; modern?: unknown } | undefined
+): { legacy?: boolean; modern?: boolean } | undefined {
+  if (!raw) return undefined;
+  const leaves: { legacy?: boolean; modern?: boolean } = {};
+  if (raw.legacy === false) leaves.legacy = false;
+  if (raw.modern === false) leaves.modern = false;
+  return Object.keys(leaves).length > 0 ? leaves : undefined;
+}
+
 export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
   firstPageOnly: true | undefined;
   supportsMrtr: false | undefined;
   suppressListenChannel: true | undefined;
   dropToolListChanged: true | undefined;
-  suppressRequestCancellation: true | undefined;
+  toolCallCancellation: { legacy?: boolean; modern?: boolean } | undefined;
 } {
   const profile =
     mcpProfile !== null && typeof mcpProfile === "object"
@@ -281,18 +295,9 @@ export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
       toolListChanged?.listens === false ? true : undefined,
     dropToolListChanged:
       toolListChanged?.refetches === false ? true : undefined,
-    // One flag: the host's own version pin says which era its connections
-    // speak, so the leaf is resolved here rather than at request time.
-    suppressRequestCancellation:
-      toolCallCancellation?.[
-        cancellationLeafForVersion(
-          typeof profile?.mcpProtocolVersion === "string"
-            ? profile.mcpProtocolVersion
-            : undefined
-        )
-      ] === false
-        ? true
-        : undefined,
+    // Forwarded, not resolved: the era is only known once the connection
+    // negotiates, so the SDK picks the leaf. Only degraded leaves travel.
+    toolCallCancellation: degradedCancellationLeaves(toolCallCancellation),
   };
 }
 
@@ -319,7 +324,7 @@ export function applyHostConformanceKnobs<
     supportsMrtr?: boolean;
     suppressListenChannel?: boolean;
     dropToolListChanged?: boolean;
-    suppressRequestCancellation?: boolean;
+    toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   }
 >(
   pins: T | undefined,
@@ -328,7 +333,7 @@ export function applyHostConformanceKnobs<
     supportsMrtr: false | undefined;
     suppressListenChannel: true | undefined;
     dropToolListChanged: true | undefined;
-    suppressRequestCancellation: true | undefined;
+    toolCallCancellation: { legacy?: boolean; modern?: boolean } | undefined;
   }
 ): T | undefined {
   let next = pins;
@@ -356,10 +361,13 @@ export function applyHostConformanceKnobs<
     const { dropToolListChanged: _hostOverrides, ...rest } = next;
     next = rest as T;
   }
-  if (host.suppressRequestCancellation === true) {
-    next = { ...((next ?? {}) as T), suppressRequestCancellation: true };
-  } else if (next?.suppressRequestCancellation !== undefined) {
-    const { suppressRequestCancellation: _hostOverrides, ...rest } = next;
+  if (host.toolCallCancellation !== undefined) {
+    next = {
+      ...((next ?? {}) as T),
+      toolCallCancellation: host.toolCallCancellation,
+    };
+  } else if (next?.toolCallCancellation !== undefined) {
+    const { toolCallCancellation: _hostOverrides, ...rest } = next;
     next = rest as T;
   }
   return next;

--- a/mcpjam-inspector/server/utils/effective-auth.ts
+++ b/mcpjam-inspector/server/utils/effective-auth.ts
@@ -240,6 +240,7 @@ export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
   supportsMrtr: false | undefined;
   suppressListenChannel: true | undefined;
   dropToolListChanged: true | undefined;
+  suppressRequestCancellation: true | undefined;
 } {
   const profile =
     mcpProfile !== null && typeof mcpProfile === "object"
@@ -247,6 +248,7 @@ export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
           paginationTraversal?: unknown;
           mrtrSupport?: unknown;
           toolListChanged?: unknown;
+          toolCallCancellation?: unknown;
         })
       : undefined;
   // Nested record, so it is narrowed separately; an unreadable value falls
@@ -267,6 +269,8 @@ export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
       toolListChanged?.listens === false ? true : undefined,
     dropToolListChanged:
       toolListChanged?.refetches === false ? true : undefined,
+    suppressRequestCancellation:
+      profile?.toolCallCancellation === false ? true : undefined,
   };
 }
 
@@ -293,6 +297,7 @@ export function applyHostConformanceKnobs<
     supportsMrtr?: boolean;
     suppressListenChannel?: boolean;
     dropToolListChanged?: boolean;
+    suppressRequestCancellation?: boolean;
   }
 >(
   pins: T | undefined,
@@ -301,6 +306,7 @@ export function applyHostConformanceKnobs<
     supportsMrtr: false | undefined;
     suppressListenChannel: true | undefined;
     dropToolListChanged: true | undefined;
+    suppressRequestCancellation: true | undefined;
   }
 ): T | undefined {
   let next = pins;
@@ -326,6 +332,12 @@ export function applyHostConformanceKnobs<
     next = { ...((next ?? {}) as T), dropToolListChanged: true };
   } else if (next?.dropToolListChanged !== undefined) {
     const { dropToolListChanged: _hostOverrides, ...rest } = next;
+    next = rest as T;
+  }
+  if (host.suppressRequestCancellation === true) {
+    next = { ...((next ?? {}) as T), suppressRequestCancellation: true };
+  } else if (next?.suppressRequestCancellation !== undefined) {
+    const { suppressRequestCancellation: _hostOverrides, ...rest } = next;
     next = rest as T;
   }
   return next;

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -478,8 +478,11 @@ export function parseConnectionDefaults(
   if (input.supportsMrtr === false) {
     out.supportsMrtr = false;
   }
-  if (input.suppressRequestCancellation === true) {
-    out.suppressRequestCancellation = true;
+  if (input.suppressLegacyRequestCancellation === true) {
+    out.suppressLegacyRequestCancellation = true;
+  }
+  if (input.suppressModernRequestCancellation === true) {
+    out.suppressModernRequestCancellation = true;
   }
 
   // Enterprise-managed authorization policy. UNLIKE every field above, this
@@ -622,7 +625,8 @@ export function toMCPServerConfig(
      */
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
-    suppressRequestCancellation?: boolean;
+    suppressLegacyRequestCancellation?: boolean;
+    suppressModernRequestCancellation?: boolean;
     /**
      * The host's enterprise-managed authorization policy (validated `on`
      * value). Present ⇒ the EMA extension is advertised on EVERY server of
@@ -698,8 +702,10 @@ export function toMCPServerConfig(
     // unlike the mirroring flag they are forwarded here as well as on HTTP.
     if (options?.firstPageOnly === true) stdio.firstPageOnly = true;
     if (options?.supportsMrtr === false) stdio.supportsMrtr = false;
-    if (options?.suppressRequestCancellation === true)
-      stdio.suppressRequestCancellation = true;
+    if (options?.suppressLegacyRequestCancellation === true)
+      stdio.suppressLegacyRequestCancellation = true;
+    if (options?.suppressModernRequestCancellation === true)
+      stdio.suppressModernRequestCancellation = true;
     return stdio as MCPServerConfig;
   }
 
@@ -779,8 +785,10 @@ export function toMCPServerConfig(
     http.mirrorToolParamHeaders = false;
   if (options?.firstPageOnly === true) http.firstPageOnly = true;
   if (options?.supportsMrtr === false) http.supportsMrtr = false;
-  if (options?.suppressRequestCancellation === true)
-    http.suppressRequestCancellation = true;
+  if (options?.suppressLegacyRequestCancellation === true)
+    http.suppressLegacyRequestCancellation = true;
+  if (options?.suppressModernRequestCancellation === true)
+    http.suppressModernRequestCancellation = true;
 
   // Attach the SDK's 401-recovery hook only when this is a hosted-OAuth
   // server (we have a token from `authorize-batch-local`) AND the caller
@@ -1076,6 +1084,8 @@ export async function resolveLocalStdioServerConfig(
     supportedProtocolVersions?: string[];
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
+    suppressLegacyRequestCancellation?: boolean;
+    suppressModernRequestCancellation?: boolean;
     xaaPolicy?: XaaEnterprisePolicy;
     /**
      * Secret-reveal scope + delegated identity, threaded from
@@ -1135,7 +1145,8 @@ export async function resolveLocalStdioServerConfig(
     supportedProtocolVersions: options?.supportedProtocolVersions,
     firstPageOnly: options?.firstPageOnly,
     supportsMrtr: options?.supportsMrtr,
-    suppressRequestCancellation: options?.suppressRequestCancellation,
+    suppressLegacyRequestCancellation: options?.suppressLegacyRequestCancellation,
+    suppressModernRequestCancellation: options?.suppressModernRequestCancellation,
     // Advertises the EMA extension host-wide on stdio too, matching the
     // /api/mcp path; stdio never gets OAuth/XAA hooks, so no
     // refreshContext / xaaUnauthorizedHandler here.
@@ -1418,7 +1429,10 @@ export async function resolveLocalServerForConnect(
     // Same path again for the sibling conformance knobs.
     firstPageOnly: options?.defaults?.firstPageOnly,
     supportsMrtr: options?.defaults?.supportsMrtr,
-    suppressRequestCancellation: options?.defaults?.suppressRequestCancellation,
+    suppressLegacyRequestCancellation:
+      options?.defaults?.suppressLegacyRequestCancellation,
+    suppressModernRequestCancellation:
+      options?.defaults?.suppressModernRequestCancellation,
     oauthAccessToken: resolvedOauthAccessToken,
     refreshContext: {
       bearerToken,

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -478,8 +478,15 @@ export function parseConnectionDefaults(
   if (input.supportsMrtr === false) {
     out.supportsMrtr = false;
   }
-  if (input.suppressRequestCancellation === true) {
-    out.suppressRequestCancellation = true;
+  if (input.toolCallCancellation && typeof input.toolCallCancellation === "object") {
+    const raw = input.toolCallCancellation as {
+      legacy?: unknown;
+      modern?: unknown;
+    };
+    const leaves: { legacy?: boolean; modern?: boolean } = {};
+    if (raw.legacy === false) leaves.legacy = false;
+    if (raw.modern === false) leaves.modern = false;
+    if (Object.keys(leaves).length > 0) out.toolCallCancellation = leaves;
   }
 
   // Enterprise-managed authorization policy. UNLIKE every field above, this
@@ -622,7 +629,7 @@ export function toMCPServerConfig(
      */
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
-    suppressRequestCancellation?: boolean;
+    toolCallCancellation?: { legacy?: boolean; modern?: boolean };
     /**
      * The host's enterprise-managed authorization policy (validated `on`
      * value). Present ⇒ the EMA extension is advertised on EVERY server of
@@ -698,8 +705,8 @@ export function toMCPServerConfig(
     // unlike the mirroring flag they are forwarded here as well as on HTTP.
     if (options?.firstPageOnly === true) stdio.firstPageOnly = true;
     if (options?.supportsMrtr === false) stdio.supportsMrtr = false;
-    if (options?.suppressRequestCancellation === true)
-      stdio.suppressRequestCancellation = true;
+    if (options?.toolCallCancellation)
+      stdio.toolCallCancellation = options.toolCallCancellation;
     return stdio as MCPServerConfig;
   }
 
@@ -779,8 +786,8 @@ export function toMCPServerConfig(
     http.mirrorToolParamHeaders = false;
   if (options?.firstPageOnly === true) http.firstPageOnly = true;
   if (options?.supportsMrtr === false) http.supportsMrtr = false;
-  if (options?.suppressRequestCancellation === true)
-    http.suppressRequestCancellation = true;
+  if (options?.toolCallCancellation)
+    http.toolCallCancellation = options.toolCallCancellation;
 
   // Attach the SDK's 401-recovery hook only when this is a hosted-OAuth
   // server (we have a token from `authorize-batch-local`) AND the caller
@@ -1076,7 +1083,7 @@ export async function resolveLocalStdioServerConfig(
     supportedProtocolVersions?: string[];
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
-    suppressRequestCancellation?: boolean;
+    toolCallCancellation?: { legacy?: boolean; modern?: boolean };
     xaaPolicy?: XaaEnterprisePolicy;
     /**
      * Secret-reveal scope + delegated identity, threaded from
@@ -1136,7 +1143,7 @@ export async function resolveLocalStdioServerConfig(
     supportedProtocolVersions: options?.supportedProtocolVersions,
     firstPageOnly: options?.firstPageOnly,
     supportsMrtr: options?.supportsMrtr,
-    suppressRequestCancellation: options?.suppressRequestCancellation,
+    toolCallCancellation: options?.toolCallCancellation,
     // Advertises the EMA extension host-wide on stdio too, matching the
     // /api/mcp path; stdio never gets OAuth/XAA hooks, so no
     // refreshContext / xaaUnauthorizedHandler here.
@@ -1419,7 +1426,7 @@ export async function resolveLocalServerForConnect(
     // Same path again for the sibling conformance knobs.
     firstPageOnly: options?.defaults?.firstPageOnly,
     supportsMrtr: options?.defaults?.supportsMrtr,
-    suppressRequestCancellation: options?.defaults?.suppressRequestCancellation,
+    toolCallCancellation: options?.defaults?.toolCallCancellation,
     oauthAccessToken: resolvedOauthAccessToken,
     refreshContext: {
       bearerToken,

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -478,6 +478,9 @@ export function parseConnectionDefaults(
   if (input.supportsMrtr === false) {
     out.supportsMrtr = false;
   }
+  if (input.suppressRequestCancellation === true) {
+    out.suppressRequestCancellation = true;
+  }
 
   // Enterprise-managed authorization policy. UNLIKE every field above, this
   // one is enforcement, not advisory: silently dropping a malformed value
@@ -619,6 +622,7 @@ export function toMCPServerConfig(
      */
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
+    suppressRequestCancellation?: boolean;
     /**
      * The host's enterprise-managed authorization policy (validated `on`
      * value). Present ⇒ the EMA extension is advertised on EVERY server of
@@ -694,6 +698,8 @@ export function toMCPServerConfig(
     // unlike the mirroring flag they are forwarded here as well as on HTTP.
     if (options?.firstPageOnly === true) stdio.firstPageOnly = true;
     if (options?.supportsMrtr === false) stdio.supportsMrtr = false;
+    if (options?.suppressRequestCancellation === true)
+      stdio.suppressRequestCancellation = true;
     return stdio as MCPServerConfig;
   }
 
@@ -773,6 +779,8 @@ export function toMCPServerConfig(
     http.mirrorToolParamHeaders = false;
   if (options?.firstPageOnly === true) http.firstPageOnly = true;
   if (options?.supportsMrtr === false) http.supportsMrtr = false;
+  if (options?.suppressRequestCancellation === true)
+    http.suppressRequestCancellation = true;
 
   // Attach the SDK's 401-recovery hook only when this is a hosted-OAuth
   // server (we have a token from `authorize-batch-local`) AND the caller
@@ -1127,6 +1135,7 @@ export async function resolveLocalStdioServerConfig(
     supportedProtocolVersions: options?.supportedProtocolVersions,
     firstPageOnly: options?.firstPageOnly,
     supportsMrtr: options?.supportsMrtr,
+    suppressRequestCancellation: options?.suppressRequestCancellation,
     // Advertises the EMA extension host-wide on stdio too, matching the
     // /api/mcp path; stdio never gets OAuth/XAA hooks, so no
     // refreshContext / xaaUnauthorizedHandler here.
@@ -1409,6 +1418,7 @@ export async function resolveLocalServerForConnect(
     // Same path again for the sibling conformance knobs.
     firstPageOnly: options?.defaults?.firstPageOnly,
     supportsMrtr: options?.defaults?.supportsMrtr,
+    suppressRequestCancellation: options?.defaults?.suppressRequestCancellation,
     oauthAccessToken: resolvedOauthAccessToken,
     refreshContext: {
       bearerToken,

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -478,11 +478,8 @@ export function parseConnectionDefaults(
   if (input.supportsMrtr === false) {
     out.supportsMrtr = false;
   }
-  if (input.suppressLegacyRequestCancellation === true) {
-    out.suppressLegacyRequestCancellation = true;
-  }
-  if (input.suppressModernRequestCancellation === true) {
-    out.suppressModernRequestCancellation = true;
+  if (input.suppressRequestCancellation === true) {
+    out.suppressRequestCancellation = true;
   }
 
   // Enterprise-managed authorization policy. UNLIKE every field above, this
@@ -625,8 +622,7 @@ export function toMCPServerConfig(
      */
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
-    suppressLegacyRequestCancellation?: boolean;
-    suppressModernRequestCancellation?: boolean;
+    suppressRequestCancellation?: boolean;
     /**
      * The host's enterprise-managed authorization policy (validated `on`
      * value). Present ⇒ the EMA extension is advertised on EVERY server of
@@ -702,10 +698,8 @@ export function toMCPServerConfig(
     // unlike the mirroring flag they are forwarded here as well as on HTTP.
     if (options?.firstPageOnly === true) stdio.firstPageOnly = true;
     if (options?.supportsMrtr === false) stdio.supportsMrtr = false;
-    if (options?.suppressLegacyRequestCancellation === true)
-      stdio.suppressLegacyRequestCancellation = true;
-    if (options?.suppressModernRequestCancellation === true)
-      stdio.suppressModernRequestCancellation = true;
+    if (options?.suppressRequestCancellation === true)
+      stdio.suppressRequestCancellation = true;
     return stdio as MCPServerConfig;
   }
 
@@ -785,10 +779,8 @@ export function toMCPServerConfig(
     http.mirrorToolParamHeaders = false;
   if (options?.firstPageOnly === true) http.firstPageOnly = true;
   if (options?.supportsMrtr === false) http.supportsMrtr = false;
-  if (options?.suppressLegacyRequestCancellation === true)
-    http.suppressLegacyRequestCancellation = true;
-  if (options?.suppressModernRequestCancellation === true)
-    http.suppressModernRequestCancellation = true;
+  if (options?.suppressRequestCancellation === true)
+    http.suppressRequestCancellation = true;
 
   // Attach the SDK's 401-recovery hook only when this is a hosted-OAuth
   // server (we have a token from `authorize-batch-local`) AND the caller
@@ -1084,8 +1076,7 @@ export async function resolveLocalStdioServerConfig(
     supportedProtocolVersions?: string[];
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
-    suppressLegacyRequestCancellation?: boolean;
-    suppressModernRequestCancellation?: boolean;
+    suppressRequestCancellation?: boolean;
     xaaPolicy?: XaaEnterprisePolicy;
     /**
      * Secret-reveal scope + delegated identity, threaded from
@@ -1145,8 +1136,7 @@ export async function resolveLocalStdioServerConfig(
     supportedProtocolVersions: options?.supportedProtocolVersions,
     firstPageOnly: options?.firstPageOnly,
     supportsMrtr: options?.supportsMrtr,
-    suppressLegacyRequestCancellation: options?.suppressLegacyRequestCancellation,
-    suppressModernRequestCancellation: options?.suppressModernRequestCancellation,
+    suppressRequestCancellation: options?.suppressRequestCancellation,
     // Advertises the EMA extension host-wide on stdio too, matching the
     // /api/mcp path; stdio never gets OAuth/XAA hooks, so no
     // refreshContext / xaaUnauthorizedHandler here.
@@ -1429,10 +1419,7 @@ export async function resolveLocalServerForConnect(
     // Same path again for the sibling conformance knobs.
     firstPageOnly: options?.defaults?.firstPageOnly,
     supportsMrtr: options?.defaults?.supportsMrtr,
-    suppressLegacyRequestCancellation:
-      options?.defaults?.suppressLegacyRequestCancellation,
-    suppressModernRequestCancellation:
-      options?.defaults?.suppressModernRequestCancellation,
+    suppressRequestCancellation: options?.defaults?.suppressRequestCancellation,
     oauthAccessToken: resolvedOauthAccessToken,
     refreshContext: {
       bearerToken,

--- a/mcpjam-inspector/server/utils/mcp-tool-options.ts
+++ b/mcpjam-inspector/server/utils/mcp-tool-options.ts
@@ -62,6 +62,15 @@ export interface McpToolOptionsInput {
   /** Resolved task seam, or absent for tasks-off. Never re-derived here: the
    *  surface owns its own row in the policy matrix (`task-seam.ts`). */
   tasks?: ToolTaskSeamOptions | undefined;
+  /**
+   * The host's tool-cancellation setting, resolved for THIS turn.
+   *
+   * Carried per turn rather than read off the connection: the connection's
+   * copy is captured when it connects, so a setting saved mid-session does
+   * not reach it until something reconnects — which reads as the toggle
+   * doing nothing.
+   */
+  toolCallCancellation?: { legacy?: boolean; modern?: boolean } | undefined;
 }
 
 /**
@@ -78,5 +87,8 @@ export function mcpToolOptionsFor(
     options.modelVisibleMcpToolResults = input.modelVisibleMcpToolResults;
   }
   if (input.tasks !== undefined) options.tasks = input.tasks;
+  if (input.toolCallCancellation !== undefined) {
+    options.toolCallCancellation = input.toolCallCancellation;
+  }
   return Object.keys(options).length > 0 ? options : undefined;
 }

--- a/mcpjam-inspector/server/utils/mcp-tool-options.ts
+++ b/mcpjam-inspector/server/utils/mcp-tool-options.ts
@@ -1,7 +1,7 @@
 /**
  * ONE builder for `getToolsForAiSdk`'s host-derived options.
  *
- * `MCPClientManager.getToolsForAiSdk(serverIds?, options = {})` takes four
+ * `MCPClientManager.getToolsForAiSdk(serverIds?, options = {})` takes five
  * host-derived inputs and, by its own docblock, refuses to resolve any of them
  * itself ("the mode is resolved by the CALLER — this class must not read host
  * configs"). Every execution surface therefore has to build the same object,
@@ -33,7 +33,12 @@
  *  - `includeAppOnly` when true (the caller resolves `respectToolVisibility
  *    === false` into it — an explicit opt-out of SEP-1865 filtering);
  *  - `modelVisibleMcpToolResults` when defined (a policy object, no default);
- *  - `tasks` when defined (absent === tasks off; see `task-seam.ts`).
+ *  - `tasks` when defined (absent === tasks off; see `task-seam.ts`);
+ *  - `toolCallCancellation` when defined — INCLUDING the empty record. Unlike
+ *    every field above it, absent and empty differ here: the manager reads
+ *    `override ?? config?.toolCallCancellation`, so absent falls through to the
+ *    connection's connect-time copy while `{}` overrides it with "no era is
+ *    suppressed". A caller that resolved a host config says so with `{}`.
  */
 import type { MCPClientManager, ToolTaskSeamOptions } from "@mcpjam/sdk";
 import type { ModelVisibleMcpToolResults } from "@mcpjam/sdk/host-config/internal";

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -273,6 +273,13 @@ export interface WebChatTurnPrepareInputs {
    */
   excludeMcpToolNames?: readonly string[];
   modelVisibleMcpToolResults?: ModelVisibleMcpToolResults;
+  /**
+   * The host's tool-cancellation setting, resolved for this turn from the
+   * server-side host config. Forwarded per turn because the connection's copy
+   * is captured at connect time; an empty record means "cancels normally" and
+   * must still be sent so it overrides the connection's stale value.
+   */
+  toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   customProviders?: CustomProviderConfig[];
   /** UI messages from the inbound request, converted to ModelMessages by helper. */
   uiMessages: UIMessage[] | unknown[];
@@ -582,6 +589,9 @@ export async function streamWebChatTurn(
         ? { excludeMcpToolNames: prepare.excludeMcpToolNames }
         : {}),
       modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
+      ...(prepare.toolCallCancellation !== undefined
+        ? { toolCallCancellation: prepare.toolCallCancellation }
+        : {}),
       customProviders: prepare.customProviders,
       priorMessages: modelMessages,
       ...(prepare.harness ? { harness: prepare.harness } : {}),

--- a/mcpjam-inspector/shared/connection-defaults.ts
+++ b/mcpjam-inspector/shared/connection-defaults.ts
@@ -96,13 +96,14 @@ export type ConnectionDefaults = {
   suppressListenChannel?: true;
   dropToolListChanged?: true;
   /**
-   * Resolved from `mcpProfile.toolCallCancellation`, picking the leaf for THIS
-   * connection's protocol version: the host ends a stopped tool call locally
-   * and never signals the server. Same only-the-non-default rule, and like the
-   * pagination/MRTR knobs it is not HTTP-only — withholding the caller's abort
-   * signal suppresses whichever mechanism the connection would have used.
+   * Per-era cancellation from `mcpProfile.toolCallCancellation`, carrying only
+   * the degraded (`false`) leaves. NOT reduced to one flag here: on an
+   * unpinned host the era is not known until the connection negotiates, so the
+   * SDK picks the leaf then. Like the pagination/MRTR knobs it is not
+   * HTTP-only — withholding the caller's abort signal suppresses whichever
+   * mechanism that era would have used.
    */
-  suppressRequestCancellation?: true;
+  toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   /**
    * The host's enterprise-managed authorization policy, resolved client-side
    * via `readXaaEnterprisePolicy(hostConfig.mcpProfile)`. Present only when

--- a/mcpjam-inspector/shared/connection-defaults.ts
+++ b/mcpjam-inspector/shared/connection-defaults.ts
@@ -96,14 +96,13 @@ export type ConnectionDefaults = {
   suppressListenChannel?: true;
   dropToolListChanged?: true;
   /**
-   * Resolved from `mcpProfile.toolCallCancellation.{legacy,modern} === false`:
-   * on that era's connections the host ends a stopped tool call locally and
-   * never signals the server. Same only-the-non-default rule, and like the
-   * pagination/MRTR knobs neither is HTTP-only — withholding the caller's
-   * abort signal suppresses whichever mechanism that era would have used.
+   * Resolved from `mcpProfile.toolCallCancellation`, picking the leaf for THIS
+   * connection's protocol version: the host ends a stopped tool call locally
+   * and never signals the server. Same only-the-non-default rule, and like the
+   * pagination/MRTR knobs it is not HTTP-only — withholding the caller's abort
+   * signal suppresses whichever mechanism the connection would have used.
    */
-  suppressLegacyRequestCancellation?: true;
-  suppressModernRequestCancellation?: true;
+  suppressRequestCancellation?: true;
   /**
    * The host's enterprise-managed authorization policy, resolved client-side
    * via `readXaaEnterprisePolicy(hostConfig.mcpProfile)`. Present only when

--- a/mcpjam-inspector/shared/connection-defaults.ts
+++ b/mcpjam-inspector/shared/connection-defaults.ts
@@ -96,6 +96,14 @@ export type ConnectionDefaults = {
   suppressListenChannel?: true;
   dropToolListChanged?: true;
   /**
+   * Resolved from `mcpProfile.toolCallCancellation === false`: the host ends
+   * a stopped tool call locally and never signals the server. Same
+   * only-the-non-default rule, and like the pagination/MRTR knobs it is not
+   * HTTP-only — withholding the caller's abort signal suppresses whichever
+   * cancellation mechanism the negotiated era would have used.
+   */
+  suppressRequestCancellation?: true;
+  /**
    * The host's enterprise-managed authorization policy, resolved client-side
    * via `readXaaEnterprisePolicy(hostConfig.mcpProfile)`. Present only when
    * the policy is validly ON — the client surfaces an `invalid` policy as a

--- a/mcpjam-inspector/shared/connection-defaults.ts
+++ b/mcpjam-inspector/shared/connection-defaults.ts
@@ -96,13 +96,14 @@ export type ConnectionDefaults = {
   suppressListenChannel?: true;
   dropToolListChanged?: true;
   /**
-   * Resolved from `mcpProfile.toolCallCancellation === false`: the host ends
-   * a stopped tool call locally and never signals the server. Same
-   * only-the-non-default rule, and like the pagination/MRTR knobs it is not
-   * HTTP-only — withholding the caller's abort signal suppresses whichever
-   * cancellation mechanism the negotiated era would have used.
+   * Resolved from `mcpProfile.toolCallCancellation.{legacy,modern} === false`:
+   * on that era's connections the host ends a stopped tool call locally and
+   * never signals the server. Same only-the-non-default rule, and like the
+   * pagination/MRTR knobs neither is HTTP-only — withholding the caller's
+   * abort signal suppresses whichever mechanism that era would have used.
    */
-  suppressRequestCancellation?: true;
+  suppressLegacyRequestCancellation?: true;
+  suppressModernRequestCancellation?: true;
   /**
    * The host's enterprise-managed authorization policy, resolved client-side
    * via `readXaaEnterprisePolicy(hostConfig.mcpProfile)`. Present only when

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -830,6 +830,7 @@ export type {
 } from "./sandbox-policy.js";
 // MCP protocol-version constants + predicates. Browser-safe by
 // construction (pure data + pure functions, no Node deps).
+export { cancellationLeafForVersion } from "./host-config/index.js";
 export {
   MCP_PROTOCOL_VERSIONS,
   isKnownProtocolVersion,

--- a/sdk/src/host-config/canonicalize.ts
+++ b/sdk/src/host-config/canonicalize.ts
@@ -755,18 +755,20 @@ function canonicalizeMcpProfile(
     out.toolParamHeaderMirroring = input.toolParamHeaderMirroring;
   }
 
-  // Boolean sibling of the enum knobs below: absent is the conforming answer
-  // (the client cancels), so only an explicit `false` is ever emitted, and a
-  // non-boolean is rejected rather than coerced — the backend validates the
-  // same field the same way, and a coerced value would hash differently on
-  // the two sides.
+  // Nested boolean record like `toolListChanged` below, one leaf per era: a
+  // host can cancel on 2025 and not on 2026. Absent per leaf is the conforming
+  // answer, so only an explicit `false` is emitted, and a malformed value is
+  // rejected rather than coerced — the backend validates this field the same
+  // way, and a coerced value would hash differently on the two sides.
   if (input.toolCallCancellation !== undefined) {
-    if (typeof input.toolCallCancellation !== "boolean") {
-      throw new Error(
-        "hostConfigV2: mcpProfile.toolCallCancellation must be a boolean"
-      );
+    const cancellation = canonicalBooleanCapabilityRecord(
+      "mcpProfile.toolCallCancellation",
+      input.toolCallCancellation,
+      ["legacy", "modern"]
+    );
+    if (Object.keys(cancellation).length > 0) {
+      out.toolCallCancellation = cancellation;
     }
-    out.toolCallCancellation = input.toolCallCancellation;
   }
 
   // Client-conformance knobs (siblings of toolParamHeaderMirroring). Same

--- a/sdk/src/host-config/canonicalize.ts
+++ b/sdk/src/host-config/canonicalize.ts
@@ -755,6 +755,20 @@ function canonicalizeMcpProfile(
     out.toolParamHeaderMirroring = input.toolParamHeaderMirroring;
   }
 
+  // Boolean sibling of the enum knobs below: absent is the conforming answer
+  // (the client cancels), so only an explicit `false` is ever emitted, and a
+  // non-boolean is rejected rather than coerced — the backend validates the
+  // same field the same way, and a coerced value would hash differently on
+  // the two sides.
+  if (input.toolCallCancellation !== undefined) {
+    if (typeof input.toolCallCancellation !== "boolean") {
+      throw new Error(
+        "hostConfigV2: mcpProfile.toolCallCancellation must be a boolean"
+      );
+    }
+    out.toolCallCancellation = input.toolCallCancellation;
+  }
+
   // Client-conformance knobs (siblings of toolParamHeaderMirroring). Same
   // omit-when-absent discipline: absent → spec-conforming, hashes stable.
   // One validation loop; the top-level re-key below sorts every emitted

--- a/sdk/src/host-config/host-connection.ts
+++ b/sdk/src/host-config/host-connection.ts
@@ -1,5 +1,4 @@
 import { extractHostExecutionPolicy } from "./host-policy.js";
-import { cancellationLeafForVersion } from "./types.js";
 
 /**
  * The MCP connection facts a host advertises — what to send in the `initialize`
@@ -44,15 +43,13 @@ export interface HostConnectionProfile {
    */
   supportsMrtr?: false;
   /**
-   * `true` = cancelling an in-flight request never reaches the server. The
-   * client abandons the call locally; the server runs the tool to completion.
-   *
-   * ONE flag, even though the host config measures two eras: this connection
-   * speaks exactly one, so the leaf is picked here — where the version is
-   * already resolved — and the client just obeys. Maps onto
-   * `MCPServerConfig.suppressRequestCancellation`.
+   * Per-era cancellation, forwarded verbatim rather than reduced to one flag:
+   * the era is only known after the connection negotiates, which on an
+   * unpinned host has not happened yet. Maps onto
+   * `MCPServerConfig.toolCallCancellation`, where the manager picks the leaf
+   * for the era actually negotiated.
    */
-  suppressRequestCancellation?: true;
+  toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   /**
    * `true` = the client never opens the server→client notification channel
    * (legacy: the standalone GET SSE stream; 2026-07-28:
@@ -131,19 +128,20 @@ export function hostConnectionProfile(
       : undefined;
   const supportsMrtr =
     mcpProfile?.mrtrSupport === "none" ? (false as const) : undefined;
-  // Nested record, but the same discipline as the enum knobs: only an explicit
-  // `false` leaf degrades, and an absent or malformed leaf stays conforming.
-  // The version pin resolves WHICH leaf governs this connection, so only one
-  // reaches the wire.
-  const toolCallCancellation =
+  // Nested record, same discipline as the enum knobs: only an explicit `false`
+  // leaf degrades, and an absent or malformed leaf stays conforming. Reduced
+  // to just the degraded leaves so an all-conforming host still emits nothing.
+  const rawCancellation =
     mcpProfile && isRecord(mcpProfile.toolCallCancellation)
       ? mcpProfile.toolCallCancellation
       : undefined;
-  const suppressRequestCancellation =
-    toolCallCancellation?.[cancellationLeafForVersion(mcpProtocolVersion)] ===
-    false
-      ? (true as const)
-      : undefined;
+  const toolCallCancellation = rawCancellation
+    ? Object.fromEntries(
+        (["legacy", "modern"] as const)
+          .filter((key) => rawCancellation[key] === false)
+          .map((key) => [key, false])
+      )
+    : undefined;
   // A nested record rather than an enum, but the same discipline: only an
   // explicit `false` leaf degrades, and absent stays absent. Narrowed like
   // `initialize` above — `mcpProfile` is an untyped record here.
@@ -174,7 +172,9 @@ export function hostConnectionProfile(
       : {}),
     ...(firstPageOnly ? { firstPageOnly } : {}),
     ...(supportsMrtr === false ? { supportsMrtr: false } : {}),
-    ...(suppressRequestCancellation ? { suppressRequestCancellation } : {}),
+    ...(toolCallCancellation && Object.keys(toolCallCancellation).length > 0
+      ? { toolCallCancellation }
+      : {}),
     ...(suppressListenChannel ? { suppressListenChannel } : {}),
     ...(dropToolListChanged ? { dropToolListChanged } : {}),
     respectToolVisibility,

--- a/sdk/src/host-config/host-connection.ts
+++ b/sdk/src/host-config/host-connection.ts
@@ -43,11 +43,18 @@ export interface HostConnectionProfile {
    */
   supportsMrtr?: false;
   /**
-   * `true` = cancelling an in-flight request never reaches the server. The
-   * client abandons the call locally; the server runs the tool to
-   * completion. Maps onto `MCPServerConfig.suppressRequestCancellation`.
+   * `true` = cancelling an in-flight request never reaches the server on that
+   * era's connections. The client abandons the call locally; the server runs
+   * the tool to completion.
+   *
+   * Two flat flags rather than a record, because that is how the sibling
+   * nested knob already reduces: `toolListChanged: {listens, refetches}` →
+   * `suppressListenChannel` + `dropToolListChanged`. Map onto the matching
+   * `MCPServerConfig` fields; a connection negotiates exactly one era, and the
+   * manager consults the flag for the era it actually landed on.
    */
-  suppressRequestCancellation?: true;
+  suppressLegacyRequestCancellation?: true;
+  suppressModernRequestCancellation?: true;
   /**
    * `true` = the client never opens the server→client notification channel
    * (legacy: the standalone GET SSE stream; 2026-07-28:
@@ -126,8 +133,16 @@ export function hostConnectionProfile(
       : undefined;
   const supportsMrtr =
     mcpProfile?.mrtrSupport === "none" ? (false as const) : undefined;
-  const suppressRequestCancellation =
-    mcpProfile?.toolCallCancellation === false ? (true as const) : undefined;
+  // Nested record, but the same discipline as the enum knobs: only an explicit
+  // `false` leaf degrades, and an absent or malformed leaf stays conforming.
+  const toolCallCancellation =
+    mcpProfile && isRecord(mcpProfile.toolCallCancellation)
+      ? mcpProfile.toolCallCancellation
+      : undefined;
+  const suppressLegacyRequestCancellation =
+    toolCallCancellation?.legacy === false ? (true as const) : undefined;
+  const suppressModernRequestCancellation =
+    toolCallCancellation?.modern === false ? (true as const) : undefined;
   // A nested record rather than an enum, but the same discipline: only an
   // explicit `false` leaf degrades, and absent stays absent. Narrowed like
   // `initialize` above — `mcpProfile` is an untyped record here.
@@ -158,7 +173,12 @@ export function hostConnectionProfile(
       : {}),
     ...(firstPageOnly ? { firstPageOnly } : {}),
     ...(supportsMrtr === false ? { supportsMrtr: false } : {}),
-    ...(suppressRequestCancellation ? { suppressRequestCancellation } : {}),
+    ...(suppressLegacyRequestCancellation
+      ? { suppressLegacyRequestCancellation }
+      : {}),
+    ...(suppressModernRequestCancellation
+      ? { suppressModernRequestCancellation }
+      : {}),
     ...(suppressListenChannel ? { suppressListenChannel } : {}),
     ...(dropToolListChanged ? { dropToolListChanged } : {}),
     respectToolVisibility,

--- a/sdk/src/host-config/host-connection.ts
+++ b/sdk/src/host-config/host-connection.ts
@@ -43,6 +43,12 @@ export interface HostConnectionProfile {
    */
   supportsMrtr?: false;
   /**
+   * `true` = cancelling an in-flight request never reaches the server. The
+   * client abandons the call locally; the server runs the tool to
+   * completion. Maps onto `MCPServerConfig.suppressRequestCancellation`.
+   */
+  suppressRequestCancellation?: true;
+  /**
    * `true` = the client never opens the server→client notification channel
    * (legacy: the standalone GET SSE stream; 2026-07-28:
    * `subscriptions/listen`). ChatGPT measures this way — prober saw it never
@@ -120,6 +126,8 @@ export function hostConnectionProfile(
       : undefined;
   const supportsMrtr =
     mcpProfile?.mrtrSupport === "none" ? (false as const) : undefined;
+  const suppressRequestCancellation =
+    mcpProfile?.toolCallCancellation === false ? (true as const) : undefined;
   // A nested record rather than an enum, but the same discipline: only an
   // explicit `false` leaf degrades, and absent stays absent. Narrowed like
   // `initialize` above — `mcpProfile` is an untyped record here.
@@ -150,6 +158,7 @@ export function hostConnectionProfile(
       : {}),
     ...(firstPageOnly ? { firstPageOnly } : {}),
     ...(supportsMrtr === false ? { supportsMrtr: false } : {}),
+    ...(suppressRequestCancellation ? { suppressRequestCancellation } : {}),
     ...(suppressListenChannel ? { suppressListenChannel } : {}),
     ...(dropToolListChanged ? { dropToolListChanged } : {}),
     respectToolVisibility,

--- a/sdk/src/host-config/host-connection.ts
+++ b/sdk/src/host-config/host-connection.ts
@@ -1,4 +1,5 @@
 import { extractHostExecutionPolicy } from "./host-policy.js";
+import { cancellationLeafForVersion } from "./types.js";
 
 /**
  * The MCP connection facts a host advertises — what to send in the `initialize`
@@ -43,18 +44,15 @@ export interface HostConnectionProfile {
    */
   supportsMrtr?: false;
   /**
-   * `true` = cancelling an in-flight request never reaches the server on that
-   * era's connections. The client abandons the call locally; the server runs
-   * the tool to completion.
+   * `true` = cancelling an in-flight request never reaches the server. The
+   * client abandons the call locally; the server runs the tool to completion.
    *
-   * Two flat flags rather than a record, because that is how the sibling
-   * nested knob already reduces: `toolListChanged: {listens, refetches}` →
-   * `suppressListenChannel` + `dropToolListChanged`. Map onto the matching
-   * `MCPServerConfig` fields; a connection negotiates exactly one era, and the
-   * manager consults the flag for the era it actually landed on.
+   * ONE flag, even though the host config measures two eras: this connection
+   * speaks exactly one, so the leaf is picked here — where the version is
+   * already resolved — and the client just obeys. Maps onto
+   * `MCPServerConfig.suppressRequestCancellation`.
    */
-  suppressLegacyRequestCancellation?: true;
-  suppressModernRequestCancellation?: true;
+  suppressRequestCancellation?: true;
   /**
    * `true` = the client never opens the server→client notification channel
    * (legacy: the standalone GET SSE stream; 2026-07-28:
@@ -135,14 +133,17 @@ export function hostConnectionProfile(
     mcpProfile?.mrtrSupport === "none" ? (false as const) : undefined;
   // Nested record, but the same discipline as the enum knobs: only an explicit
   // `false` leaf degrades, and an absent or malformed leaf stays conforming.
+  // The version pin resolves WHICH leaf governs this connection, so only one
+  // reaches the wire.
   const toolCallCancellation =
     mcpProfile && isRecord(mcpProfile.toolCallCancellation)
       ? mcpProfile.toolCallCancellation
       : undefined;
-  const suppressLegacyRequestCancellation =
-    toolCallCancellation?.legacy === false ? (true as const) : undefined;
-  const suppressModernRequestCancellation =
-    toolCallCancellation?.modern === false ? (true as const) : undefined;
+  const suppressRequestCancellation =
+    toolCallCancellation?.[cancellationLeafForVersion(mcpProtocolVersion)] ===
+    false
+      ? (true as const)
+      : undefined;
   // A nested record rather than an enum, but the same discipline: only an
   // explicit `false` leaf degrades, and absent stays absent. Narrowed like
   // `initialize` above — `mcpProfile` is an untyped record here.
@@ -173,12 +174,7 @@ export function hostConnectionProfile(
       : {}),
     ...(firstPageOnly ? { firstPageOnly } : {}),
     ...(supportsMrtr === false ? { supportsMrtr: false } : {}),
-    ...(suppressLegacyRequestCancellation
-      ? { suppressLegacyRequestCancellation }
-      : {}),
-    ...(suppressModernRequestCancellation
-      ? { suppressModernRequestCancellation }
-      : {}),
+    ...(suppressRequestCancellation ? { suppressRequestCancellation } : {}),
     ...(suppressListenChannel ? { suppressListenChannel } : {}),
     ...(dropToolListChanged ? { dropToolListChanged } : {}),
     respectToolVisibility,

--- a/sdk/src/host-config/index.ts
+++ b/sdk/src/host-config/index.ts
@@ -17,6 +17,7 @@
  * `@mcpjam/sdk/host-config/internal`; see `./types.ts`.
  */
 
+export { cancellationLeafForVersion } from "./types.js";
 export {
   Host,
   isHostJson,

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -252,6 +252,7 @@ export const MRTR_SUPPORT_MODES = [
 export const CONFORMANCE_PROFILE_KEYS = [
   "paginationTraversal",
   "mrtrSupport",
+  "toolCallCancellation",
 ] as const;
 
 export type CspDomainSet = {
@@ -289,14 +290,25 @@ export type HostConfigMcpProfileV1 = {
   // Whether cancelling an in-flight tool call reaches the server, or only ends
   // the turn locally while the server runs it to completion.
   //
-  // Boolean rather than an enum, and only an explicit `false` is ever written
-  // — absent is the conforming answer, like the `toolListChanged` leaves. One
-  // field for every era: the negotiated revision picks the MECHANISM (closing
-  // the response stream on 2026-07-28 Streamable HTTP, `notifications/cancelled`
-  // on all of 2025 and on stdio), never whether the host bothers. A host
-  // cannot be right on one era and wrong on the other by its own choice, so
-  // splitting this in two would model a state the spec does not allow.
-  toolCallCancellation?: boolean;
+  // Measured PER ERA, because a host really can be right on one and wrong on
+  // the other: MCPJam sent `notifications/cancelled` correctly on 2025 while
+  // never aborting the stream on 2026 (inspector#4474). Through the 2026
+  // migration that split is common, and one boolean cannot say it.
+  //
+  // A record of independently measured leaves, like `toolListChanged` — absent
+  // per leaf is the conforming answer, so a fully cancelling client writes
+  // nothing and only an explicit `false` is ever stored.
+  //
+  // The era selects the leaf, not the transport: a 2026 stdio connection is
+  // `modern` even though its mechanism is `notifications/cancelled`. What is
+  // modeled is whether the host cancels on that era's connections, not which
+  // message it sends.
+  toolCallCancellation?: {
+    /** Every 2025 revision. */
+    legacy?: boolean;
+    /** `2026-07-28`. */
+    modern?: boolean;
+  };
   // How the client handles `notifications/tools/list_changed` (probe-measured;
   // MCP spec "List Changed Notification" under server/tools, every revision
   // since 2024-11-05). Two independently-measured facts, not one flag:

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -22,7 +22,10 @@
  * Pure + browser-safe: no `convex/values`, no `ctx.db`, no Node-only APIs.
  */
 
-import type { McpProtocolVersion } from "../mcp-client-manager/mcp-protocol-version.js";
+import {
+  isStatelessProtocolVersion,
+  type McpProtocolVersion,
+} from "../mcp-client-manager/mcp-protocol-version.js";
 
 export type { McpProtocolVersion };
 
@@ -241,6 +244,25 @@ export const MRTR_SUPPORT_MODES = [
   "none",
 ] as const satisfies readonly MrtrSupport[];
 
+
+/**
+ * Which cancellation leaf a connection on `version` is governed by.
+ *
+ * The two leaves are measured per era, but a CONNECTION only ever speaks one,
+ * so the leaf is resolved once — where the version is already known — and the
+ * client is handed a single yes/no. It never has to ask the live connection
+ * what era it landed on.
+ *
+ * An unresolved version (`"auto"`, or absent) reads as `"modern"`: auto
+ * negotiates newest-first, so that is the era such a connection lands on
+ * against any server that supports it.
+ */
+export function cancellationLeafForVersion(
+  version: string | undefined,
+): "legacy" | "modern" {
+  if (version === undefined || version === "auto") return "modern";
+  return isStatelessProtocolVersion(version) ? "modern" : "legacy";
+}
 
 /**
  * The conformance-knob keys shared verbatim between the public `HostMcp`

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -241,6 +241,7 @@ export const MRTR_SUPPORT_MODES = [
   "none",
 ] as const satisfies readonly MrtrSupport[];
 
+
 /**
  * The conformance-knob keys shared verbatim between the public `HostMcp`
  * authoring shape and the internal `mcpProfile` (same names on both sides),
@@ -285,6 +286,17 @@ export type HostConfigMcpProfileV1 = {
   // Whether the client drives MRTR retry rounds at all. WHICH elicitation
   // modes it fulfills stays in `clientCapabilities.elicitation`.
   mrtrSupport?: MrtrSupport;
+  // Whether cancelling an in-flight tool call reaches the server, or only ends
+  // the turn locally while the server runs it to completion.
+  //
+  // Boolean rather than an enum, and only an explicit `false` is ever written
+  // — absent is the conforming answer, like the `toolListChanged` leaves. One
+  // field for every era: the negotiated revision picks the MECHANISM (closing
+  // the response stream on 2026-07-28 Streamable HTTP, `notifications/cancelled`
+  // on all of 2025 and on stdio), never whether the host bothers. A host
+  // cannot be right on one era and wrong on the other by its own choice, so
+  // splitting this in two would model a state the spec does not allow.
+  toolCallCancellation?: boolean;
   // How the client handles `notifications/tools/list_changed` (probe-measured;
   // MCP spec "List Changed Notification" under server/tools, every revision
   // since 2024-11-05). Two independently-measured facts, not one flag:

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -213,6 +213,7 @@ export type {
   ServerSkillsLogger,
   VerifiedServerSkill,
 } from "./server-skills.js";
+export { cancellationLeafForVersion } from "./host-config/index.js";
 export {
   MCP_PROTOCOL_VERSIONS,
   isKnownProtocolVersion,

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -306,6 +306,15 @@ type UpstreamToolDefinition = NonNullable<
   NonNullable<Parameters<ManagedMcpClient["callTool"]>[1]>["toolDefinition"]
 >;
 
+/**
+ * How long a request whose cancellation is suppressed may run.
+ *
+ * Far beyond any real tool call, because the simulated host never cancels and
+ * the only honest stopping point is the server's own response — but bounded,
+ * so a server that never replies cannot leak the entry forever.
+ */
+const SUPPRESSED_CANCELLATION_TIMEOUT_MS = 86_400_000;
+
 export class MCPClientManager {
   // State management
   private readonly registeredServers = new Map<string, RegisteredServerState>();
@@ -976,6 +985,15 @@ export class MCPClientManager {
       /** Host policy for model visibility of MCP tool-result content/resources. */
       modelVisibleMcpToolResults?: ModelVisibleMcpToolResults;
       /**
+       * Per-turn override of the host's tool-cancellation setting.
+       *
+       * The connection's own copy is read at CONNECT time, so a host config
+       * saved mid-session does not reach it until something reconnects. This
+       * carries the freshly-resolved value with the turn instead, which is the
+       * only source guaranteed to match what the user just saved.
+       */
+      toolCallCancellation?: { legacy?: boolean; modern?: boolean };
+      /**
        * Task policy for the tool calls this set produces. Omit (the default)
        * and every call takes the pre-existing path, byte-for-byte: no `_meta`,
        * no declaration, no extra request field. See `tool-task-seam.ts`.
@@ -1006,14 +1024,16 @@ export class MCPClientManager {
             readResource: async ({ uri, options: readOptions }) => {
               const { requestOptions, settle } = this.applyCancellationPolicy(
                 id,
-                readOptions?.abortSignal
+                readOptions?.abortSignal,
+                options.toolCallCancellation
               );
               return settle(this.readResource(id, { uri }, requestOptions));
             },
             callTool: async ({ name, args, options: callOptions }) => {
               const { requestOptions, settle } = this.applyCancellationPolicy(
                 id,
-                callOptions?.abortSignal
+                callOptions?.abortSignal,
+                options.toolCallCancellation
               );
               const toolArgs = (args ?? {}) as ExecuteToolArguments;
               if (!options.tasks) {
@@ -4162,9 +4182,15 @@ export class MCPClientManager {
    */
   private applyCancellationPolicy(
     serverId: string,
-    abortSignal: AbortSignal | undefined
+    abortSignal: AbortSignal | undefined,
+    /**
+     * Freshly-resolved value for this turn. Takes precedence over the
+     * connection's connect-time copy, which goes stale the moment the host
+     * config is saved without a reconnect.
+     */
+    override?: { legacy?: boolean; modern?: boolean }
   ): {
-    requestOptions: { signal: AbortSignal } | undefined;
+    requestOptions: { signal?: AbortSignal; timeout?: number } | undefined;
     settle: <T>(promise: Promise<T>) => Promise<T>;
   } {
     // Resolve the era from what the connection actually negotiated — the same
@@ -4180,9 +4206,10 @@ export class MCPClientManager {
     const negotiated: string | undefined =
       this.getNegotiatedProtocolVersion(serverId) ??
       (typeof configPin === "string" ? configPin : undefined);
-    const leaves = config?.toolCallCancellation;
+    const leaves = override ?? config?.toolCallCancellation;
     const suppressed =
       leaves?.[cancellationLeafForVersion(negotiated)] === false;
+
 
     if (abortSignal === undefined) {
       return { requestOptions: undefined, settle: (promise) => promise };
@@ -4194,7 +4221,19 @@ export class MCPClientManager {
       };
     }
     return {
-      requestOptions: undefined,
+      // The request must also outlive its own timeout. The protocol layer runs
+      // the SAME cancellation on a timeout as on an abort — closing the
+      // response stream on a modern connection — so leaving the default 60s
+      // timer in place means a host configured never to cancel still cancels,
+      // just a minute later. That is indistinguishable from the knob not
+      // working, and it is why this read as flaky rather than off.
+      //
+      // A host that never tells the server also never times out and tells it.
+      // The call runs to completion instead, which is the behavior being
+      // simulated: the server keeps working on a tool nobody awaits any more.
+      // Bounded rather than infinite so a server that never replies cannot
+      // leak the entry forever.
+      requestOptions: { timeout: SUPPRESSED_CANCELLATION_TIMEOUT_MS },
       settle: (promise) => this.awaitWithAbort(promise, abortSignal),
     };
   }

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -4140,7 +4140,8 @@ export class MCPClientManager {
   }
 
   /**
-   * Applies `suppressRequestCancellation` to one caller-supplied abort signal.
+   * Applies the era's cancellation-suppression flag to one caller-supplied
+   * abort signal.
    *
    * The signal is the ONLY thing that reaches the wire: the protocol layer
    * hangs both cancellation mechanisms off it — aborting the per-request
@@ -4166,9 +4167,21 @@ export class MCPClientManager {
     requestOptions: { signal: AbortSignal } | undefined;
     settle: <T>(promise: Promise<T>) => Promise<T>;
   } {
+    const config = this.registeredServers.get(serverId)?.config;
+    // The era this connection actually negotiated decides which flag applies;
+    // a host that cancels on 2025 but not on 2026 must behave differently on
+    // the two, which is the whole reason the knob has two leaves.
+    //
+    // Unknown era (not yet negotiated) is treated as conforming. By the time a
+    // tool call is in flight the era is always known, so this only guards the
+    // window before that — where suppressing would be a guess.
+    const era = this.getManagedClient(serverId)?.getProtocolEra?.();
     const suppressed =
-      this.registeredServers.get(serverId)?.config
-        .suppressRequestCancellation === true;
+      era === "modern"
+        ? config?.suppressModernRequestCancellation === true
+        : era === "legacy"
+          ? config?.suppressLegacyRequestCancellation === true
+          : false;
 
     if (abortSignal === undefined) {
       return { requestOptions: undefined, settle: (promise) => promise };

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -1030,11 +1030,12 @@ export class MCPClientManager {
               return settle(this.readResource(id, { uri }, requestOptions));
             },
             callTool: async ({ name, args, options: callOptions }) => {
-              const { requestOptions, settle } = this.applyCancellationPolicy(
-                id,
-                callOptions?.abortSignal,
-                options.toolCallCancellation
-              );
+              const { requestOptions, readRequestOptions, settle } =
+                this.applyCancellationPolicy(
+                  id,
+                  callOptions?.abortSignal,
+                  options.toolCallCancellation
+                );
               const toolArgs = (args ?? {}) as ExecuteToolArguments;
               if (!options.tasks) {
                 const result = await settle(
@@ -1065,7 +1066,7 @@ export class MCPClientManager {
                       }),
                     getTask: async (taskId) =>
                       extensionTaskToObservation(
-                        await this.getTaskExt(id, taskId, requestOptions)
+                        await this.getTaskExt(id, taskId, readRequestOptions)
                       ),
                     updateTask: async (taskId, inputResponses) => {
                       // The await driver is wire-neutral and types responses as
@@ -1076,7 +1077,7 @@ export class MCPClientManager {
                         id,
                         taskId,
                         inputResponses as TaskExtInputResponses,
-                        requestOptions
+                        readRequestOptions
                       );
                     },
                   },
@@ -4190,7 +4191,21 @@ export class MCPClientManager {
      */
     override?: { legacy?: boolean; modern?: boolean }
   ): {
+    /** For the leg that carries the TOOL CALL itself. */
     requestOptions: { signal?: AbortSignal; timeout?: number } | undefined;
+    /**
+     * For the seam's read legs (`tasks/get` polls, `tasks/update`).
+     *
+     * Separate from `requestOptions` because the suppression is about the tool
+     * call, not about every request made while awaiting it. Cancelling a
+     * `tasks/get` does not cancel the task, so a poll can keep the connection's
+     * ordinary timeout — and must, or a hung poll would sit on the suppressed
+     * call's day-long timer with nothing to end it: the await driver's own
+     * deadline abandons the in-flight promise rather than aborting its request.
+     */
+    readRequestOptions:
+      | { signal?: AbortSignal; timeout?: number }
+      | undefined;
     settle: <T>(promise: Promise<T>) => Promise<T>;
   } {
     // Resolve the era from what the connection actually negotiated — the same
@@ -4212,11 +4227,17 @@ export class MCPClientManager {
 
 
     if (abortSignal === undefined) {
-      return { requestOptions: undefined, settle: (promise) => promise };
+      return {
+        requestOptions: undefined,
+        readRequestOptions: undefined,
+        settle: (promise) => promise,
+      };
     }
     if (!suppressed) {
+      const passThrough = { signal: abortSignal };
       return {
-        requestOptions: { signal: abortSignal },
+        requestOptions: passThrough,
+        readRequestOptions: passThrough,
         settle: (promise) => promise,
       };
     }
@@ -4234,6 +4255,10 @@ export class MCPClientManager {
       // Bounded rather than infinite so a server that never replies cannot
       // leak the entry forever.
       requestOptions: { timeout: SUPPRESSED_CANCELLATION_TIMEOUT_MS },
+      // Reads keep the connection's own timeout (`withTimeout` fills it in for
+      // an absent one) and, like the call, are given no signal — the silence
+      // being simulated is silence about the tool call, and the poll is not it.
+      readRequestOptions: undefined,
       settle: (promise) => this.awaitWithAbort(promise, abortSignal),
     };
   }

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -1003,58 +1003,64 @@ export class MCPClientManager {
             includeAppOnly: options.includeAppOnly,
             modelVisibleMcpToolResults: options.modelVisibleMcpToolResults,
             readResource: async ({ uri, options: readOptions }) => {
-              const requestOptions = readOptions?.abortSignal
-                ? { signal: readOptions.abortSignal }
-                : undefined;
-              return this.readResource(id, { uri }, requestOptions);
+              const { requestOptions, settle } = this.applyCancellationPolicy(
+                id,
+                readOptions?.abortSignal
+              );
+              return settle(this.readResource(id, { uri }, requestOptions));
             },
             callTool: async ({ name, args, options: callOptions }) => {
-              const requestOptions = callOptions?.abortSignal
-                ? { signal: callOptions.abortSignal }
-                : undefined;
+              const { requestOptions, settle } = this.applyCancellationPolicy(
+                id,
+                callOptions?.abortSignal
+              );
               const toolArgs = (args ?? {}) as ExecuteToolArguments;
               if (!options.tasks) {
-                const result = await this.executeTool(
-                  id,
-                  name,
-                  toolArgs,
-                  requestOptions
+                const result = await settle(
+                  this.executeTool(id, name, toolArgs, requestOptions)
                 );
                 return assertCallToolResult(result, `Tool "${name}" result`);
               }
               // `id` is captured per server, so the wire is resolved per call:
               // a mixed tool set does the right thing for each server without
               // any caller knowing mixed sets exist.
-              return runToolTaskSeam(
-                {
-                  serverId: id,
-                  toolName: name,
-                  wire: this.getTasksSupport(id).wire,
-                  callPlain: () =>
-                    this.executeTool(id, name, toolArgs, requestOptions),
-                  callEligible: () =>
-                    this.executeTool(id, name, toolArgs, {
-                      ...(requestOptions ? { request: requestOptions } : {}),
-                      allowTaskResult: true,
-                    }),
-                  getTask: async (taskId) =>
-                    extensionTaskToObservation(
-                      await this.getTaskExt(id, taskId, requestOptions)
-                    ),
-                  updateTask: async (taskId, inputResponses) => {
-                    // The await driver is wire-neutral and types responses as
-                    // plain JSON; on this branch the wire is known to be the
-                    // extension, whose `InputResponses` is the narrower shape
-                    // `collectTaskInputResponses` already validated against.
-                    await this.updateTask(
-                      id,
-                      taskId,
-                      inputResponses as TaskExtInputResponses,
-                      requestOptions
-                    );
+              //
+              // The whole seam is settled, not just its first leg: a task-wire
+              // call polls across several requests, and a host that cancels
+              // nothing must abandon the polling loop locally rather than
+              // cancel any one leg on the wire.
+              return settle(
+                runToolTaskSeam(
+                  {
+                    serverId: id,
+                    toolName: name,
+                    wire: this.getTasksSupport(id).wire,
+                    callPlain: () =>
+                      this.executeTool(id, name, toolArgs, requestOptions),
+                    callEligible: () =>
+                      this.executeTool(id, name, toolArgs, {
+                        ...(requestOptions ? { request: requestOptions } : {}),
+                        allowTaskResult: true,
+                      }),
+                    getTask: async (taskId) =>
+                      extensionTaskToObservation(
+                        await this.getTaskExt(id, taskId, requestOptions)
+                      ),
+                    updateTask: async (taskId, inputResponses) => {
+                      // The await driver is wire-neutral and types responses as
+                      // plain JSON; on this branch the wire is known to be the
+                      // extension, whose `InputResponses` is the narrower shape
+                      // `collectTaskInputResponses` already validated against.
+                      await this.updateTask(
+                        id,
+                        taskId,
+                        inputResponses as TaskExtInputResponses,
+                        requestOptions
+                      );
+                    },
                   },
-                },
-                options.tasks
+                  options.tasks
+                )
               );
             },
           });
@@ -4131,6 +4137,52 @@ export class MCPClientManager {
       return undefined;
     }
     return this.mrtrInputCollectors.get(serverId);
+  }
+
+  /**
+   * Applies `suppressRequestCancellation` to one caller-supplied abort signal.
+   *
+   * The signal is the ONLY thing that reaches the wire: the protocol layer
+   * hangs both cancellation mechanisms off it — aborting the per-request
+   * response stream on `2026-07-28` Streamable HTTP, POSTing
+   * `notifications/cancelled` on every other era and on stdio. So a host that
+   * cancels nothing is modeled by withholding the signal from the request and
+   * racing the caller against it locally instead.
+   *
+   * That split is the whole point. Dropping the signal outright would leave a
+   * cancelled turn hanging until the tool finished; passing it through would
+   * cancel on the wire. `awaitWithAbort` gives the caller its prompt rejection
+   * while the server hears nothing — which is exactly what these hosts do.
+   *
+   * Deliberately NOT implemented by hiding the transport's
+   * `hasPerRequestStream`: that would make a modern connection fall back to
+   * POSTing `notifications/cancelled`, a message no conforming client sends on
+   * `2026-07-28`. The simulated host must be silent, not wrong.
+   */
+  private applyCancellationPolicy(
+    serverId: string,
+    abortSignal: AbortSignal | undefined
+  ): {
+    requestOptions: { signal: AbortSignal } | undefined;
+    settle: <T>(promise: Promise<T>) => Promise<T>;
+  } {
+    const suppressed =
+      this.registeredServers.get(serverId)?.config
+        .suppressRequestCancellation === true;
+
+    if (abortSignal === undefined) {
+      return { requestOptions: undefined, settle: (promise) => promise };
+    }
+    if (!suppressed) {
+      return {
+        requestOptions: { signal: abortSignal },
+        settle: (promise) => promise,
+      };
+    }
+    return {
+      requestOptions: undefined,
+      settle: (promise) => this.awaitWithAbort(promise, abortSignal),
+    };
   }
 
   /**

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -4140,8 +4140,7 @@ export class MCPClientManager {
   }
 
   /**
-   * Applies the era's cancellation-suppression flag to one caller-supplied
-   * abort signal.
+   * Applies `suppressRequestCancellation` to one caller-supplied abort signal.
    *
    * The signal is the ONLY thing that reaches the wire: the protocol layer
    * hangs both cancellation mechanisms off it — aborting the per-request
@@ -4167,21 +4166,14 @@ export class MCPClientManager {
     requestOptions: { signal: AbortSignal } | undefined;
     settle: <T>(promise: Promise<T>) => Promise<T>;
   } {
-    const config = this.registeredServers.get(serverId)?.config;
-    // The era this connection actually negotiated decides which flag applies;
-    // a host that cancels on 2025 but not on 2026 must behave differently on
-    // the two, which is the whole reason the knob has two leaves.
-    //
-    // Unknown era (not yet negotiated) is treated as conforming. By the time a
-    // tool call is in flight the era is always known, so this only guards the
-    // window before that — where suppressing would be a guess.
-    const era = this.getManagedClient(serverId)?.getProtocolEra?.();
+    // One flag, already resolved for this connection's era by whoever built
+    // the config. Deliberately NOT re-derived from the live client here:
+    // `getProtocolEra()` is optional on the managed-client interface, so on
+    // the adapters that do not implement it the era reads as unknown and the
+    // suppression would silently never apply.
     const suppressed =
-      era === "modern"
-        ? config?.suppressModernRequestCancellation === true
-        : era === "legacy"
-          ? config?.suppressLegacyRequestCancellation === true
-          : false;
+      this.registeredServers.get(serverId)?.config
+        .suppressRequestCancellation === true;
 
     if (abortSignal === undefined) {
       return { requestOptions: undefined, settle: (promise) => promise };

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -186,6 +186,7 @@ import {
   type XMcpHeaderDeclaration,
 } from "./mcp-header-mirror.js";
 import type { ModelVisibleMcpToolResults } from "../host-config/types.js";
+import { cancellationLeafForVersion } from "../host-config/types.js";
 import {
   applyRuntimeClientCapabilities,
   getDefaultClientCapabilities,
@@ -4166,14 +4167,22 @@ export class MCPClientManager {
     requestOptions: { signal: AbortSignal } | undefined;
     settle: <T>(promise: Promise<T>) => Promise<T>;
   } {
-    // One flag, already resolved for this connection's era by whoever built
-    // the config. Deliberately NOT re-derived from the live client here:
-    // `getProtocolEra()` is optional on the managed-client interface, so on
-    // the adapters that do not implement it the era reads as unknown and the
-    // suppression would silently never apply.
+    // Resolve the era from what the connection actually negotiated — the same
+    // value the UI reports — falling back to the configured pin before the
+    // handshake has landed. Config-time resolution cannot work for an
+    // unpinned (`"auto"`) host: the era does not exist yet, and guessing one
+    // makes the other era's toggle unreachable.
+    const config = this.registeredServers.get(serverId)?.config;
+    const configPin =
+      config && "mcpProtocolVersion" in config
+        ? config.mcpProtocolVersion
+        : undefined;
+    const negotiated: string | undefined =
+      this.getNegotiatedProtocolVersion(serverId) ??
+      (typeof configPin === "string" ? configPin : undefined);
+    const leaves = config?.toolCallCancellation;
     const suppressed =
-      this.registeredServers.get(serverId)?.config
-        .suppressRequestCancellation === true;
+      leaves?.[cancellationLeafForVersion(negotiated)] === false;
 
     if (abortSignal === undefined) {
       return { requestOptions: undefined, settle: (promise) => promise };

--- a/sdk/src/mcp-client-manager/transport-utils.ts
+++ b/sdk/src/mcp-client-manager/transport-utils.ts
@@ -180,6 +180,20 @@ export function wrapTransportForLogging(
       return (this.inner as any).sessionId;
     }
 
+    /**
+     * Forwarded, not defaulted. The protocol layer reads this to pick the
+     * era-correct cancellation signal: on 2026-07-28 a transport that owns a
+     * per-request stream is cancelled by ABORTING that stream, and only a
+     * transport without one falls back to POSTing `notifications/cancelled`.
+     * A wrapper that swallows the flag silently downgrades every modern
+     * connection to the legacy signal — which the 2026 spec says a server
+     * neither requires nor expects, and which never reaches the in-flight
+     * request on stateless HTTP.
+     */
+    get hasPerRequestStream(): boolean | undefined {
+      return (this.inner as any).hasPerRequestStream;
+    }
+
     setProtocolVersion?(version: string): void {
       if (typeof this.inner.setProtocolVersion === "function") {
         this.inner.setProtocolVersion(version);
@@ -397,6 +411,20 @@ export function wrapTransportForDroppedListChanged(
       return (this.inner as any).sessionId;
     }
 
+    /**
+     * Forwarded, not defaulted. The protocol layer reads this to pick the
+     * era-correct cancellation signal: on 2026-07-28 a transport that owns a
+     * per-request stream is cancelled by ABORTING that stream, and only a
+     * transport without one falls back to POSTing `notifications/cancelled`.
+     * A wrapper that swallows the flag silently downgrades every modern
+     * connection to the legacy signal — which the 2026 spec says a server
+     * neither requires nor expects, and which never reaches the in-flight
+     * request on stateless HTTP.
+     */
+    get hasPerRequestStream(): boolean | undefined {
+      return (this.inner as any).hasPerRequestStream;
+    }
+
     setProtocolVersion?(version: string): void {
       if (typeof this.inner.setProtocolVersion === "function") {
         this.inner.setProtocolVersion(version);
@@ -490,6 +518,20 @@ export function wrapTransportForTaskResults(transport: Transport): Transport {
 
     get sessionId(): string | undefined {
       return (this.inner as any).sessionId;
+    }
+
+    /**
+     * Forwarded, not defaulted. The protocol layer reads this to pick the
+     * era-correct cancellation signal: on 2026-07-28 a transport that owns a
+     * per-request stream is cancelled by ABORTING that stream, and only a
+     * transport without one falls back to POSTing `notifications/cancelled`.
+     * A wrapper that swallows the flag silently downgrades every modern
+     * connection to the legacy signal — which the 2026 spec says a server
+     * neither requires nor expects, and which never reaches the in-flight
+     * request on stateless HTTP.
+     */
+    get hasPerRequestStream(): boolean | undefined {
+      return (this.inner as any).hasPerRequestStream;
     }
 
     setProtocolVersion?(version: string): void {
@@ -675,6 +717,20 @@ export function wrapTransportForFirstPageOnly(transport: Transport): Transport {
 
     get sessionId(): string | undefined {
       return (this.inner as any).sessionId;
+    }
+
+    /**
+     * Forwarded, not defaulted. The protocol layer reads this to pick the
+     * era-correct cancellation signal: on 2026-07-28 a transport that owns a
+     * per-request stream is cancelled by ABORTING that stream, and only a
+     * transport without one falls back to POSTing `notifications/cancelled`.
+     * A wrapper that swallows the flag silently downgrades every modern
+     * connection to the legacy signal — which the 2026 spec says a server
+     * neither requires nor expects, and which never reaches the in-flight
+     * request on stateless HTTP.
+     */
+    get hasPerRequestStream(): boolean | undefined {
+      return (this.inner as any).hasPerRequestStream;
     }
 
     setProtocolVersion?(version: string): void {

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -350,7 +350,8 @@ export type BaseServerConfig = {
    */
   supportsMrtr?: boolean;
   /**
-   * Whether cancelling an in-flight request reaches the server.
+   * Whether cancelling an in-flight request reaches the server, per negotiated
+   * era.
    *
    * `undefined` (the default) and `false` both signal it. `true` simulates a
    * host that ends the turn locally and tells the server nothing: the caller's
@@ -358,18 +359,22 @@ export type BaseServerConfig = {
    * completion — side effects, cost and all — because it never learns the user
    * pressed stop.
    *
-   * Applies on every era and every transport, because the caller's signal is
-   * the single input to both mechanisms: on `2026-07-28` Streamable HTTP the
-   * protocol layer aborts that request's response stream, and everywhere else
-   * (all of 2025, and stdio on any revision) it POSTs
-   * `notifications/cancelled`. Withholding the signal withholds whichever one
-   * the negotiated revision would have used, which is exactly the host
-   * behavior being modeled.
+   * Split by era because hosts really are split: MCPJam cancelled correctly on
+   * 2025 while never aborting the stream on 2026. A connection negotiates
+   * exactly one era, so the manager reads the flag for the era it landed on
+   * and ignores the other.
+   *
+   * The era selects the flag, not the transport. A 2026 stdio connection reads
+   * `suppressModernRequestCancellation` even though its mechanism is
+   * `notifications/cancelled` — withholding the caller's signal withholds
+   * whichever mechanism that era would have used, because the signal is the
+   * single input to both.
    *
    * Wired into the inspector via
-   * `hostConfig.mcpProfile.toolCallCancellation === false`.
+   * `hostConfig.mcpProfile.toolCallCancellation.{legacy,modern} === false`.
    */
-  suppressRequestCancellation?: boolean;
+  suppressLegacyRequestCancellation?: boolean;
+  suppressModernRequestCancellation?: boolean;
   /** Error handler for this server */
   onError?: (error: unknown) => void;
   /** Enable simple console logging of JSON-RPC traffic */

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -349,6 +349,27 @@ export type BaseServerConfig = {
    * separate, already-modeled fact (`clientCapabilities.elicitation`).
    */
   supportsMrtr?: boolean;
+  /**
+   * Whether cancelling an in-flight request reaches the server.
+   *
+   * `undefined` (the default) and `false` both signal it. `true` simulates a
+   * host that ends the turn locally and tells the server nothing: the caller's
+   * promise still rejects promptly, but the server keeps running the tool to
+   * completion — side effects, cost and all — because it never learns the user
+   * pressed stop.
+   *
+   * Applies on every era and every transport, because the caller's signal is
+   * the single input to both mechanisms: on `2026-07-28` Streamable HTTP the
+   * protocol layer aborts that request's response stream, and everywhere else
+   * (all of 2025, and stdio on any revision) it POSTs
+   * `notifications/cancelled`. Withholding the signal withholds whichever one
+   * the negotiated revision would have used, which is exactly the host
+   * behavior being modeled.
+   *
+   * Wired into the inspector via
+   * `hostConfig.mcpProfile.toolCallCancellation === false`.
+   */
+  suppressRequestCancellation?: boolean;
   /** Error handler for this server */
   onError?: (error: unknown) => void;
   /** Enable simple console logging of JSON-RPC traffic */

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -350,29 +350,30 @@ export type BaseServerConfig = {
    */
   supportsMrtr?: boolean;
   /**
-   * Whether cancelling an in-flight request reaches the server.
+   * Whether cancelling an in-flight request reaches the server, per era.
    *
-   * `undefined` (the default) and `false` both signal it. `true` simulates a
-   * host that ends the turn locally and tells the server nothing: the caller's
+   * Absent per leaf (and `true`) both signal normally. `false` simulates a host
+   * that ends the turn locally and tells the server nothing: the caller's
    * promise still rejects promptly, but the server keeps running the tool to
    * completion — side effects, cost and all — because it never learns the user
    * pressed stop.
    *
-   * ONE flag, though the host config measures cancellation per era: a
-   * connection speaks exactly one era, so the leaf is resolved upstream (see
-   * `cancellationLeafForVersion`) where the version pin is already known. This
-   * layer never asks the live connection what it negotiated — that answer is
-   * not always available, and a missing one would silently read as "cancels".
+   * Both leaves are carried rather than pre-reduced to one flag, because the
+   * era is only known once the connection has negotiated. On an unpinned
+   * (`"auto"`) host that answer does not exist at config-build time, and
+   * guessing there made one era's toggle unreachable. The manager reads
+   * {@link MCPClientManager.getNegotiatedProtocolVersion} — the same value the
+   * UI shows — and picks the leaf for the era the connection actually landed
+   * on.
    *
-   * Withholding the caller's signal withholds whichever mechanism the
-   * connection would have used, because the signal is the single input to
-   * both: closing the response stream on 2026-07-28 Streamable HTTP, POSTing
+   * Withholding the caller's signal withholds whichever mechanism that era
+   * would have used, because the signal is the single input to both: closing
+   * the response stream on 2026-07-28 Streamable HTTP, POSTing
    * `notifications/cancelled` everywhere else.
    *
-   * Wired into the inspector via
-   * `hostConfig.mcpProfile.toolCallCancellation.{legacy,modern} === false`.
+   * Wired into the inspector via `hostConfig.mcpProfile.toolCallCancellation`.
    */
-  suppressRequestCancellation?: boolean;
+  toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   /** Error handler for this server */
   onError?: (error: unknown) => void;
   /** Enable simple console logging of JSON-RPC traffic */

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -350,8 +350,7 @@ export type BaseServerConfig = {
    */
   supportsMrtr?: boolean;
   /**
-   * Whether cancelling an in-flight request reaches the server, per negotiated
-   * era.
+   * Whether cancelling an in-flight request reaches the server.
    *
    * `undefined` (the default) and `false` both signal it. `true` simulates a
    * host that ends the turn locally and tells the server nothing: the caller's
@@ -359,22 +358,21 @@ export type BaseServerConfig = {
    * completion — side effects, cost and all — because it never learns the user
    * pressed stop.
    *
-   * Split by era because hosts really are split: MCPJam cancelled correctly on
-   * 2025 while never aborting the stream on 2026. A connection negotiates
-   * exactly one era, so the manager reads the flag for the era it landed on
-   * and ignores the other.
+   * ONE flag, though the host config measures cancellation per era: a
+   * connection speaks exactly one era, so the leaf is resolved upstream (see
+   * `cancellationLeafForVersion`) where the version pin is already known. This
+   * layer never asks the live connection what it negotiated — that answer is
+   * not always available, and a missing one would silently read as "cancels".
    *
-   * The era selects the flag, not the transport. A 2026 stdio connection reads
-   * `suppressModernRequestCancellation` even though its mechanism is
-   * `notifications/cancelled` — withholding the caller's signal withholds
-   * whichever mechanism that era would have used, because the signal is the
-   * single input to both.
+   * Withholding the caller's signal withholds whichever mechanism the
+   * connection would have used, because the signal is the single input to
+   * both: closing the response stream on 2026-07-28 Streamable HTTP, POSTing
+   * `notifications/cancelled` everywhere else.
    *
    * Wired into the inspector via
    * `hostConfig.mcpProfile.toolCallCancellation.{legacy,modern} === false`.
    */
-  suppressLegacyRequestCancellation?: boolean;
-  suppressModernRequestCancellation?: boolean;
+  suppressRequestCancellation?: boolean;
   /** Error handler for this server */
   onError?: (error: unknown) => void;
   /** Enable simple console logging of JSON-RPC traffic */

--- a/sdk/src/widget-runtime/logging-transport.ts
+++ b/sdk/src/widget-runtime/logging-transport.ts
@@ -37,6 +37,16 @@ export class LoggingTransport implements Transport {
     this.inner.sessionId = value;
   }
 
+  /**
+   * Forwarded so the protocol layer can still see that the wrapped transport
+   * owns a per-request stream — the 2026-07-28 cancellation signal is aborting
+   * that stream, not POSTing `notifications/cancelled`.
+   */
+  get hasPerRequestStream(): boolean | undefined {
+    return (this.inner as unknown as { hasPerRequestStream?: boolean })
+      .hasPerRequestStream;
+  }
+
   async start() {
     this.inner.onmessage = (message, extra) => {
       this.onReceive?.(message);

--- a/sdk/tests/cancellation-sequence.integration.test.ts
+++ b/sdk/tests/cancellation-sequence.integration.test.ts
@@ -3,6 +3,18 @@ import { MCPClientManager } from "../src/mcp-client-manager/index.js";
 import { serveMultiPageFixtureOnPort, type ServedMultiPageFixture } from "./support/multi-page-fixture.js";
 import { getWireField } from "./support/raw-capture.js";
 
+/**
+ * READING THESE ASSERTIONS: an absent `tools/call` means the call is still
+ * RUNNING, not that it was never dispatched.
+ *
+ * `served.exchanges` records COMPLETED request/response pairs, and `slow-tool`
+ * is held open — so a suppressed call, which the server keeps working on,
+ * never lands there, while a cancelled one does: the abort (or the timeout)
+ * closes the stream, the exchange terminates, and only then is it logged.
+ * Dispatch is proven separately by `waitForToolCall`, which every case awaits
+ * before asserting anything.
+ */
+
 describe("on -> off -> on, one manager, reconnect between saves", () => {
   const fixtures: ServedMultiPageFixture[] = [];
   let manager: MCPClientManager | undefined;

--- a/sdk/tests/cancellation-sequence.integration.test.ts
+++ b/sdk/tests/cancellation-sequence.integration.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { MCPClientManager } from "../src/mcp-client-manager/index.js";
+import { serveMultiPageFixtureOnPort, type ServedMultiPageFixture } from "./support/multi-page-fixture.js";
+import { getWireField } from "./support/raw-capture.js";
+
+describe("on -> off -> on, one manager, reconnect between saves", () => {
+  const fixtures: ServedMultiPageFixture[] = [];
+  let manager: MCPClientManager | undefined;
+  afterEach(async () => {
+    await manager?.disconnectAllServers().catch(() => {});
+    for (const f of fixtures) await f.close();
+  });
+
+  async function fresh() {
+    const f = await serveMultiPageFixtureOnPort({ listSlowTool: true });
+    fixtures.push(f);
+    return f;
+  }
+
+  async function turn(served: ServedMultiPageFixture, override: { legacy?: boolean; modern?: boolean }, callId: string) {
+    const tools = await manager!.getToolsForAiSdk("fixture", { toolCallCancellation: override });
+    const controller = new AbortController();
+    const before = served.exchanges.length;
+    const p = tools["slow-tool"]!.execute!({ delayMs: 60_000 }, { toolCallId: callId, messages: [], abortSignal: controller.signal });
+    await served.waitForToolCall("slow-tool");
+    controller.abort();
+    const outcome = await Promise.resolve(p).then(() => "resolved", () => "rejected");
+    await new Promise((r) => setTimeout(r, 500));
+    return { outcome, methods: served.exchanges.slice(before).map((e) => getWireField(e.request.json, "method")) };
+  }
+
+  async function reconnect(staleConfig: Record<string, unknown>) {
+    const served = await fresh();
+    await manager!.disconnectServer("fixture").catch(() => {});
+    await manager!.connectToServer("fixture", { url: served.url, timeout: 10_000, ...staleConfig });
+    return served;
+  }
+
+  it("cancels again after the off->on save", async () => {
+    const f1 = await fresh();
+    manager = new MCPClientManager();
+    await manager.connectToServer("fixture", { url: f1.url, timeout: 10_000 });
+
+    const run1 = await turn(f1, {}, "c1");
+    expect(run1.methods).toContain("tools/call");
+
+    const f2 = await reconnect({});
+    const run2 = await turn(f2, { legacy: false, modern: false }, "c2");
+    expect(run2.methods).not.toContain("tools/call");
+    expect(run2.methods).not.toContain("notifications/cancelled");
+
+    const f3 = await reconnect({ toolCallCancellation: { legacy: false, modern: false } });
+    const run3 = await turn(f3, {}, "c3");
+    expect(run3.methods).toContain("tools/call");
+  }, 60_000);
+});
+
+/**
+ * The suppressed path must also survive the request TIMEOUT. The protocol
+ * layer runs the same cancellation on a timeout as on an abort, so a
+ * suppressed call left on the connection's default timer would still cancel —
+ * just later. That is what made the knob read as flaky rather than off, and a
+ * 500ms observation window after the abort cannot see it.
+ *
+ * Driven with a deliberately TINY connection timeout so the boundary is
+ * reachable in a test: the policy replaces it wholesale, so if it ever stops
+ * doing so this fails in a second rather than in a day.
+ */
+describe("a suppressed call outlives the request timeout", () => {
+  const fixtures: ServedMultiPageFixture[] = [];
+  let manager: MCPClientManager | undefined;
+  afterEach(async () => {
+    await manager?.disconnectAllServers().catch(() => {});
+    for (const f of fixtures) await f.close();
+    fixtures.length = 0;
+    manager = undefined;
+  });
+
+  async function runPastTimeout(connectOverrides: Record<string, unknown>) {
+    const served = await serveMultiPageFixtureOnPort({ listSlowTool: true });
+    fixtures.push(served);
+    manager = new MCPClientManager();
+    // 1s per-request timeout: short enough to expire inside this test.
+    await manager.connectToServer("fixture", { url: served.url, timeout: 1_000 });
+
+    const tools = await manager.getToolsForAiSdk("fixture", {
+      toolCallCancellation: connectOverrides,
+    });
+    // A signal that never fires: the turn is still live, so the ONLY thing
+    // that could cancel here is the timeout.
+    const controller = new AbortController();
+    const call = tools["slow-tool"]!.execute!(
+      { delayMs: 60_000 },
+      { toolCallId: "timeout-1", messages: [], abortSignal: controller.signal }
+    );
+    void call.catch(() => {});
+    await served.waitForToolCall("slow-tool");
+    // Well past the 1s timeout.
+    await new Promise((r) => setTimeout(r, 2_500));
+    return served.exchanges.map((e) => getWireField(e.request.json, "method"));
+  }
+
+  it("sends nothing when the era's leaf is off", async () => {
+    const methods = await runPastTimeout({ legacy: false, modern: false });
+    expect(methods).not.toContain("tools/call");
+    expect(methods).not.toContain("notifications/cancelled");
+  }, 30_000);
+
+  it("times out and cancels with no leaf set (control)", async () => {
+    // Proves the window above is long enough to see a cancellation that
+    // really happens — without this the test would pass on a broken fixture.
+    const methods = await runPastTimeout({});
+    expect(methods).toContain("tools/call");
+  }, 30_000);
+});

--- a/sdk/tests/host-connection.test.ts
+++ b/sdk/tests/host-connection.test.ts
@@ -117,20 +117,31 @@ describe("hostConnectionProfile", () => {
           profileVersion: 1,
           paginationTraversal: "firstPageOnly",
           mrtrSupport: "none",
+          toolCallCancellation: false,
         },
       });
       expect(p.firstPageOnly).toBe(true);
       expect(p.supportsMrtr).toBe(false);
+      expect(p.suppressRequestCancellation).toBe(true);
     });
 
     it("collapses default literals AND absent fields to no wire field", () => {
       for (const mcpProfile of [
-        { profileVersion: 1, paginationTraversal: "full", mrtrSupport: "full" },
+        {
+          profileVersion: 1,
+          paginationTraversal: "full",
+          mrtrSupport: "full",
+          toolCallCancellation: true,
+        },
         { profileVersion: 1 },
         undefined,
       ]) {
         const p = hostConnectionProfile(mcpProfile ? { mcpProfile } : {});
-        for (const key of ["firstPageOnly", "supportsMrtr"]) {
+        for (const key of [
+          "firstPageOnly",
+          "supportsMrtr",
+          "suppressRequestCancellation",
+        ]) {
           expect(key in p).toBe(false);
         }
       }
@@ -182,8 +193,10 @@ describe("hostConnectionProfile", () => {
           profileVersion: 1,
           paginationTraversal: "everyOtherPage",
           mrtrSupport: "partial",
+          toolCallCancellation: true,
         },
       });
+      expect("suppressRequestCancellation" in p).toBe(false);
       expect("firstPageOnly" in p).toBe(false);
       expect("supportsMrtr" in p).toBe(false);
     });

--- a/sdk/tests/host-connection.test.ts
+++ b/sdk/tests/host-connection.test.ts
@@ -122,8 +122,7 @@ describe("hostConnectionProfile", () => {
       });
       expect(p.firstPageOnly).toBe(true);
       expect(p.supportsMrtr).toBe(false);
-      expect(p.suppressLegacyRequestCancellation).toBe(true);
-      expect(p.suppressModernRequestCancellation).toBe(true);
+      expect(p.suppressRequestCancellation).toBe(true);
     });
 
     it("collapses default literals AND absent fields to no wire field", () => {
@@ -141,8 +140,7 @@ describe("hostConnectionProfile", () => {
         for (const key of [
           "firstPageOnly",
           "supportsMrtr",
-          "suppressLegacyRequestCancellation",
-          "suppressModernRequestCancellation",
+          "suppressRequestCancellation",
         ]) {
           expect(key in p).toBe(false);
         }
@@ -187,26 +185,51 @@ describe("hostConnectionProfile", () => {
       }
     });
 
-    it("reduces each cancellation leaf independently", () => {
-      // The reason this knob is a record: a host that cancels on 2025 but not
-      // on 2026 must produce exactly one flag, never both.
-      const legacyOnly = hostConnectionProfile({
+    it("picks the cancellation leaf from the version pin", () => {
+      // The knob is measured per era, but a connection speaks one — so the pin
+      // decides which leaf reaches the wire, and the other is ignored. This is
+      // the seam that used to ask the live client for its era, which silently
+      // did nothing on adapters that cannot report one.
+      const modernPin = (toolCallCancellation: Record<string, boolean>) =>
+        hostConnectionProfile({
+          mcpProfile: {
+            profileVersion: 1,
+            mcpProtocolVersion: "2026-07-28",
+            toolCallCancellation,
+          },
+        });
+      const legacyPin = (toolCallCancellation: Record<string, boolean>) =>
+        hostConnectionProfile({
+          mcpProfile: {
+            profileVersion: 1,
+            mcpProtocolVersion: "2025-11-25",
+            toolCallCancellation,
+          },
+        });
+
+      expect(modernPin({ modern: false }).suppressRequestCancellation).toBe(
+        true
+      );
+      expect("suppressRequestCancellation" in modernPin({ legacy: false })).toBe(
+        false
+      );
+      expect(legacyPin({ legacy: false }).suppressRequestCancellation).toBe(
+        true
+      );
+      expect("suppressRequestCancellation" in legacyPin({ modern: false })).toBe(
+        false
+      );
+    });
+
+    it("reads an unpinned host as modern (auto negotiates newest first)", () => {
+      const p = hostConnectionProfile({
         mcpProfile: {
           profileVersion: 1,
+          mcpProtocolVersion: "auto",
           toolCallCancellation: { modern: false },
         },
       });
-      expect(legacyOnly.suppressModernRequestCancellation).toBe(true);
-      expect("suppressLegacyRequestCancellation" in legacyOnly).toBe(false);
-
-      const modernOnly = hostConnectionProfile({
-        mcpProfile: {
-          profileVersion: 1,
-          toolCallCancellation: { legacy: false },
-        },
-      });
-      expect(modernOnly.suppressLegacyRequestCancellation).toBe(true);
-      expect("suppressModernRequestCancellation" in modernOnly).toBe(false);
+      expect(p.suppressRequestCancellation).toBe(true);
     });
 
     it("fails closed on unrecognized literals", () => {
@@ -222,8 +245,7 @@ describe("hostConnectionProfile", () => {
           toolCallCancellation: "sometimes",
         },
       });
-      expect("suppressLegacyRequestCancellation" in p).toBe(false);
-      expect("suppressModernRequestCancellation" in p).toBe(false);
+      expect("suppressRequestCancellation" in p).toBe(false);
       expect("firstPageOnly" in p).toBe(false);
       expect("supportsMrtr" in p).toBe(false);
     });

--- a/sdk/tests/host-connection.test.ts
+++ b/sdk/tests/host-connection.test.ts
@@ -117,12 +117,13 @@ describe("hostConnectionProfile", () => {
           profileVersion: 1,
           paginationTraversal: "firstPageOnly",
           mrtrSupport: "none",
-          toolCallCancellation: false,
+          toolCallCancellation: { legacy: false, modern: false },
         },
       });
       expect(p.firstPageOnly).toBe(true);
       expect(p.supportsMrtr).toBe(false);
-      expect(p.suppressRequestCancellation).toBe(true);
+      expect(p.suppressLegacyRequestCancellation).toBe(true);
+      expect(p.suppressModernRequestCancellation).toBe(true);
     });
 
     it("collapses default literals AND absent fields to no wire field", () => {
@@ -131,7 +132,7 @@ describe("hostConnectionProfile", () => {
           profileVersion: 1,
           paginationTraversal: "full",
           mrtrSupport: "full",
-          toolCallCancellation: true,
+          toolCallCancellation: { legacy: true, modern: true },
         },
         { profileVersion: 1 },
         undefined,
@@ -140,7 +141,8 @@ describe("hostConnectionProfile", () => {
         for (const key of [
           "firstPageOnly",
           "supportsMrtr",
-          "suppressRequestCancellation",
+          "suppressLegacyRequestCancellation",
+          "suppressModernRequestCancellation",
         ]) {
           expect(key in p).toBe(false);
         }
@@ -185,6 +187,28 @@ describe("hostConnectionProfile", () => {
       }
     });
 
+    it("reduces each cancellation leaf independently", () => {
+      // The reason this knob is a record: a host that cancels on 2025 but not
+      // on 2026 must produce exactly one flag, never both.
+      const legacyOnly = hostConnectionProfile({
+        mcpProfile: {
+          profileVersion: 1,
+          toolCallCancellation: { modern: false },
+        },
+      });
+      expect(legacyOnly.suppressModernRequestCancellation).toBe(true);
+      expect("suppressLegacyRequestCancellation" in legacyOnly).toBe(false);
+
+      const modernOnly = hostConnectionProfile({
+        mcpProfile: {
+          profileVersion: 1,
+          toolCallCancellation: { legacy: false },
+        },
+      });
+      expect(modernOnly.suppressLegacyRequestCancellation).toBe(true);
+      expect("suppressModernRequestCancellation" in modernOnly).toBe(false);
+    });
+
     it("fails closed on unrecognized literals", () => {
       // A future mode this SDK build does not know must not read as the
       // non-default value.
@@ -193,10 +217,13 @@ describe("hostConnectionProfile", () => {
           profileVersion: 1,
           paginationTraversal: "everyOtherPage",
           mrtrSupport: "partial",
-          toolCallCancellation: true,
+          // Not a record at all, and a record with an unknown leaf: neither
+          // may read as the degraded value.
+          toolCallCancellation: "sometimes",
         },
       });
-      expect("suppressRequestCancellation" in p).toBe(false);
+      expect("suppressLegacyRequestCancellation" in p).toBe(false);
+      expect("suppressModernRequestCancellation" in p).toBe(false);
       expect("firstPageOnly" in p).toBe(false);
       expect("supportsMrtr" in p).toBe(false);
     });

--- a/sdk/tests/host-connection.test.ts
+++ b/sdk/tests/host-connection.test.ts
@@ -122,7 +122,7 @@ describe("hostConnectionProfile", () => {
       });
       expect(p.firstPageOnly).toBe(true);
       expect(p.supportsMrtr).toBe(false);
-      expect(p.suppressRequestCancellation).toBe(true);
+      expect(p.toolCallCancellation).toEqual({ legacy: false, modern: false });
     });
 
     it("collapses default literals AND absent fields to no wire field", () => {
@@ -140,7 +140,7 @@ describe("hostConnectionProfile", () => {
         for (const key of [
           "firstPageOnly",
           "supportsMrtr",
-          "suppressRequestCancellation",
+          "toolCallCancellation",
         ]) {
           expect(key in p).toBe(false);
         }
@@ -185,51 +185,39 @@ describe("hostConnectionProfile", () => {
       }
     });
 
-    it("picks the cancellation leaf from the version pin", () => {
-      // The knob is measured per era, but a connection speaks one — so the pin
-      // decides which leaf reaches the wire, and the other is ignored. This is
-      // the seam that used to ask the live client for its era, which silently
-      // did nothing on adapters that cannot report one.
-      const modernPin = (toolCallCancellation: Record<string, boolean>) =>
+    it("forwards only the degraded leaves, never resolving the era here", () => {
+      // Resolution is the SDK's job at request time: on an unpinned host the
+      // era does not exist yet, and picking one here made the other era's
+      // toggle unreachable.
+      const forward = (toolCallCancellation: Record<string, unknown>) =>
         hostConnectionProfile({
-          mcpProfile: {
-            profileVersion: 1,
-            mcpProtocolVersion: "2026-07-28",
-            toolCallCancellation,
-          },
-        });
-      const legacyPin = (toolCallCancellation: Record<string, boolean>) =>
-        hostConnectionProfile({
-          mcpProfile: {
-            profileVersion: 1,
-            mcpProtocolVersion: "2025-11-25",
-            toolCallCancellation,
-          },
-        });
+          mcpProfile: { profileVersion: 1, toolCallCancellation },
+        }).toolCallCancellation;
 
-      expect(modernPin({ modern: false }).suppressRequestCancellation).toBe(
-        true
-      );
-      expect("suppressRequestCancellation" in modernPin({ legacy: false })).toBe(
-        false
-      );
-      expect(legacyPin({ legacy: false }).suppressRequestCancellation).toBe(
-        true
-      );
-      expect("suppressRequestCancellation" in legacyPin({ modern: false })).toBe(
-        false
-      );
+      expect(forward({ legacy: false })).toEqual({ legacy: false });
+      expect(forward({ modern: false })).toEqual({ modern: false });
+      // Conforming and malformed leaves are dropped, so an all-good host emits
+      // nothing and keeps hashing as it did before the field existed.
+      expect(forward({ legacy: true, modern: false })).toEqual({
+        modern: false,
+      });
+      expect(forward({ legacy: "false" })).toBeUndefined();
     });
 
-    it("reads an unpinned host as modern (auto negotiates newest first)", () => {
-      const p = hostConnectionProfile({
-        mcpProfile: {
-          profileVersion: 1,
-          mcpProtocolVersion: "auto",
-          toolCallCancellation: { modern: false },
-        },
-      });
-      expect(p.suppressRequestCancellation).toBe(true);
+    it("is unaffected by the version pin", () => {
+      // The pin used to decide the leaf here. It must not any more — a pinned
+      // and an unpinned host forward the same thing.
+      for (const mcpProtocolVersion of ["2026-07-28", "2025-11-25", "auto"]) {
+        expect(
+          hostConnectionProfile({
+            mcpProfile: {
+              profileVersion: 1,
+              mcpProtocolVersion,
+              toolCallCancellation: { legacy: false },
+            },
+          }).toolCallCancellation
+        ).toEqual({ legacy: false });
+      }
     });
 
     it("fails closed on unrecognized literals", () => {
@@ -245,7 +233,7 @@ describe("hostConnectionProfile", () => {
           toolCallCancellation: "sometimes",
         },
       });
-      expect("suppressRequestCancellation" in p).toBe(false);
+      expect("toolCallCancellation" in p).toBe(false);
       expect("firstPageOnly" in p).toBe(false);
       expect("supportsMrtr" in p).toBe(false);
     });

--- a/sdk/tests/modern-evidence.integration.test.ts
+++ b/sdk/tests/modern-evidence.integration.test.ts
@@ -533,10 +533,11 @@ describe("SEP-2243 mirroring disabled (mirrorToolParamHeaders: false)", () => {
  * the tool's `execute`, and the manager decides there whether it reaches the
  * wire.
  *
- * The flags are read per NEGOTIATED era, so the load-bearing case is the
- * crossover: the flag for the other era must not touch this connection.
+ * One resolved flag reaches this layer — which era it came from was decided
+ * upstream from the version pin (see host-connection.test.ts). Here the only
+ * question is whether the flag is obeyed on each era's wire.
  */
-describe("per-era cancellation suppression", () => {
+describe("cancellation suppression", () => {
   let served: ServedMultiPageFixture | undefined;
   let manager: MCPClientManager | undefined;
 
@@ -587,7 +588,7 @@ describe("per-era cancellation suppression", () => {
 
   it("2026: the modern flag leaves the server running the tool", async () => {
     const methods = await abortSlowToolThroughAiSdk({
-      suppressModernRequestCancellation: true,
+      suppressRequestCancellation: true,
     });
 
     // Nothing was said. Not the 2026 signal (the held-open `tools/call`
@@ -608,20 +609,9 @@ describe("per-era cancellation suppression", () => {
     expect(methods).not.toContain("notifications/cancelled");
   }, 30_000);
 
-  it("2026: the LEGACY flag does not touch a modern connection", async () => {
-    // The crossover, and the reason the knob has two leaves. A host measured
-    // as never cancelling on 2025 must still cancel normally here.
-    const methods = await abortSlowToolThroughAiSdk({
-      suppressLegacyRequestCancellation: true,
-    });
-
-    expect(methods).toContain("tools/call");
-    expect(methods).not.toContain("notifications/cancelled");
-  }, 30_000);
-
-  it("2025: the legacy flag withholds notifications/cancelled", async () => {
+  it("2025: the flag withholds notifications/cancelled", async () => {
     const methods = await abortSlowToolThroughAiSdk(
-      { suppressLegacyRequestCancellation: true },
+      { suppressRequestCancellation: true },
       "2025-11-25"
     );
 
@@ -636,14 +626,4 @@ describe("per-era cancellation suppression", () => {
     expect(methods).toContain("notifications/cancelled");
   }, 30_000);
 
-  it("2025: the MODERN flag does not touch a legacy connection", async () => {
-    // Crossover in the other direction: MCPJam's own bug shape — correct on
-    // 2025, broken on 2026 — must leave 2025 fully working.
-    const methods = await abortSlowToolThroughAiSdk(
-      { suppressModernRequestCancellation: true },
-      "2025-11-25"
-    );
-
-    expect(methods).toContain("notifications/cancelled");
-  }, 30_000);
 });

--- a/sdk/tests/modern-evidence.integration.test.ts
+++ b/sdk/tests/modern-evidence.integration.test.ts
@@ -226,7 +226,18 @@ describe("modern-era (2026-07-28) wire evidence", () => {
     // The spec cancellation signal on modern is the aborted per-request
     // stream itself — there must be no explicit notifications/cancelled
     // POST alongside it.
+    //
+    // The settle window is load-bearing: the protocol layer's legacy
+    // cancellation branch POSTs the notification fire-and-forget, so asserting
+    // the instant `callPromise` rejects passes even when the client DID send
+    // one. Give that POST time to land before reading `exchanges`.
+    await new Promise((resolve) => setTimeout(resolve, 500));
     expect(byMethod("notifications/cancelled")).toHaveLength(0);
+
+    // Positive counterpart: the aborted `tools/call` exchange must have
+    // actually terminated. A client that only rejects locally leaves the
+    // held-open stream running, and the exchange never completes.
+    expect(byMethod("tools/call")).toHaveLength(1);
   });
 });
 

--- a/sdk/tests/modern-evidence.integration.test.ts
+++ b/sdk/tests/modern-evidence.integration.test.ts
@@ -550,13 +550,13 @@ describe("cancellation suppression", () => {
 
   async function abortSlowToolThroughAiSdk(
     connectOverrides: Record<string, unknown> = {},
-    protocolVersion: "2026-07-28" | "2025-11-25" = "2026-07-28"
+    protocolVersion: "2026-07-28" | "2025-11-25" | undefined = "2026-07-28"
   ) {
     served = await serveMultiPageFixtureOnPort({ listSlowTool: true });
     manager = new MCPClientManager();
     await manager.connectToServer("fixture", {
       url: served.url,
-      mcpProtocolVersion: protocolVersion,
+      ...(protocolVersion ? { mcpProtocolVersion: protocolVersion } : {}),
       timeout: 10_000,
       ...connectOverrides,
     });
@@ -588,7 +588,7 @@ describe("cancellation suppression", () => {
 
   it("2026: the modern flag leaves the server running the tool", async () => {
     const methods = await abortSlowToolThroughAiSdk({
-      suppressRequestCancellation: true,
+      toolCallCancellation: { modern: false },
     });
 
     // Nothing was said. Not the 2026 signal (the held-open `tools/call`
@@ -611,7 +611,7 @@ describe("cancellation suppression", () => {
 
   it("2025: the flag withholds notifications/cancelled", async () => {
     const methods = await abortSlowToolThroughAiSdk(
-      { suppressRequestCancellation: true },
+      { toolCallCancellation: { legacy: false } },
       "2025-11-25"
     );
 
@@ -626,4 +626,32 @@ describe("cancellation suppression", () => {
     expect(methods).toContain("notifications/cancelled");
   }, 30_000);
 
+  it("applies only the negotiated era's leaf, never the other one", async () => {
+    // The crossover. A host measured broken on 2025 must still cancel normally
+    // on a 2026 connection, and vice versa.
+    const modernConn = await abortSlowToolThroughAiSdk({
+      toolCallCancellation: { legacy: false },
+    });
+    expect(modernConn).toContain("tools/call");
+
+    const legacyConn = await abortSlowToolThroughAiSdk(
+      { toolCallCancellation: { modern: false } },
+      "2025-11-25"
+    );
+    expect(legacyConn).toContain("notifications/cancelled");
+  }, 60_000);
+
+  it("resolves the leaf on an UNPINNED connection from what it negotiated", async () => {
+    // The bug this design replaces: with no pin there is no era at config
+    // time, so the old code guessed "modern" and the 2025 leaf could never
+    // apply. Here the connection negotiates against the fixture and whichever
+    // era it lands on must be the leaf that governs.
+    const methods = await abortSlowToolThroughAiSdk(
+      { toolCallCancellation: { legacy: false, modern: false } },
+      undefined
+    );
+
+    expect(methods).not.toContain("notifications/cancelled");
+    expect(methods).not.toContain("tools/call");
+  }, 30_000);
 });

--- a/sdk/tests/modern-evidence.integration.test.ts
+++ b/sdk/tests/modern-evidence.integration.test.ts
@@ -524,16 +524,19 @@ describe("SEP-2243 mirroring disabled (mirrorToolParamHeaders: false)", () => {
 });
 
 /**
- * `MCPServerConfig.suppressRequestCancellation` — the host-config knob
- * (`mcpProfile.requestCancellation: "none"`) that models a host which ends the
- * turn locally and tells the server nothing.
+ * The per-era cancellation-suppression flags — the host-config knob
+ * (`mcpProfile.toolCallCancellation.{legacy,modern}: false`) modeling a host
+ * that ends the turn locally and tells the server nothing.
  *
  * Driven through `getToolsForAiSdk`, because that is the seam a chat turn's
  * stop button actually travels: the AI SDK hands the turn's `abortSignal` to
  * the tool's `execute`, and the manager decides there whether it reaches the
  * wire.
+ *
+ * The flags are read per NEGOTIATED era, so the load-bearing case is the
+ * crossover: the flag for the other era must not touch this connection.
  */
-describe("suppressRequestCancellation (host cancels nothing)", () => {
+describe("per-era cancellation suppression", () => {
   let served: ServedMultiPageFixture | undefined;
   let manager: MCPClientManager | undefined;
 
@@ -544,14 +547,17 @@ describe("suppressRequestCancellation (host cancels nothing)", () => {
     manager = undefined;
   });
 
-  async function abortSlowToolThroughAiSdk(suppress: boolean) {
+  async function abortSlowToolThroughAiSdk(
+    connectOverrides: Record<string, unknown> = {},
+    protocolVersion: "2026-07-28" | "2025-11-25" = "2026-07-28"
+  ) {
     served = await serveMultiPageFixtureOnPort({ listSlowTool: true });
     manager = new MCPClientManager();
     await manager.connectToServer("fixture", {
       url: served.url,
-      mcpProtocolVersion: "2026-07-28",
+      mcpProtocolVersion: protocolVersion,
       timeout: 10_000,
-      ...(suppress ? { suppressRequestCancellation: true } : {}),
+      ...connectOverrides,
     });
 
     const tools = await manager.getToolsForAiSdk("fixture");
@@ -579,8 +585,10 @@ describe("suppressRequestCancellation (host cancels nothing)", () => {
     return served.exchanges.map((e) => getWireField(e.request.json, "method"));
   }
 
-  it("leaves the server running the tool: no cancelled notification, no terminated call", async () => {
-    const methods = await abortSlowToolThroughAiSdk(true);
+  it("2026: the modern flag leaves the server running the tool", async () => {
+    const methods = await abortSlowToolThroughAiSdk({
+      suppressModernRequestCancellation: true,
+    });
 
     // Nothing was said. Not the 2026 signal (the held-open `tools/call`
     // exchange never completes, so it never appears here) and not the 2025 one
@@ -590,13 +598,52 @@ describe("suppressRequestCancellation (host cancels nothing)", () => {
     expect(methods).not.toContain("tools/call");
   }, 30_000);
 
-  it("still cancels on the wire when the knob is off (control)", async () => {
-    const methods = await abortSlowToolThroughAiSdk(false);
+  it("2026: still cancels with no flag set (control)", async () => {
+    const methods = await abortSlowToolThroughAiSdk();
 
     // Same abort, same seam, opposite outcome: the stream is aborted, so the
     // exchange terminates and lands in the log. Without this control the test
     // above would pass on a client that had simply stopped calling tools.
     expect(methods).toContain("tools/call");
     expect(methods).not.toContain("notifications/cancelled");
+  }, 30_000);
+
+  it("2026: the LEGACY flag does not touch a modern connection", async () => {
+    // The crossover, and the reason the knob has two leaves. A host measured
+    // as never cancelling on 2025 must still cancel normally here.
+    const methods = await abortSlowToolThroughAiSdk({
+      suppressLegacyRequestCancellation: true,
+    });
+
+    expect(methods).toContain("tools/call");
+    expect(methods).not.toContain("notifications/cancelled");
+  }, 30_000);
+
+  it("2025: the legacy flag withholds notifications/cancelled", async () => {
+    const methods = await abortSlowToolThroughAiSdk(
+      { suppressLegacyRequestCancellation: true },
+      "2025-11-25"
+    );
+
+    // On this era the signal would have gone out as an explicit notification,
+    // so its absence IS the suppression.
+    expect(methods).not.toContain("notifications/cancelled");
+  }, 30_000);
+
+  it("2025: sends notifications/cancelled with no flag set (control)", async () => {
+    const methods = await abortSlowToolThroughAiSdk({}, "2025-11-25");
+
+    expect(methods).toContain("notifications/cancelled");
+  }, 30_000);
+
+  it("2025: the MODERN flag does not touch a legacy connection", async () => {
+    // Crossover in the other direction: MCPJam's own bug shape — correct on
+    // 2025, broken on 2026 — must leave 2025 fully working.
+    const methods = await abortSlowToolThroughAiSdk(
+      { suppressModernRequestCancellation: true },
+      "2025-11-25"
+    );
+
+    expect(methods).toContain("notifications/cancelled");
   }, 30_000);
 });

--- a/sdk/tests/modern-evidence.integration.test.ts
+++ b/sdk/tests/modern-evidence.integration.test.ts
@@ -522,3 +522,81 @@ describe("SEP-2243 mirroring disabled (mirrorToolParamHeaders: false)", () => {
     expect(headers["mcp-name"]).toBe("tool-1");
   });
 });
+
+/**
+ * `MCPServerConfig.suppressRequestCancellation` — the host-config knob
+ * (`mcpProfile.requestCancellation: "none"`) that models a host which ends the
+ * turn locally and tells the server nothing.
+ *
+ * Driven through `getToolsForAiSdk`, because that is the seam a chat turn's
+ * stop button actually travels: the AI SDK hands the turn's `abortSignal` to
+ * the tool's `execute`, and the manager decides there whether it reaches the
+ * wire.
+ */
+describe("suppressRequestCancellation (host cancels nothing)", () => {
+  let served: ServedMultiPageFixture | undefined;
+  let manager: MCPClientManager | undefined;
+
+  afterEach(async () => {
+    await manager?.disconnectAllServers().catch(() => {});
+    await served?.close();
+    served = undefined;
+    manager = undefined;
+  });
+
+  async function abortSlowToolThroughAiSdk(suppress: boolean) {
+    served = await serveMultiPageFixtureOnPort({ listSlowTool: true });
+    manager = new MCPClientManager();
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      timeout: 10_000,
+      ...(suppress ? { suppressRequestCancellation: true } : {}),
+    });
+
+    const tools = await manager.getToolsForAiSdk("fixture");
+    const slowTool = tools["slow-tool"];
+    expect(slowTool?.execute).toBeTypeOf("function");
+
+    const controller = new AbortController();
+    const callPromise = slowTool!.execute!(
+      { delayMs: 60_000 },
+      { toolCallId: "call-1", messages: [], abortSignal: controller.signal }
+    );
+    await served.waitForToolCall("slow-tool");
+    controller.abort();
+
+    // Either way the caller is released promptly — a host that cancels nothing
+    // still ends its own turn. What differs is whether the server hears it.
+    const outcome = await Promise.resolve(callPromise).then(
+      () => "resolved" as const,
+      (error: unknown) => error
+    );
+    expect(outcome).not.toBe("resolved");
+
+    // Let any cancellation the client chose to send actually land.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    return served.exchanges.map((e) => getWireField(e.request.json, "method"));
+  }
+
+  it("leaves the server running the tool: no cancelled notification, no terminated call", async () => {
+    const methods = await abortSlowToolThroughAiSdk(true);
+
+    // Nothing was said. Not the 2026 signal (the held-open `tools/call`
+    // exchange never completes, so it never appears here) and not the 2025 one
+    // either — withholding the signal withholds both, which is the point:
+    // the simulated host is silent, not non-conforming.
+    expect(methods).not.toContain("notifications/cancelled");
+    expect(methods).not.toContain("tools/call");
+  }, 30_000);
+
+  it("still cancels on the wire when the knob is off (control)", async () => {
+    const methods = await abortSlowToolThroughAiSdk(false);
+
+    // Same abort, same seam, opposite outcome: the stream is aborted, so the
+    // exchange terminates and lands in the log. Without this control the test
+    // above would pass on a client that had simply stopped calling tools.
+    expect(methods).toContain("tools/call");
+    expect(methods).not.toContain("notifications/cancelled");
+  }, 30_000);
+});

--- a/sdk/tests/support/multi-page-fixture.ts
+++ b/sdk/tests/support/multi-page-fixture.ts
@@ -116,6 +116,15 @@ export interface MultiPageFixtureOptions {
    * or silently reverts to a conforming one.
    */
   hideFromList?: string[];
+  /**
+   * Advertise the held-open `slow-tool` in `tools/list` as well as serving it.
+   *
+   * Off by default because every pagination assertion in this fixture counts
+   * `FIXTURE_TOTAL_ITEMS`, and an extra listed tool would move those numbers.
+   * Opt in when the tool has to arrive through a path that only knows listed
+   * tools — `getToolsForAiSdk`, for one, builds its set from `tools/list`.
+   */
+  listSlowTool?: boolean;
 }
 
 /** The SEP-2243 `HeaderMismatch` JSON-RPC error code (2026-07-28). */
@@ -212,10 +221,23 @@ export function buildMultiPageFixtureServer(
   const { tools, prompts, resources, resourceTemplates } = buildItems();
 
   if (caps.tools) {
+    const baseTools = options.listSlowTool
+      ? [
+          ...tools,
+          {
+            name: "slow-tool",
+            description: "Held open until the caller aborts",
+            inputSchema: {
+              type: "object" as const,
+              properties: { delayMs: { type: "number" as const } },
+            },
+          },
+        ]
+      : tools;
     const listedTools =
       options.hideFromList && options.hideFromList.length > 0
-        ? tools.filter((tool) => !options.hideFromList!.includes(tool.name))
-        : tools;
+        ? baseTools.filter((tool) => !options.hideFromList!.includes(tool.name))
+        : baseTools;
     server.setRequestHandler("tools/list", (request: any) => {
       const { items, nextCursor } = paginatedPage(
         listedTools,

--- a/sdk/tests/tool-task-seam.test.ts
+++ b/sdk/tests/tool-task-seam.test.ts
@@ -353,6 +353,79 @@ describe("await mode", () => {
   });
 });
 
+/**
+ * A suppressed tool call gets a day-long request timeout so the call itself is
+ * never cancelled by its own timer. That budget belongs to the CALL and must
+ * not spread to the seam's reads.
+ *
+ * Ending a `tasks/get` does not cancel the task, so a poll gains nothing from
+ * the long timer — and loses something real to it: the await driver's deadline
+ * abandons an in-flight poll rather than aborting its request (it only stops
+ * waiting), so a hung poll on the call's timer would hold its socket for a day
+ * with nothing left to end it.
+ */
+describe("cancellation suppression does not reach the seam's reads", () => {
+  async function optionsSeenBy(
+    toolCallCancellation: { legacy?: boolean; modern?: boolean } | undefined
+  ) {
+    const fixture = await serve({
+      tools: { [TASK_TOOL_NAME]: taskTool(completingPhases()) },
+    });
+    const manager = await connect(fixture.url);
+    const { options } = collectingSeam({}, "await");
+
+    const seen: Array<Record<string, unknown> | undefined> = [];
+    const realGetTaskExt = manager.getTaskExt.bind(manager);
+    (manager as any).getTaskExt = (
+      serverId: string,
+      taskId: string,
+      requestOptions?: Record<string, unknown>
+    ) => {
+      seen.push(requestOptions);
+      return realGetTaskExt(serverId, taskId, requestOptions as never);
+    };
+
+    const tools = await manager.getToolsForAiSdk([SERVER_ID], {
+      tasks: options,
+      ...(toolCallCancellation ? { toolCallCancellation } : {}),
+    });
+    // A live turn: the signal is what makes the policy apply at all, and it is
+    // never aborted here — the question is only which options each leg gets.
+    await (tools[TASK_TOOL_NAME] as any).execute(
+      {},
+      {
+        toolCallId: "c1",
+        messages: [],
+        abortSignal: new AbortController().signal,
+      }
+    );
+    expect(seen.length).toBeGreaterThan(0);
+    return seen;
+  }
+
+  it("leaves polls on the connection's own timeout when the call is suppressed", async () => {
+    const seen = await optionsSeenBy({ legacy: false, modern: false });
+
+    // No day-long timer, and no signal either: withholding the signal is the
+    // suppression, and it is about the call, not the poll.
+    for (const requestOptions of seen) {
+      expect(requestOptions?.timeout).toBeUndefined();
+      expect(requestOptions?.signal).toBeUndefined();
+    }
+  });
+
+  it("still hands polls the turn's signal when nothing is suppressed", async () => {
+    // The control: without suppression the reads are unchanged from before the
+    // split, so aborting a turn still ends an in-flight poll.
+    const seen = await optionsSeenBy(undefined);
+
+    for (const requestOptions of seen) {
+      expect(requestOptions?.signal).toBeInstanceOf(AbortSignal);
+      expect(requestOptions?.timeout).toBeUndefined();
+    }
+  });
+});
+
 describe("mixed wires", () => {
   it("declares only on the extension server and never throws on the others", async () => {
     // `withTaskEligibilityDeclaration` THROWS on `wire: "none"`, so a turn


### PR DESCRIPTION
…he stream

MCP 2026-07-28 makes closing the per-request stream the cancellation signal on Streamable HTTP, and says no notifications/cancelled is expected. The client package forks on `era === modern && transport.hasPerRequestStream === true`, but every transport we pass to a client is wrapped, and the wrappers forwarded sessionId and setProtocolVersion while dropping hasPerRequestStream.

The flag read undefined, so the fork took the legacy branch on every connection — including plain ones, since wrapTransportForTaskResults is applied unconditionally at each HTTP transport site. We POSTed a notification modern servers do not expect, and because that notification is a separate request from the call being cancelled, the server ran the tool to completion having never seen the one signal that would have reached it.

Forward the flag from all five wrappers (four in transport-utils, one in the widget runtime). Forwarded, not defaulted: over stdio the notification is still the correct signal.

The existing modern-abort test passed the whole time because the legacy branch POSTs fire-and-forget and the assertion ran before it landed. Let that settle, and also assert the aborted tools/call exchange actually terminates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes modern MCP cancellation so the protocol layer aborts the per-request stream instead of POSTing `notifications/cancelled`, and models tool cancellation per era as a host behavior that can be simulated, compared, and published.

- All five transport wrappers dropped `hasPerRequestStream`, forcing every connection onto the legacy branch; they now forward it, never defaulting, so stdio keeps the notification signal.
- One leaf per era (`legacy`/`modern`) in `mcpProfile.toolCallCancellation`; a `false` leaf withholds the caller's abort signal so the turn rejects promptly while the server runs the tool to completion.
- Both leaves travel to the connection and are resolved after the handshake from `getNegotiatedProtocolVersion()`, falling back to the configured pin before negotiation lands; unpinned hosts read as modern.
- Absence keeps an untouched host's canonical hash, and the field survives the `CONFORMANCE_PROFILE_KEYS` round-trip and `isMcpProfileEmpty`.
- The leaves reach `MCPServerConfig` through every layer, and the share-link overlay removes body-supplied suppression when the host cancels normally.
- The Protocol tab shows two switches, one per era; caniuse.dev hides any row no published host has measured yet, gating the eras independently.
- Saving a cancellation toggle reconnects connected servers once the app shows the saved config, never interactively, and a failed reconnect warns rather than failing the save.
- Suppressed calls carry a long bounded timeout so the protocol layer's timeout path can't cancel late, while task-seam reads keep the connection's ordinary timeout and signal; chat routes pass the setting per turn so a save applies without any reconnect.

<sup>Written for commit 060e5cf7d08e41c8c64695d6435314aea1c133e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

