### PR TITLE
fix(computers): attach the bearer to the local-terminal nonce mint

### DIFF
--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -333,6 +333,12 @@ const HOSTED_AUTH_PATH_PREFIXES = [
   // via authFetch (not a manual header) keeps the on-401 session-token refresh
   // so a dev-server restart doesn't strand consent at 401 until a page reload.
   "/api/mcp/computers/local-consent",
+  // The local-terminal nonce mint mounts the same bearerAuthMiddleware +
+  // `requireVerifiedAuth` stack as the consent routes, so it needs the user's
+  // bearer for the same reason — without it the mint 401s on the missing
+  // bearer before the consent check ever runs, and the terminal can never
+  // open on a WorkOS-signed-in inspector.
+  "/api/mcp/computers/local-terminal-token",
   // Convex HTTP actions called via absolute URL (OAuth completion, etc.).
   "/web/oauth/",
   // Registry catalog/star routes are Convex HTTP actions called via absolute


### PR DESCRIPTION
## Problem

Opening the local terminal ("This machine" face of the Computer tab) always fails with **"Could not open a terminal on this machine."** on a WorkOS-signed-in inspector. The console shows `POST /api/mcp/computers/local-terminal-token 401 (Unauthorized)`.

## Root cause

The mint route mounts `bearerAuthMiddleware` + `requireVerifiedAuth()` (`server/routes/mcp/computers.ts`), and `bearerAuthMiddleware` 401s outright on a missing `Authorization` header.

The client mints via `authFetch`, which attaches the user's WorkOS bearer only to paths on its `HOSTED_AUTH_PATH_PREFIXES` allowlist. The consent routes got their entry (`/api/mcp/computers/local-consent` — with a comment saying exactly why: the routes mount `requireVerifiedAuth`, so they need the bearer), but the terminal mint path was never added. So consent grant/verify/revoke succeed while the mint goes out bearer-less and dies at the middleware, before the consent check ever runs.

The OSS escape hatch (`AuthKitConfigError` → pass when WorkOS isn't configured) doesn't help: with WorkOS configured, `bearerAuthMiddleware` rejects first. Any signed-in WorkOS user hits this, so it would also have broken at launch for the `self_hosted` cohort.

## Fix

Add `/api/mcp/computers/local-terminal-token` to the allowlist, directly under the consent entry, with the same rationale. One line (plus comment).

## Testing

- `session-token.hosted-registry.test.ts`, `session-token.readiness.test.ts`, `local-computer-consent.test.ts` — 28/28 pass.
- `npm run typecheck:client` clean.
- No test file enumerates the local-computer allowlist paths today, so no test was added (kept the change minimal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSsaUHWwK68vbX9zhMoDyr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single allowlist entry scoped to one authenticated API path; no auth logic or server behavior changes.
> 
> **Overview**
> Fixes **"Could not open a terminal on this machine"** for WorkOS-signed-in users by adding `/api/mcp/computers/local-terminal-token` to `HOSTED_AUTH_PATH_PREFIXES` in `session-token.ts`.
> 
> `authFetch` only attaches the hosted `Authorization` bearer for allowlisted paths. Local consent routes were already listed; the terminal nonce mint was not, so `POST` to the mint went out without a bearer, hit `bearerAuthMiddleware` with a 401, and never reached consent checks. The new entry mirrors the local-consent rationale and keeps 401 refresh behavior via `authFetch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62e7fbd66156bef8670f3657d723bb5005d21efd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the local-terminal nonce mint so it attaches the user's WorkOS bearer, letting the terminal open on a WorkOS-signed-in inspector. Previously the mint went out bearer-less and 401'd on the missing header before the consent check ever ran.

<sup>Written for commit 62e7fbd66156bef8670f3657d723bb5005d21efd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

