### PR TITLE
Give a judge case the iteration it graded

### DIFF
--- a/.changeset/judge-case-iteration-id.md
+++ b/.changeset/judge-case-iteration-id.md
@@ -1,0 +1,14 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/inspector": patch
+---
+
+A judge case carries the iteration it graded
+
+`judges.goalCompletion.cases[]` and `judges.groundedness.cases[]` projected only `caseKey` — a random `ui_*` storage key that matches nothing any other route returns. Not the `id` or `declaredId` from the case routes, not the iteration ids from `eval iterations`. The field's own documentation says so, and correctly warns callers off joining it against case ids.
+
+Which left **array position** as the only way to pair a judge score with the iteration it graded: assume the judge's ordering matches the iterations' ordering and hope. Nothing in the contract guarantees that, and being wrong attributes a score to the wrong case without any signal that it happened.
+
+The join key was already persisted — `saveGoalCompletion` patches each iteration through the case's `iterationId`. This exposes it rather than inventing one, on both judges and on `PlatformEvalRunJudgeCase`.
+
+`iterationId` is **optional**: judge results written before it was persisted carry none, and a caller must be able to tell "this run predates the join key" from a value it can act on.

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -13957,6 +13957,10 @@
             "type": "string",
             "description": "The stable AUTHORED-case identity, as persisted. NOT a case row id — do not join it against the ids the per-case routes take."
           },
+          "iterationId": {
+            "type": "string",
+            "description": "The iteration this case graded. The join key between a judge case and the iterations the run returns; `caseKey` is a storage key and joins to nothing. Absent on judge results written before it was persisted."
+          },
           "score": {
             "type": ["number", "null"]
           },
