### PR TITLE
oauth: let the debugger's warnings arrive as warnings

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/error-reporting.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/error-reporting.test.ts
@@ -147,6 +147,31 @@ describe("reportCaught", () => {
     );
   });
 
+  // Sentry reads `level`; PostHog error tracking reads `$exception_level`, and
+  // groups, alerts and filters on it. Sending only `level` left every report at
+  // PostHog's `error` default, which silently overrode the one caller that asks
+  // for something quieter.
+  it("declares the level on the key PostHog actually reads", () => {
+    reportCaught(new Error("server under test misbehaved"), {
+      source: "oauth_debugger_step",
+      level: "warning",
+    });
+
+    expect(posthogCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ $exception_level: "warning" }),
+    );
+  });
+
+  it("still defaults to error when the caller names no level", () => {
+    reportCaught(new Error("boom"), { source: "unit" });
+
+    expect(posthogCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ $exception_level: "error" }),
+    );
+  });
+
   it("reports to Sentry but NOT PostHog on a non-capture surface", async () => {
     // `capture_exceptions: false` only disables posthog-js's automatic
     // window.onerror handler — an explicit captureException still sends. A

--- a/mcpjam-inspector/client/src/lib/error-reporting.ts
+++ b/mcpjam-inspector/client/src/lib/error-reporting.ts
@@ -189,6 +189,22 @@ export function reportCaught(error: unknown, options: ReportOptions): void {
       posthog.captureException(normalized, {
         source: options.source,
         level: options.level ?? "error",
+        // The severity PostHog actually reads. `captureException(err, props)`
+        // merges `props` OVER the properties it built, and error tracking
+        // groups, alerts and filters on `$exception_level` — so the plain
+        // `level` above lands as a custom property nothing looks at, and every
+        // report kept the `error` default no matter what the caller declared.
+        //
+        // That silently overrode the one caller that asks for anything else.
+        // `oauth_debugger_step` is `warning` on purpose — it reports the
+        // server UNDER TEST misbehaving, which is what a debugger is for, and
+        // its value is the aggregate trend rather than a page. It alerted as
+        // an Inspector crash anyway: 378 events across 97 users in 18 days,
+        // more than half of every client `$exception` in the project.
+        //
+        // `level` is kept alongside it: it has been on these events since the
+        // sink was written, and dropping it would break any saved filter.
+        $exception_level: options.level ?? "error",
         ...(options.extra ?? {}),
       });
     }

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-step-reporting.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-step-reporting.test.ts
@@ -163,6 +163,43 @@ describe("OAuth debugger step-failure reporting", () => {
     expect(reportCaught).toHaveBeenCalledTimes(2);
   });
 
+  it("reports one failure once when the hint is appended after it", () => {
+    // The SDK writes the bare message, then the same message with the recovery
+    // hint (`errorWithFallbackHint`). Two strings, one refusal — and exact
+    // comparison reported both, a millisecond apart.
+    const { wrapped } = wrappedUpdateState();
+
+    wrapped({ error: "Dynamic Client Registration failed (400)." });
+    wrapped({
+      error:
+        "Dynamic Client Registration failed (400). Configure a pre-registered client or enable DCR on the authorization server.",
+    });
+
+    expect(reportCaught).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows the pair in the other order too", () => {
+    // Nothing guarantees which of the two lands first, and a guard that only
+    // works one way round is a guard that works half the time.
+    const { wrapped } = wrappedUpdateState();
+
+    wrapped({ error: "Client registration failed: timeout. Configure a pre-registered client." });
+    wrapped({ error: "Client registration failed: timeout." });
+
+    expect(reportCaught).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not swallow a different failure that merely follows", () => {
+    // The narrowness is the point: an unrelated message never begins with the
+    // whole text of the one before it.
+    const { wrapped } = wrappedUpdateState();
+
+    wrapped({ error: "Dynamic Client Registration failed (400)." });
+    wrapped({ error: "Authenticated request failed: 401 Unauthorized" });
+
+    expect(reportCaught).toHaveBeenCalledTimes(2);
+  });
+
   it("still forwards every update to the caller's updateState", () => {
     const { wrapped, updateState } = wrappedUpdateState();
 

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -273,6 +273,28 @@ const UNREPORTED_STEP_FAILURES = new Set([
 ]);
 
 /**
+ * One failure, or two?
+ *
+ * A step that fails twice over — DCR, say — writes its bare message first and
+ * then the same message with the recovery hint appended
+ * (`errorWithFallbackHint` in the SDK is `${error} ${FALLBACK_HINT}`). Exact
+ * comparison saw two different strings and reported both, one millisecond
+ * apart, so a single refusal arrived as a pair: 29 of 378 events over 18 days.
+ *
+ * Prefix, not equality, and in whichever order they arrive. This is
+ * deliberately narrow — an unrelated failure never begins with the whole text
+ * of the one before it, so widening a step's message cannot swallow the next
+ * step's.
+ */
+function isSameStepFailure(
+  error: string,
+  lastReported: string | undefined
+): boolean {
+  if (lastReported === undefined) return false;
+  return error.startsWith(lastReported) || lastReported.startsWith(error);
+}
+
+/**
  * Wrap the caller's `updateState` so every NEW step failure is reported.
  *
  * This is the only reliable hook: the SDK state machine catches its own step
@@ -309,7 +331,11 @@ function withStepFailureReporting(
       updateState(updates);
       return;
     }
-    if (typeof error === "string" && error !== "" && error !== lastReportedError) {
+    if (
+      typeof error === "string" &&
+      error !== "" &&
+      !isSameStepFailure(error, lastReportedError)
+    ) {
       lastReportedError = error;
       reportCaught(new Error(sanitizeStepError(error)), {
         source: "oauth_debugger_step",


### PR DESCRIPTION
Triage of the PostHog alert on [`Dynamic Client Registration failed (400)`](https://us.posthog.com/project/212744/error_tracking/01a049c4-73f8-7b70-bcf8-52813781b8d7).

## What the alert actually was

Four events, one user, two sessions, all from `http://127.0.0.1:6274/p/…/oauth-flow` — someone debugging their own MCP server's OAuth handshake on their own machine. The four messages under that one title:

| message | what it is |
|---|---|
| `Dynamic Client Registration failed (400).` | their auth server refuses DCR |
| `Dynamic Client Registration failed (400). Configure a pre-registered client…` | *the same failure*, hint appended |
| `Authenticated request failed: 401 Unauthorized` | their server |
| `…Unsupported protocol version: 2026-07-28. Supported versions: 2025-11-25, …` | their server |

All `$exception_handled: true`. None of them is the Inspector failing. Three unrelated problems and one duplicate, filed under a title naming only one of them.

## The defect

`withStepFailureReporting` already decided this, in as many words:

> `warning` level, not `error`: many of these are the server-under-test misbehaving, which is exactly what a debugger is for. The value is the aggregate trend, not a page.

That decision never reached PostHog. `reportCaught` passes a property named `level`; PostHog error tracking groups, alerts and filters on **`$exception_level`**, and `captureException(err, props)` merges `props` over the properties it built — so `level` landed as a custom property nothing reads and the `error` default stood.

Measured over 30 days — every source, declared level vs. recorded level:

| source | declared | recorded | events | users |
|---|---|---|---|---|
| **`oauth_debugger_step`** | **warning** | **error** | **378** | **97** |
| `react_boundary` | error | error | 103 | 16 |
| `route_error_element` | error | error | 102 | 34 |
| `client` | — | error | 62 | 20 |
| `react_boundary:integrations_github_checks` | error | error | 38 | 25 |
| `chat_request_failed` | error | error | 18 | 13 |

`oauth_debugger_step` is the only source that declares anything but `error`, so it is the only one this ever affected — and it is more than half of every client `$exception` in the project. Sentry had the level right the whole time (`Sentry.captureException` takes `level` directly), which is why the two earlier passes at this noise, #3955 and #3959, could quiet Sentry message by message and leave PostHog untouched.

## The second, smaller one

The two DCR events landed at `19:06:44.276` and `.277`. The SDK writes the bare message, then the same message with the recovery hint appended (`errorWithFallbackHint` is `${error} ${FALLBACK_HINT}`); the dedupe compared exact strings, saw two, and reported both. **29 of the 378** are a single refusal reported twice.

`isSameStepFailure` compares by prefix in either order. Narrow on purpose: an unrelated failure never begins with the whole text of the one before it, so widening a step's message cannot swallow the next step's. Pinned by a test in both directions plus a negative.

## Neither change hides anything

The events still arrive in PostHog. They stop claiming to be crashes, so alert rules can key on severity instead of on a growing list of message patterns.

## Not done here

**106 distinct messages are collapsing into 33 issues** — one issue holds 54 of them. Cause is in the event data, not in this code: `"resolve_failure": "Refusing to fetch from non-public address: http://127.0.0.1:6274/assets/index-BxFnJSWw.js"`. PostHog cannot fetch source maps from a localhost bundle, so every frame stays minified and identical, and grouping falls back to the stack. That is why the alert title named a DCR failure while the issue also contained a 401 and a protocol-version mismatch. Fixing it means uploading source maps at release rather than resolving them at read time — a build-pipeline change, out of scope here.

**`Token request failed: [object Object] - Unknown error`** — 60 events across three issues. An object reaching string concatenation; the real reason is lost before it is ever reported. Separate bug, worth its own fix.

## Tests

All four new tests verified to fail without the fix and pass with it.

- `client/src/lib/__tests__/error-reporting.test.ts` — the declared level reaches `$exception_level`; absent one, it still defaults to `error`
- `client/src/lib/oauth/__tests__/debug-state-machine-step-reporting.test.ts` — the hint-suffixed pair reports once, in either order, and a genuinely different failure still reports twice

Run from `mcpjam-inspector/` (the `@/` alias needs the workspace's own vitest config):

- `npx vitest run client/src/lib client/src/components/__tests__/OAuthFlowTab` — 2795 passed, 250 files
- `npm run typecheck` (from `inspector/`) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth debugger failure reporting so warnings reach PostHog as warnings instead of errors, and a single failure with an appended recovery hint is no longer reported twice.

**Bug Fixes**
- `reportCaught` now sends `$exception_level`, the key PostHog error tracking actually reads; `level` stays for compatibility with saved filters.
- Duplicate reports that differ only by the appended hint are collapsed with prefix matching, in either order.
- Matching is deliberately narrow, so a genuinely different failure still reports separately.

<sup>Written for commit d6e25cca2d3b3cdf8b3047a7f2c5622c81270fcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

