### PR TITLE
feat(browserd): boot recipe — start browserd in a desktop sandbox (W1 PR e1)

### DIFF
--- a/mcpjam-inspector/server/services/browserd/__tests__/boot-browserd.test.ts
+++ b/mcpjam-inspector/server/services/browserd/__tests__/boot-browserd.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { bootBrowserd, type BrowserdSandbox } from "../boot-browserd";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+const READY = (over: Record<string, unknown> = {}) =>
+  `${JSON.stringify({ event: "listening", host: "0.0.0.0", port: 8791, bootId: "boot-1", ...over })}\n`;
+
+function fakeSandbox() {
+  const state = {
+    command: "",
+    envs: {} as Record<string, string>,
+    onStdout: (_c: string) => {},
+    kills: 0,
+  };
+  let resolveWait!: () => void;
+  let rejectWait!: (e: unknown) => void;
+  const waitPromise = new Promise<void>((res, rej) => {
+    resolveWait = res;
+    rejectWait = rej;
+  });
+  const sandbox: BrowserdSandbox = {
+    async runBackground(command, options) {
+      state.command = command;
+      state.envs = options.envs;
+      state.onStdout = options.onStdout;
+      return {
+        kill: async () => {
+          state.kills++;
+          return true;
+        },
+        wait: () => waitPromise,
+      };
+    },
+    getHost: (port) => `box-${port}.e2b.dev`,
+  };
+  return {
+    sandbox,
+    state,
+    emit: (chunk: string) => state.onStdout(chunk),
+    exit: () => resolveWait(),
+    exitWith: (e: Error) => rejectWait(e),
+  };
+}
+
+const OPTS = {
+  scriptPath: "/opt/mcpjam/mcpjam-browserd.mjs",
+  port: 8791,
+  userDataDir: "/home/user/.mcpjam-browserd",
+};
+
+describe("bootBrowserd", () => {
+  it("resolves with the bearer, bootId, and public origin once browserd reports listening", async () => {
+    const fake = fakeSandbox();
+    const p = bootBrowserd(fake.sandbox, OPTS);
+    await tick();
+    fake.emit(READY());
+    const handle = await p;
+    expect(handle.bearer).toMatch(/^[0-9a-f]{64}$/); // a real per-boot secret
+    expect(handle.bootId).toBe("boot-1");
+    expect(handle.port).toBe(8791);
+    expect(handle.publicOrigin).toBe("https://box-8791.e2b.dev");
+  });
+
+  it("passes the token in envs, NEVER on the command line", async () => {
+    const fake = fakeSandbox();
+    const p = bootBrowserd(fake.sandbox, {
+      ...OPTS,
+      windowSize: "1600,1200",
+      headless: true,
+    });
+    await tick();
+    fake.emit(READY());
+    const handle = await p;
+    expect(fake.state.command).toBe('node "/opt/mcpjam/mcpjam-browserd.mjs"');
+    expect(fake.state.command).not.toContain(handle.bearer);
+    expect(fake.state.envs).toMatchObject({
+      MCPJAM_BROWSERD_TOKEN: handle.bearer,
+      MCPJAM_BROWSERD_PORT: "8791",
+      MCPJAM_BROWSERD_USER_DATA_DIR: "/home/user/.mcpjam-browserd",
+      MCPJAM_BROWSERD_WINDOW_SIZE: "1600,1200",
+      MCPJAM_BROWSERD_HEADLESS: "true",
+    });
+  });
+
+  it("omits the optional envs when not configured", async () => {
+    const fake = fakeSandbox();
+    const p = bootBrowserd(fake.sandbox, OPTS);
+    await tick();
+    fake.emit(READY());
+    await p;
+    expect(fake.state.envs.MCPJAM_BROWSERD_WINDOW_SIZE).toBeUndefined();
+    expect(fake.state.envs.MCPJAM_BROWSERD_HEADLESS).toBeUndefined();
+  });
+
+  it("reassembles a ready line split across chunks and ignores noise before it", async () => {
+    const fake = fakeSandbox();
+    const p = bootBrowserd(fake.sandbox, OPTS);
+    await tick();
+    fake.emit("starting up...\n");
+    const line = READY({ bootId: "boot-9" });
+    fake.emit(line.slice(0, 20));
+    fake.emit(line.slice(20));
+    const handle = await p;
+    expect(handle.bootId).toBe("boot-9");
+  });
+
+  it("rejects and reaps the process if browserd exits before listening", async () => {
+    const fake = fakeSandbox();
+    const p = bootBrowserd(fake.sandbox, OPTS);
+    await tick();
+    fake.exit(); // the daemon process ended without a ready line
+    await expect(p).rejects.toThrow(/exited before it reported listening/);
+    expect(fake.state.kills).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects if browserd does not report listening within the deadline", async () => {
+    const fake = fakeSandbox();
+    const p = bootBrowserd(fake.sandbox, { ...OPTS, readyTimeoutMs: 20 });
+    await expect(p).rejects.toThrow(/within 20ms/);
+  });
+
+  it("stop() reaps the daemon", async () => {
+    const fake = fakeSandbox();
+    const p = bootBrowserd(fake.sandbox, OPTS);
+    await tick();
+    fake.emit(READY());
+    const handle = await p;
+    await handle.stop();
+    expect(fake.state.kills).toBe(1);
+  });
+});

