### PR TITLE
Fix/bb 63 swarm server readiness

### DIFF
--- a/.changeset/bb-63-swarm-server-readiness.md
+++ b/.changeset/bb-63-swarm-server-readiness.md
@@ -1,0 +1,25 @@
+---
+"@mcpjam/inspector": patch
+---
+
+"No servers to run against" stops telling you to connect a server you already have
+
+Opening Swarms → New with a server in your project but none attached to the setup produced an amber warning whose remedy was "Connect a server and turn on Auto-connect on the Servers tab" — an instruction to redo work already done, next to a picker plainly listing the server you had. That is the whole of BB-63's "what did I do wrong?".
+
+The readiness check now separates the three situations that shared one sentence, because each has a different fix:
+
+- **Your project has a usable server, it just isn't in this setup.** The common case, and the one the old copy got wrong. The notice now names the server — "Your project has draw. Pick what this run should use." — which is both the next step and the evidence that nothing you did was wrong. Past two servers it names two and counts the rest rather than growing into a paragraph.
+- **Your project is empty.** The only case where "connect a server" was ever the right instruction, and it keeps it.
+- **Your servers exist but none is reachable from a cloud run.** Previously indistinguishable from the empty case, so the advice was to connect yet another server that would fail the same way. It now points at the same reachability remedy `local_only` gives.
+
+`attachable` deliberately excludes stdio and localhost servers: offering one would have walked the user into the `local_only` failure on the very next click.
+
+Alongside that, a new server group no longer opens as a form whose only answer was never in doubt. In a project with three or fewer servers the group arrives with them already ticked and Create already live, and the name is derived from the contents — `draw`, or `draw + 2` — instead of `group 1`. BB-3 reported a `group 1` holding a server called `rabona`; groups still cannot be renamed, so a name that starts out meaning something is worth more here than usual.
+
+The launch gate itself is unchanged. A setup that would resolve to zero servers is still blocked before it writes personas and goals — that block exists because of a real `ENV_NO_SERVERS` failure (BB-36) and removing it would only move the failure later.
+
+The band itself is calmer, too. "Less warning coded" is not only a copy problem: a calm sentence inside an amber box with an alert triangle still reads as an alarm. The notice now takes a tone, decided next to the copy rather than in the component that paints it, and the line it draws is which situation this is — nothing attached yet is a step in setup and renders quietly; servers that ARE attached and still cannot run keep the amber, because that one really is a problem to act on. `warning` stays the default, so the two callers that already had one — the swarm sandbox block and the evals suite pin — are untouched.
+
+And the hint under the disabled Continue says what is missing instead of ordering a repair: "Pick a server to continue." rather than "Fix where it runs to continue." Nothing was broken; a required field simply has not been filled in.
+
+An empty project also gets the one button that resolves it. "Connect a server and it shows up here" named an action the user could not take from where they were standing, and for a project with nothing in it that navigation is unavoidable — there is nothing on the screen to pick. The block now carries a Connect a server button, and the sentence drops the imperative so the prose explains while the button acts. Only the empty case gets one: a project that already has servers is fixed by choosing one right here, and sending that user to Connect would be the original misdiagnosis wearing a button. The draft survives the trip — the flow already mirrors name, description and targets into session storage on every change.

