### PR TITLE
feat(webmcp): select the hosted browser per session, so W5's provider is reachable

### DIFF
--- a/mcpjam-inspector/client/src/components/webmcp-inspector/WebmcpInspectorTab.tsx
+++ b/mcpjam-inspector/client/src/components/webmcp-inspector/WebmcpInspectorTab.tsx
@@ -4,6 +4,7 @@ import { Input } from "@mcpjam/design-system/input";
 import { Badge } from "@mcpjam/design-system/badge";
 import { cn } from "@/lib/utils";
 import { useWebmcpInspectorStore } from "@/stores/webmcp-inspector-store";
+import { useHostContextStore } from "@/stores/client-context-store";
 import { ToolsPanel } from "./ToolsPanel";
 import { ToolInvokePane } from "./ToolInvokePane";
 import { ActivityTimeline } from "./ActivityTimeline";
@@ -58,6 +59,15 @@ export function WebmcpInspectorTab() {
   const [url, setUrl] = useState("http://localhost:3000");
   const [selectedToolKey, setSelectedToolKey] = useState<string | undefined>();
   const [rightTab, setRightTab] = useState<"tools" | "activity">("tools");
+  /**
+   * Opt-in, and deliberately not remembered: a hosted session reserves a
+   * desktop computer and bills its awake time, so it is a choice made per
+   * session rather than a preference that quietly persists.
+   */
+  const [hosted, setHosted] = useState(false);
+  const activeProjectId = useHostContextStore(
+    (state) => state.activeProjectId,
+  );
 
   // The browser outlives this screen on purpose — a developer may tab away
   // mid-flow — so unmounting closes the event stream and nothing else. Coming
@@ -189,10 +199,33 @@ export function WebmcpInspectorTab() {
             </Button>
           </>
         ) : null}