--- a/mcpjam-inspector/server/services/browserd/boot-browserd.ts
+++ b/mcpjam-inspector/server/services/browserd/boot-browserd.ts
@@ -1,0 +1,190 @@
+/**
+ * Boot mcpjam-browserd inside a provisioned desktop sandbox.
+ *
+ * This is the inspector-SERVER side (it drives the sandbox); it is deliberately
+ * OUTSIDE `daemon/`, so it is never pulled into the bundled daemon artifact. It
+ * mirrors the plugin-box shim boot (`server/utils/computers/plugin-box.ts`):
+ * start the daemon in the BACKGROUND with a command that never times out, pass
+ * secrets in `envs` (never argv — visible to every process in the box and the
+ * vendor command log), block on the one stdout ready-line, and reap the process
+ * on any unsuccessful start so a durable computer never accumulates orphaned
+ * daemons.
+ *
+ * What it adds over the shim boot: it mints the per-boot bearer the inspector
+ * will use to authenticate its own requests to browserd (browserd self-auths
+ * every request because each getHost port is public), and it captures the
+ * daemon's `bootId` from the ready-line — the inspector stores it so a command
+ * replayed against a different boot is rejected rather than re-run.
+ */
+import { randomBytes } from "node:crypto";
+
+/** The minimal sandbox surface the boot needs; the debug route adapts a real
+ *  E2B box to this, tests provide a fake. */
+export interface BrowserdSandbox {
+  /**
+   * Start a long-lived background process. Resolves once the process is
+   * launched (NOT once it exits) with handles to reap it and to await its exit.
+   */
+  runBackground(
+    command: string,
+    options: { envs: Record<string, string>; onStdout: (chunk: string) => void },
+  ): Promise<{ kill: () => Promise<unknown>; wait: () => Promise<unknown> }>;
+  /** The public HTTPS host for a sandbox port. */
+  getHost(port: number): string;
+}
+
+export interface BootBrowserdOptions {
+  /** Absolute path to the bundled daemon inside the sandbox. */
+  scriptPath: string;
+  port: number;
+  userDataDir: string;
+  /** `--window-size` matched to the X screen geometry, if known. */
+  windowSize?: string;
+  headless?: boolean;
+  readyTimeoutMs?: number;
+}
+
+export interface BrowserdHandle {
+  /** The per-boot bearer the inspector presents on every browserd request. */
+  bearer: string;
+  /** The daemon's boot nonce, echoed on every response (idempotency guard). */
+  bootId: string;
+  port: number;
+  /** `https://<getHost(port)>` — where the inspector reaches browserd. */
+  publicOrigin: string;
+  /** Reap the daemon. Idempotent and never throws. */
+  stop: () => Promise<void>;
+}
+
+const DEFAULT_READY_TIMEOUT_MS = 30_000;
+
+interface BrowserdReadyLine {
+  port: number;
+  bootId: string;
+}
+
+function parseReadyLine(line: string): BrowserdReadyLine | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const record = parsed as Record<string, unknown>;
+  if (record.event !== "listening") return null;
+  if (typeof record.port !== "number") return null;
+  if (typeof record.bootId !== "string" || record.bootId.length === 0) return null;
+  return { port: record.port, bootId: record.bootId };
+}
+
+function buildEnv(bearer: string, options: BootBrowserdOptions): Record<string, string> {
+  const env: Record<string, string> = {
+    MCPJAM_BROWSERD_TOKEN: bearer,
+    MCPJAM_BROWSERD_PORT: String(options.port),
+    MCPJAM_BROWSERD_USER_DATA_DIR: options.userDataDir,
+  };
+  if (options.windowSize) env.MCPJAM_BROWSERD_WINDOW_SIZE = options.windowSize;
+  if (options.headless) env.MCPJAM_BROWSERD_HEADLESS = "true";
+  return env;
+}
+
+/**
+ * Start browserd in `sandbox` and resolve once it reports listening. Rejects —
+ * after reaping the process — if the daemon exits before listening or does not
+ * report within `readyTimeoutMs`. The kill/finish choreography mirrors the shim
+ * boot exactly: the ready line can arrive on `onStdout` before the run promise
+ * resolves, so success is detected there and the run promise only reaps on a
+ * FAILED start (`failed`, not `settled`).
+ */
+export function bootBrowserd(
+  sandbox: BrowserdSandbox,
+  options: BootBrowserdOptions,
+): Promise<BrowserdHandle> {
+  const bearer = randomBytes(32).toString("hex");
+  const env = buildEnv(bearer, options);
+  const readyTimeoutMs = options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
+
+  return new Promise<BrowserdHandle>((resolve, reject) => {
+    let settled = false;
+    let failed = false;
+    let carry = "";
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let started: { kill: () => Promise<unknown> } | undefined;
+
+    const kill = async (): Promise<void> => {
+      try {
+        await started?.kill();
+      } catch {
+        // Already gone or the box is unreachable — nothing further to do.
+      }
+    };
+
+    const finish = (outcome: BrowserdReadyLine | Error): void => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      if (outcome instanceof Error) {
+        failed = true;
+        void kill(); // never leave an orphan daemon in a durable computer
+        reject(outcome);
+        return;
+      }
+      resolve({
+        bearer,
+        bootId: outcome.bootId,
+        port: outcome.port,
+        publicOrigin: `https://${sandbox.getHost(outcome.port)}`,
+        stop: kill,
+      });
+    };
+
+    void sandbox
+      .runBackground(`node ${JSON.stringify(options.scriptPath)}`, {
+        envs: env,
+        onStdout: (chunk) => {
+          if (settled) return;
+          carry += chunk;
+          let index: number;
+          while ((index = carry.indexOf("\n")) >= 0) {
+            const line = carry.slice(0, index);
+            carry = carry.slice(index + 1);
+            const ready = parseReadyLine(line);
+            if (ready) finish(ready);
+          }
+        },
+      })
+      .then((command) => {
+        started = command;
+        // The deadline may have fired before the handle existed; reap here.
+        // Gated on `failed`, not `settled` — a success commonly settles from
+        // onStdout before this resolves.
+        if (failed) {
+          void kill();
+          return;
+        }
+        void command
+          .wait()
+          .then(() => finish(new Error("browserd exited before it reported listening")))
+          .catch((error) =>
+            finish(
+              new Error(
+                `browserd exited before it reported listening (${
+                  error instanceof Error ? error.message : "unknown"
+                })`,
+              ),
+            ),
+          );
+      })
+      .catch((error) => finish(error instanceof Error ? error : new Error(String(error))));
+
+    timer = setTimeout(
+      () => finish(new Error(`browserd did not report listening within ${readyTimeoutMs}ms`)),
+      readyTimeoutMs,
+    );
+    // A synchronous ready line settles before the timer exists; clear it.
+    if (settled) clearTimeout(timer);
+  });
+}