--- a/mcpjam-inspector/client/src/components/computer/CloudUnreachableNotice.tsx
+++ b/mcpjam-inspector/client/src/components/computer/CloudUnreachableNotice.tsx
@@ -46,6 +46,7 @@ export function CloudUnreachableNotice({
 }) {
   const isWarning = tone === "warning";
   const Icon = isWarning ? AlertTriangle : Server;
+  const rootTestId = testId ?? "cloud-unreachable-notice";
   return (
     <div
       className={cn(
@@ -55,7 +56,7 @@ export function CloudUnreachableNotice({
           : "border-border bg-muted/40",
       )}
       data-tone={tone}
-      data-testid={testId ?? "cloud-unreachable-notice"}
+      data-testid={rootTestId}
     >
       <Icon
         className={cn(
@@ -64,7 +65,7 @@ export function CloudUnreachableNotice({
             ? "text-amber-600 dark:text-amber-500"
             : "text-muted-foreground",
         )}
-        {...(isWarning ? { "data-testid": "cloud-notice-alert-icon" } : {})}
+        {...(isWarning ? { "data-testid": `${rootTestId}-alert-icon` } : {})}
       />
       <div className="min-w-0 text-sm">
         <p className="font-medium text-foreground">{message}</p>
@@ -75,7 +76,7 @@ export function CloudUnreachableNotice({
           <button
             type="button"
             onClick={action.onClick}
-            data-testid="cloud-notice-action"
+            data-testid={`${rootTestId}-action`}
             className="mt-2 inline-flex items-center rounded border border-border bg-background px-2 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {action.label}

--- a/mcpjam-inspector/client/src/components/computer/CloudUnreachableNotice.tsx
+++ b/mcpjam-inspector/client/src/components/computer/CloudUnreachableNotice.tsx
@@ -1,4 +1,6 @@
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Server } from "lucide-react";
+import type { CloudBlockTone } from "@/lib/cloud-server-readiness";
+import { cn } from "@/lib/utils";
 
 /**
  * One sentence, two surfaces: the suite header's disabled-run tooltip and the
@@ -16,7 +18,7 @@ export const EVAL_REPLAY_SNAPSHOT_CLOUD_UNREACHABLE_MESSAGE =
   "This run replays from its pinned sandbox image, but this inspector can't run MCPJam cloud sandboxes.";
 
 /**
- * Amber preflight band for a cloud-only surface whose sandbox execution this
+ * Preflight band for a cloud-only surface whose sandbox execution this
  * inspector cannot provide (`ephemeralCloudAvailable === false`) — shown
  * BEFORE a run is started, so the user isn't invited into a known failure.
  *
@@ -27,22 +29,57 @@ export const EVAL_REPLAY_SNAPSHOT_CLOUD_UNREACHABLE_MESSAGE =
 export function CloudUnreachableNotice({
   message,
   detail,
+  tone = "warning",
+  action,
   "data-testid": testId,
 }: {
   message: string;
   detail?: string;
+  /**
+   * `guidance` for a setup step not taken yet: same shape and place, no alarm
+   * colour or glyph. Defaults to `warning` so existing callers keep theirs.
+   */
+  tone?: CloudBlockTone;
+  /** Omit unless it actually resolves this — a merely-related link is worse than none. */
+  action?: { label: string; onClick: () => void };
   "data-testid"?: string;
 }) {
+  const isWarning = tone === "warning";
+  const Icon = isWarning ? AlertTriangle : Server;
   return (
     <div
-      className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3"
+      className={cn(
+        "flex items-start gap-2 rounded-md border px-4 py-3",
+        isWarning
+          ? "border-amber-500/30 bg-amber-500/10"
+          : "border-border bg-muted/40",
+      )}
+      data-tone={tone}
       data-testid={testId ?? "cloud-unreachable-notice"}
     >
-      <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-500" />
+      <Icon
+        className={cn(
+          "mt-0.5 size-4 shrink-0",
+          isWarning
+            ? "text-amber-600 dark:text-amber-500"
+            : "text-muted-foreground",
+        )}
+        {...(isWarning ? { "data-testid": "cloud-notice-alert-icon" } : {})}
+      />
       <div className="min-w-0 text-sm">
         <p className="font-medium text-foreground">{message}</p>
         {detail ? (
           <p className="mt-0.5 text-xs text-muted-foreground">{detail}</p>
+        ) : null}
+        {action ? (
+          <button
+            type="button"
+            onClick={action.onClick}
+            data-testid="cloud-notice-action"
+            className="mt-2 inline-flex items-center rounded border border-border bg-background px-2 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {action.label}
+          </button>
         ) : null}
       </div>
     </div>

--- a/mcpjam-inspector/client/src/components/computer/__tests__/CloudUnreachableNotice.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/CloudUnreachableNotice.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * BB-63. The band is shared: the swarm sandbox block and the evals suite pin
+ * both render it, and both are genuine warnings. So the alarm treatment stays
+ * the DEFAULT and only the caller that asked for calm gets it — a de-escalation
+ * with no blast radius.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { CloudUnreachableNotice } from "../CloudUnreachableNotice";
+
+describe("CloudUnreachableNotice", () => {
+  it("paints a warning by default, so existing callers are untouched", () => {
+    render(<CloudUnreachableNotice message="Sandbox unavailable" detail="d" />);
+    const root = screen.getByTestId("cloud-unreachable-notice");
+    expect(root).toHaveAttribute("data-tone", "warning");
+    expect(root.className).toMatch(/amber/);
+    expect(screen.getByTestId("cloud-notice-alert-icon")).toBeInTheDocument();
+  });
+
+  // The actual BB-63 requirement, as an assertion: no alarm colour, no alarm
+  // glyph. Asserting the class is deliberate — "less warning coded" IS a claim
+  // about the colour, so a rename that quietly restores amber should fail here.
+  it("drops the alarm colour and the alert glyph in guidance tone", () => {
+    render(
+      <CloudUnreachableNotice
+        message="MCPJam has no servers attached yet."
+        detail="Your project has draw. Pick what this run should use."
+        tone="guidance"
+      />
+    );
+    const root = screen.getByTestId("cloud-unreachable-notice");
+    expect(root).toHaveAttribute("data-tone", "guidance");
+    expect(root.className).not.toMatch(/amber/);
+    expect(
+      screen.queryByTestId("cloud-notice-alert-icon")
+    ).not.toBeInTheDocument();
+  });
+
+  it("says the same thing in either tone", () => {
+    for (const tone of ["warning", "guidance"] as const) {
+      const { unmount } = render(
+        <CloudUnreachableNotice message="The finding" detail="The next step" tone={tone} />
+      );
+      expect(screen.getByText("The finding")).toBeVisible();
+      expect(screen.getByText("The next step")).toBeVisible();
+      unmount();
+    }
+  });
+});
+
+describe("CloudUnreachableNotice action", () => {
+  it("renders nothing extra when no action is given", () => {
+    render(<CloudUnreachableNotice message="m" detail="d" tone="guidance" />);
+    expect(
+      screen.queryByTestId("cloud-notice-action")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the action and calls it", async () => {
+    const onClick = vi.fn();
+    render(
+      <CloudUnreachableNotice
+        message="Claude has no servers to run against."
+        detail="These sessions run against an MCP server, so there has to be one."
+        tone="guidance"
+        action={{ label: "Connect a server", onClick }}
+      />
+    );
+    const button = screen.getByRole("button", { name: "Connect a server" });
+    await userEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/client/src/components/computer/__tests__/CloudUnreachableNotice.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/CloudUnreachableNotice.test.tsx
@@ -15,7 +15,7 @@ describe("CloudUnreachableNotice", () => {
     const root = screen.getByTestId("cloud-unreachable-notice");
     expect(root).toHaveAttribute("data-tone", "warning");
     expect(root.className).toMatch(/amber/);
-    expect(screen.getByTestId("cloud-notice-alert-icon")).toBeInTheDocument();
+    expect(screen.getByTestId("cloud-unreachable-notice-alert-icon")).toBeInTheDocument();
   });
 
   // The actual BB-63 requirement, as an assertion: no alarm colour, no alarm
@@ -33,7 +33,7 @@ describe("CloudUnreachableNotice", () => {
     expect(root).toHaveAttribute("data-tone", "guidance");
     expect(root.className).not.toMatch(/amber/);
     expect(
-      screen.queryByTestId("cloud-notice-alert-icon")
+      screen.queryByTestId("cloud-unreachable-notice-alert-icon")
     ).not.toBeInTheDocument();
   });
 
@@ -53,7 +53,7 @@ describe("CloudUnreachableNotice action", () => {
   it("renders nothing extra when no action is given", () => {
     render(<CloudUnreachableNotice message="m" detail="d" tone="guidance" />);
     expect(
-      screen.queryByTestId("cloud-notice-action")
+      screen.queryByTestId("cloud-unreachable-notice-action")
     ).not.toBeInTheDocument();
   });
 
@@ -70,5 +70,21 @@ describe("CloudUnreachableNotice action", () => {
     const button = screen.getByRole("button", { name: "Connect a server" });
     await userEvent.click(button);
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  // Review finding 5. Two of these bands already share one screen; a fixed id
+  // makes them indistinguishable the moment the second one gains an action.
+  it("scopes the action testid to the notice it belongs to", () => {
+    render(
+      <CloudUnreachableNotice
+        message="m"
+        detail="d"
+        data-testid="new-swarm-server-unreachable"
+        action={{ label: "Connect a server", onClick: vi.fn() }}
+      />
+    );
+    expect(
+      screen.getByTestId("new-swarm-server-unreachable-action")
+    ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/environment-composer/__tests__/use-cloud-server-readiness.test.tsx
+++ b/mcpjam-inspector/client/src/components/environment-composer/__tests__/use-cloud-server-readiness.test.tsx
@@ -106,6 +106,8 @@ describe("useCloudServerReadiness", () => {
     expect(assess(composeState())).toEqual({
       status: "no_servers",
       labels: ["Claude"],
+      attachable: [],
+      poolSize: 0,
     });
   });
 
@@ -138,7 +140,12 @@ describe("useCloudServerReadiness", () => {
         },
         [environment()],
       ),
-    ).toEqual({ status: "no_servers", labels: ["Staging"] });
+    ).toEqual({
+      status: "no_servers",
+      labels: ["Staging"],
+      attachable: [],
+      poolSize: 0,
+    });
   });
 
   it("leaves an environment with pinned plugins to the resolver", () => {

--- a/mcpjam-inspector/client/src/components/environment-composer/use-cloud-server-readiness.ts
+++ b/mcpjam-inspector/client/src/components/environment-composer/use-cloud-server-readiness.ts
@@ -62,7 +62,9 @@ export function useCloudServerReadiness({
     const groupById = new Map(
       serverAttachments.map((group) => [group._id, group])
     );
-    const catalog = servers ?? [];
+    // Passed through undefined on purpose: an unanswered query is not an
+    // empty project, and the two lead to opposite advice.
+    const catalog = servers;
 
     /** A client's own set, as a target. Absent count stays UNKNOWN. */
     const hostTarget = (

--- a/mcpjam-inspector/client/src/components/hosts/ServerGroupPicker.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/ServerGroupPicker.tsx
@@ -199,6 +199,8 @@ export function ServerGroupPicker({
   );
 
   // The name follows the picked servers until the user writes their own.
+  // Re-deriving when the group list changes can rename the field mid-edit; that
+  // is preferred to letting them submit a name that has since been taken.
   useEffect(() => {
     if (!showCreate || nameEdited) return;
     setCreateName(

--- a/mcpjam-inspector/client/src/components/hosts/ServerGroupPicker.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/ServerGroupPicker.tsx
@@ -10,6 +10,10 @@ import {
 } from "lucide-react";
 import { useMutation, useConvexAuth } from "convex/react";
 import { toast } from "@/lib/toast";
+import {
+  deriveServerGroupName,
+  newGroupDraft,
+} from "@/components/hosts/server-group-name";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
@@ -103,6 +107,11 @@ export function ServerGroupPicker({
     new Set()
   );
   const [isCreating, setIsCreating] = useState(false);
+  // Once the user types their own name, stop rewriting it under them.
+  const [nameEdited, setNameEdited] = useState(false);
+  // A preselected form is reachable without the user having touched it, so
+  // click-away must not commit one they only looked at.
+  const [createTouched, setCreateTouched] = useState(false);
   // Optimistic record for the row we just created — the live
   // `serverAttachments` query takes a beat to refetch, so without
   // this fallback the trigger would briefly show the "pick one"
@@ -184,21 +193,33 @@ export function ServerGroupPicker({
     [deleteServerAttachment, value, onClearSelection],
   );
 
-  // Auto-name new groups "group 1", "group 2", … using the lowest number
-  // not already taken — the name no longer depends on the picked servers.
-  const nextGroupName = useCallback(() => {
-    const used = new Set<number>();
-    for (const a of serverAttachments) {
-      const m = /^group (\d+)$/i.exec((a.name ?? "").trim());
-      if (m) used.add(Number(m[1]));
-    }
-    let n = 1;
-    while (used.has(n)) n++;
-    return `group ${n}`;
-  }, [serverAttachments]);
+  const existingGroupNames = useMemo(
+    () => serverAttachments.map((a) => a.name ?? ""),
+    [serverAttachments]
+  );
+
+  // The name follows the picked servers until the user writes their own.
+  useEffect(() => {
+    if (!showCreate || nameEdited) return;
+    setCreateName(
+      deriveServerGroupName(
+        projectServers
+          .filter((server) => createServerIds.has(server._id))
+          .map((server) => server.name),
+        existingGroupNames
+      )
+    );
+  }, [
+    showCreate,
+    nameEdited,
+    createServerIds,
+    projectServers,
+    existingGroupNames,
+  ]);
 
   const handleToggleServer = useCallback(
     (serverId: string, checked: boolean) => {
+      setCreateTouched(true);
       setCreateServerIds((prev) => {
         const next = new Set(prev);
         if (checked) next.add(serverId);
@@ -233,6 +254,8 @@ export function ServerGroupPicker({
       setOpen(false);
       setShowCreate(false);
       setCreateName("");
+      setNameEdited(false);
+      setCreateTouched(false);
       setCreateServerIds(new Set());
     } catch (err) {
       const raw = err instanceof Error ? err.message : "";
@@ -271,6 +294,8 @@ export function ServerGroupPicker({
           // a half-filled create form from the last session.
           setShowCreate(false);
           setCreateName("");
+          setNameEdited(false);
+          setCreateTouched(false);
           setCreateServerIds(new Set());
         }
       }}
@@ -327,7 +352,12 @@ export function ServerGroupPicker({
           // click-away IS the save. Keep the popover open until
           // handleCreate resolves (it closes itself on success) so the
           // trigger doesn't flash empty during the mutation.
-          if (showCreate && createName.trim() && createServerIds.size > 0) {
+          if (
+            showCreate &&
+            createTouched &&
+            createName.trim() &&
+            createServerIds.size > 0
+          ) {
             e.preventDefault();
             void handleCreate();
           }
@@ -477,8 +507,15 @@ export function ServerGroupPicker({
               <button
                 type="button"
                 onClick={() => {
+                  const draft = newGroupDraft(
+                    projectServers,
+                    existingGroupNames
+                  );
                   setShowCreate(true);
-                  setCreateName(nextGroupName());
+                  setNameEdited(false);
+                  setCreateTouched(false);
+                  setCreateServerIds(new Set(draft.serverIds));
+                  setCreateName(draft.name);
                 }}
                 className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
               >
@@ -496,14 +533,20 @@ export function ServerGroupPicker({
               <Input
                 id="server-attachment-name"
                 value={createName}
-                onChange={(e) => setCreateName(e.target.value)}
-                placeholder="e.g. group 3"
+                onChange={(e) => {
+                  setNameEdited(true);
+                  setCreateTouched(true);
+                  setCreateName(e.target.value);
+                }}
+                placeholder="Name this group"
                 className="h-7 text-xs"
                 onKeyDown={(e) => {
                   if (e.key === "Enter") void handleCreate();
                   if (e.key === "Escape") {
                     setShowCreate(false);
                     setCreateName("");
+                    setNameEdited(false);
+                    setCreateTouched(false);
                     setCreateServerIds(new Set());
                   }
                 }}
@@ -557,6 +600,8 @@ export function ServerGroupPicker({
                 onClick={() => {
                   setShowCreate(false);
                   setCreateName("");
+                  setNameEdited(false);
+                  setCreateTouched(false);
                   setCreateServerIds(new Set());
                 }}
               >

--- a/mcpjam-inspector/client/src/components/hosts/__tests__/ServerGroupPicker.create.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/__tests__/ServerGroupPicker.create.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * The create form's opening state, wired end to end. `server-group-name.test.ts`
+ * covers the rules; this covers that the picker actually asks for them.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { serversRef, attachmentsRef, createMock } = vi.hoisted(() => ({
+  serversRef: { current: [] as Array<{ _id: string; name: string }> },
+  attachmentsRef: {
+    current: [] as Array<{ _id: string; name: string; serverIds: string[] }>,
+  },
+  createMock: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true }),
+  useMutation: () => createMock,
+}));
+
+vi.mock("@/hooks/useViews", () => ({
+  useProjectServers: () => ({ servers: serversRef.current, isLoading: false }),
+  useProjectServerAttachments: () => ({
+    serverAttachments: attachmentsRef.current,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), dismiss: vi.fn() },
+}));
+
+import { ServerGroupPicker } from "../ServerGroupPicker";
+
+const pool = (...names: string[]) =>
+  names.map((name, i) => ({ _id: `s-${i}`, name }));
+
+async function openCreateForm() {
+  const user = userEvent.setup();
+  render(
+    <ServerGroupPicker
+      projectId="p-1"
+      value={null}
+      onChange={vi.fn()}
+      triggerTestId="picker"
+    />
+  );
+  await user.click(screen.getByTestId("picker"));
+  await user.click(screen.getByRole("button", { name: /create new group/i }));
+  return user;
+}
+
+describe("ServerGroupPicker — the create form's opening state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createMock.mockResolvedValue("new-id");
+    attachmentsRef.current = [];
+  });
+
+  it("opens with the only server picked, named after it, ready to submit", async () => {
+    serversRef.current = pool("big-response");
+    await openCreateForm();
+
+    expect(screen.getByLabelText(/group name/i)).toHaveValue("big-response");
+    expect(screen.getByText(/servers \(1 picked\)/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled();
+  });
+
+  it("names a small pool after its first server and counts the rest", async () => {
+    serversRef.current = pool("draw", "Notion", "Linear");
+    await openCreateForm();
+
+    expect(screen.getByLabelText(/group name/i)).toHaveValue("draw + 2");
+    expect(screen.getByText(/servers \(3 picked\)/i)).toBeInTheDocument();
+  });
+
+  // Past three, guessing is wrong more often than right, so the form asks.
+  it("picks nothing once the pool is big enough to be a real choice", async () => {
+    serversRef.current = pool("a", "b", "c", "d");
+    await openCreateForm();
+
+    expect(screen.getByLabelText(/group name/i)).toHaveValue("group 1");
+    expect(screen.getByText(/servers \(0 picked\)/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^create$/i })).toBeDisabled();
+  });
+
+  it("keeps the derived name in step with the servers being picked", async () => {
+    serversRef.current = pool("a", "b", "c", "d");
+    const user = await openCreateForm();
+
+    await user.click(screen.getByRole("checkbox", { name: "a" }));
+    expect(screen.getByLabelText(/group name/i)).toHaveValue("a");
+
+    await user.click(screen.getByRole("checkbox", { name: "b" }));
+    expect(screen.getByLabelText(/group name/i)).toHaveValue("a + 1");
+  });
+
+  it("stops deriving once the user names the group themselves", async () => {
+    serversRef.current = pool("a", "b", "c", "d");
+    const user = await openCreateForm();
+
+    const field = screen.getByLabelText(/group name/i);
+    await user.clear(field);
+    await user.type(field, "prod");
+    await user.click(screen.getByRole("checkbox", { name: "a" }));
+
+    expect(field).toHaveValue("prod");
+  });
+});
+
+/**
+ * Clicking away from the create form commits it, because Create can sit below
+ * the fold on a long list. Preselection made that reachable without the user
+ * having touched anything, so a look-and-leave would have created a group.
+ */
+describe("ServerGroupPicker — click-away only commits what the user built", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createMock.mockResolvedValue("new-id");
+    attachmentsRef.current = [];
+  });
+
+  it("discards a form the user only looked at", async () => {
+    serversRef.current = pool("big-response");
+    const user = await openCreateForm();
+
+    await user.click(document.body);
+
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("still commits once the user has picked something", async () => {
+    serversRef.current = pool("big-response", "draw");
+    const user = await openCreateForm();
+
+    await user.click(screen.getByRole("checkbox", { name: "draw" }));
+    await user.click(document.body);
+
+    expect(createMock).toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/__tests__/ServerGroupPicker.create.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/__tests__/ServerGroupPicker.create.test.tsx
@@ -6,12 +6,13 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { serversRef, attachmentsRef, createMock } = vi.hoisted(() => ({
+const { serversRef, attachmentsRef, createMock, onChangeMock } = vi.hoisted(() => ({
   serversRef: { current: [] as Array<{ _id: string; name: string }> },
   attachmentsRef: {
     current: [] as Array<{ _id: string; name: string; serverIds: string[] }>,
   },
   createMock: vi.fn(),
+  onChangeMock: vi.fn(),
 }));
 
 vi.mock("convex/react", () => ({
@@ -42,7 +43,7 @@ async function openCreateForm() {
     <ServerGroupPicker
       projectId="p-1"
       value={null}
-      onChange={vi.fn()}
+      onChange={onChangeMock}
       triggerTestId="picker"
     />
   );
@@ -54,7 +55,7 @@ async function openCreateForm() {
 describe("ServerGroupPicker — the create form's opening state", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    createMock.mockResolvedValue("new-id");
+    createMock.mockResolvedValue({ _id: "new-id" });
     attachmentsRef.current = [];
   });
 
@@ -117,7 +118,7 @@ describe("ServerGroupPicker — the create form's opening state", () => {
 describe("ServerGroupPicker — click-away only commits what the user built", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    createMock.mockResolvedValue("new-id");
+    createMock.mockResolvedValue({ _id: "new-id" });
     attachmentsRef.current = [];
   });
 
@@ -138,5 +139,14 @@ describe("ServerGroupPicker — click-away only commits what the user built", ()
     await user.click(document.body);
 
     expect(createMock).toHaveBeenCalled();
+    // The mutation answers with the created row; the id it carries is what the
+    // caller selects by. Asserting only that it fired would pass while the
+    // selection is handed an undefined id.
+    await vi.waitFor(() =>
+      expect(onChangeMock).toHaveBeenCalledWith(
+        "new-id",
+        expect.objectContaining({ _id: "new-id" })
+      )
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/hosts/__tests__/server-group-name.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/__tests__/server-group-name.test.ts
@@ -96,3 +96,36 @@ describe("newGroupDraft", () => {
     });
   });
 });
+
+/**
+ * Review finding 3. Ticking a server the run cannot reach walks the user from
+ * the calm state into the amber one by doing what the form offered.
+ */
+describe("newGroupDraft leaves unreachable servers alone", () => {
+  it("does not preselect a stdio server", () => {
+    expect(
+      newGroupDraft([{ _id: "s-0", name: "big-mcp", command: "uvx" }], [])
+    ).toEqual({ serverIds: [], name: "group 1" });
+  });
+
+  it("does not preselect a loopback server", () => {
+    expect(
+      newGroupDraft(
+        [{ _id: "s-0", name: "local", url: "http://localhost:3000/mcp" }],
+        []
+      )
+    ).toEqual({ serverIds: [], name: "group 1" });
+  });
+
+  it("preselects only the reachable half of a mixed pool", () => {
+    expect(
+      newGroupDraft(
+        [
+          { _id: "s-0", name: "big-mcp", command: "uvx" },
+          { _id: "s-1", name: "draw", url: "https://mcp.example.com/mcp" },
+        ],
+        []
+      )
+    ).toEqual({ serverIds: ["s-1"], name: "draw" });
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/__tests__/server-group-name.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/__tests__/server-group-name.test.ts
@@ -1,0 +1,98 @@
+/**
+ * BB-3 / BB-63. `group 1` is a name that says nothing about what is inside it.
+ * Ignacio's report is the whole specification: "i'm uncomfortable with 'group1'
+ * and can't change it" — and his screenshot shows a group called `group 1`
+ * holding a server called `rabona`.
+ *
+ * Renaming is a separate fix (there is no update mutation yet). This is the
+ * other half: a name derived from the contents means far fewer groups ever
+ * need renaming.
+ */
+import { describe, expect, it } from "vitest";
+import { deriveServerGroupName, newGroupDraft } from "../server-group-name";
+
+describe("deriveServerGroupName", () => {
+  it("names a single-server group after its server", () => {
+    expect(deriveServerGroupName(["draw"], [])).toBe("draw");
+  });
+
+  it("names a multi-server group after the first, and counts the rest", () => {
+    expect(deriveServerGroupName(["draw", "Notion", "Linear"], [])).toBe(
+      "draw + 2"
+    );
+  });
+
+  // Nothing picked yet is the one case with nothing to derive from, so the
+  // numbered fallback survives — it just stops being the DEFAULT.
+  it("falls back to a numbered name when nothing is picked", () => {
+    expect(deriveServerGroupName([], [])).toBe("group 1");
+  });
+
+  it("takes the lowest free number for the fallback", () => {
+    expect(deriveServerGroupName([], ["group 1", "group 3"])).toBe("group 2");
+  });
+
+  it("disambiguates a derived name that is already taken", () => {
+    expect(deriveServerGroupName(["draw"], ["draw"])).toBe("draw 2");
+  });
+
+  it("keeps counting while the suffixed names are taken too", () => {
+    expect(deriveServerGroupName(["draw"], ["draw", "draw 2"])).toBe("draw 3");
+  });
+
+  it("matches existing names case-insensitively and ignores their padding", () => {
+    expect(deriveServerGroupName(["draw"], ["  DRAW  "])).toBe("draw 2");
+  });
+
+  it("ignores a blank server name rather than producing an empty group name", () => {
+    expect(deriveServerGroupName(["   "], [])).toBe("group 1");
+  });
+});
+
+/**
+ * BB-63, the "confusing inputs" half. The reported state is a create form with
+ * ONE server available, that server unticked, `Servers (0 picked)`, and a dead
+ * Create button. Every click in that form is a click whose answer was never in
+ * doubt.
+ *
+ * So the draft arrives already answered when the pool is small enough that
+ * there is only one sensible answer. Above that the guess would be wrong more
+ * often than right, and an unasked-for selection is worse than an empty one.
+ */
+describe("newGroupDraft", () => {
+  const pool = (...names: string[]) =>
+    names.map((name, i) => ({ _id: `s-${i}`, name }));
+
+  it("preselects the only server in a one-server project", () => {
+    expect(newGroupDraft(pool("draw"), [])).toEqual({
+      serverIds: ["s-0"],
+      name: "draw",
+    });
+  });
+
+  it("preselects a small pool whole, and names it after the contents", () => {
+    expect(newGroupDraft(pool("draw", "Notion", "Linear"), [])).toEqual({
+      serverIds: ["s-0", "s-1", "s-2"],
+      name: "draw + 2",
+    });
+  });
+
+  // Past a handful, "all of them" stops being the obvious answer, so we ask.
+  it("preselects nothing once the pool is large enough to be a real choice", () => {
+    expect(newGroupDraft(pool("a", "b", "c", "d"), [])).toEqual({
+      serverIds: [],
+      name: "group 1",
+    });
+  });
+
+  it("has nothing to preselect in an empty project", () => {
+    expect(newGroupDraft([], [])).toEqual({ serverIds: [], name: "group 1" });
+  });
+
+  it("avoids colliding with a group that already has the derived name", () => {
+    expect(newGroupDraft(pool("draw"), ["draw"])).toEqual({
+      serverIds: ["s-0"],
+      name: "draw 2",
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/server-group-name.ts
+++ b/mcpjam-inspector/client/src/components/hosts/server-group-name.ts
@@ -1,3 +1,5 @@
+import { isLocalOnlyMcpServerConfig } from "@/shared/local-only-mcp";
+
 /**
  * Default name and selection for a new server group, derived from its contents.
  *
@@ -58,6 +60,8 @@ const PRESELECT_MAX = 3;
 export interface GroupDraftServer {
   _id: string;
   name: string;
+  command?: unknown;
+  url?: unknown;
 }
 
 /** The state a brand-new group form opens in: a small pool arrives already answered. */
@@ -65,8 +69,13 @@ export function newGroupDraft(
   pool: readonly GroupDraftServer[],
   existingGroupNames: readonly string[],
 ): { serverIds: string[]; name: string } {
+  // A local server cannot run in the cloud, so ticking one for the user would
+  // build a group that fails the moment it is attached. Offer it, never pick it.
+  const reachable = pool.filter(
+    (server) => !isLocalOnlyMcpServerConfig(server),
+  );
   const preselected =
-    pool.length > 0 && pool.length <= PRESELECT_MAX ? pool : [];
+    reachable.length > 0 && reachable.length <= PRESELECT_MAX ? reachable : [];
   return {
     serverIds: preselected.map((server) => server._id),
     name: deriveServerGroupName(

--- a/mcpjam-inspector/client/src/components/hosts/server-group-name.ts
+++ b/mcpjam-inspector/client/src/components/hosts/server-group-name.ts
@@ -1,0 +1,77 @@
+/**
+ * Default name and selection for a new server group, derived from its contents.
+ *
+ * The picker's rows show only a name and a count, and groups cannot be renamed
+ * (there is no update mutation yet), so a name that says what is inside it is
+ * worth more here than usual. Pure so the numbering rule — collisions, case,
+ * off-by-one — is testable without a popover and a Convex mock.
+ */
+
+/** Trimmed and lowercased, for collision checks that ignore padding and case. */
+function normalize(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+/** `group 1`, `group 2`, … — the lowest number not already taken. */
+function nextNumberedName(existing: readonly string[]): string {
+  const used = new Set<number>();
+  for (const name of existing) {
+    const match = /^group (\d+)$/i.exec(name.trim());
+    if (match) used.add(Number(match[1]));
+  }
+  let n = 1;
+  while (used.has(n)) n += 1;
+  return `group ${n}`;
+}
+
+/**
+ * @param pickedServerNames Servers selected for the new group, in picker order.
+ * @param existingGroupNames Names already in use in this project.
+ */
+export function deriveServerGroupName(
+  pickedServerNames: readonly string[],
+  existingGroupNames: readonly string[],
+): string {
+  const picked = pickedServerNames
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0);
+
+  // Nothing to derive from.
+  if (picked.length === 0) return nextNumberedName(existingGroupNames);
+
+  const base =
+    picked.length === 1 ? picked[0] : `${picked[0]} + ${picked.length - 1}`;
+
+  const taken = new Set(existingGroupNames.map(normalize));
+  if (!taken.has(normalize(base))) return base;
+
+  // The unsuffixed name is conceptually the first, so the suffix starts at 2.
+  let suffix = 2;
+  while (taken.has(normalize(`${base} ${suffix}`))) suffix += 1;
+  return `${base} ${suffix}`;
+}
+
+/** Above this, "all of them" stops being the obvious answer. */
+const PRESELECT_MAX = 3;
+
+/** A server as the picker knows it — id to select by, name to derive from. */
+export interface GroupDraftServer {
+  _id: string;
+  name: string;
+}
+
+/** The state a brand-new group form opens in: a small pool arrives already answered. */
+export function newGroupDraft(
+  pool: readonly GroupDraftServer[],
+  existingGroupNames: readonly string[],
+): { serverIds: string[]; name: string } {
+  const preselected =
+    pool.length > 0 && pool.length <= PRESELECT_MAX ? pool : [];
+  return {
+    serverIds: preselected.map((server) => server._id),
+    name: deriveServerGroupName(
+      preselected.map((server) => server.name),
+      existingGroupNames,
+    ),
+  };
+}

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.createFlow.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.createFlow.test.tsx
@@ -555,10 +555,18 @@ describe("SwarmsTab — New swarm create flow", () => {
     fillDescribe();
 
     expect(screen.getByTestId("new-swarm-continue")).toBeDisabled();
+    const block = screen.getByTestId("new-swarm-server-unreachable");
+    expect(block).toHaveTextContent(/prod-like has no servers to run against/i);
+    // BB-63 G1: nothing is attached yet, so this is a setup step — not an
+    // alarm about something the user broke.
+    expect(block).toHaveAttribute("data-tone", "guidance");
+    // BB-63 G2: name what is missing instead of ordering a fix.
+    expect(screen.getByText(/pick a server to continue/i)).toBeVisible();
+    // BB-63: an empty project cannot be fixed on this screen, so the one
+    // navigation that does fix it is a click rather than a sentence.
     expect(
-      screen.getByTestId("new-swarm-server-unreachable"),
-    ).toHaveTextContent(/prod-like has no servers to run against/i);
-    expect(screen.getByText(/fix where it runs to continue/i)).toBeVisible();
+      screen.getByRole("button", { name: /connect a server/i }),
+    ).toBeVisible();
     expect(createSwarmMock).not.toHaveBeenCalled();
   });
 

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-composer.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-composer.test.tsx
@@ -5,6 +5,9 @@ import {
   emptyComposerState,
   type EnvironmentComposerState,
 } from "@/components/environment-composer/environment-stack";
+import type { CloudServerBlockCopy } from "@/lib/cloud-server-readiness";
+
+const { navigateAppMock } = vi.hoisted(() => ({ navigateAppMock: vi.fn() }));
 
 const flagState = vi.hoisted(() => ({
   skills: false,
@@ -97,8 +100,12 @@ vi.mock(
   })
 );
 vi.mock("@/lib/app-navigation", () => ({
-  navigateApp: vi.fn(),
-  routePaths: { hosts: "/hosts", environments: "/environments" },
+  navigateApp: navigateAppMock,
+  routePaths: {
+    hosts: "/hosts",
+    environments: "/environments",
+    servers: "/servers",
+  },
 }));
 vi.mock("@/lib/toast", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
@@ -120,6 +127,7 @@ function Harness({
     },
   ],
   onChange,
+  serverBlock,
 }: {
   environments?: Array<{
     environmentId: string;
@@ -132,6 +140,7 @@ function Harness({
     pluginVersionIds?: string[];
   }>;
   onChange?: (next: EnvironmentComposerState) => void;
+  serverBlock?: CloudServerBlockCopy | null;
 }) {
   const [value, setValue] = useState<EnvironmentComposerState>(
     emptyComposerState
@@ -146,6 +155,7 @@ function Harness({
         onChange?.(next);
       }}
       draftNameHint="Billing"
+      serverBlock={serverBlock}
     />
   );
 }
@@ -417,5 +427,28 @@ describe("SwarmTargetComposer — multi-environment seeding", () => {
     expect(
       screen.getByTestId("new-swarm-environments-picker"),
     ).not.toBeDisabled();
+  });
+});
+
+/**
+ * The copy module names a route key; this layer turns it into a destination.
+ * Asserting the button exists would not catch an index that resolves to
+ * undefined, which is the only way this mapping can be wrong.
+ */
+describe("SwarmTargetComposer — the block's way out", () => {
+  it("sends the empty-project action to Servers", () => {
+    navigateAppMock.mockClear();
+    render(
+      <Harness
+        serverBlock={{
+          message: "Claude has no servers to run against.",
+          detail: "These sessions run against an MCP server.",
+          tone: "guidance",
+          action: { label: "Connect a server", route: "servers" },
+        }}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Connect a server" }));
+    expect(navigateAppMock).toHaveBeenCalledWith("/servers");
   });
 });

--- a/mcpjam-inspector/client/src/components/swarms/new-swarm-create-flow.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/new-swarm-create-flow.tsx
@@ -788,7 +788,7 @@ export function NewSwarmCreateFlow({
     if (!canContinue) {
       // The notice above carries the finding and the fix; repeating it here
       // would put the same two sentences on screen twice.
-      if (serverBlock) return "Fix where it runs to continue.";
+      if (serverBlock) return "Pick a server to continue.";
       if (!hasSwarmName) return "Name this swarm to continue.";
       if (wantsGenerate) {
         return environmentsEnabled

--- a/mcpjam-inspector/client/src/components/swarms/swarm-target-composer.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-target-composer.tsx
@@ -10,6 +10,7 @@ import { Button } from "@mcpjam/design-system/button";
 import { Label } from "@mcpjam/design-system/label";
 import { RequiredMark } from "@/components/shared/required-mark";
 import { CloudRunBadge } from "@/components/computer/CloudRunBadge";
+import type { CloudServerBlockCopy } from "@/lib/cloud-server-readiness";
 import { CloudUnreachableNotice } from "@/components/computer/CloudUnreachableNotice";
 import { EnvironmentComposer } from "@/components/environment-composer/environment-composer";
 import {
@@ -51,7 +52,7 @@ export function SwarmTargetComposer({
    * gates its primary action on it; this only paints it, next to the pickers
    * that fix it.
    */
-  serverBlock?: { message: string; detail: string } | null;
+  serverBlock?: CloudServerBlockCopy | null;
   /** Renders the required marker beside the label. The caller still owns gating. */
   required?: boolean;
 }) {
@@ -94,6 +95,8 @@ export function SwarmTargetComposer({
     value.stack.skillSelection,
   ]);
 
+  const blockAction = serverBlock?.action;
+
   return (
     <div className="space-y-3" data-testid="new-swarm-target-composer">
       <div className="space-y-1">
@@ -129,6 +132,17 @@ export function SwarmTargetComposer({
           data-testid="new-swarm-server-unreachable"
           message={serverBlock.message}
           detail={serverBlock.detail}
+          // The copy module grades the tone and decides whether there is a way
+          // out; this layer only knows how to get there.
+          tone={serverBlock.tone}
+          {...(blockAction
+            ? {
+                action: {
+                  label: blockAction.label,
+                  onClick: () => navigateApp(routePaths[blockAction.route]),
+                },
+              }
+            : {})}
         />
       ) : null}
 

--- a/mcpjam-inspector/client/src/lib/__tests__/cloud-server-readiness.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/cloud-server-readiness.test.ts
@@ -49,7 +49,12 @@ describe("assessCloudServerReadiness", () => {
         targets: [client("Claude", 0), client("Cursor", 1)],
         servers: [REMOTE],
       }),
-    ).toEqual({ status: "no_servers", labels: ["Claude"] });
+    ).toEqual({
+      status: "no_servers",
+      labels: ["Claude"],
+      attachable: ["Notion"],
+      poolSize: 1,
+    });
   });
 
   it("reports a target whose servers are all local-only, naming them", () => {
@@ -105,8 +110,13 @@ describe("assessCloudServerReadiness", () => {
       assessCloudServerReadiness({
         targets: [client("Claude", 0), client("Cursor", 1)],
         servers: [STDIO],
-      }),
-    ).toEqual({ status: "no_servers", labels: ["Claude"] });
+      })
+    ).toEqual({
+      status: "no_servers",
+      labels: ["Claude"],
+      attachable: [],
+      poolSize: 1,
+    });
   });
 
   it("judges a named group by its own members, not the whole catalog", () => {
@@ -193,11 +203,14 @@ describe("describeCloudServerBlock", () => {
     const copy = describeCloudServerBlock({
       status: "no_servers",
       labels: ["Claude", "Cursor"],
+      attachable: [],
+      poolSize: 0,
     });
     expect(copy?.message).toBe(
       "Claude and Cursor have no servers to run against.",
     );
-    expect(copy?.detail).toMatch(/connect a server/i);
+    // The imperative moved to the action button (BB-63).
+    expect(copy?.action?.label).toMatch(/connect a server/i);
   });
 
   // The distinction SUTB-5 asks for: the server EXISTS, and the next step is
@@ -212,5 +225,252 @@ describe("describeCloudServerBlock", () => {
     expect(copy?.message).toContain("Fetch");
     expect(copy?.detail).toMatch(/MCPJam's cloud/);
     expect(copy?.detail).toMatch(/tunnel/i);
+  });
+});
+
+/**
+ * BB-63. "No servers to run against" is THREE situations wearing one sentence,
+ * and the most common one is the one the copy gets wrong: the project already
+ * has a usable server, it just isn't in this setup. Telling that user to
+ * "connect a server" sends them to redo something they already did — which is
+ * precisely the "what did I do wrong?" the ticket reports.
+ *
+ * So the assessment has to say not just THAT the target is empty, but what the
+ * project could put in it. `attachable` is the reachable subset of the catalog
+ * (a cloud run cannot use a stdio or loopback server, so offering one would
+ * walk the user into the `unrunnable_servers` failure on the next click), and
+ * `poolSize` separates "nothing to offer because the project is empty" from
+ * "nothing to offer because none of it is reachable" — different fixes.
+ */
+describe("no_servers tells the three situations apart (BB-63)", () => {
+  it("reports what the project could attach when the pool has a reachable server", () => {
+    expect(
+      assessCloudServerReadiness({
+        targets: [client("MCPJam", 0)],
+        servers: [REMOTE],
+      })
+    ).toEqual({
+      status: "no_servers",
+      labels: ["MCPJam"],
+      attachable: ["Notion"],
+      poolSize: 1,
+    });
+  });
+
+  it("reports an empty project as nothing to attach", () => {
+    expect(
+      assessCloudServerReadiness({
+        targets: [client("MCPJam", 0)],
+        servers: [],
+      })
+    ).toEqual({
+      status: "no_servers",
+      labels: ["MCPJam"],
+      attachable: [],
+      poolSize: 0,
+    });
+  });
+
+  // The trap this closes: "Use Fetch" would resolve, then fail at connect time
+  // inside the cloud run. A server we cannot offer is not attachable.
+  it("does not offer a local-only server — a cloud run cannot reach it", () => {
+    expect(
+      assessCloudServerReadiness({
+        targets: [client("MCPJam", 0)],
+        servers: [STDIO, LOOPBACK],
+      })
+    ).toEqual({
+      status: "no_servers",
+      labels: ["MCPJam"],
+      attachable: [],
+      poolSize: 2,
+    });
+  });
+
+  it("offers only the reachable half of a mixed pool", () => {
+    expect(
+      assessCloudServerReadiness({
+        targets: [client("MCPJam", 0)],
+        servers: [STDIO, REMOTE],
+      })
+    ).toEqual({
+      status: "no_servers",
+      labels: ["MCPJam"],
+      attachable: ["Notion"],
+      poolSize: 2,
+    });
+  });
+});
+
+describe("describeCloudServerBlock points at the fix the user can take (BB-63)", () => {
+  const target = { status: "no_servers" as const, labels: ["MCPJam"] };
+
+  it("names the server the project already has instead of asking for a new one", () => {
+    const copy = describeCloudServerBlock({
+      ...target,
+      attachable: ["Notion"],
+      poolSize: 1,
+    });
+    const text = `${copy?.message} ${copy?.detail}`;
+    expect(text).toContain("Notion");
+    // The defect verbatim: this user HAS a server. "Connect a server" is an
+    // instruction to redo work already done.
+    expect(text).not.toMatch(/connect a server/i);
+  });
+
+  it("names a couple of servers and counts the rest rather than listing everything", () => {
+    const copy = describeCloudServerBlock({
+      ...target,
+      attachable: ["Notion", "Linear", "Sentry", "Stripe"],
+      poolSize: 4,
+    });
+    const text = `${copy?.message} ${copy?.detail}`;
+    expect(text).toContain("Notion");
+    expect(text).toContain("Linear");
+    expect(text).toMatch(/2 more/);
+    expect(text).not.toContain("Stripe");
+  });
+
+  it("points an unreachable-only project at reachability, not at connecting more", () => {
+    const copy = describeCloudServerBlock({
+      ...target,
+      attachable: [],
+      poolSize: 2,
+    });
+    const text = `${copy?.message} ${copy?.detail}`;
+    expect(text).toMatch(/tunnel/i);
+    expect(text).not.toMatch(/connect a server/i);
+  });
+
+  /**
+   * The jargon guardrail, and the reason it is a test rather than a review
+   * note: "A cloud run takes its servers from the client" is the resolver's
+   * own model. It is accurate and it is unreadable to someone who has never
+   * been told what a client is in MCPJam.
+   *
+   * Scoped to `no_servers` on purpose — `unrunnable_servers` still says "point the
+   * client at that URL", which has the same problem and is outside BB-63.
+   */
+  it("never explains an empty setup in terms of clients", () => {
+    for (const readiness of [
+      { ...target, attachable: ["Notion"], poolSize: 1 },
+      { ...target, attachable: [], poolSize: 0 },
+      { ...target, attachable: [], poolSize: 2 },
+    ]) {
+      const copy = describeCloudServerBlock(readiness);
+      expect(`${copy?.message} ${copy?.detail}`).not.toMatch(/\bclients?\b/i);
+    }
+  });
+});
+
+/**
+ * BB-63 asks for "guidance messaging that is calm and less warning coded".
+ * Rewriting the sentence was only half of that — the amber band and the alert
+ * triangle are the other half, and a calm sentence inside an alarm box is
+ * still an alarm.
+ *
+ * The tone is decided HERE rather than in the component that paints it,
+ * because it follows from which situation this is, and that is what this
+ * module already knows. The line it draws: nothing attached yet is a step in
+ * setup; attached-but-unusable is a problem the user has to act on.
+ */
+describe("describeCloudServerBlock grades how loud the block should be (BB-63)", () => {
+  it("treats a setup with nothing attached yet as guidance", () => {
+    const unattached = [
+      {
+        status: "no_servers" as const,
+        labels: ["MCPJam"],
+        attachable: ["Notion"],
+        poolSize: 1,
+      },
+      {
+        status: "no_servers" as const,
+        labels: ["MCPJam"],
+        attachable: [],
+        poolSize: 0,
+      },
+      {
+        status: "no_servers" as const,
+        labels: ["MCPJam"],
+        attachable: [],
+        poolSize: 2,
+      },
+    ];
+    for (const readiness of unattached) {
+      expect(describeCloudServerBlock(readiness)?.tone).toBe("guidance");
+    }
+  });
+
+  it("keeps a warning for servers that ARE attached and still cannot run", () => {
+    expect(
+      describeCloudServerBlock({
+        status: "unrunnable_servers",
+        labels: ["Staging"],
+        serverNames: ["Fetch"],
+      })?.tone
+    ).toBe("warning");
+  });
+});
+
+/**
+ * BB-63. "Connect a server and it shows up here" names an action the user
+ * cannot take from where they are standing. For an empty project that
+ * navigation is unavoidable — there is nothing on this screen to pick — so the
+ * least the block can do is make it one click.
+ *
+ * Only the empty case gets it. A project that HAS servers is fixed by picking
+ * one right here, and sending that user to Connect would be the original
+ * misdiagnosis wearing a button.
+ */
+describe("describeCloudServerBlock offers a way out of an empty project (BB-63)", () => {
+  it("points an empty project at Connect", () => {
+    const copy = describeCloudServerBlock({
+      status: "no_servers",
+      labels: ["Claude"],
+      attachable: [],
+      poolSize: 0,
+    });
+    expect(copy?.action).toEqual({
+      label: "Connect a server",
+      route: "servers",
+    });
+  });
+
+  it("offers no such shortcut when the project already has servers", () => {
+    const withServers = describeCloudServerBlock({
+      status: "no_servers",
+      labels: ["Claude"],
+      attachable: ["Notion"],
+      poolSize: 1,
+    });
+    expect(withServers?.action).toBeUndefined();
+
+    const unreachable = describeCloudServerBlock({
+      status: "no_servers",
+      labels: ["Claude"],
+      attachable: [],
+      poolSize: 2,
+    });
+    expect(unreachable?.action).toBeUndefined();
+
+    const localOnly = describeCloudServerBlock({
+      status: "unrunnable_servers",
+      labels: ["Staging"],
+      serverNames: ["Fetch"],
+    });
+    expect(localOnly?.action).toBeUndefined();
+  });
+
+  // The prose explains; the button acts. Repeating the imperative in both
+  // reads as a stutter.
+  it("leaves the imperative to the button", () => {
+    const copy = describeCloudServerBlock({
+      status: "no_servers",
+      labels: ["Claude"],
+      attachable: [],
+      poolSize: 0,
+    });
+    expect(copy?.detail).not.toMatch(/connect a server/i);
+    expect(copy?.detail).toMatch(/shows up here/i);
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/cloud-server-readiness.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/cloud-server-readiness.test.ts
@@ -474,3 +474,63 @@ describe("describeCloudServerBlock offers a way out of an empty project (BB-63)"
     expect(copy?.detail).toMatch(/shows up here/i);
   });
 });
+
+/**
+ * Review finding 1. The catalog arrives on its own query, so "still loading"
+ * and "project is empty" reach this module as the same empty array. They lead
+ * to opposite advice, and the wrong one ships a button that navigates away.
+ */
+describe("an unknown catalog is not an empty project (review)", () => {
+  it("reports the pool as unknown rather than zero", () => {
+    expect(
+      assessCloudServerReadiness({
+        targets: [client("Claude", 0)],
+        servers: undefined,
+      })
+    ).toEqual({
+      status: "no_servers",
+      labels: ["Claude"],
+      attachable: [],
+      poolSize: null,
+    });
+  });
+
+  it("offers no shortcut and claims nothing while the pool is unknown", () => {
+    const copy = describeCloudServerBlock({
+      status: "no_servers",
+      labels: ["Claude"],
+      attachable: [],
+      poolSize: null,
+    });
+    expect(copy?.action).toBeUndefined();
+    expect(copy?.tone).toBe("guidance");
+    // Neither "connect your first one" nor "expose it over HTTPS" is known to
+    // be true yet, so it must say neither.
+    expect(copy?.detail).not.toMatch(/connect/i);
+    expect(copy?.detail).not.toMatch(/https|tunnel/i);
+  });
+});
+
+/** Review finding 2. Capping at two costs characters when there are three. */
+describe("naming three servers (review)", () => {
+  it("spells all three out instead of counting one of them", () => {
+    const copy = describeCloudServerBlock({
+      status: "no_servers",
+      labels: ["Claude"],
+      attachable: ["a", "b", "c"],
+      poolSize: 3,
+    });
+    expect(copy?.detail).toContain("a, b and c");
+    expect(copy?.detail).not.toMatch(/1 more/);
+  });
+
+  it("still counts the tail at four", () => {
+    const copy = describeCloudServerBlock({
+      status: "no_servers",
+      labels: ["Claude"],
+      attachable: ["a", "b", "c", "d"],
+      poolSize: 4,
+    });
+    expect(copy?.detail).toMatch(/a, b and 2 more/);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/cloud-server-readiness.ts
+++ b/mcpjam-inspector/client/src/lib/cloud-server-readiness.ts
@@ -60,7 +60,14 @@ export type CloudLaunchTarget = {
 export type CloudServerReadiness =
   | { status: "ok" }
   /** At least one target resolves to zero servers — the `ENV_NO_SERVERS` shape. */
-  | { status: "no_servers"; labels: string[] }
+  | {
+      status: "no_servers";
+      labels: string[];
+      /** Reachable only: offering one the run refuses leads straight to `unrunnable_servers`. */
+      attachable: string[];
+      /** Whole catalog. Separates an empty project from an unreachable one. */
+      poolSize: number;
+    }
   /** A target carries a server the run refuses: one stdio member, or a set
    * that is unreachable end to end. `serverNames` lists only the offenders. */
   | { status: "unrunnable_servers"; labels: string[]; serverNames: string[] };
@@ -152,7 +159,15 @@ export function assessCloudServerReadiness(args: {
   }
 
   if (emptyLabels.length > 0) {
-    return { status: "no_servers", labels: emptyLabels };
+    return {
+      status: "no_servers",
+      labels: emptyLabels,
+      // Catalog order: the copy has to match the order shown in the picker.
+      attachable: args.servers
+        .filter((server) => !isLocalOnlyMcpServerConfig(server))
+        .map((server) => server.name),
+      poolSize: args.servers.length,
+    };
   }
   if (unrunnableLabels.length > 0) {
     return {
@@ -170,6 +185,12 @@ export function joinLabels(labels: readonly string[]): string {
   return `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`;
 }
 
+/** Name up to `cap` servers and count the rest, so a large catalog stays one sentence. */
+function joinNamesCapped(names: readonly string[], cap = 2): string {
+  if (names.length <= cap) return joinLabels(names);
+  return `${names.slice(0, cap).join(", ")} and ${names.length - cap} more`;
+}
+
 /**
  * User-facing copy for a block. `null` for `ok`, so a caller can render the
  * notice and gate its button off the same value.
@@ -178,21 +199,62 @@ export function joinLabels(labels: readonly string[]): string {
  * shape `CloudUnreachableNotice` already renders for the sandbox block, and the
  * same split `environment-error.ts` uses for the resolver's own failure.
  */
-export function describeCloudServerBlock(readiness: CloudServerReadiness): {
+export type CloudBlockTone =
+  /** Nothing is attached yet — a step in setup, rendered calmly. */
+  | "guidance"
+  /** Something IS attached and still cannot run — worth an alarm. */
+  | "warning";
+
+export type CloudServerBlockCopy = {
   message: string;
   detail: string;
-} | null {
+  tone: CloudBlockTone;
+  /**
+   * A way out, only for cases this screen cannot fix on its own. A route key
+   * rather than a path — the surface that renders it owns the router.
+   */
+  action?: { label: string; route: "servers" };
+};
+
+export function describeCloudServerBlock(
+  readiness: CloudServerReadiness
+): CloudServerBlockCopy | null {
   if (readiness.status === "ok") return null;
   const subject = joinLabels(readiness.labels);
   const verb = readiness.labels.length > 1 ? "have" : "has";
   if (readiness.status === "no_servers") {
+    // Naming the server turns the remedy into "pick that one".
+    if (readiness.attachable.length > 0) {
+      return {
+        message: `${subject} ${verb} no servers attached yet.`,
+        detail: `Your project has ${joinNamesCapped(
+          readiness.attachable
+        )}. Pick what this run should use.`,
+        tone: "guidance",
+      };
+    }
+    // The only case where connecting something is the right instruction.
+    if (readiness.poolSize === 0) {
+      return {
+        message: `${subject} ${verb} no servers to run against.`,
+        // The prose explains; the button carries the imperative.
+        detail:
+          "These sessions run against an MCP server, so there has to be one. Once you connect it, it shows up here.",
+        tone: "guidance",
+        action: { label: "Connect a server", route: "servers" },
+      };
+    }
+    // Servers exist but none is reachable: the fix is reachability, not another server.
     return {
-      message: `${subject} ${verb} no servers to run against.`,
+      message: `${subject} ${verb} no servers this run can reach.`,
       detail:
-        "A cloud run takes its servers from the client, so this setup would be rejected at launch. Connect a server and turn on Auto-connect on the Servers tab, or attach a server group to the setup.",
+        "The servers in your project are local — stdio, or a localhost/private-address URL — and these sessions run in MCPJam's cloud. Expose one over HTTPS (Create tunnel on its card does this), or run this from a local surface instead.",
+      tone: "guidance",
     };
   }
   return {
+    // Attached and unusable — a problem to act on, so it stays loud.
+    tone: "warning",
     message: `${subject} ${verb} servers this run can't reach: ${joinLabels(readiness.serverNames)}.`,
     detail:
       "Sessions run in MCPJam's cloud, which can't reach a stdio server or a localhost/private-address URL. Expose the server over HTTPS (Create tunnel on its card does this) and point the client at that URL, or run it from a local surface instead.",

--- a/mcpjam-inspector/client/src/lib/cloud-server-readiness.ts
+++ b/mcpjam-inspector/client/src/lib/cloud-server-readiness.ts
@@ -65,8 +65,11 @@ export type CloudServerReadiness =
       labels: string[];
       /** Reachable only: offering one the run refuses leads straight to `unrunnable_servers`. */
       attachable: string[];
-      /** Whole catalog. Separates an empty project from an unreachable one. */
-      poolSize: number;
+      /**
+       * Whole catalog. Separates an empty project from an unreachable one.
+       * `null` while the catalog query has not answered — not the same as zero.
+       */
+      poolSize: number | null;
     }
   /** A target carries a server the run refuses: one stdio member, or a set
    * that is unreachable end to end. `serverNames` lists only the offenders. */
@@ -117,10 +120,11 @@ export function serversAreRunnable(
  */
 export function assessCloudServerReadiness(args: {
   targets: readonly CloudLaunchTarget[];
-  /** The project's server catalog. Empty while it loads — treated as unknown. */
-  servers: readonly CloudServerCatalogEntry[];
+  /** The project's server catalog. `undefined` until the query answers. */
+  servers: readonly CloudServerCatalogEntry[] | undefined;
 }): CloudServerReadiness {
-  const byId = new Map(args.servers.map((server) => [server._id, server]));
+  const catalog = args.servers ?? [];
+  const byId = new Map(catalog.map((server) => [server._id, server]));
   const emptyLabels: string[] = [];
   const unrunnableLabels: string[] = [];
   const unrunnableServerNames = new Set<string>();
@@ -148,7 +152,7 @@ export function assessCloudServerReadiness(args: {
       if (typeof target.serverCount !== "number" || target.serverCount === 0) {
         continue;
       }
-      candidates = [...args.servers];
+      candidates = [...catalog];
     }
 
     if (candidates.length === 0) continue;
@@ -163,10 +167,10 @@ export function assessCloudServerReadiness(args: {
       status: "no_servers",
       labels: emptyLabels,
       // Catalog order: the copy has to match the order shown in the picker.
-      attachable: args.servers
+      attachable: catalog
         .filter((server) => !isLocalOnlyMcpServerConfig(server))
         .map((server) => server.name),
-      poolSize: args.servers.length,
+      poolSize: args.servers === undefined ? null : args.servers.length,
     };
   }
   if (unrunnableLabels.length > 0) {
@@ -185,9 +189,13 @@ export function joinLabels(labels: readonly string[]): string {
   return `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`;
 }
 
-/** Name up to `cap` servers and count the rest, so a large catalog stays one sentence. */
+/**
+ * Name up to `cap` servers and count the rest, so a large catalog stays one
+ * sentence. One over the cap still spells out — "a, b and 1 more" is longer
+ * than "a, b and c" and tells you less.
+ */
 function joinNamesCapped(names: readonly string[], cap = 2): string {
-  if (names.length <= cap) return joinLabels(names);
+  if (names.length <= cap + 1) return joinLabels(names);
   return `${names.slice(0, cap).join(", ")} and ${names.length - cap} more`;
 }
 
@@ -230,6 +238,15 @@ export function describeCloudServerBlock(
         detail: `Your project has ${joinNamesCapped(
           readiness.attachable
         )}. Pick what this run should use.`,
+        tone: "guidance",
+      };
+    }
+    // Nothing is known about the project yet, so neither remedy can be
+    // claimed. Say only what holds in every case, and offer no shortcut.
+    if (readiness.poolSize === null) {
+      return {
+        message: `${subject} ${verb} no servers attached yet.`,
+        detail: "Pick the servers this run should use.",
         tone: "guidance",
       };
     }


### PR DESCRIPTION
Closes BB-63

## What this changes

BB-63 reported two blocks on the Swarm create screen. Both came from the same place: a preflight check that could tell a setup was empty but not why, and so said the same thing however it got there.

- The notice told you to *"Connect a server and turn on Auto-connect on the  Servers tab"* while the picker beside it listed the server you already had.
- Opening **Create new group…** put you in a form whose only answer was never in  doubt: one available server, unticked, `Servers (0 picked)`, Create dead.

`assessCloudServerReadiness` reported `no_servers` for four different situations and `describeCloudServerBlock` had one sentence for all of them. It was correct for exactly one — an empty project. For the other three it prescribed work already done, or work that would fail the same way.

The readiness result now carries what the project could offer:

- **`attachable`** — catalog servers a cloud run can actually reach. Offering a  stdio or loopback server here would walk the user into the `local_only` failure  on the next click, which is the trap the old copy set.
- **`poolSize: number | null`** — `null` while the catalog query has not answered.  The hook used to write `servers ?? []`, collapsing "still loading" into  "project is empty". Those prescribe opposite remedies, so a project that had  servers rendered the empty-project copy and its Connect button on first paint,  then swapped once the query landed. The race predates this work; giving the  cases different copy is what made it visible.

Copy is chosen from those two, most specific first: name the servers you have → connect your first one → expose a local one over HTTPS → say only what holds whilethe pool is unknown.

**Tone is part of the fix, not a coat of paint.** A calm sentence inside an amber box with an alert triangle still reads as an alarm, so `describeCloudServerBlock` grades it next to the copy: nothing attached yet is a step in setup and renders quietly; servers that *are* attached and cannot run keep the warning. `warning` stays the component default, so the swarm sandbox block and the evals suite pin are untouched.

The group form arrives answered. With three or fewer reachable servers it opens with them ticked, Create live, and a name from the contents rather than `group 1` (BB-3). Preselection made the click-away commit reachable without the user having touched anything, so that path is now gated on a real interaction — otherwise opening the form and clicking away created a group nobody asked for.

## Impact

| | Before | After |
|---|---|---|
| Block situations | 4 | 4 |
| Distinct messages for them | 1 | 4 |
| Situations rendered in amber | 5 of 5 | 1 of 5 |
| Empty project: affordances | 0 | 1 (`Connect a server`) |
| Disabled-Continue hint | *Fix where it runs to continue.* | *Pick a server to continue.* |

New group form, project with one reachable server:

| | Before | After |
|---|---|---|
| Servers preselected | 0 | 1 |
| Create on open | disabled | enabled |
| Default name | `group 1` | the server's name |
| Click-away on an untouched form | creates a group | discards |

Three-server list: `a, b and 1 more` (15 chars) → `a, b and c` (10). The cap only pays for itself at four.

## Notes for reviewers

**`score run resume > stays silent when sessionStorage is unavailable` fails on this branch and is not from this PR.** It comes from #4500 and reproduces with these changes stashed. CI stays red until someone on that change looks at it.

**Conflict ahead.** `BB-59_Swarm_update_Personas_page_and_UX` has committed a rename of `local_only` → `unrunnable_servers` in `cloud-server-readiness.ts`, plus a rule change — one stdio member sinks the run. The `no_servers` half of this PR merges clean; that branch does not. Whoever lands second reconciles the `local_only` branch, and this PR's `tone: "warning"` line lives inside it.

**BB-160 rewrites `new-swarm-create-flow.tsx`** for the 3-step designs. The one line this PR changes there — the disabled-Continue hint — goes with it. Paper's V2 frames carry no empty-state for this picker, so the copy here fills a gap rather than contradicting them; the V2 label (*"Choose the clients and servers your users will interact with"*) reads as its lead-in.

**The launch gate is unchanged.** A setup resolving to zero servers is still blocked before it writes personas and goals. That block exists because of a real `ENV_NO_SERVERS` failure (BB-36) and softening it would only move the failure later — the point of BB-63 is how it is said, not whether.

**One thing left alone deliberately.** The group name re-derives when the group list changes, which can rename the field mid-edit. Freezing it would let the user submit a name taken since they opened the form, and the churn stops the moment they type. Recorded in a comment so the next review doesn't re-raise it.

**`local_only`'s detail still says *"point the client at that URL"*** — the same jargon this PR removes next door. Out of BB-63's scope; flagged rather than fixed.

## Tests

164 across the directly affected files.

**New** — `server-group-name.test.ts` (16), `ServerGroupPicker.create.test.tsx` (7), `CloudUnreachableNotice.test.tsx` (6). The picker file covers the wiring the pure module cannot: that the form actually asks for the derived state, and that click-away discards an untouched one.

**Extended** — `cloud-server-readiness.test.ts` 15 → 31.

**Migrated** — `use-cloud-server-readiness.test.tsx` (2 assertions) and `SwarmsTab.createFlow.test.tsx` (1 test) to the new shape and copy.

Verified they aren't decorative. Every fix was written test-first, and the whole change was then reverted with the tests kept: 24 fail against the pre-fix code, in 6 files. The six that survive are negative guards — they assert the absence of something new, or pin behaviour deliberately kept, so they cannot fail against a baseline that lacks the field. One test that passed both ways was **deleted** rather than kept: it asserted `/connect/i` on copy that said "Connect a server" before and after, and the case it covered is already pinned by an assertion on the exact action object.

Pre-existing tests changed deliberately, not loosened: three `assessCloudServerReadiness` assertions gained the new fields; the empty-case copy assertion moved from `detail` to `action.label` because the imperative moved to the button; three `data-testid` lookups follow the notice's own id now that two of these bands can share a screen.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes BB-63: the Swarm create screen's preflight block now says what's actually wrong in each of the four situations it reported as `no_servers`, instead of telling users to "connect a server" when their project already had one. The launch gate itself is unchanged.

**New Features**
- A project with reachable servers gets copy naming them ("Your project has draw. Pick what this run should use.") instead of a connect instruction, spelling out up to three names before counting the rest.
- An empty project gets a "Connect a server" button that navigates to Servers, since leaving the screen is its only fix; the draft survives the trip.
- A new server group in a project with up to three reachable servers opens with them preselected, Create enabled, and a name derived from the contents instead of `group 1` (partial BB-3; renaming still needs a mutation).

**Bug Fixes**
- `poolSize` stays `null` while the catalog query loads, so an empty project no longer flashes the wrong copy on first paint.
- Servers a cloud run can't reach (stdio, loopback) are excluded from the attachable list and from new-group preselection, so the advice never leads into the `unrunnable_servers` failure on the next click.
- Nothing-attached-yet blocks render in a calm `guidance` tone; only attached-but-unusable servers keep the amber `warning`, which stays the default for shared callers.
- Click-away only commits a new-group form the user actually interacted with, and the disabled-Continue hint now says "Pick a server to continue."
- Tests now assert the created group's id reaches the caller and the empty-project button navigates to Servers, which caught a missing `servers` route key in the test stub.

<sup>Written for commit 1ecfaf577c65e471a05421445fee0bdbba4b2de2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

