### PR TITLE
feat(browserd): inspector→browserd HTTP client (W1 PR e3a)

### DIFF
--- a/mcpjam-inspector/server/services/browserd/__tests__/browserd-client.test.ts
+++ b/mcpjam-inspector/server/services/browserd/__tests__/browserd-client.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { BrowserdClient, BrowserdClientError } from "../browserd-client";
+import type { BrowserCommand } from "../protocol";
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function stub(response: Response) {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    return response;
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+const CMD: BrowserCommand = {
+  commandId: "c1",
+  source: "chat",
+  action: { kind: "navigate", url: "https://x.test/" },
+};
+
+function makeClient(response: Response, over: { baseUrl?: string } = {}) {
+  const s = stub(response);
+  return {
+    ...s,
+    client: new BrowserdClient({
+      baseUrl: over.baseUrl ?? "https://box-8791.e2b.dev",
+      bearer: "boot-bearer",
+      fetchImpl: s.fetchImpl,
+    }),
+  };
+}
+
+describe("BrowserdClient.sendCommand", () => {
+  it("maps 200 to ok, authenticates, and sends {command, expectedBootId}", async () => {
+    const { client, calls } = makeClient(
+      json(200, {
+        status: "ok",
+        result: { ok: true, output: { url: "https://x.test/" } },
+        bootId: "boot-1",
+      }),
+    );
+    const res = await client.sendCommand(CMD, "boot-1");
+    expect(res).toEqual({
+      status: "ok",
+      result: { ok: true, output: { url: "https://x.test/" } },
+      bootId: "boot-1",
+    });
+    const { url, init } = calls[0];
+    expect(url).toBe("https://box-8791.e2b.dev/v1/commands");
+    expect(new Headers(init.headers).get("authorization")).toBe("Bearer boot-bearer");
+    expect(JSON.parse(init.body as string)).toEqual({ command: CMD, expectedBootId: "boot-1" });
+  });
+
+  it("maps 429 → busy, 503 → at_capacity", async () => {
+    expect(
+      await makeClient(json(429, { status: "busy", bootId: "b" })).client.sendCommand(CMD),
+    ).toEqual({ status: "busy", bootId: "b" });
+    expect(
+      await makeClient(json(503, { error: "daemon_at_capacity", bootId: "b" })).client.sendCommand(
+        CMD,
+      ),
+    ).toEqual({ status: "at_capacity", bootId: "b" });
+  });
+
+  it("distinguishes the three 409 rejections by body.error", async () => {
+    expect(
+      await makeClient(json(409, { error: "command_expired", bootId: "b" })).client.sendCommand(CMD),
+    ).toEqual({ status: "expired", bootId: "b" });
+    expect(
+      await makeClient(json(409, { error: "command_unknown_boot", bootId: "b" })).client.sendCommand(
+        CMD,
+      ),
+    ).toEqual({ status: "unknown_boot", bootId: "b" });
+    const stale = await makeClient(
+      json(409, {
+        error: "stale_observation",
+        result: { ok: false, staleObservation: true },
+        bootId: "b",
+      }),
+    ).client.sendCommand(CMD);
+    expect(stale).toMatchObject({
+      status: "stale_observation",
+      result: { staleObservation: true },
+      bootId: "b",
+    });
+  });
+
+  it("throws on an uninterpretable status (401/400 = a wiring bug, not a signal)", async () => {
+    await expect(
+      makeClient(json(401, {})).client.sendCommand(CMD),
+    ).rejects.toBeInstanceOf(BrowserdClientError);
+    await expect(
+      makeClient(json(400, { error: "invalid_command" })).client.sendCommand(CMD),
+    ).rejects.toThrow(/HTTP 400.*invalid_command/);
+  });
+});
+
+describe("BrowserdClient.health", () => {
+  it("reports ok on 200 and does NOT authenticate healthz", async () => {
+    const { client, calls } = makeClient(json(200, { ok: true }));
+    expect(await client.health()).toEqual({ ok: true, detail: undefined });
+    expect(calls[0].url).toBe("https://box-8791.e2b.dev/healthz");
+    expect(new Headers(calls[0].init.headers).get("authorization")).toBeNull();
+  });
+
+  it("reports a dead browser (503) with its detail", async () => {
+    const { client } = makeClient(json(503, { ok: false, detail: "chromium exited" }));
+    expect(await client.health()).toEqual({ ok: false, detail: "chromium exited" });
+  });
+});
+
+describe("BrowserdClient base URL", () => {
+  it("normalises a trailing slash so paths never double up", async () => {
+    const { client, calls } = makeClient(json(200, { ok: true }), {
+      baseUrl: "https://box-8791.e2b.dev/",
+    });
+    await client.health();
+    expect(calls[0].url).toBe("https://box-8791.e2b.dev/healthz");
+  });
+});

--- a/mcpjam-inspector/server/services/browserd/browserd-client.ts
+++ b/mcpjam-inspector/server/services/browserd/browserd-client.ts
@@ -1,0 +1,155 @@
+/**
+ * The inspector-server → browserd HTTP client: the mirror image of the daemon's
+ * request handler (`daemon/request-handler.ts`). Given a booted daemon's public
+ * origin + per-boot bearer (from `bootBrowserd`), it sends a `BrowserCommand` to
+ * `/v1/commands` and turns the HTTP response back into a typed outcome, and it
+ * probes `/healthz`. Everything above it — the debug route now, the `browser_*`
+ * tools in W3 — speaks commands through this client and never touches fetch or
+ * status codes directly.
+ *
+ * The `expectedBootId` a caller passes is echoed to the daemon so a command
+ * replayed against a DIFFERENT boot is rejected (`unknown_boot`) rather than
+ * re-run; the caller learns the current bootId from every response and stores it.
+ */
+import type { BrowserCommand, BrowserCommandResult } from "./protocol";
+
+/** The daemon's reply, reconstructed from the HTTP status + body. Distinct from
+ *  the queue's `BrowserCommandOutcome`: it also carries the two boundary-only
+ *  rejections (`stale_observation`, `unknown_boot`) the handler maps to 409. */
+export type BrowserdCommandResponse =
+  | { status: "ok"; result: BrowserCommandResult; bootId: string }
+  | { status: "busy"; bootId: string }
+  | { status: "expired"; bootId: string }
+  | { status: "at_capacity"; bootId: string }
+  | { status: "stale_observation"; result?: BrowserCommandResult; bootId: string }
+  | { status: "unknown_boot"; bootId: string };
+
+export interface BrowserdHealth {
+  ok: boolean;
+  detail?: string;
+}
+
+/** browserd answered with a status the client cannot interpret (e.g. 401/400).
+ *  These are bugs in the boot wiring, not normal protocol signals, so they throw
+ *  rather than becoming a response variant. */
+export class BrowserdClientError extends Error {
+  constructor(
+    message: string,
+    readonly httpStatus: number,
+  ) {
+    super(message);
+    this.name = "BrowserdClientError";
+  }
+}
+
+export interface BrowserdClientConfig {
+  /** The daemon's public origin, e.g. `https://box-8791.e2b.dev`. */
+  baseUrl: string;
+  /** The per-boot bearer minted at boot; presented on every request. */
+  bearer: string;
+  /** Injectable for tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Per-request timeout. */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export class BrowserdClient {
+  private readonly baseUrl: string;
+  private readonly bearer: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(config: BrowserdClientConfig) {
+    // Normalise so `${baseUrl}/path` never doubles a slash.
+    this.baseUrl = config.baseUrl.replace(/\/+$/, "");
+    this.bearer = config.bearer;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  /** Probe `/healthz` (unauthenticated). A dead browser is 503 → `{ok:false}`. */
+  async health(): Promise<BrowserdHealth> {
+    const res = await this.request("/healthz", { method: "GET" }, false);
+    const body = (await this.json(res)) as { ok?: unknown; detail?: unknown };
+    return {
+      ok: res.status === 200 && body?.ok === true,
+      detail: typeof body?.detail === "string" ? body.detail : undefined,
+    };
+  }
+
+  /** Send a command and interpret the daemon's reply. */
+  async sendCommand(
+    command: BrowserCommand,
+    expectedBootId?: string,
+  ): Promise<BrowserdCommandResponse> {
+    const res = await this.request(
+      "/v1/commands",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ command, expectedBootId }),
+      },
+      true,
+    );
+    const body = (await this.json(res)) as Record<string, unknown>;
+    const bootId = typeof body.bootId === "string" ? body.bootId : "";
+
+    switch (res.status) {
+      case 200:
+        return {
+          status: "ok",
+          result: body.result as BrowserCommandResult,
+          bootId,
+        };
+      case 429:
+        return { status: "busy", bootId };
+      case 503:
+        return { status: "at_capacity", bootId };
+      case 409:
+        if (body.error === "stale_observation") {
+          return {
+            status: "stale_observation",
+            result: body.result as BrowserCommandResult | undefined,
+            bootId,
+          };
+        }
+        if (body.error === "command_unknown_boot") {
+          return { status: "unknown_boot", bootId };
+        }
+        return { status: "expired", bootId };
+      default:
+        // 401 (bad bearer), 400 (bad envelope), or anything else: a wiring bug,
+        // not a protocol signal.
+        throw new BrowserdClientError(
+          `browserd rejected the command (HTTP ${res.status}${
+            typeof body.error === "string" ? `, ${body.error}` : ""
+          })`,
+          res.status,
+        );
+    }
+  }
+
+  private async request(
+    path: string,
+    init: RequestInit,
+    authenticated: boolean,
+  ): Promise<Response> {
+    const headers = new Headers(init.headers);
+    if (authenticated) headers.set("authorization", `Bearer ${this.bearer}`);
+    return this.fetchImpl(`${this.baseUrl}${path}`, {
+      ...init,
+      headers,
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+  }
+
+  private async json(res: Response): Promise<Record<string, unknown>> {
+    try {
+      return (await res.json()) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }
+}


### PR DESCRIPTION
**W1 PR (e3a)** of the Hosted Browser + WebMCP Runtime. Follows e1 (#4478, boot recipe) — now merged.

The **inspector-server → browserd HTTP client**: the mirror image of the daemon's request handler (PR b). Given a booted daemon's public origin + per-boot bearer (from `bootBrowserd`), it sends a `BrowserCommand` to `/v1/commands` and turns the HTTP response back into a typed outcome; it also probes `/healthz`. Everything above it — the debug route (e3), the `browser_*` tools (W3) — speaks commands through this and never touches fetch or status codes.

- Reconstructs a `BrowserdCommandResponse` from status + body, distinguishing the two **boundary-only 409 rejections** the handler emits (`stale_observation`, `unknown_boot`) from `command_expired`, plus `busy` (429) / `at_capacity` (503).
- Echoes the caller's `expectedBootId` so a replay against a different boot is rejected, not re-run; the caller learns the current `bootId` from every response.
- **401 / 400** (bad bearer / bad envelope) throw `BrowserdClientError` — a wiring bug, not a protocol signal.

## Tests
Injected fetch → fully unit-tested: auth header present on commands and ABSENT on `/healthz`, request body shape, every status→outcome mapping, the three distinct 409s, URL trailing-slash normalisation. 7 tests; **104 green + 1 gated skip; tsc clean.**

## Why now
Pre-staged while **e2** (backend desktop-provision) is in review — this is the one piece of **e3** (the debug route) that's fully independent of the backend, and every W3 `browser_*` tool will speak browserd through it. **e3** then assembles: provision desktop (e2) → `bootBrowserd` (e1) → drive via this client, behind `COMPUTER_BROWSER_DEBUG_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated client module with unit tests only; no production routes or auth paths changed yet.
> 
> **Overview**
> Introduces **`BrowserdClient`**, the typed HTTP layer the inspector server will use to talk to a booted browserd daemon (origin + per-boot bearer from `bootBrowserd`).
> 
> **`sendCommand`** POSTs `{ command, expectedBootId }` to `/v1/commands` with Bearer auth and maps daemon HTTP responses into **`BrowserdCommandResponse`** (`ok`, `busy`, `at_capacity`, `expired`, `stale_observation`, `unknown_boot`), always surfacing **`bootId`**. **`health`** hits unauthenticated `/healthz`. Mis-wired **401/400** responses throw **`BrowserdClientError`** instead of being treated as protocol outcomes. Requests use a configurable timeout and trailing-slash normalization on **`baseUrl`**.
> 
> Adds **Vitest** coverage with injectable **`fetch`**: auth on commands vs none on health, body shape, status mappings (including three distinct **409** cases), and URL normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a38ff207e96acac167a72255326386bc70099cf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the inspector-server → browserd HTTP client: it sends `BrowserCommand`s to a booted daemon's `/v1/commands` endpoint and turns each response into a typed outcome, with a separate unauthenticated `/healthz` probe. Everything above it — the debug route and the W3 `browser_*` tools — will speak browserd through this client instead of touching fetch directly.

**Behavior**
- Maps 429 → busy, 503 → at_capacity, and splits 409 into `stale_observation`, `unknown_boot`, or expired.
- Echoes the caller's `expectedBootId` so a command replayed against a different boot is rejected, and surfaces the current bootId from every response.
- Throws `BrowserdClientError` on 401/400, treating them as wiring bugs rather than protocol signals.

<sup>Written for commit a38ff207e96acac167a72255326386bc70099cf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

