### PR TITLE
Add .gitattributes so line endings stop being a Windows minefield

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# Every text file is stored with LF in the repository and checked out with LF on
+# every platform.
+#
+# Without this, a Windows checkout is a minefield. `core.autocrlf` is unset (so
+# it defaults to false) on most clones here, and git then compares bytes: an
+# editor or tool that rewrites a file with CRLF makes it "modified" against a
+# repository that is 100% LF, with every line changed and no content difference.
+# That is not hypothetical — it produced a 295-file, 225,178-insertion /
+# 225,178-deletion phantom diff, and touching one line of one file staged the
+# whole file's re-ending (a 12-line change reading as 1,038). It also drowns
+# `lint:ci` in `Delete ␍` prettier errors that Linux CI never sees, which makes
+# the local run useless as a preflight signal.
+#
+# `text=auto` keeps git's binary detection; `eol=lf` pins the working-tree
+# ending so the normalization is visible in the editor, not just in the index.
+* text=auto eol=lf
+
+# Declared rather than left to the heuristic: an asset that happens to start
+# with text-looking bytes must never be re-ended.
+*.png binary
+*.ico binary
+
+# A patch's line endings are part of its content — `git apply` rejects a
+# rewritten one. `.release-plan/release.patch` is generated and applied by the
+# release tooling.
+*.patch -text


### PR DESCRIPTION
There is no `.gitattributes` in this repo, and most clones leave `core.autocrlf` unset (it defaults to `false`). Git then compares **bytes** — so on Windows any editor or tool that rewrites a file with CRLF makes it "modified" against a repository that is 100% LF: every line changed, no content difference.

## What it actually costs

Measured over one afternoon of work in this repo and its sibling backend:

- **A phantom dirty tree.** 295 files, 225,178 insertions and 225,178 deletions, all line endings. It hides real work and makes `git add .` unsafe.
- **Reviewer time, per file, per PR.** Editing one line of a file stages that file's entire re-ending. A 12-line change read as **1,038 changed lines** until each touched file was converted back to LF by hand. I did that four times today before writing this.
- **The local lint gate becomes useless.** `lint:ci` in `mcpjam-backend` reported **342,012** `Delete ␍` prettier errors that Linux CI never sees. That same run contained exactly one *real* error — a prettier wrap on `main` that was blocking every open backend PR — and it was indistinguishable from the noise.

## The fix

```
* text=auto eol=lf
```

`text=auto` keeps git's binary detection; `eol=lf` pins the working-tree ending so the normalization is visible in the editor, not only in the index.

## This changes no file's content

The repo is already entirely LF, so there is no renormalization commit hiding behind this:

- `git grep -Il $'\r' HEAD` → **0 files**
- `git add --renormalize .` across the whole tree stages **nothing but `.gitattributes`**

Both verified before committing. The one file that looked like a renormalization hit (`mcp/src/generated/McpAppsHtml.bundled.ts`) turned out to be a pre-existing local build artifact with a real content diff; it is not in this PR.

I also confirmed the fix works end to end in the backend repo, where the churn was live: with `.gitattributes` committed, the same 293-file CRLF working tree reports `git status` **clean**, because git now compares normalized content instead of raw bytes. Windows contributors therefore need no cleanup step — those files simply stop reading as modified.

## Two explicit exceptions

- `*.png` / `*.ico` as `binary`, so an asset that happens to begin with text-looking bytes can never be re-ended. These are the only binary extensions tracked here.
- `*.patch` as `-text`, because a patch's line endings are part of its content and `git apply` rejects a rewritten one. `.release-plan/release.patch` is generated and applied by the release tooling.

There are no `.bat` or `.cmd` files in the repo, so nothing here legitimately needs CRLF.

## Companion

[mcpjam-backend#1202](https://github.com/MCPJam/mcpjam-backend/pull/1202) does the same for the backend, where the symptom was worse.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `.gitattributes` file that forces LF line endings for text files, so Windows checkouts no longer produce phantom diffs or local lint noise. The repo is already entirely LF, so no file's content changes and no renormalization commit is needed.

**Notes**
- `*.png` and `*.ico` are declared binary, and `*.patch` as `-text`, to prevent accidental re-ending.
- Windows contributors with a CRLF working tree can run `git add --renormalize . && git checkout .` to get a clean slate.

<sup>Written for commit b25daac6a54f37dc343be7b223f435830863074a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

