### PR TITLE
tasks/list also treats an empty-string cursor as a cursor (follow-up to #4462)

### DIFF
--- a/.changeset/tasks-list-empty-string-cursor.md
+++ b/.changeset/tasks-list-empty-string-cursor.md
@@ -1,0 +1,18 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/inspector": patch
+---
+
+`tasks/list` also treats an empty-string cursor as a cursor, not the end of a listing
+
+The follow-up to the same fix for `tools`/`prompts`/`resources`/`resource templates`/`skills`. `tasks/list` belongs to the separately-versioned 2025-11-25 in-core tasks utility rather than to the core listing set, so it was left out of that change's scope; it carried the identical defect.
+
+MCP `2026-07-28` (and `draft`) `server/utilities/pagination`:
+
+> Clients MUST treat cursors as opaque tokens: ... Don't make any determination based on cursor value other than whether a non-null value was provided (e.g. an empty string is a valid cursor and thus MUST NOT be treated as the end of results)
+
+Two sites forwarded the cursor by truthiness — the SDK's `tasks/list` request params, and the hosted `/api/web/tasks/list` request body. A `""` handed back by the previous page was dropped on the way out, which does not end a caller's walk so much as silently restart it at page one. Both now forward by presence.
+
+No repeated-cursor guard was added anywhere on this path, and none exists to remove. Comparing two cursors for equality is itself a determination based on cursor value: nothing requires a server to change its token between pages, and `""` is the spec's own example of a valid one — so a cycle check would break the exact case the clause exists to protect. Bounding a walk is the caller's page cap, which limits our own work rather than interpreting somebody else's token.
+
+Nothing in this repo walks `tasks/list` — every caller reads a single page, and the Tasks tab issues it deliberately as one inseparable batch — so this changes no behaviour against a server that pages normally. It is what lets a caller that does walk, or a user passing `mcpjam tasks list --cursor ""`, reach page two.

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-tasks-api.hosted.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-tasks-api.hosted.test.ts
@@ -19,6 +19,7 @@ import {
   getTask,
   getTaskCapabilities,
   getTasksBatch,
+  listTasks,
   updateTask,
 } from "../mcp-tasks-api";
 
@@ -119,6 +120,68 @@ describe("mcp-tasks-api (hosted mode)", () => {
     await cancelTask("my-server", "t1");
 
     expect(lastCall().path).toBe("/api/web/tasks/cancel");
+  });
+
+  it("omits the cursor entirely when the caller supplies none", async () => {
+    authFetchMock.mockResolvedValue(jsonResponse({ wire: "legacy", tasks: [] }));
+
+    await listTasks("my-server");
+
+    expect(lastCall().path).toBe("/api/web/tasks/list");
+    expect("cursor" in lastCall().body).toBe(false);
+  });
+
+  it("carries an empty-string cursor to the hosted route instead of dropping it", async () => {
+    // MCP 2026-07-28 `server/utilities/pagination`: "an empty string is a valid
+    // cursor and thus MUST NOT be treated as the end of results". Dropping it
+    // here did not end a caller's walk so much as restart it at page one.
+    authFetchMock.mockResolvedValue(jsonResponse({ wire: "legacy", tasks: [] }));
+
+    await listTasks("my-server", "");
+
+    expect(lastCall().path).toBe("/api/web/tasks/list");
+    expect(lastCall().body.cursor).toBe("");
+  });
+
+  it("walks past an empty-string nextCursor and re-sends it on the follow-up", async () => {
+    authFetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({ wire: "legacy", tasks: [{ taskId: "t1" }], nextCursor: "" }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ wire: "legacy", tasks: [{ taskId: "t2" }] }),
+      );
+
+    const first = await listTasks("my-server");
+    // ABSENCE ends a walk, not emptiness — so this page continues it.
+    expect(typeof (first as any).nextCursor).toBe("string");
+
+    const second = await listTasks("my-server", (first as any).nextCursor);
+
+    expect(second.tasks.map((task: any) => task.taskId)).toEqual(["t2"]);
+    expect(authFetchMock.mock.calls).toHaveLength(2);
+    expect(JSON.parse(authFetchMock.mock.calls[0][1].body).cursor).toBeUndefined();
+    expect(JSON.parse(authFetchMock.mock.calls[1][1].body).cursor).toBe("");
+  });
+
+  it("keeps forwarding a cursor a server repeats across pages", async () => {
+    // A server holding its pagination state server-side may legally hand back
+    // one constant opaque handle, and comparing two cursors for equality is
+    // itself a determination based on cursor value — so there is no
+    // repeated-cursor guard anywhere on this path. Every page goes out.
+    authFetchMock.mockResolvedValue(
+      jsonResponse({ wire: "legacy", tasks: [{ taskId: "t1" }], nextCursor: "" }),
+    );
+
+    await listTasks("my-server");
+    await listTasks("my-server", "");
+    await listTasks("my-server", "");
+
+    expect(
+      authFetchMock.mock.calls.map(
+        ([, init]: [string, RequestInit]) => JSON.parse(init.body as string).cursor,
+      ),
+    ).toEqual([undefined, "", ""]);
   });
 
   it("reports no progress hosted without touching the network", async () => {

--- a/mcpjam-inspector/client/src/lib/apis/web/tasks-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/tasks-api.ts
@@ -35,7 +35,10 @@ export async function listHostedTasks(request: {
 }): Promise<any> {
   return webPost("/api/web/tasks/list", {
     ...buildServerRequest(request.serverNameOrId),
-    ...(request.cursor ? { cursor: request.cursor } : {}),
+    // Presence, not truthiness: `""` is a valid continuation cursor (MCP
+    // 2026-07-28 `server/utilities/pagination`), so it has to reach the route
+    // verbatim rather than being dropped as if no cursor had been supplied.
+    ...(request.cursor !== undefined ? { cursor: request.cursor } : {}),
   });
 }
 

--- a/sdk/src/mcp-client-manager/tasks.ts
+++ b/sdk/src/mcp-client-manager/tasks.ts
@@ -42,7 +42,14 @@ export async function listTasks(
   return client.requestWithSchema(
     {
       method: "tasks/list",
-      params: cursor ? { cursor } : {},
+      // Presence, not truthiness: `""` is a valid continuation cursor. MCP
+      // 2026-07-28 `server/utilities/pagination` states that a client "MUST
+      // NOT" decide anything from a cursor's value beyond whether a non-null
+      // one was provided, and that "an empty string is a valid cursor and thus
+      // MUST NOT be treated as the end of results". A truthiness test here
+      // dropped a `""` handed back by the previous page, which does not end a
+      // caller's walk so much as silently restart it at page one.
+      params: cursor !== undefined ? { cursor } : {},
     },
     LEGACY_TASKS_RESULT_SCHEMA,
     options

--- a/sdk/tests/tasks-list-empty-cursor.test.ts
+++ b/sdk/tests/tasks-list-empty-cursor.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { MCPClientManager } from "../src/mcp-client-manager";
+import type { ManagedMcpClient } from "../src/mcp-client-manager/managed-mcp-client.js";
+
+/**
+ * `tasks/list` pagination — the empty-string cursor.
+ *
+ * MCP 2026-07-28 (and `draft`) `server/utilities/pagination` says a client
+ * "MUST NOT" decide anything from a cursor's value beyond whether a non-null
+ * one was provided, and that "an empty string is a valid cursor and thus MUST
+ * NOT be treated as the end of results".
+ *
+ * `tasks/list` belongs to the separately-versioned 2025-11-25 in-core tasks
+ * utility (SEP-2663 removed it from the newer wire), so it was left out of the
+ * `tools/prompts/resources/templates/skills` fix in #4462. It carried the same
+ * defect: `params: cursor ? { cursor } : {}` dropped a `""` handed back by the
+ * previous page, which restarts a caller's walk at page one instead of
+ * advancing it.
+ *
+ * There is no page walk over `tasks/list` in this repo — every caller reads a
+ * single page — so these tests drive the walk the way a caller would, and
+ * assert on the exact request params that reach the wire.
+ */
+
+const LEGACY_TASK_CAPS = {
+  tools: {},
+  tasks: { list: true, cancel: true, requests: { tools: { call: true } } },
+} as const;
+
+interface Recorded {
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+/**
+ * A manager whose one live client answers `tasks/list` from a queue of pages
+ * and records every request verbatim.
+ */
+function seedManager(pages: unknown[]): {
+  manager: MCPClientManager;
+  calls: Recorded[];
+  serverId: string;
+} {
+  const serverId = "srv";
+  const calls: Recorded[] = [];
+  const manager = new MCPClientManager();
+  let index = 0;
+
+  const client = {
+    getServerCapabilities: () => LEGACY_TASK_CAPS,
+    getNegotiatedProtocolVersion: () => "2025-11-25",
+    getProtocolEra: () => undefined,
+    getServerVersion: () => ({ name: "fixture", version: "1.0.0" }),
+    getInstructions: () => undefined,
+    requestWithSchema: async (req: Recorded) => {
+      calls.push(JSON.parse(JSON.stringify(req)));
+      const page = pages[Math.min(index, pages.length - 1)];
+      index += 1;
+      return page;
+    },
+  } as unknown as ManagedMcpClient;
+
+  (manager as any).registeredServers.set(serverId, {
+    config: { url: "https://example.test/mcp" },
+    timeout: 1000,
+  });
+  (manager as any).liveClientStates.set(serverId, { client });
+
+  return { manager, calls, serverId };
+}
+
+/** The walk a caller writes: absence ends it, `""` does not. */
+async function walkTasks(
+  manager: MCPClientManager,
+  serverId: string,
+  maxPages: number
+): Promise<{ taskIds: string[]; complete: boolean }> {
+  const taskIds: string[] = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < maxPages; page++) {
+    const result: any = await manager.listTasks(serverId, cursor);
+    for (const task of result.tasks ?? []) taskIds.push(task.taskId);
+
+    const nextCursor =
+      typeof result.nextCursor === "string" ? result.nextCursor : undefined;
+    // ABSENCE ends the walk, not emptiness.
+    if (nextCursor === undefined) return { taskIds, complete: true };
+    cursor = nextCursor;
+  }
+
+  // Stopped at the cap: the listing was NOT read to the end.
+  return { taskIds, complete: false };
+}
+
+describe("tasks/list cursor forwarding", () => {
+  it("sends no cursor at all when the caller supplies none", async () => {
+    const { manager, calls, serverId } = seedManager([{ tasks: [] }]);
+
+    await manager.listTasks(serverId);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe("tasks/list");
+    expect(calls[0].params).toEqual({});
+  });
+
+  it("forwards an empty-string cursor verbatim instead of dropping it", async () => {
+    const { manager, calls, serverId } = seedManager([{ tasks: [] }]);
+
+    await manager.listTasks(serverId, "");
+
+    expect(calls[0].params).toEqual({ cursor: "" });
+  });
+
+  it("continues the walk past a page whose nextCursor is the empty string, and re-sends it", async () => {
+    const { manager, calls, serverId } = seedManager([
+      { tasks: [{ taskId: "t1" }], nextCursor: "" },
+      { tasks: [{ taskId: "t2" }] },
+    ]);
+
+    const walk = await walkTasks(manager, serverId, 8);
+
+    // The second page was reached, so `""` was not read as the end of results.
+    expect(walk.taskIds).toEqual(["t1", "t2"]);
+    expect(walk.complete).toBe(true);
+    // ...and the follow-up request actually carried it on the wire.
+    expect(calls).toHaveLength(2);
+    expect(calls[0].params).toEqual({});
+    expect(calls[1].params).toEqual({ cursor: "" });
+  });
+
+  it("ends the walk when nextCursor is absent, null, or not a string", async () => {
+    for (const page of [
+      { tasks: [{ taskId: "t1" }] },
+      { tasks: [{ taskId: "t1" }], nextCursor: null },
+      { tasks: [{ taskId: "t1" }], nextCursor: 42 },
+    ]) {
+      const { manager, calls, serverId } = seedManager([page]);
+
+      const walk = await walkTasks(manager, serverId, 8);
+
+      expect(walk.taskIds).toEqual(["t1"]);
+      expect(walk.complete).toBe(true);
+      expect(calls).toHaveLength(1);
+    }
+  });
+
+  it("walks a server that repeats one constant cursor rather than truncating at it", async () => {
+    // A server holding its pagination state server-side may legally hand back
+    // one constant opaque handle. Comparing two cursors for equality would be
+    // a determination based on cursor value — and `""` would join any seen-set
+    // and break the very case above — so there is no repeated-cursor guard.
+    // The page cap bounds our own work instead, and a cap stop reports the
+    // listing as INCOMPLETE rather than as a finished read.
+    const { manager, calls, serverId } = seedManager([
+      { tasks: [{ taskId: "t1" }], nextCursor: "" },
+      { tasks: [{ taskId: "t2" }], nextCursor: "" },
+      { tasks: [{ taskId: "t3" }], nextCursor: "" },
+      { tasks: [{ taskId: "t4" }] },
+    ]);
+
+    const walk = await walkTasks(manager, serverId, 8);
+
+    expect(walk.taskIds).toEqual(["t1", "t2", "t3", "t4"]);
+    expect(walk.complete).toBe(true);
+    expect(calls).toHaveLength(4);
+    expect(calls.map((call) => call.params)).toEqual([
+      {},
+      { cursor: "" },
+      { cursor: "" },
+      { cursor: "" },
+    ]);
+  });
+
+  it("stops a never-ending constant cursor at the page cap, reported as incomplete", async () => {
+    const { manager, calls, serverId } = seedManager([
+      { tasks: [{ taskId: "t1" }], nextCursor: "same" },
+    ]);
+
+    const walk = await walkTasks(manager, serverId, 3);
+
+    expect(walk.complete).toBe(false);
+    expect(calls).toHaveLength(3);
+    expect(calls.map((call) => call.params)).toEqual([
+      {},
+      { cursor: "same" },
+      { cursor: "same" },
+    ]);
+  });
+});


### PR DESCRIPTION
Follow-up to #4462, which fixed the empty-string cursor across `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list` and `skills/list` and deliberately left `tasks/list` out of scope. This is that one.

## Why it was a separate PR

`tasks/list` is not part of the core listing set. It belongs to the **2025-11-25 in-core tasks utility**, which is versioned separately from the pagination clause being applied and which SEP-2663 subsequently **removed from the newer wire** — so on `2026-07-28`+ there is no `tasks/list` at all and the client-side tracker is the list. Splitting it kept #4462's scope to one coherent set; the defect it carried was identical.

## The clause

MCP `2026-07-28` (and `draft`), `server/utilities/pagination`:

> Clients MUST treat cursors as opaque tokens: ... Don't make any determination based on cursor value other than whether a non-null value was provided (e.g. an empty string is a valid cursor and thus MUST NOT be treated as the end of results)

Same semantics as the parent PR:

1. A walk ends **iff** `nextCursor` is `undefined`, `null`, or not a string. `""` continues it.
2. A cursor is forwarded by **presence** — `cursor !== undefined ? { cursor } : {}` — never by truthiness.

## What was wrong

Two sites on the `tasks/list` path dropped a `""` on the way **out**:

- **`sdk/src/mcp-client-manager/tasks.ts`** — `params: cursor ? { cursor } : {}`. This is the wire itself, so it also fixes `mcpjam tasks list --cursor ""` and both Inspector routes transitively.
- **`mcpjam-inspector/client/src/lib/apis/web/tasks-api.ts`** — `...(request.cursor ? { cursor: request.cursor } : {})` on the hosted `/api/web/tasks/list` body.

Dropping a `""` handed back by the previous page does not end a caller's walk so much as **silently restart it at page one**.

## No repeated-cursor guards were added

None exist on this path, and none were introduced. Comparing two cursors for equality is itself a determination based on cursor value: nothing requires a server to change its token between pages, a server holding its pagination state server-side may legally return one constant opaque handle, and `""` — the spec's own example of a valid cursor — would join any seen-set and break the exact case the clause exists to protect. #4462's final commit removed these guards everywhere, including pre-existing ones; this PR does not reintroduce them.

The bound is the caller's **page cap**: it limits our own work rather than interpreting somebody else's token, it bounds the adversarial server (which would emit distinct cursors forever, defeating any equality check) identically, and a cap stop reports the listing as **incomplete** rather than as a finished read. One of the new SDK tests pins that last part.

Applied **unconditionally**, not era-gated, exactly as in #4462.

## Sweep result

The whole `tasks/list` path was swept in both directions — the request (`cursor` forwarded) and the response (`nextCursor` read) — across `sdk/src`, `cli/src`, `mcpjam-inspector/server`, `mcpjam-inspector/client/src` and the other workspace packages. It found the two sites above and nothing else.

**Already correct, left alone:**

- `mcpjam-inspector/server/routes/mcp/tasks.ts` (`/api/mcp/tasks/list`), `server/routes/web/tasks.ts` (`/api/web/tasks/list`), `server/utils/task-route-handlers.ts` (`listTasksForWire`), and `client/src/lib/apis/mcp-tasks-api.ts` (`listTasks` / `listTasksLocal`) all already pass the cursor through by presence, and `listTasksForWire` spreads the whole page so a `nextCursor` reaches the caller untouched.
- `taskListSchema` in `server/routes/web/auth.ts` is `z.string().optional()` — no `.min(1)`, so it already accepts `cursor: ""`. (The parent PR had to drop a `.min(1)` from the `list_server_*` schema; there is no equivalent here.)
- `cli/src/commands/tasks.ts` forwards `options.cursor` straight into `manager.listTasks`, so it inherits the SDK fix.

**Deliberately not paginated — no pagination invented:**

- **`client/src/components/TasksTab.tsx`** calls `listTasks(serverName)` with **no cursor at all** and never reads `nextCursor`. Its comment explains why: "`tasks/list` is an INSEPARABLE batch: one request returns every task, so issuing it reads — and reschedules — the slowest member along with the fastest." The tab gates the call on *every* active member being due precisely so a batch cannot drag a slow task's poll floor down. Adding a page walk there would issue N requests per tick against that design. The registry-recovery read at the same site is a single call for the same reason. Untouched.
- `MCPClientManager.listTasks` answers `{ tasks: [] }` locally on the extension wire (SEP-2663 removed the method) and on a `-32601`. Not a walk, no cursor, untouched.

**Out of scope**, per the parent PR — MCPJam's own REST/Convex pagination, whose contract is "`nextCursor` omitted when done" and where `""` is never meaningful: `server/routes/v1/**`, `server/services/hosted-task-registry.ts` (`/internal/v1/hosted-tasks/list`), and the eval/session listing paths named in #4462.

There is, as of this PR, **no page walk over `tasks/list` anywhere in the repo** — every caller reads a single page. So against a server that pages normally this changes no behaviour. It is what lets a caller that *does* walk, or a user passing `--cursor ""`, reach page two.

## Tests

Both halves are asserted in both packages: the walk continues past a `""` page **and** the follow-up request actually carried `cursor: ""`.

- **`sdk/tests/tasks-list-empty-cursor.test.ts`** (new, 6 tests) — against a recording `ManagedMcpClient` through `MCPClientManager.listTasks`, so the assertions are on the exact request params that reach the wire: no cursor sent when none is supplied; `""` forwarded verbatim; a `""` `nextCursor` continues the walk and is re-sent (`calls[1].params` is `{ cursor: "" }`); absent / `null` / non-string `nextCursor` still ends it; a server repeating one constant cursor is **walked to completion, not truncated at page two**; and a never-ending constant cursor stops at the page cap reported as `complete: false`.
- **`client/src/lib/apis/__tests__/mcp-tasks-api.hosted.test.ts`** (+5) — the hosted route body: cursor key absent when none is supplied; `cursor: ""` present on the wire; a two-page drive whose second `authFetch` body carries `cursor: ""`; and a repeated cursor forwarded on every page rather than short-circuited.

Both new suites were verified to **fail without the fix** (3 of 6 and 3 of 14 respectively) and pass with it.

## Verification actually run

| Command | Result |
|---|---|
| `npm run typecheck -w @mcpjam/sdk` | **exit 0** |
| `npm run typecheck:client -w @mcpjam/inspector` | **exit 0** |
| `NODE_OPTIONS=--max-old-space-size=8192 npm run build -w @mcpjam/sdk` | **exit 0** |
| `npm run test -w @mcpjam/sdk` (full SDK suite) | **exit 0** — 313 files, **6869 passed**, 8 skipped |
| SDK tasks suites (7 files: the new one plus legacy/extension wire, integration, policy, era-gate) | **exit 0** — 188 passed |
| inspector `vitest run` on the 14 tasks-related client + server suites | **exit 0** — 138 passed |

Notes on the environment, stated rather than hidden:

- The inspector server suites fail to *collect* until `pretest` has run (`Cannot find module './shim/PluginShim.bundled.js'` — a generated bundle that is not in git). Running `node scripts/bundle-plugin-shim.mjs` and its two siblings first makes them pass. Not related to this diff.
- `prettier --check` already warns on `sdk/src/mcp-client-manager/tasks.ts` and `client/src/lib/apis/__tests__/mcp-tasks-api.hosted.test.ts` on pristine `origin/main` (verified by stashing). Formatting was matched by hand rather than running `--write` over unrelated lines.
- The CLI suite was **not** run: this PR changes no CLI file, and in a worktree `@mcpjam/sdk` resolves to the shared checkout's copy rather than this branch's, so a CLI run would not have exercised the change anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFM1b5a2DHDmaoQN6LCr6b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow pagination-parameter fix on the tasks/list path with thorough tests; no auth, data migration, or Tasks tab batching behavior changes.
> 
> **Overview**
> Follow-up to the empty-string cursor fix for core MCP listings: **`tasks/list`** now forwards cursors by **presence** (`cursor !== undefined`) instead of truthiness, matching MCP pagination rules where **`""` is a valid continuation token**.
> 
> The change is in two outbound paths: the SDK **`tasks/list`** request params (also affects CLI **`mcpjam tasks list --cursor ""`**) and the Inspector hosted **`/api/web/tasks/list`** POST body. Previously, a **`""`** from **`nextCursor`** was dropped and the walk silently restarted at page one.
> 
> **New tests** cover SDK wire params and hosted route bodies: omit cursor when unset, send **`cursor: ""`** verbatim, continue multi-page walks, and keep forwarding repeated opaque cursors (no equality guard). In-repo callers still mostly fetch a single page, so day-to-day UI behavior is unchanged unless something paginates through **`tasks/list`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd4b8e270a3823130d77327bb60707e14623d799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `tasks/list` pagination to treat an empty-string cursor as a cursor, so a caller's walk advances to page two instead of silently restarting at page one. The SDK request params and the hosted `/api/web/tasks/list` body previously dropped `""` by forwarding via truthiness; both now forward by presence (`cursor !== undefined`).

**Notes**
- No repeated-cursor guard was added; walks are bounded by the caller's page cap, and a cap stop reports the listing as incomplete.
- Nothing in the repo walks `tasks/list`, so behavior is unchanged against servers that page normally.
- New tests in `@mcpjam/sdk` and `@mcpjam/inspector` pin the `""` walk behavior on both sides of the wire.

<sup>Written for commit cd4b8e270a3823130d77327bb60707e14623d799. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

