### PR TITLE
fix(auth): keep hosted sign-in by proxying AuthKit through our own origin

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -79,7 +79,6 @@ jobs:
       # all — until then.
       RAILWAY_PREVIEW_SOURCE_ENVIRONMENT: ${{ vars.RAILWAY_PREVIEW_TEMPLATE_ENVIRONMENT || vars.RAILWAY_STAGING_ENVIRONMENT }}
       STAGING_WORKOS_CLIENT_ID: ${{ vars.STAGING_WORKOS_CLIENT_ID }}
-      STAGING_WORKOS_API_HOSTNAME: ${{ vars.STAGING_WORKOS_API_HOSTNAME || 'api.workos.com' }}
       # Default Convex backend for previews when no per-PR backend preview
       # exists. Points at the shared preview deployment once the
       # PREVIEW_BACKEND_* repo vars are provisioned (see
@@ -169,9 +168,7 @@ jobs:
             MCPJAM_ALLOWED_HOSTS="staging.mcpjam.com,*.up.railway.app" \
             VITE_MCPJAM_HOSTED_MODE=true \
             VITE_WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
-            VITE_WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \
             WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
-            WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \
             ALLOWED_ORIGINS="https://*.up.railway.app,$STAGING_APP_URL" \
             WEB_ALLOWED_ORIGINS="https://*.up.railway.app,$STAGING_APP_URL" \
             VITE_CONVEX_URL="$DEFAULT_BACKEND_VITE_CONVEX_URL" \
@@ -384,7 +381,6 @@ jobs:
       # all — until then.
       RAILWAY_PREVIEW_SOURCE_ENVIRONMENT: ${{ vars.RAILWAY_PREVIEW_TEMPLATE_ENVIRONMENT || vars.RAILWAY_STAGING_ENVIRONMENT }}
       STAGING_WORKOS_CLIENT_ID: ${{ vars.STAGING_WORKOS_CLIENT_ID }}
-      STAGING_WORKOS_API_HOSTNAME: ${{ vars.STAGING_WORKOS_API_HOSTNAME || 'api.workos.com' }}
       # Default Convex backend for previews when no per-PR backend preview
       # exists. Points at the shared preview deployment once the
       # PREVIEW_BACKEND_* repo vars are provisioned (see
@@ -453,9 +449,7 @@ jobs:
             MCPJAM_ALLOWED_HOSTS="staging.mcpjam.com,*.up.railway.app" \
             VITE_MCPJAM_HOSTED_MODE=true \
             VITE_WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
-            VITE_WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \
             WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
-            WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \
             ALLOWED_ORIGINS="https://*.up.railway.app,$STAGING_APP_URL" \
             WEB_ALLOWED_ORIGINS="https://*.up.railway.app,$STAGING_APP_URL" \
             VITE_CONVEX_URL="$DEFAULT_BACKEND_VITE_CONVEX_URL" \
@@ -789,7 +783,6 @@ jobs:
       RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
       RAILWAY_INSPECTOR_SERVICE: ${{ vars.RAILWAY_INSPECTOR_SERVICE }}
       STAGING_WORKOS_CLIENT_ID: ${{ vars.STAGING_WORKOS_CLIENT_ID }}
-      STAGING_WORKOS_API_HOSTNAME: ${{ vars.STAGING_WORKOS_API_HOSTNAME || 'api.workos.com' }}
       # See upsert-preview: shared preview deployment when provisioned,
       # staging deployment until then.
       DEFAULT_BACKEND_VITE_CONVEX_URL: ${{ vars.PREVIEW_BACKEND_VITE_CONVEX_URL || vars.STAGING_VITE_CONVEX_URL }}
@@ -851,9 +844,7 @@ jobs:
             MCPJAM_ALLOWED_HOSTS="staging.mcpjam.com,*.up.railway.app" \
             VITE_MCPJAM_HOSTED_MODE=true \
             VITE_WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
-            VITE_WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \
             WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
-            WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \
             VITE_CONVEX_URL="${{ steps.backend_target.outputs.vite_convex_url }}" \
             CONVEX_HTTP_URL="${{ steps.backend_target.outputs.convex_http_url }}"
 

