### PR TITLE
Docs: optional TOA verify after doctor/conformance in CI

### DIFF
--- a/docs/cli/ci.mdx
+++ b/docs/cli/ci.mdx
@@ -244,7 +244,7 @@ Single-run `protocol conformance`, `oauth conformance`, and `apps conformance` a
 
 ### Optional: verify Tool Outcome Attestation (TOA) after doctor / conformance
 
-Doctor and protocol conformance cover connect, capabilities, and protocol behavior. [Tool Outcome Attestation](https://github.com/Carmel-Labs-Inc/toa) (`toa/0.1`) is a separate, Apache-2.0 signed JSON artifact for **tool delivery** grades (reach, invoke, functional, shape, and related layers). It is not a wire protocol and is not meant to run on every live `tools/call`.
+Doctor and protocol conformance cover connect, capabilities, and protocol behavior. [Tool Outcome Attestation](https://github.com/Carmel-Labs-Inc/toa) (`toa/0.1`) is a separate, Ed25519-signed JSON artifact (Apache-2.0 project) for **tool delivery** grades (reach, invoke, functional, shape, and related layers). It is not a wire protocol and is not meant to run on every live `tools/call`.
 
 If your pipeline already has a `toa.json` from AgentStatus (or another emitter whose key you pin), you can fail the job when verify fails. The example below requires `emitter.name=agentstatus` and uses the packaged AgentStatus key; pass `--public-key` for another issuer. No AgentStatus account is required to verify.
 

--- a/docs/cli/ci.mdx
+++ b/docs/cli/ci.mdx
@@ -262,7 +262,7 @@ If your pipeline already has a `toa.json` from any emitter, you can fail the job
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 

--- a/docs/cli/ci.mdx
+++ b/docs/cli/ci.mdx
@@ -246,7 +246,7 @@ Single-run `protocol conformance`, `oauth conformance`, and `apps conformance` a
 
 Doctor and protocol conformance cover connect, capabilities, and protocol behavior. [Tool Outcome Attestation](https://github.com/Carmel-Labs-Inc/toa) (`toa/0.1`) is a separate, Apache-2.0 signed JSON artifact for **tool delivery** grades (reach, invoke, functional, shape, and related layers). It is not a wire protocol and is not meant to run on every live `tools/call`.
 
-If your pipeline already has a `toa.json` from any emitter, you can fail the job when verify fails. No AgentStatus account is required to verify.
+If your pipeline already has a `toa.json` from AgentStatus (or another emitter whose key you pin), you can fail the job when verify fails. The example below requires `emitter.name=agentstatus` and uses the packaged AgentStatus key; pass `--public-key` for another issuer. No AgentStatus account is required to verify.
 
 ```yaml
       - name: Doctor

--- a/docs/cli/ci.mdx
+++ b/docs/cli/ci.mdx
@@ -242,6 +242,32 @@ Run the server-side MCP Apps surface checks from a config file and publish JUnit
 
 Single-run `protocol conformance`, `oauth conformance`, and `apps conformance` also accept `--reporter junit-xml` when you only need one target/check selection instead of a suite config file.
 
+### Optional: verify Tool Outcome Attestation (TOA) after doctor / conformance
+
+Doctor and protocol conformance cover connect, capabilities, and protocol behavior. [Tool Outcome Attestation](https://github.com/Carmel-Labs-Inc/toa) (`toa/0.1`) is a separate, Apache-2.0 signed JSON artifact for **tool delivery** grades (reach, invoke, functional, shape, and related layers). It is not a wire protocol and is not meant to run on every live `tools/call`.
+
+If your pipeline already has a `toa.json` from any emitter, you can fail the job when verify fails. No AgentStatus account is required to verify.
+
+```yaml
+      - name: Doctor
+        run: npx -y @mcpjam/cli@latest server doctor --url ${{ secrets.MCP_SERVER_URL }} --format json
+
+      - name: Protocol conformance
+        run: |
+          npx -y @mcpjam/cli@latest protocol conformance \
+            --url ${{ secrets.MCP_SERVER_URL }} \
+            --reporter junit-xml > protocol-report.xml
+
+      # Optional. Skip when toa.json is absent.
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass
+```
+
+Pin the emitter public key using the flags documented in the toa repo when you need a specific signer.
+
 ---
 
 ## GitLab CI

--- a/docs/cli/ci.mdx
+++ b/docs/cli/ci.mdx
@@ -262,7 +262,7 @@ If your pipeline already has a `toa.json` from any emitter, you can fail the job
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
           toa-verify toa.json --require-layer functional=pass
 ```
 

--- a/docs/cli/ci.mdx
+++ b/docs/cli/ci.mdx
@@ -262,8 +262,8 @@ If your pipeline already has a `toa.json` from any emitter, you can fail the job
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 
 Pin the emitter public key using the flags documented in the toa repo when you need a specific signer.


### PR DESCRIPTION
## Summary

Docs-only change to `docs/cli/ci.mdx`: optional `toa-verify` after doctor / protocol conformance when a `toa.json` is present.

toa is Apache-2.0 open schema + offline verify for tool delivery evidence. It does not replace MCPJam doctor, OAuth, protocol conformance, or evals.

Related: https://github.com/MCPJam/inspector/issues/4497

## Test plan

- [ ] New section renders in Mintlify
- [ ] Example YAML is clearly optional / gated on `toa.json`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional TOA verify step after doctor and protocol conformance in the GitHub Actions CI docs, enabled only when a `toa.json` exists.

- Clarifies TOA is a separate Ed25519-signed delivery-evidence artifact (Apache-2.0 project), not a replacement for doctor or conformance checks; verification requires no AgentStatus account.
- Pins the `toa-verify` install to a commit SHA that packages the signer public key, and aligns the prose with the example's `--require-emitter agentstatus` / `--max-age` flags, so the docs don't depend on moving defaults.

<sup>Written for commit a8ce31792fdcec02194c637f3c3bbffe1dc62186. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