+        {!live && activeProjectId ? (
+          <Button
+            size="sm"
+            variant={hosted ? "default" : "outline"}
+            aria-pressed={hosted}
+            onClick={() => setHosted((on) => !on)}
+            disabled={starting}
+            title={
+              hosted
+                ? "Runs on your MCPJam computer. It cannot reach localhost, and its awake time is billed."
+                : "Runs in a window on this machine."
+            }
+          >
+            {hosted ? "On my computer" : "On this machine"}
+          </Button>
+        ) : null}
         {!live ? (
           <Button
             size="sm"
-            onClick={() => void startSession(url)}
+            onClick={() =>
+              void startSession(
+                url,
+                hosted && activeProjectId
+                  ? { transport: "hosted", projectId: activeProjectId }
+                  : undefined,
+              )
+            }
             disabled={starting}
           >
             {starting ? "Opening…" : "Open browser"}

--- a/mcpjam-inspector/client/src/stores/webmcp-inspector-store.ts
+++ b/mcpjam-inspector/client/src/stores/webmcp-inspector-store.ts
@@ -44,6 +44,13 @@ export interface PageToolInvocationResult {
 /** How long to wait for a settle event before giving up on the stream. */
 const INVOCATION_WAIT_TIMEOUT_MS = 90_000;
 
+/** Where a session's browser runs. See `startSession`. */
+export interface StartSessionOptions {
+  transport?: "local" | "hosted";
+  /** Required when `transport` is `"hosted"`. */
+  projectId?: string;
+}
+
 interface WebMcpInspectorState {
   session: WebMcpSessionPublic | undefined;
   tools: WebMcpToolDescriptor[];
@@ -66,7 +73,15 @@ interface WebMcpInspectorState {
    */
   pageToolsLive(): boolean;
 
-  startSession(url: string): Promise<void>;
+  /**
+   * Open a browser at `url`.
+   *
+   * `options.transport` picks WHERE it runs: omitted or `"local"` opens a
+   * window on this machine (the default, unchanged); `"hosted"` runs it on the
+   * project's MCPJam computer and needs `projectId`, because that is the
+   * computer being reserved and billed.
+   */
+  startSession(url: string, options?: StartSessionOptions): Promise<void>;
   closeSession(): Promise<void>;
   sendCommand(command: WebMcpCommand): Promise<unknown>;
   invokeTool(toolKey: string, input: Record<string, unknown>): Promise<void>;
@@ -339,7 +354,7 @@ export const useWebmcpInspectorStore = create<WebMcpInspectorState>(
         return chatEnabled && Boolean(session) && session?.status !== "closed";
       },
 
-      async startSession(url) {
+      async startSession(url, options) {
         // A new session starts a new timeline, so the dedup set starts over
         // with it — otherwise it grows for the life of the tab.
         seenActivityIds = new Set();
@@ -353,7 +368,14 @@ export const useWebmcpInspectorStore = create<WebMcpInspectorState>(
         });
         const result = await request<WebMcpSessionPublic>("/sessions", {
           method: "POST",
-          body: JSON.stringify({ url }),
+          // `transport` is omitted entirely when local, so an older server
+          // that does not know the field behaves exactly as it does today.
+          body: JSON.stringify({
+            url,
+            ...(options?.transport === "hosted"
+              ? { transport: "hosted", projectId: options.projectId }
+              : {}),
+          }),
         });
         if (!result.ok) {
           set({ starting: false, error: result.error });

--- a/mcpjam-inspector/server/config.ts
+++ b/mcpjam-inspector/server/config.ts
@@ -44,6 +44,28 @@ export const WEBMCP_INSPECTOR_ENABLED =
   !HOSTED_MODE && process.env.MCPJAM_WEBMCP_INSPECTOR_ENABLED !== "false";
 
 /**
+ * Is the hosted browser (E2B Desktop + browserd) reachable at all?
+ *
+ * The dark switch the hosted runtime ships behind until the durable backend
+ * exposure gate opens (W7). READ AT CALL TIME, not captured at import: this is
+ * flipped per-process in staging and per-test, and a module constant would
+ * freeze whatever the environment happened to say when the module first
+ * loaded.
+ *
+ * Two callers must agree on it — the built-in tool registry, which decides
+ * whether the MODEL gets browser tools, and the WebMCP Inspector route, which
+ * decides whether a person may run their inspector session on a hosted
+ * browser. Both reserve a desktop computer and both bill for it, so a second
+ * copy of this literal is how one of them stays reachable after the other is
+ * turned off.
+ */
+export function hostedBrowserEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env.HOSTED_BROWSER_TOOLS_ENABLED === "1";
+}
+
+/**
  * Feed model-visible widget→host tool calls (recorded by Interact steps) to the
  * eval model as a per-turn system-prompt addendum, so the model reasons over a
  * widget interaction on its next turn (the headless analogue of Playground's

--- a/mcpjam-inspector/server/routes/mcp/__tests__/webmcp-inspector.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/webmcp-inspector.test.ts
@@ -5,12 +5,28 @@
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-const configState = vi.hoisted(() => ({ enabled: true }));
+const configState = vi.hoisted(() => ({ enabled: true, hostedBrowser: false }));
 vi.mock("../../../config", () => ({
   get WEBMCP_INSPECTOR_ENABLED() {
     return configState.enabled;
   },
+  hostedBrowserEnabled: () => configState.hostedBrowser,
   HOSTED_MODE: false,
+}));
+
+// The hosted transport's two live seams. Mocked so the switch can be tested
+// without an E2B sandbox: what matters here is WHICH provider the route
+// picks, and with what identity — the provider's own behaviour is covered in
+// `services/webmcp-inspector/__tests__/browserd-provider.test.ts`.
+const hostedState = vi.hoisted(() => ({
+  ensureArgs: [] as Array<Record<string, unknown>>,
+  createdProviders: 0,
+}));
+vi.mock("../../../services/browserd/live-session-deps.js", () => ({
+  ensureLiveBrowserSession: (args: Record<string, unknown>) => {
+    hostedState.ensureArgs.push(args);
+    return Promise.reject(new Error("ensureLiveBrowserSession not reached in this test"));
+  },
 }));
 
 import {
@@ -274,5 +290,94 @@ describe("webmcp-inspector routes", () => {
     );
     const text = await new Response(res.body).text();
     expect(text).toContain("session_gone");
+  });
+});
+
+/**
+ * The W5 transport switch. `browserd-provider.ts` shipped tested but
+ * unreferenced — nothing selected it, so every session ran locally no matter
+ * what. These cover the selection itself, and the three refusals that guard
+ * it: a hosted session spends someone's credits, so it must never be the
+ * thing that happens by accident.
+ */
+describe("POST /sessions — transport selection", () => {
+  beforeEach(() => {
+    configState.hostedBrowser = false;
+    hostedState.ensureArgs.length = 0;
+  });
+
+  it("refuses hosted while the hosted runtime is off", async () => {
+    const { status, body } = await call(
+      "/api/mcp/webmcp/sessions",
+      json({ url: "https://a.test", transport: "hosted", projectId: "p1" }),
+    );
+    expect(status).toBe(503);
+    expect(body.code).toBe("hosted-browser-disabled");
+    // Nothing was reserved: the refusal happens before any seam is touched.
+    expect(hostedState.ensureArgs).toHaveLength(0);
+  });
+
+  it("refuses hosted with no project — there is no computer to run on", async () => {
+    configState.hostedBrowser = true;
+    const { status, body } = await call(
+      "/api/mcp/webmcp/sessions",
+      json({ url: "https://a.test", transport: "hosted" }),
+    );
+    expect(status).toBe(400);
+    expect(body.code).toBe("hosted-project-required");
+    expect(hostedState.ensureArgs).toHaveLength(0);
+  });
+
+  it("refuses hosted with no Authorization — the computer is billed to someone", async () => {
+    configState.hostedBrowser = true;
+    const { status, body } = await call(
+      "/api/mcp/webmcp/sessions",
+      json({ url: "https://a.test", transport: "hosted", projectId: "p1" }),
+    );
+    expect(status).toBe(401);
+    expect(body.code).toBe("hosted-auth-required");
+    expect(hostedState.ensureArgs).toHaveLength(0);
+  });
+
+  it("selects the hosted provider and passes the caller's identity through", async () => {
+    configState.hostedBrowser = true;
+    const { status } = await call("/api/mcp/webmcp/sessions", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        url: "https://a.test",
+        transport: "hosted",
+        projectId: "p1",
+      }),
+    });
+
+    // The mocked seam rejects, so the request fails — but reaching it at all
+    // is the proof the hosted provider was selected rather than the local one
+    // (which would have tried to launch Chromium).
+    expect(status).toBe(500);
+    expect(hostedState.ensureArgs).toHaveLength(1);
+    expect(hostedState.ensureArgs[0]).toMatchObject({
+      bearer: "Bearer user-token",
+      projectId: "p1",
+      // A person driving their own page gets the persistent profile; an eval
+      // would get `ephemeral`. Handing the wrong one over is a silent
+      // correctness failure in either direction.
+      contextMode: "persistent",
+    });
+  });
+
+  it("leaves the LOCAL path untouched — an omitted transport reserves nothing", async () => {
+    configState.hostedBrowser = true;
+    // Invalid URL so the request stops at validation without launching a real
+    // browser; the point is that the hosted seam is never consulted.
+    const { status } = await call(
+      "/api/mcp/webmcp/sessions",
+      json({ url: "file:///etc/passwd" }),
+    );
+    expect(status).toBe(400);
+    expect(hostedState.ensureArgs).toHaveLength(0);
   });
 });

--- a/mcpjam-inspector/server/routes/mcp/webmcp-inspector.ts
+++ b/mcpjam-inspector/server/routes/mcp/webmcp-inspector.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { z } from "zod";
 import "../../types/hono";
-import { WEBMCP_INSPECTOR_ENABLED } from "../../config";
+import { WEBMCP_INSPECTOR_ENABLED, hostedBrowserEnabled } from "../../config";
 import {
   startWebMcpSession,
   webMcpSessions,
@@ -18,6 +18,8 @@ import {
   WebMcpUnsupportedError,
 } from "../../services/webmcp-inspector/provider";
 import { WebMcpQueueFullError } from "../../services/webmcp-inspector/session-runtime";
+import { createBrowserdWebMcpProvider } from "../../services/webmcp-inspector/browserd-provider";
+import { ensureLiveBrowserSession } from "../../services/browserd/live-session-deps.js";
 import { reportRouteFailure } from "../../utils/route-error-report.js";
 
 /**
@@ -61,7 +63,27 @@ const httpUrlSchema = z
     { message: "Enter an http:// or https:// URL." },
   );
 
-const startSchema = z.object({ url: httpUrlSchema });
+/**
+ * WHERE the browser runs, chosen per session rather than per deployment.
+ *
+ * `local` (the default, and what every existing caller gets by omitting the
+ * field) opens Chromium on the machine running this inspector — the V1
+ * behaviour, unchanged.
+ *
+ * `hosted` runs it on the member's MCPJam computer through browserd and
+ * reports `remote-interactive-url`, so the viewport lives in the Browser
+ * panel. It is opt-IN and never inferred: a hosted session reserves a desktop
+ * computer and bills for its awake time, and silently spending someone's
+ * credits because they clicked "Open browser" is not a default anyone would
+ * choose. It also cannot reach `localhost` — the browser is in a datacenter,
+ * so the page has to be somewhere that datacenter can fetch.
+ */
+const startSchema = z.object({
+  url: httpUrlSchema,
+  transport: z.enum(["local", "hosted"]).optional(),
+  /** Required for `hosted`: the project whose desktop computer is reserved. */
+  projectId: z.string().min(1).optional(),
+});
 
 const commandSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("navigate"), url: httpUrlSchema }),
@@ -145,8 +167,65 @@ webmcpInspector.post("/sessions", async (c) => {
       400,
     );
   }
+  const { url, transport, projectId } = parsed.data;
+
+  let provider;
+  if (transport === "hosted") {
+    // Every refusal below is a 4xx with a code the UI can explain, never a
+    // 500: each one is a thing the person can actually fix (turn the feature
+    // on, pick a project, sign in).
+    if (!hostedBrowserEnabled()) {
+      return c.json(
+        {
+          error:
+            "The hosted browser is not enabled on this server. Start it locally, or ask an operator to enable the hosted runtime.",
+          code: "hosted-browser-disabled",
+        },
+        503,
+      );
+    }
+    if (!projectId) {
+      return c.json(
+        {
+          error: "Pick a project first — a hosted browser runs on that project's computer.",
+          code: "hosted-project-required",
+        },
+        400,
+      );
+    }
+    // The USER's control-plane bearer, exactly as the chat routes take it. The
+    // hosted browser is billed to whoever owns the computer, so it needs a
+    // real identity — unlike the local browser, which needs none because it
+    // runs on the machine the caller is already sitting at.
+    const bearer = c.req.header("authorization");
+    if (!bearer) {
+      return c.json(
+        {
+          error: "Sign in to run the browser on your MCPJam computer.",
+          code: "hosted-auth-required",
+        },
+        401,
+      );
+    }
+    provider = createBrowserdWebMcpProvider({
+      ensureSession: ({ signal }) =>
+        ensureLiveBrowserSession({
+          bearer,
+          projectId,
+          // The inspector is a person driving their own page, so it gets the
+          // persistent profile — the same rule the built-in browser tools
+          // follow, and the reason evals get an ephemeral one instead.
+          contextMode: "persistent",
+          ...(signal ? { signal } : {}),
+        }),
+    });
+  }
+
   try {
-    const session = await startWebMcpSession({ url: parsed.data.url });
+    const session = await startWebMcpSession({
+      url,
+      ...(provider ? { provider } : {}),
+    });
     return c.json(session, 201);
   } catch (error) {
     return webMcpErrorResponse(c, error, "Could not open a browser session.");

--- a/mcpjam-inspector/server/utils/built-in-tools/registry.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/registry.ts
@@ -46,6 +46,7 @@
 import type { ToolSet } from "ai";
 import type { PlatformApiClient } from "@mcpjam/sdk/platform";
 import { logger } from "../logger.js";
+import { hostedBrowserEnabled } from "../../config.js";
 import { isHostedBrowserExposable } from "../computers/runtime-config.js";
 import { type ExecutionScope } from "../execution-scope.js";
 import {
@@ -425,7 +426,7 @@ export function resolveHostTools(
       // Dark switch: the runtime ships behind an env flag so staging can drive
       // it before the durable backend exposure gate opens (W7). Absent ⇒ the
       // capability simply is not advertised.
-      if (process.env.HOSTED_BROWSER_TOOLS_ENABLED !== "1") {
+      if (!hostedBrowserEnabled()) {
         logger.debug(
           "[built-in-tools] browser requested while HOSTED_BROWSER_TOOLS_ENABLED is off; skipping",
           { projectId: ctx.projectId },


### PR DESCRIPTION
## What this fixes

W5 shipped `browserd-provider.ts` — the hosted WebMCP provider — **tested but unreferenced**. The only file importing it was its own test, so `session-registry.ts` always fell through to the Playwright provider and every WebMCP Inspector session opened a window on the viewer's machine. The `remote-interactive-url` transport the wave exists to produce could not be reached by any code path.

This wires the selection.

## The design call: per session, not per deployment

A hosted session reserves a desktop computer and bills its awake time. Spending someone's credits because they clicked "Open browser" is not a default anyone would choose, so `transport` is an explicit field on `POST /sessions`:

- omitted / `"local"` — a window on this machine, **byte-identical to today**
- `"hosted"` — browserd on the project's MCPJam computer, reporting `remote-interactive-url`

Existing callers are unaffected, and an older client against a newer server keeps the local window.

`startWebMcpSession` already accepted a `provider` override, so no registry surgery was needed — the route just picks one.

## Three refusals, all before any seam is touched

Each is a 4xx with a code the UI can explain, never a 500, because each is something the person can fix:

| Condition | Status | Code |
| --- | --- | --- |
| hosted runtime off | 503 | `hosted-browser-disabled` |
| no project | 400 | `hosted-project-required` |
| no `Authorization` | 401 | `hosted-auth-required` |

The auth asymmetry is deliberate: the local browser needs no identity because it runs on the machine the caller is already sitting at; the hosted one is billed to somebody.

## `hostedBrowserEnabled()` moved to `config.ts`

The built-in tool registry and this route now both gate on it, and **both reserve and bill the same desktop**. A second copy of that env literal is how one surface stays reachable after the other is turned off. It is a function rather than a constant because staging and tests flip it per-process — a module constant would freeze whatever the environment said at first import (the existing registry tests set it at runtime).

No new environment variable is introduced; this reuses `HOSTED_BROWSER_TOOLS_ENABLED`.

## UI

A small toggle beside the URL bar, shown only when a project is selected. Off by default and deliberately not remembered — a per-session cost decision, not a preference that quietly persists. It states that a hosted browser **cannot reach `localhost`**, which matters given the URL bar defaults to `http://localhost:3000`. The `remote-interactive-url` notice the tab already carried now has a way to actually appear.

## Verification

- **5 new route tests**, verified non-vacuous: removing the selection fails 4 of them.
- **135 tests pass** across the affected suites (route, webmcp-inspector services, built-in tools registry, inspector store, tab).
- The registry's 47 tests still pass after the gate refactor.
- Client typecheck clean; no new server type errors.
- Two suites fail in my environment on a missing `playwright` package (`playwright-provider.integration`, `webmcp-cdp.spike`). Both were reproduced failing **with these changes stashed** — environmental, not from this PR.

## Still scaffold-grade — what this does NOT do

The switch makes the provider reachable; it does not finish it. Two gaps documented in the provider's own header remain:

1. **Tool discovery is polled** (~2s), not pushed. The daemon has the real CCDP events; there is no server-push channel yet.
2. **No activity or popup signal**, so a session someone is only *watching* through the Browser panel can be reaped as idle.

Both need an SSE endpoint on the daemon. Worth closing before this is called a real product surface.

## Dark

The hosted branch is unreachable unless `HOSTED_BROWSER_TOOLS_ENABLED=1` **and** a desktop template and credit rate are configured. Nothing here changes the local path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY7NKoBrR8WCc6sA5rYThK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hosted sessions reserve billed desktops and depend on auth/bearer forwarding; mistakes could charge credits or pick the wrong profile, though local default and explicit refusals limit blast radius.
> 
> **Overview**
> Wires the previously unused **browserd** hosted WebMCP provider into `POST /sessions` so inspector sessions can run on a project’s MCPJam computer instead of only local Chromium.
> 
> **Server:** `transport` (`local` default vs `hosted`) and `projectId` are added to the start payload. The hosted path gates on `hostedBrowserEnabled()` (`HOSTED_BROWSER_TOOLS_ENABLED`), requires auth and project, returns explicit error codes, and passes bearer + `contextMode: "persistent"` into `ensureLiveBrowserSession` via `createBrowserdWebMcpProvider`. Local behavior is unchanged when `transport` is omitted. **`hostedBrowserEnabled()`** is centralized in `config.ts` and shared with the built-in browser tools registry.
> 
> **Client:** Per-session toggle (“On this machine” / “On my computer”) when a project is active; `startSession` sends hosted options only when toggled. The choice is not persisted.
> 
> **Tests:** Five route tests cover refusals and hosted provider selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12299652717d947281978a50895eb2d8c769c961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the hosted WebMCP browser provider so WebMCP Inspector sessions can run on a project's MCPJam computer instead of always opening a window on the viewer's machine.

`POST /sessions` now accepts a per-session `transport` field: omitted or `"local"` keeps the current local-window behavior, and `"hosted"` selects the browserd provider and reports `remote-interactive-url`. Existing callers are unaffected, and an older client against a newer server still gets a local window.

The hosted path is opt-in and refuses with a 4xx before touching any seam when the runtime is off (503 `hosted-browser-disabled`), no project is given (400 `hosted-project-required`), or no `Authorization` header is present (401 `hosted-auth-required`) — the local browser needs no identity, but the hosted one is billed to someone.

The inspector tab adds a toggle to pick the transport, off by default and deliberately not remembered since a hosted session bills awake time, and notes the hosted browser cannot reach `localhost`, which matters because the URL bar defaults to `http://localhost:3000`.

`hostedBrowserEnabled()` moved to `config.ts` and now gates both the built-in tool registry and this route, so both reserve and bill the same desktop. Adds 5 route tests for the selection and each refusal. `playwright-provider.integration` and `webmcp-cdp.spike` fail on a missing `playwright` package in this environment; both fail identically with these changes stashed.

<sup>Written for commit 12299652717d947281978a50895eb2d8c769c961. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