--- a/mcpjam-inspector/client/src/lib/__tests__/workos-authkit-config.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/workos-authkit-config.test.ts
@@ -48,6 +48,56 @@ describe("workos authkit config", () => {
     });
   });
 
+  // The staging regression, as a test. AuthKit's initialize() makes NO network
+  // call unless the page's own cookies carry `workos-has-session`, and only a
+  // same-origin response can set it — so a hosted deployment without a
+  // same-site WorkOS domain has to proxy through itself or every reload reads
+  // as signed out and drops the user to a guest.
+  it("proxies AuthKit calls through its own origin on a hosted deployment", () => {
+    expect(
+      resolveWorkosClientOptions(
+        { DEV: false },
+        { hostname: "staging.mcpjam.com", port: "", protocol: "https:" },
+        true
+      )
+    ).toEqual({
+      apiHostname: "staging.mcpjam.com",
+      https: true,
+    });
+  });
+
+  // Every preview gets a different hostname, discovered only after deploy —
+  // so this can never come from a build-time variable.
+  it("proxies AuthKit calls through a preview's own origin", () => {
+    expect(
+      resolveWorkosClientOptions(
+        { DEV: false },
+        {
+          hostname: "mcp-inspector-pr-4501.up.railway.app",
+          port: "",
+          protocol: "https:",
+        },
+        true
+      )
+    ).toEqual({
+      apiHostname: "mcp-inspector-pr-4501.up.railway.app",
+      https: true,
+    });
+  });
+
+  // Prod pins `auth.mcpjam.com`, which is same-site with the app and needs no
+  // proxy. An explicit hostname must keep winning or this change would quietly
+  // reroute production sign-in through our own server.
+  it("keeps an explicit host override ahead of the hosted same-origin default", () => {
+    expect(
+      resolveWorkosClientOptions(
+        { DEV: false, VITE_WORKOS_API_HOSTNAME: "auth.mcpjam.com" },
+        { hostname: "app.mcpjam.com", port: "", protocol: "https:" },
+        true
+      )
+    ).toEqual({ apiHostname: "auth.mcpjam.com" });
+  });
+
   it("allows explicit WorkOS API host overrides", () => {
     expect(
       resolveWorkosClientOptions(

--- a/mcpjam-inspector/client/src/lib/workos-authkit-config.ts
+++ b/mcpjam-inspector/client/src/lib/workos-authkit-config.ts
@@ -34,20 +34,44 @@ const LOCAL_WORKOS_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
  */
 export const WORKOS_DEV_MODE = false;
 
+/**
+ * Where AuthKit should send its requests.
+ *
+ * Precedence: an explicit `VITE_WORKOS_API_HOSTNAME` wins (prod pins
+ * `auth.mcpjam.com`), then the proxy opt-out, then this origin.
+ *
+ * The same-origin default covers hosted deployments as well as localhost,
+ * because the reason is the same in both: AuthKit's `initialize()` short-
+ * circuits — no network call whatsoever — unless the page's OWN cookies carry
+ * `workos-has-session`, and only a first-party response can set it. A client
+ * calling `api.workos.com` direct gets that cookie written on WorkOS's domain,
+ * where the page cannot see it, so every reload reads as signed out and the
+ * app drops to a guest. That was staging's bug.
+ *
+ * Hosted has to be told, not sniffed: the deciding factor is whether this
+ * origin's server mounts the `/user_management` proxy, which a hostname cannot
+ * reveal. Deployments that keep a same-site WorkOS domain simply set the
+ * explicit hostname above and never reach this branch.
+ */
 export function resolveWorkosClientOptions(
   env: WorkosAuthkitEnv,
-  location?: WorkosAuthkitLocation
+  location?: WorkosAuthkitLocation,
+  hostedMode = false
 ): WorkosClientOptions {
   if (env.VITE_WORKOS_API_HOSTNAME) {
     return { apiHostname: env.VITE_WORKOS_API_HOSTNAME };
   }
 
   const disableProxy = env.VITE_WORKOS_DISABLE_LOCAL_PROXY === "true";
-  if (
-    disableProxy ||
-    !location ||
-    !LOCAL_WORKOS_HOSTNAMES.has(location.hostname)
-  ) {
+  if (disableProxy || !location) {
+    return {};
+  }
+
+  // Both branches mean the same thing: this origin's server mounts the
+  // `/user_management` proxy, so AuthKit can be pointed at it.
+  const servesAuthkitProxy =
+    hostedMode || LOCAL_WORKOS_HOSTNAMES.has(location.hostname);
+  if (!servesAuthkitProxy) {
     return {};
   }
 

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -184,7 +184,11 @@ if (isInIframe) {
   const handoffRuntimeApiHostname = getRuntimeWorkosApiHostname();
   const handoffWorkosOptions = handoffRuntimeApiHostname
     ? { apiHostname: handoffRuntimeApiHostname }
-    : resolveWorkosClientOptions(import.meta.env, window.location);
+    : resolveWorkosClientOptions(
+        import.meta.env,
+        window.location,
+        HOSTED_MODE
+      );
   const root = createRoot(document.getElementById("root")!);
   root.render(
     <StrictMode>
@@ -317,7 +321,8 @@ if (isInIframe) {
     ? { apiHostname: runtimeWorkosApiHostname }
     : resolveWorkosClientOptions(
         import.meta.env,
-        typeof window === "undefined" ? undefined : window.location
+        typeof window === "undefined" ? undefined : window.location,
+        HOSTED_MODE
       );
   clearLegacyWorkosRefreshTokenStorage();
 

--- a/mcpjam-inspector/server/__tests__/hosted-authkit-proxy.test.ts
+++ b/mcpjam-inspector/server/__tests__/hosted-authkit-proxy.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * THE AUTHKIT PROXY IS MOUNTED IN HOSTED MODE.
+ *
+ * AuthKit's `initialize()` makes no network call whatsoever unless the page's
+ * own cookies carry `workos-has-session` (see `create-client.ts` in
+ * `@workos-inc/authkit-js`), and only a same-origin response can set that
+ * cookie. A hosted deployment whose AuthKit points straight at
+ * `api.workos.com` therefore reads as permanently signed out: sign-in
+ * succeeds, and the very next page load falls back to a guest with no error
+ * and no failed request to show for it. That was staging for months.
+ *
+ * `/user_management` was gated behind `!HOSTED_MODE`, so the proxy that makes
+ * the cookie first-party existed but could never run where it was needed.
+ * These tests boot the real app with hosted mode on and assert the route is
+ * reachable — the gate cannot come back without turning this red.
+ */
+
+type App = { fetch: (request: Request) => Response | Promise<Response> };
+
+async function bootHostedApp(): Promise<App> {
+  vi.resetModules();
+  vi.stubEnv("VITE_MCPJAM_HOSTED_MODE", "true");
+  vi.stubEnv("NODE_ENV", "test");
+  vi.stubEnv("ELECTRON_APP", "");
+  vi.stubEnv("MCPJAM_WORKOS_SESSION_SECRET", "test-workos-session-secret");
+
+  const { createHonoApp } = await import("../app.js");
+  return (await createHonoApp()).app;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("hosted mode AuthKit proxy", () => {
+  it("mounts /user_management/authenticate", async () => {
+    const app = await bootHostedApp();
+
+    const response = await app.fetch(
+      new Request("https://staging.mcpjam.com/user_management/authenticate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_id: "client_123",
+          grant_type: "refresh_token",
+        }),
+      }),
+    );
+
+    // 400 "No local WorkOS session" is the handler answering: there is no
+    // session cookie on this bare request. What matters is that the route
+    // EXISTS — a 404 is the gated build, which is the regression.
+    expect(response.status).not.toBe(404);
+    expect(await response.json()).toEqual({
+      error_description: "No local WorkOS session",
+    });
+  }, 120_000);
+
+  it("mounts /user_management/authorize", async () => {
+    const app = await bootHostedApp();
+
+    const response = await app.fetch(
+      new Request(
+        "https://staging.mcpjam.com/user_management/authorize?client_id=client_123",
+        { redirect: "manual" },
+      ),
+    );
+
+    // Redirects the browser on to WorkOS proper. Again: not a 404.
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain("api.workos.com");
+  }, 120_000);
+});

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -6,6 +6,7 @@ import { webBodyLimit } from "./middleware/web-body-limit.js";
 import { logger } from "hono/logger";
 import { logger as appLogger } from "./utils/logger.js";
 import { serveStatic } from "@hono/node-server/serve-static";
+import { isSpaDocumentRequest } from "./utils/spa-document-request.js";
 import { readFileSync } from "fs";
 import { dirname } from "path";
 import { fileURLToPath } from "url";
@@ -366,9 +367,9 @@ export async function createHonoApp() {
   );
   app.route("/api/v1", v1Routes);
 
-  if (!HOSTED_MODE || process.env.NODE_ENV === "development") {
-    app.route("/user_management", workosAuthkitRoutes);
-  }
+  // Mounted in every runtime, hosted included — see the mirror of this mount
+  // in server/index.ts for why the gate had to go.
+  app.route("/user_management", workosAuthkitRoutes);
 
   // CLI OAuth bridge (mcpjam cloud login). Public front-channel routes — no session
   // auth (see session-auth.ts UNPROTECTED_PREFIXES) and no tokens returned;
@@ -498,7 +499,16 @@ export async function createHonoApp() {
 
     // Serve all static files from client root (images, svgs, etc.)
     // This handles files like /mcp_jam_light.png, /favicon.ico, etc.
-    app.use("/*", serveStatic({ root }));
+    //
+    // Document requests fall THROUGH to the injecting handler below — mirror
+    // of the guard in server/index.ts. See isSpaDocumentRequest.
+    const clientStaticFiles = serveStatic({ root });
+    app.use("/*", async (c, next) => {
+      if (isSpaDocumentRequest(c.req.path)) {
+        return next();
+      }
+      return clientStaticFiles(c, next);
+    });
 
     // For HTML pages, inject the session token (only for localhost requests)
     app.get("/*", async (c) => {

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -12,6 +12,7 @@ import { reportRouteFailure } from "./utils/route-error-report.js";
 import { attachSocketDiagnostics } from "./utils/socket-diagnostics.js";
 import { startProcessVitalsSampler } from "./utils/process-vitals.js";
 import { serveStatic } from "@hono/node-server/serve-static";
+import { isSpaDocumentRequest } from "./utils/spa-document-request.js";
 import { readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
@@ -569,9 +570,19 @@ app.route("/api/v1", v1Routes);
 app.route("/api/slack/link", slackLinkRoutes);
 app.route("/api/surface-link", surfaceLinkRoutes);
 
-if (!HOSTED_MODE || process.env.NODE_ENV === "development") {
-  app.route("/user_management", workosAuthkitRoutes);
-}
+// Mounted in EVERY runtime, hosted included. AuthKit's `initialize()` makes no
+// network call at all unless the page's own cookies carry `workos-has-session`
+// (see create-client.ts in @workos-inc/authkit-js) — and a client pointed
+// straight at `api.workos.com` can never have it, because WorkOS sets that
+// cookie on its own domain. Staging read as permanently signed out for exactly
+// that reason: sign-in succeeded, then the next page load fell back to guest.
+//
+// Proxying through this origin makes the cookie first-party, which is what
+// local dev has always relied on. Hosts that keep a same-site WorkOS domain
+// (prod's `auth.mcpjam.com`) never route here — the client only calls this
+// when its apiHostname resolves to its own origin. Mirror of the mount in
+// server/app.ts.
+app.route("/user_management", workosAuthkitRoutes);
 
 // In-process self-dispatch for the workspace built-in tools' platform
 // client (see utils/self-app.ts). Mirror of the registration in
@@ -697,7 +708,17 @@ if (process.env.NODE_ENV === "production") {
 
   // Serve all static files from client root (images, svgs, etc.)
   // This handles files like /mcp_jam_light.png, /favicon.ico, etc.
-  app.use("/*", serveStatic({ root: clientRoot }));
+  //
+  // Document requests must fall THROUGH to the injecting handler below —
+  // see isSpaDocumentRequest. Without this guard the catch-all answered `/`
+  // with the raw index.html and every injected script was silently dropped.
+  const clientStaticFiles = serveStatic({ root: clientRoot });
+  app.use("/*", async (c, next) => {
+    if (isSpaDocumentRequest(c.req.path)) {
+      return next();
+    }
+    return clientStaticFiles(c, next);
+  });
 
   // SPA fallback - serve index.html with token injection for non-API routes
   app.get("*", async (c) => {

--- a/mcpjam-inspector/server/routes/__tests__/workos-authkit.test.ts
+++ b/mcpjam-inspector/server/routes/__tests__/workos-authkit.test.ts
@@ -248,4 +248,75 @@ describe("workos authkit local session bridge", () => {
     });
     expect(fetch).not.toHaveBeenCalled();
   });
+
+  // The hosted path. Everything above runs on localhost, where the refresh
+  // token goes in a plain local jar; a deployed origin takes the other branch
+  // entirely — sealed `__Host-` cookie, Secure flags — and that branch is what
+  // staging and previews now depend on.
+  describe("on a deployed https origin", () => {
+    it("seals the refresh token into a Secure __Host- cookie", async () => {
+      const app = createTestApp();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        jsonResponse({
+          access_token: "access-token-1",
+          refresh_token: "refresh-token-1",
+          user: { id: "user_1" },
+        })
+      );
+
+      const res = await app.request(
+        "https://staging.mcpjam.com/user_management/authenticate",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            client_id: "client_123",
+            grant_type: "authorization_code",
+            code: "code_123",
+            code_verifier: "verifier_123",
+          }),
+        }
+      );
+
+      expect(res.status).toBe(200);
+      const setCookie = res.headers.get("set-cookie") ?? "";
+      expect(setCookie).toContain("__Host-mcpjam_workos_session=");
+      expect(setCookie).toContain("HttpOnly");
+      // The refresh token must never reach the deployed browser in the clear.
+      expect(setCookie).not.toContain("refresh-token-1");
+    });
+
+    // THE regression. Without this cookie on the app's own origin, AuthKit's
+    // initialize() short-circuits before making any request and the user is
+    // silently demoted to a guest on the next page load — which is exactly how
+    // staging behaved while it pointed at api.workos.com.
+    it("sets workos-has-session on this origin so AuthKit will attempt a refresh", async () => {
+      const app = createTestApp();
+      vi.mocked(fetch).mockResolvedValueOnce(
+        jsonResponse({
+          access_token: "access-token-1",
+          refresh_token: "refresh-token-1",
+          user: { id: "user_1" },
+        })
+      );
+
+      const res = await app.request(
+        "https://staging.mcpjam.com/user_management/authenticate",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            client_id: "client_123",
+            grant_type: "authorization_code",
+            code: "code_123",
+            code_verifier: "verifier_123",
+          }),
+        }
+      );
+
+      const setCookie = res.headers.get("set-cookie") ?? "";
+      expect(setCookie).toContain("workos-has-session=true");
+      expect(setCookie).toContain("Secure");
+    });
+  });
 });

--- a/mcpjam-inspector/server/utils/__tests__/spa-document-request.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/spa-document-request.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isSpaDocumentRequest } from "../spa-document-request.js";
+
+describe("isSpaDocumentRequest", () => {
+  // These are the paths that must reach the injecting document handler. When
+  // the catch-all serveStatic answered them first, hosted documents shipped
+  // with no runtime config, no session token, no guest bootstrap and no
+  // `no-store` — which is how staging's WorkOS hostname config never reached
+  // the browser at all.
+  it.each(["/", "/servers", "/p/abc123/home", "/embed/score", "/callback"])(
+    "routes %s to the document handler",
+    (path) => {
+      expect(isSpaDocumentRequest(path)).toBe(true);
+    },
+  );
+
+  // Everything in dist/client has an extension, so this is what keeps real
+  // files being served as files rather than swallowed by the SPA fallback.
+  it.each([
+    "/mcp_jam.svg",
+    "/favicon.ico",
+    "/assets/index-C1FTdFWO.js",
+    "/assets/index-DYymtqx-.css",
+    "/demo_1.png",
+  ])("leaves %s to the static handler", (path) => {
+    expect(isSpaDocumentRequest(path)).toBe(false);
+  });
+
+  // A dot earlier in the path is not a file extension — only the last segment
+  // decides, or a project route carrying a dotted id would 404.
+  it("only considers the last path segment", () => {
+    expect(isSpaDocumentRequest("/p/some.project/servers")).toBe(true);
+  });
+});

--- a/mcpjam-inspector/server/utils/spa-document-request.ts
+++ b/mcpjam-inspector/server/utils/spa-document-request.ts
@@ -1,0 +1,21 @@
+/**
+ * Whether a request should be answered with the SPA document rather than a
+ * file from `dist/client`.
+ *
+ * Both production entrypoints mount a catch-all `serveStatic` over `/*` and
+ * then an `app.get("*")` that serves `index.html` WITH its injected scripts —
+ * runtime config, the session token, the guest bootstrap — and a `no-store`
+ * header. Registered in that order, the static handler answers `/` with the
+ * raw `index.html` off disk and the injecting handler never runs: hosted
+ * documents shipped with none of those scripts and no `no-store` at all.
+ *
+ * So the static handler has to let document requests fall through. The test is
+ * the last path segment's file extension, which every asset in `dist/client`
+ * has and no SPA route does (`/`, `/p/<id>/servers`, `/embed/score`). Keep it
+ * that way: an extensionless file added under `dist/client` would become
+ * unreachable, and a route with a dot in its last segment would 404.
+ */
+export function isSpaDocumentRequest(path: string): boolean {
+  const lastSegment = path.slice(path.lastIndexOf("/") + 1);
+  return !lastSegment.includes(".");
+}


### PR DESCRIPTION
- Signing in on staging looked broken: you'd sign in, come back, and be a guest again. AuthKit checks the page's own cookies for `workos-has-session` before it does anything, and staging never had that cookie because WorkOS was setting it on `api.workos.com` instead of on us.
- Fixes it by routing AuthKit through our own server (`/user_management`), which is exactly what local dev already does — it was just switched off for hosted. Prod is untouched: it pins `auth.mcpjam.com`, which still wins.
- Staging and PR previews were pinned to `api.workos.com`, which would have made the fix do nothing, so those pins are gone. Previews now work too, without needing per-preview config.
- Also fixes a separate bug found on the way: hosted pages were served straight off disk, so the scripts we inject into the HTML (runtime config, session token, guest bootstrap) never made it to the browser at all — in prod either.
- Before merging: staging needs `MCPJAM_WORKOS_SESSION_SECRET` set, and `VITE_WORKOS_API_HOSTNAME` / `WORKOS_API_HOSTNAME` cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hosted sign-in on staging and PR previews, which silently dropped users back to guest after signing in because AuthKit couldn't see the `workos-has-session` cookie set by WorkOS. AuthKit now proxies through our own origin, and hosted document requests no longer skip script injection.

**Bug Fixes**
- AuthKit's `initialize()` only acts when the page's own cookies carry `workos-has-session`; WorkOS set that cookie on its own domain, so staging reloads always read as signed out.
- The `/user_management` AuthKit proxy is now mounted in every runtime, hosted included, and the client defaults to this origin when hosted.
- An explicit `VITE_WORKOS_API_HOSTNAME` still wins, so prod keeps `auth.mcpjam.com`.
- Staging and PR preview pins to `api.workos.com` are removed from the workflows.
- Hosted HTML documents were served raw off disk, dropping injected runtime config, session token, and guest bootstrap; document requests now fall through to the injecting handler.

**Migration**
- Set `MCPJAM_WORKOS_SESSION_SECRET` on staging before merging; PR previews inherit it.
- Clear `VITE_WORKOS_API_HOSTNAME` and `WORKOS_API_HOSTNAME` on staging and preview environments.

<sup>Written for commit daca6ae0e4ea1bed499e05bd9e848a6f9ceb853b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