@@ -13975,6 +13979,10 @@
           "caseKey": {
             "type": "string",
             "description": "The stable AUTHORED-case identity, as persisted. NOT a case row id — do not join it against the ids the per-case routes take."
+          },
+          "iterationId": {
+            "type": "string",
+            "description": "The iteration this case graded. The join key between a judge case and the iterations the run returns; `caseKey` is a storage key and joins to nothing. Absent on judge results written before it was persisted."
           },
           "score": {
             "type": ["number", "null"]
@@ -14007,6 +14015,10 @@
           "caseKey": {
             "type": "string",
             "description": "The stable AUTHORED-case identity, as persisted. NOT a case row id — do not join it against the ids the per-case routes take."
+          },
+          "iterationId": {
+            "type": "string",
+            "description": "The iteration this case graded. The join key between a judge case and the iterations the run returns; `caseKey` is a storage key and joins to nothing. Absent on judge results written before it was persisted."
           },
           "score": {
             "type": ["number", "null"]

--- a/mcpjam-inspector/server/routes/v1/__tests__/insights-envelope.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/insights-envelope.test.ts
@@ -443,6 +443,7 @@ describe("eval-run detail — judges envelope", () => {
           cases: [
             {
               caseKey: "ui_abc",
+              iterationId: "it_9",
               score: 0.2,
               passed: false,
               reason: "invented a total",
@@ -460,12 +461,73 @@ describe("eval-run detail — judges envelope", () => {
     expect(body.judges.groundedness.cases).toEqual([
       {
         caseKey: "ui_abc",
+        // Groundedness projects through its OWN callback, so the join key
+        // needs its own assertion — a regression in one mapper must not pass
+        // because the other is covered.
+        iterationId: "it_9",
         score: 0.2,
         passed: false,
         reason: "invented a total",
         unsupportedClaims: ["the 42 figure"],
       },
     ]);
+  });
+
+  it.each([
+    ["null", null],
+    ["an empty string", ""],
+    ["a non-string", 42],
+  ])("omits a %s iterationId on both judges", async (_label, persisted) => {
+    // The DTO promises a join key a caller can use. `""` is a string but joins
+    // to nothing, and a non-string is not a key at all — all three have to be
+    // ABSENT rather than echoed, so "no join key on this row" stays one state.
+    vi.clearAllMocks();
+    answerQueries({
+      getTestSuiteRun: {
+        ...RUN_ROW,
+        goalCompletionStatus: "completed",
+        goalCompletion: {
+          ...GRADED_RUN.goalCompletion,
+          cases: [
+            {
+              caseKey: "ui_abc",
+              iterationId: persisted,
+              score: 0.9,
+              passed: true,
+              reason: "named the right tool",
+              rubricHits: [],
+            },
+          ],
+        },
+        groundednessStatus: "completed",
+        groundedness: {
+          summary: "One answer overreached.",
+          generatedAt: 11,
+          modelUsed: "openai/gpt-5.4-mini",
+          threshold: 0.6,
+          cases: [
+            {
+              caseKey: "ui_abc",
+              iterationId: persisted,
+              score: 0.2,
+              passed: false,
+              reason: "invented a total",
+              unsupportedClaims: [],
+            },
+          ],
+        },
+      },
+      getEvalRunInsightsEnvelope: ENVELOPE,
+    });
+    const res = await makeApp(evals).request(
+      `/api/v1/projects/${PROJECT}/eval-runs/${RUN}`,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.judges.goalCompletion.cases[0]).not.toHaveProperty(
+      "iterationId",
+    );
+    expect(body.judges.groundedness.cases[0]).not.toHaveProperty("iterationId");
   });
 });
 

--- a/mcpjam-inspector/server/routes/v1/__tests__/insights-envelope.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/insights-envelope.test.ts
@@ -312,6 +312,7 @@ describe("eval-run detail — judges envelope", () => {
       cases: [
         {
           caseKey: "ui_abc",
+          iterationId: "it_1",
           score: 0.9,
           passed: true,
           reason: "named the right tool",
@@ -344,6 +345,9 @@ describe("eval-run detail — judges envelope", () => {
           // The persisted AUTHORED-case identity, kept under its own name so
           // nobody joins it against a case row id.
           caseKey: "ui_abc",
+          // The join key. Without it a caller can only pair a judge case with
+          // its iteration by array POSITION.
+          iterationId: "it_1",
           score: 0.9,
           passed: true,
           reason: "named the right tool",
@@ -351,6 +355,38 @@ describe("eval-run detail — judges envelope", () => {
         },
       ],
     });
+  });
+
+  it("omits iterationId on a judge result persisted without one", async () => {
+    // Rows written before the join key was projected must not grow a key
+    // whose value would be a guess.
+    vi.clearAllMocks();
+    answerQueries({
+      getTestSuiteRun: {
+        ...GRADED_RUN,
+        goalCompletion: {
+          ...GRADED_RUN.goalCompletion,
+          cases: [
+            {
+              caseKey: "ui_legacy",
+              score: 0.4,
+              passed: false,
+              reason: "missed the goal",
+              rubricHits: [],
+            },
+          ],
+        },
+      },
+      getEvalRunInsightsEnvelope: ENVELOPE,
+    });
+    const res = await makeApp(evals).request(
+      `/api/v1/projects/${PROJECT}/eval-runs/${RUN}`,
+    );
+    const body = (await res.json()) as any;
+    expect(body.judges.goalCompletion.cases[0]).not.toHaveProperty(
+      "iterationId",
+    );
+    expect(body.judges.goalCompletion.cases[0].caseKey).toBe("ui_legacy");
   });
 
   it("reports a never-requested judge as status null, not as an absent field", async () => {

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -1312,7 +1312,7 @@ function toRunJudgesDto(run: RunDoc) {
       run.goalCompletion,
       (row) => ({
         caseKey: String(row.caseKey ?? ""),
-        ...(typeof row.iterationId === "string"
+        ...(typeof row.iterationId === "string" && row.iterationId.length > 0
           ? { iterationId: row.iterationId }
           : {}),
         score: typeof row.score === "number" ? row.score : null,
@@ -1332,7 +1332,7 @@ function toRunJudgesDto(run: RunDoc) {
       // Projected off the persisted fields rather than forced into one shape.
       (row) => ({
         caseKey: String(row.caseKey ?? ""),
-        ...(typeof row.iterationId === "string"
+        ...(typeof row.iterationId === "string" && row.iterationId.length > 0
           ? { iterationId: row.iterationId }
           : {}),
         score: typeof row.score === "number" ? row.score : null,

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -1270,6 +1270,15 @@ function toRunEnvironmentDto(run: RunDoc) {
  * `caseKey` keeps its persisted name. It is the stable AUTHORED-case identity,
  * not a Convex row id; calling it `caseId` at this boundary would invite
  * callers to join it against the case ids the case routes take.
+ *
+ * `iterationId` is what a caller joins on. Without it the only way to pair a
+ * judge case with the iteration it graded was POSITION — `caseKey` is a random
+ * `ui_*` storage key that matches nothing the case or iteration routes return,
+ * so every consumer had to assume the judge's array order equals the
+ * iterations' and hope. It is persisted on the judge case already (the save
+ * mutation patches the iteration through it), so this exposes an existing
+ * join key rather than inventing one. Optional in the DTO because rows written
+ * before it was persisted carry none.
  */
 function toRunJudgeDto(
   status: unknown,
@@ -1303,6 +1312,9 @@ function toRunJudgesDto(run: RunDoc) {
       run.goalCompletion,
       (row) => ({
         caseKey: String(row.caseKey ?? ""),
+        ...(typeof row.iterationId === "string"
+          ? { iterationId: row.iterationId }
+          : {}),
         score: typeof row.score === "number" ? row.score : null,
         passed: row.passed === true,
         reason: typeof row.reason === "string" ? row.reason : null,
@@ -1320,6 +1332,9 @@ function toRunJudgesDto(run: RunDoc) {
       // Projected off the persisted fields rather than forced into one shape.
       (row) => ({
         caseKey: String(row.caseKey ?? ""),
+        ...(typeof row.iterationId === "string"
+          ? { iterationId: row.iterationId }
+          : {}),
         score: typeof row.score === "number" ? row.score : null,
         passed: row.passed === true,
         reason: typeof row.reason === "string" ? row.reason : null,

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -819,6 +819,16 @@ export interface PlatformEvalRunJudgeCase {
    * not join it against the ids the per-case routes take.
    */
   caseKey: string;
+  /**
+   * The iteration this case graded — the join key between a judge case and
+   * the iterations the run returns, since `caseKey` is a storage key and
+   * joins to nothing.
+   *
+   * Optional because judge results written before it was persisted carry
+   * none: a caller must be able to tell "this run predates the join key"
+   * from a value it could act on.
+   */
+  iterationId?: string;
   score: number | null;
   passed: boolean;
   reason: string | null;


### PR DESCRIPTION
## What was wrong

`judges.goalCompletion.cases[]` projected only `caseKey` — a random `ui_*` storage key that matches **nothing** any other route returns. Not the `id` or `declaredId` from `eval cases list`, not the iteration ids from `eval iterations`. The DTO's own docblock says as much, and correctly warns callers off joining it against case ids:

> `caseKey` keeps its persisted name. It is the stable AUTHORED-case identity, not a Convex row id; calling it `caseId` at this boundary would invite callers to join it against the case ids the case routes take.

True, and it leaves the caller with nothing. The only remaining join was **array position**: pair judge case *i* with iteration *i* and hope the two orderings agree. Nothing in the contract guarantees that, and on this payload being wrong silently attributes a score to the wrong case.

I hit this analysing 20 graded runs — the only way to attach 200 judge scores to their iterations was to join by index and then verify, per suite, that the order was stable across all four variants and that the reasons matched the case titles. That verification is not something an API should require.

## The fix

The join key is already persisted. `goalCompletionCaseValidator` carries `iterationId`, and `saveGoalCompletion` patches each iteration's `metadata.judgeVerdict` through it. This exposes what is already there rather than inventing anything.

`iterationId` is **optional** in the DTO: judge results written before it was persisted carry none, and a caller must never receive a join key whose value is a guess.

Both judges get it — groundedness projects the same per-case shape.

## Testing

- the existing goal-completion projection test now asserts `iterationId` reaches the DTO;
- a new test asserts a legacy case (persisted with no `iterationId`) does **not** grow the key.
- `server/routes/v1/__tests__/insights-envelope.test.ts` — 26 tests pass.
- `docs/reference/openapi.json` updated for all three judge-case schemas (`EvalRunJudgeCase`, `EvalRunGoalCompletionCase`, `EvalRunGroundednessCase`).

Repo-wide `tsc` is failing at baseline on `main` (6337 errors, including two in `server/routes/v1/evals.ts` at other line numbers); this branch introduces none — same two, same signatures, in regions I did not touch.

## Related

Same investigation, separate PRs in mcpjam-backend: MCPJam/mcpjam-backend#1184 (judge grades a multi-turn case's last answer against its first prompt) and MCPJam/mcpjam-backend#1187 (host-bound runs record no model and silently execute the per-case pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ju9R7fbwmeUR9mxrh2BN6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-path DTO projection with optional fields and strict omission rules; no auth, billing, or persistence changes in this repo.
> 
> **Overview**
> **Judge cases on eval-run detail now expose an optional `iterationId`** so clients can join goal-completion and groundedness scores to the iteration they graded, instead of relying on array order against `caseKey` (which does not match case or iteration route ids).
> 
> The v1 `toRunJudgesDto` mappers for both judges pass through a persisted `iterationId` only when it is a non-empty string; missing, legacy, null, empty, or invalid stored values leave the field absent. OpenAPI judge-case schemas, `PlatformEvalRunJudgeCase` in the SDK, and insights-envelope tests are updated to match, with a patch changeset for `@mcpjam/sdk` and `@mcpjam/inspector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64285039d31dcb86cfc53196d5c9897fbe7430bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `iterationId` to judge cases so callers can join a score to the iteration that produced it. Before, `judges.goalCompletion.cases[]` only exposed `caseKey` — a storage key that matches nothing — and pairing a grade with its case meant assuming the judge array order matched the iterations' order.

- The key is already persisted on each judge case, so this surfaces an existing join key.
- Both goal completion and groundedness judges project the field.
- The DTO keeps `iterationId` optional; rows written before it was persisted don't get one.
- OpenAPI schemas, SDK type, and tests are updated.

<sup>Written for commit 50da43ad84e9878c6c58f1b6b3adeb713fa0fc84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

