### PR TITLE
Stop local chat turns fetching project skills for a guest

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.guest-skills.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.guest-skills.test.ts
@@ -1,0 +1,260 @@
+/**
+ * CONVEX-19R regression: the local chat route must not fetch the project skill
+ * catalog for a GUEST caller.
+ *
+ * `listCloudRuntimeSkills` resolves `projectSkills:listSkills`, a signed-in-only
+ * Convex query. This route attaches a guest bearer for anonymous callers
+ * (`/api/mcp/chat-v2` is in the client's `HOSTED_AUTH_PATH_PREFIXES`), so the
+ * gate used to read "has an Authorization header" as "is a member" and sent one
+ * refused query per guest turn.
+ *
+ * The seam under test is the ROUTE's gate, so `validateGuestToken` is the only
+ * thing stubbed on the guest path — the real `isGuestChatRequest` still decides,
+ * which keeps a polarity change in that helper from passing here.
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+const {
+  prepareChatV2Mock,
+  handleMCPJamFreeChatModelMock,
+  fetchHostRuntimeConfigMock,
+  checkHarnessRuntimeAvailableMock,
+  resolveHostToolsMock,
+  listCloudRuntimeSkillsMock,
+  listLocalRuntimeSkillsMock,
+  validateGuestTokenMock,
+  validateAppToolEntriesMock,
+  validateUiToolEntriesMock,
+  validatePageToolEntriesMock,
+  validateWidgetModelContextEntriesMock,
+  buildWidgetModelContextSystemPromptMock,
+  AppToolValidationErrorMock,
+  UiToolValidationErrorMock,
+  PageToolValidationErrorMock,
+  WidgetModelContextValidationErrorMock,
+} = vi.hoisted(() => ({
+  prepareChatV2Mock: vi.fn(),
+  handleMCPJamFreeChatModelMock: vi.fn(),
+  fetchHostRuntimeConfigMock: vi.fn(),
+  checkHarnessRuntimeAvailableMock: vi.fn(),
+  resolveHostToolsMock: vi.fn(() => ({})),
+  listCloudRuntimeSkillsMock: vi.fn(),
+  listLocalRuntimeSkillsMock: vi.fn(),
+  validateGuestTokenMock: vi.fn(),
+  validateAppToolEntriesMock: vi.fn(() => []),
+  validateUiToolEntriesMock: vi.fn(() => []),
+  validatePageToolEntriesMock: vi.fn(() => []),
+  validateWidgetModelContextEntriesMock: vi.fn(() => []),
+  buildWidgetModelContextSystemPromptMock: vi.fn(() => ""),
+  AppToolValidationErrorMock: class AppToolValidationError extends Error {},
+  UiToolValidationErrorMock: class UiToolValidationError extends Error {},
+  PageToolValidationErrorMock: class PageToolValidationError extends Error {},
+  WidgetModelContextValidationErrorMock: class WidgetModelContextValidationError extends Error {},
+}));
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    convertToModelMessages: vi.fn((messages) => messages),
+  };
+});
+
+vi.mock("@/shared/types", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/shared/types")>("@/shared/types");
+  return {
+    ...actual,
+    isMCPJamProvidedModel: vi.fn().mockReturnValue(true),
+    isMCPJamGuestAllowedModel: vi.fn().mockReturnValue(true),
+  };
+});
+
+vi.mock("../../../utils/chat-v2-orchestration", () => ({
+  prepareChatV2: prepareChatV2Mock,
+  validateAppToolEntries: validateAppToolEntriesMock,
+  AppToolValidationError: AppToolValidationErrorMock,
+  validateUiToolEntries: validateUiToolEntriesMock,
+  UiToolValidationError: UiToolValidationErrorMock,
+  validatePageToolEntries: validatePageToolEntriesMock,
+  PageToolValidationError: PageToolValidationErrorMock,
+  validateWidgetModelContextEntries: validateWidgetModelContextEntriesMock,
+  buildWidgetModelContextSystemPrompt: buildWidgetModelContextSystemPromptMock,
+  WidgetModelContextValidationError: WidgetModelContextValidationErrorMock,
+}));
+
+vi.mock("../../../utils/mcpjam-stream-handler", () => ({
+  handleMCPJamFreeChatModel: handleMCPJamFreeChatModelMock,
+  warnIfChatAbortSignalMissing: () => {},
+}));
+
+vi.mock("../../../utils/host-runtime-config.js", () => ({
+  fetchHostRuntimeConfig: fetchHostRuntimeConfigMock,
+}));
+
+vi.mock("../../../utils/harness/harness-availability.js", () => ({
+  checkHarnessRuntimeAvailable: checkHarnessRuntimeAvailableMock,
+}));
+
+vi.mock("../../../utils/built-in-tools/registry.js", () => ({
+  resolveHostTools: resolveHostToolsMock,
+}));
+
+// Spread the real modules: the route imports two of these exports, and a
+// wholesale replacement would make any third one `undefined(...)` at runtime.
+vi.mock("../../../utils/computers/cloud-skill-tools.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/computers/cloud-skill-tools.js")
+  >("../../../utils/computers/cloud-skill-tools.js");
+  return { ...actual, listCloudRuntimeSkills: listCloudRuntimeSkillsMock };
+});
+
+vi.mock("../../../utils/skill-tools.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../../utils/skill-tools.js")>(
+      "../../../utils/skill-tools.js",
+    );
+  return { ...actual, listLocalRuntimeSkills: listLocalRuntimeSkillsMock };
+});
+
+vi.mock("../../../services/guest-token-verifier.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../services/guest-token-verifier.js")
+  >("../../../services/guest-token-verifier.js");
+  return { ...actual, validateGuestToken: validateGuestTokenMock };
+});
+
+import chatV2 from "../chat-v2.js";
+
+const GUEST_BEARER = "guest-session-token";
+const MEMBER_BEARER = "signed-in-session-token";
+
+function createApp() {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    (c as any).mcpClientManager = {
+      getToolsForAiSdk: vi.fn().mockResolvedValue({}),
+      getServerConfig: vi.fn(),
+    };
+    await next();
+  });
+  app.route("/api/mcp/chat-v2", chatV2);
+  return app;
+}
+
+async function postTurn(authorization: string) {
+  return createApp().request("/api/mcp/chat-v2", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: authorization,
+    },
+    body: JSON.stringify({
+      projectId: "project-1",
+      hostId: "host-emulated",
+      selectedServers: ["server-1"],
+      selectedServerIds: ["server-id-1"],
+      messages: [{ role: "user", content: "hello" }],
+      model: {
+        id: "anthropic/claude-haiku-4.5",
+        provider: "anthropic",
+        name: "Claude Haiku 4.5",
+      },
+    }),
+  });
+}
+
+describe("POST /api/mcp/chat-v2 project skill catalog — guest boundary", () => {
+  const originalConvexHttpUrl = process.env.CONVEX_HTTP_URL;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_HTTP_URL = "https://example.convex.site";
+    // No `harness` ⇒ the emulated engine, which is the path that gathers an
+    // in-memory catalog. A harness turn takes its skills on-box instead.
+    fetchHostRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        hostId: "host-emulated",
+        modelId: "anthropic/claude-haiku-4.5",
+        systemPrompt: "host system",
+        temperature: 0.2,
+        requireToolApproval: false,
+        respectToolVisibility: true,
+        selectedServerIds: ["server-id-1"],
+      },
+    });
+    checkHarnessRuntimeAvailableMock.mockReturnValue({ ok: true });
+    listLocalRuntimeSkillsMock.mockResolvedValue([]);
+    listCloudRuntimeSkillsMock.mockResolvedValue([]);
+    validateGuestTokenMock.mockImplementation((token: string) =>
+      token === GUEST_BEARER
+        ? { valid: true, guestId: "g-1" }
+        : { valid: false },
+    );
+    prepareChatV2Mock.mockResolvedValue({
+      allTools: {},
+      enhancedSystemPrompt: "system",
+      resolvedTemperature: 0.2,
+      scrubMessages: (messages: unknown) => messages,
+      progressivePlan: undefined,
+      discoveryState: undefined,
+    });
+    handleMCPJamFreeChatModelMock.mockResolvedValue(
+      new Response("ok", { status: 200 }),
+    );
+  });
+
+  afterEach(() => {
+    if (originalConvexHttpUrl === undefined) {
+      delete process.env.CONVEX_HTTP_URL;
+    } else {
+      process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
+    }
+  });
+
+  it("fetches the catalog for a signed-in caller with a project", async () => {
+    const response = await postTurn(`Bearer ${MEMBER_BEARER}`);
+
+    expect(response.status).toBe(200);
+    expect(listCloudRuntimeSkillsMock).toHaveBeenCalledWith({
+      authHeader: `Bearer ${MEMBER_BEARER}`,
+      projectId: "project-1",
+    });
+  });
+
+  it("does NOT fetch the catalog for a guest bearer", async () => {
+    // The regression. A guest bearer IS an Authorization header, so the old
+    // `requestAuthHeader &&` gate let it through and the query refused it.
+    const response = await postTurn(`Bearer ${GUEST_BEARER}`);
+
+    expect(response.status).toBe(200);
+    expect(listCloudRuntimeSkillsMock).not.toHaveBeenCalled();
+    // The turn still runs, and still carries the local catalog.
+    expect(listLocalRuntimeSkillsMock).toHaveBeenCalled();
+    expect(handleMCPJamFreeChatModelMock).toHaveBeenCalled();
+  });
+
+  it("does NOT fetch the catalog on a harness turn", async () => {
+    // Harness turns take their skills on-box; the two delivery channels are
+    // deliberately disjoint, so this stays true for a member bearer.
+    fetchHostRuntimeConfigMock.mockResolvedValueOnce({
+      ok: true,
+      config: {
+        hostId: "host-emulated",
+        modelId: "anthropic/claude-haiku-4.5",
+        systemPrompt: "host system",
+        temperature: 0.2,
+        requireToolApproval: false,
+        respectToolVisibility: true,
+        selectedServerIds: ["server-id-1"],
+        harness: "claude-code",
+      },
+    });
+
+    await postTurn(`Bearer ${MEMBER_BEARER}`);
+
+    expect(listCloudRuntimeSkillsMock).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -1282,11 +1282,17 @@ chatV2.post("/", async (c) => {
     // orchestrator used to pick between.
     //
     // Local files are always in it (this route only runs where there IS a local
-    // filesystem). The project's skills join them when the request is
-    // authenticated and names a project — the same three conditions
-    // `shouldEnableCloudSkillTools` applies on the hosted routes, restated here
-    // because this route derives guest-ness from the absence of an
-    // Authorization header rather than from a guest id.
+    // filesystem). The project's skills join them when the request comes from a
+    // SIGNED-IN caller and names a project — the same membership condition
+    // `shouldEnableCloudSkillTools` applies on the hosted routes.
+    //
+    // `requestIsGuest`, not the presence of an Authorization header: this route
+    // attaches a guest bearer for anonymous callers (`/api/mcp/chat-v2` is in
+    // the client's `HOSTED_AUTH_PATH_PREFIXES`), so a header proves a session
+    // exists, never that it belongs to a member. Reading it as membership sent
+    // one `projectSkills:listSkills` per guest turn into a signed-in-only
+    // query, which refused every one of them (CONVEX-19R). The header term
+    // survives only to narrow `string | undefined` for `authHeader` below.
     //
     // Signed out, or with no project: local-only, which is exactly what this
     // route did before. What is new is that signing IN no longer means choosing.
@@ -1311,7 +1317,12 @@ chatV2.post("/", async (c) => {
       : [];
     let cloudRuntimeSkills: RuntimeStandaloneSkill[] = [];
     let skillsFetchFailed: SkillsFetchFailure | undefined;
-    if (gathersInMemorySkills && requestAuthHeader && body.projectId) {
+    if (
+      gathersInMemorySkills &&
+      !requestIsGuest &&
+      requestAuthHeader &&
+      body.projectId
+    ) {
       const startedAt = Date.now();
       try {
         cloudRuntimeSkills = await listCloudRuntimeSkills({

--- a/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
@@ -6,6 +6,7 @@ import {
   getDefaultClientCapabilities,
 } from "@mcpjam/sdk";
 import { Hono } from "hono";
+import { isGuestAllowedV1Request } from "../guest-allowed-paths.js";
 
 /**
  * The agent Playground surface (`chat-sessions.ts` + `chat-session-turn.ts`).
@@ -771,6 +772,18 @@ describe("skills capability on the agent turn", () => {
     // was never configured for.
     expect(clientDeclaresSkillsExtension({})).toBe(false);
     expect(clientDeclaresSkillsExtension(undefined)).toBe(false);
+  });
+
+  it("keeps the turn path guest-closed", () => {
+    // The turn builds a LIVE capability set from the project skill pool, which
+    // resolves `projectSkills:listSkills` — a signed-in-only Convex query that
+    // refuses a guest bearer (CONVEX-19R). Default-deny already covers this
+    // path; asserted so an allowlist edit has to break this test to reach it.
+    // `/chat-sessions` itself IS guest-allowed, so the two live one exact-match
+    // pattern apart.
+    const TURN = "/api/v1/chat-sessions/messages";
+    expect(isGuestAllowedV1Request("POST", TURN)).toBe(false);
+    expect(isGuestAllowedV1Request("POST", "/api/v1/chat-sessions")).toBe(true);
   });
 });
 

--- a/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
+++ b/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
@@ -1020,9 +1020,18 @@ async function handleTurn(c: Context): Promise<Response> {
     // catalog failure degrades to no skills rather than failing the turn.
     let turnCapabilities: EffectiveCapabilitySet | undefined;
     let capabilitiesAreLive = false;
+    // The project pool is a MEMBER resource: `listCloudRuntimeSkills` resolves
+    // `projectSkills:listSkills`, which is signed-in-only, and
+    // `getConvexBearerForRequest` forwards a guest bearer verbatim. The v1 mount
+    // already 401s guests on this path (`/chat-sessions/messages` is absent from
+    // `guest-allowed-paths.ts`), so this term is unreachable today — it is here
+    // because that allowlist is edited independently of this file, and the
+    // reachable twin of this exact gate on the local route is what produced
+    // CONVEX-19R.
+    const callerIsGuest = Boolean(c.get("guestId"));
     if (target.environmentCapabilities) {
       turnCapabilities = target.environmentCapabilities;
-    } else if (projectId) {
+    } else if (projectId && !callerIsGuest) {
       try {
         turnCapabilities = buildLiveEffectiveCapabilities({
           standaloneSkills: await listCloudRuntimeSkills({


### PR DESCRIPTION
Fixes the dominant slice of Sentry [CONVEX-19R](https://mcpjam-gh.sentry.io/issues/CONVEX-19R) — `Uncaught Error: Authenticated user required` (2,105 events / 857 users). Tracked as BUGS-79.

## What's broken

`projectSkills:listSkills` is a `signedInQuery` on the backend. `server/routes/mcp/chat-v2.ts` gated its project-skill catalog fetch on:

```js
if (gathersInMemorySkills && requestAuthHeader && body.projectId) {
```

reading "has an Authorization header" as "is a member". The comment above it said so outright — *"this route derives guest-ness from the absence of an Authorization header"* — and that assumption is false: `/api/mcp/chat-v2` is listed in the client's `HOSTED_AUTH_PATH_PREFIXES` (`client/src/lib/session-token.ts:309`), so `authFetch` mints and attaches a **guest bearer** when nobody is signed in.

Result: every guest chat turn on `npx @mcpjam/inspector` sent one Convex query that could only be refused.

## Evidence

Aggregating the Sentry issue over `func` × `user`, not from a single sample event:

| `func` | events | last 7d |
|---|---|---|
| `projectSkills:listSkills` | 1,770 | 227 ev / 42 guests |
| `github/checkRepoConfigs:getGithubChecksSettingsAvailability` | 320 | 4 ev / 4 guests |

Every event carries a `https://api.mcpjam.com/guest|<uuid>` identity. This PR addresses the first row; the second has a different cause (a client gate that trusts the WorkOS user object rather than the identity the Convex socket holds) and gets its own PR.

Nobody reported it because the failure is caught and logged — the turn proceeds without project skills, so a guest silently loses a feature they were never eligible for, and the refusal only ever showed up in the backend's error tracker.

## The fix

The route already computed the correct signal 160 lines earlier:

```js
const requestIsGuest = isGuestChatRequest(requestAuthHeader);  // :1151
```

`isGuestChatRequest` *validates* the bearer as a guest token instead of counting its presence. The gate now uses it. `requestAuthHeader` stays in the condition only to narrow `string | undefined` for the `authHeader` argument, and the comment says so.

Two deliberate non-changes:

- **The harness condition stays `!resolvedExecution.harness`** rather than routing through `shouldEnableCloudSkillTools`. That helper's `harness !== undefined && isHostedCatalogModel(...)` is *looser* — this route gathers nothing in memory for any harness turn, which is the documented intent. Swapping it in would have changed harness behaviour under cover of an auth fix.
- **`projectSkills:listSkills` is left as `signedInQuery`.** The handler only reads `ctx.actor.userId`, which exists on guest actors too, so `userQuery` would compile — but the deliberately guest-reachable sibling `listSkillsForRuntimeExecution` restricts guests to *shared* skills and never exposes personal ones. Widening a member-only read to quiet an error report is the wrong trade; if guest project skills are wanted, that's a product decision with its own PR.

### Second gate, same shape

`server/routes/v1/chat-session-turn.ts:1025` had this gate with no guest term at all. It's unreachable today — `/chat-sessions/messages` is absent from `guest-allowed-paths.ts`, so the v1 mount 401s guests first — but that allowlist is edited independently of this file, and `/chat-sessions` itself is already guest-allowed one exact-match pattern away.

## Tests

- `server/routes/mcp/__tests__/chat-v2.guest-skills.test.ts` (new) drives the route with a member bearer, a guest bearer, and a harness turn. It stubs only `validateGuestToken`, so the real `isGuestChatRequest` still decides — a polarity change in that helper fails here too. **Verified it catches the bug**: on the old gate it fails with `expected "spy" to not be called at all, but actually been called 1 times`.
- `server/routes/v1/__tests__/chat-sessions.test.ts` asserts the v1 turn path stays guest-closed while `/chat-sessions` stays open, mirroring the existing guest-boundary assertion in `eval-checks.test.ts`.

A fourth case (no bearer at all) was written and then removed: the route 503s before reaching the gate in the test env, so the assertion passed without exercising anything.

## Verification

| Check | Result |
|---|---|
| `npm run test -w @mcpjam/inspector` | **1558 passed**, 5 skipped, 6 files failed |
| `npm run build:inspector` | exit 0 |
| `npx tsc --noEmit -p server/tsconfig.json` | no new errors in the changed files |
| new suite + `chat-sessions` | 58 passed |
| `server/routes/v1/__tests__` | 1382 passed |
| `server/routes/mcp/__tests__` + `utils/computers/__tests__` | 742 passed |

All 6 failing files were reproduced on a stashed (clean) tree at the same base commit and are Windows-environmental or already-known: `plugin-vm-shim`, `local-stdio.desktop`, `repoFiles`, `local-machine`, plus `local-runtime-skills` and `ws-native-fallback.assert` (symlink creation and bundle artifacts). None are in this diff's path.

Two local-only failures worth naming rather than hiding:

- `npm run typecheck` fails in `@mcpjam/cli` (`Property 'commandsGroup' does not exist on type 'Command'`, 7 errors). Reproduced with this diff stashed; "Build and Test" is green on `main` at this branch's base SHA, so it's a local dependency skew, not the base.
- `npm run docs:check-tokens` fails on `docs/style.css` line endings — the known CRLF issue. This diff touches neither that file nor `design-system/src/tokens.css`.
- `test:checks` exits 0, but two of its guards are `! rg …` and `rg` isn't a binary in this shell, so they passed vacuously. The one covering `mcpjam-inspector/server` was checked by hand: the only `@modelcontextprotocol/sdk` hit is in a `.generated.ts` file the guard excludes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dominant slice of Sentry [CONVEX-19R] by stopping local chat turns from fetching project skills for guest callers. The old gate read any Authorization header as a signed-in member, but guests have a guest bearer token, so every guest turn hit the `signedInQuery` `projectSkills:listSkills` and got refused. The route now uses `isGuestChatRequest`, and a similar guard was added to the v1 chat-session turn route.

- Adds a regression test that stubs only `validateGuestToken` so the real `isGuestChatRequest` logic runs, and failing on the old gate by expecting the cloud-skill fetch to be called.
- Leaves `projectSkills:listSkills` as a `signedInQuery`; widening it to guest access is a separate product decision.
- Harness turns are unchanged: they still skip the cloud catalog, and the v1 gate is asserted to stay guest-closed so an allowlist edit can't silently reach it.

<sup>Written for commit 919a9b3786af07baa3fa15241057e8803b4b6ab5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