### PR DESCRIPTION
**W1 PR (e1)** of the Hosted Browser + WebMCP Runtime — the first of the final wave. Follows #4467/#4470/#4472/#4473/#4475 (inspector) and #1186 (backend), all merged.

The **inspector-server side** that boots the daemon inside a provisioned desktop box. Deliberately **outside `daemon/`** so it's never pulled into the bundled artifact.

Mirrors the plugin-box shim boot (`server/utils/computers/plugin-box.ts`):
- start `node <bundle>` in the **background** with a no-timeout command;
- secrets in **`envs`, never argv** (visible to every process in the box + the vendor command log);
- block on the single stdout ready-line;
- **reap the process on any unsuccessful start** so a durable computer never accumulates orphaned daemons. The kill/finish choreography (the ready line can arrive on `onStdout` before the run promise resolves; reap on `failed`, not `settled`) is copied faithfully.

Adds over the shim boot:
- **mints the per-boot bearer** the inspector uses to auth its own requests to browserd (every `getHost` port is public);
- **captures the daemon's `bootId`** from the ready-line, so a command replayed against a different boot is rejected, not re-run.

## Tests
Injected `BrowserdSandbox` seam → fully unit-tested with a fake: happy path, token-in-envs-not-argv, split-line reassembly, exit-before-listening (rejects + reaps), ready-timeout, `stop()`. 7 tests; **97 green + 1 gated skip; tsc clean.**

