### PR TITLE
bench: document the canonical suite-hash contract at the worker pin seam

### DIFF
--- a/mcpjam-inspector/server/services/bench-worker.ts
+++ b/mcpjam-inspector/server/services/bench-worker.ts
@@ -1349,6 +1349,13 @@ export function assertClaimExecutable(job: ClaimedBenchmarkJob): void {
       assertCaseMetadataPinned({
         resolved: cell.caseSideEffects,
         expectedCaseMetadataHash: job.pins?.caseMetadataHash,
+        // `pins.suiteRevision` IS the canonical suite content hash — the
+        // backend pins sha256(suite.configRevision) under both legacy names
+        // (`suiteRevision` and the manifest's `suiteHash`), and its resolver
+        // refuses a definition where they diverge. So forwarding the
+        // revision as the expected suite hash is exact, not a coincidence;
+        // see ResolvedAgentEvalPolicy in mcpjam-backend
+        // convex/lib/benchmarkDefinition.ts.
         ...(job.pins?.suiteRevision
           ? { expectedSuiteHash: job.pins.suiteRevision }
           : {}),


### PR DESCRIPTION
## What this is

Comment-only companion to MCPJam/mcpjam-backend#1185 (Connector Bench two-lane foundation).

The backend now pins ONE suite identity — sha256 of the suite's `configRevision` — under both legacy names (`pins.suiteRevision` and the manifest's `suiteHash`), and its resolver refuses a definition where they diverge. The worker's forwarding of `pins.suiteRevision` as the expected suite hash for side-effect manifests (`bench-worker.ts`) is therefore exact, not a coincidence — this PR says so at the seam so nobody "fixes" it back into two values.

## Testing
- `npm test -- server/services/__tests__/bench-worker.test.ts` — 56 tests, green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178ZeYPnoh2xktgd86cZS5n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 579128166589712317ceb9a852ece30112c48439. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the canonical suite-hash contract at the worker pin seam in `bench-worker.ts`. The backend pins a single suite identity (sha256 of `suiteRevision`) under both legacy names, and the resolver rejects divergent definitions, so forwarding `pins.suiteRevision` as the expected suite hash is exact. This comment-only change prevents future refactors from reintroducing two values.

<sup>Written for commit 579128166589712317ceb9a852ece30112c48439. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