## Where this sits
W1's final wave splits three ways: **e1 (this)** ∥ **e2** (backend desktop-provision behavioral bits, being built in parallel) → **e3** (the internal debug route wiring boot + provision end to end — the W1 exit criterion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New sandbox process orchestration and bearer minting affect how browserd is authenticated on public ports; failures are mitigated by reaping and tests, but wiring into provision flows will expand blast radius.
> 
> **Overview**
> Adds **`bootBrowserd`** on the inspector server (outside `daemon/`) so the hosted browser daemon can be started inside a provisioned desktop sandbox, following the same background-start and ready-line pattern as the plugin-box shim boot.
> 
> The boot runs `node` on the bundled script with **secrets only in environment variables** (per-boot bearer, port, user data dir, optional window size/headless), waits for a JSON **`listening`** line on stdout (including split chunks), and **kills the process** on timeout, early exit, or start failure so orphaned daemons do not linger. On success it returns a handle with the minted bearer, daemon **`bootId`**, public HTTPS origin via `getHost`, and **`stop()`** for cleanup.
> 
> Seven unit tests exercise the `BrowserdSandbox` seam: happy path, env-vs-argv token handling, optional env omission, line reassembly, failure reaping, ready timeout, and stop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c0f949a3bf12e989af70af4a6e7bacbbb81a14c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the inspector-server routine that boots the `browserd` daemon inside a provisioned desktop sandbox. It stays outside `daemon/` so it's never pulled into the bundled artifact.

- Boots `node <bundle>` in the background, passes secrets in envs (never argv), blocks on the single stdout ready-line, and reaps the process on any failed start — mirroring the plugin-box shim boot.
- Mints a per-boot bearer the inspector uses to authenticate its own requests to `browserd`, since every sandbox port is public.
- Captures the daemon's `bootId` from the ready-line so a command replayed against a different boot is rejected, not re-run.
- A `BrowserdSandbox` seam keeps the boot fully unit-testable with a fake; 7 tests cover the happy path, envs-not-argv, split-line reassembly, exit-before-listening, ready-timeout, and `stop()`.

<sup>Written for commit 4c0f949a3bf12e989af70af4a6e7bacbbb81a14c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

