### PR TITLE
test(auth): assert cookie flags per cookie, not across the joined header

### DIFF
--- a/mcpjam-inspector/server/routes/__tests__/workos-authkit.test.ts
+++ b/mcpjam-inspector/server/routes/__tests__/workos-authkit.test.ts
@@ -24,6 +24,23 @@ function extractCookie(setCookie: string, name: string): string {
   return `${name}=${match[1]}`;
 }
 
+/**
+ * The ONE `Set-Cookie` header that carries `name`, with its own attributes.
+ *
+ * `headers.get("set-cookie")` joins every cookie into a single string, so
+ * asserting a flag against that tells you only that SOME cookie in the
+ * response carries it — a check that passes even when the cookie you meant is
+ * missing the flag entirely. Attributes are per-cookie, so the assertions have
+ * to be too.
+ */
+function setCookieFor(res: Response, name: string): string {
+  const entry = res.headers
+    .getSetCookie()
+    .find((cookie) => cookie.startsWith(`${name}=`));
+  if (!entry) throw new Error(`Missing Set-Cookie for ${name}`);
+  return entry;
+}
+
 describe("workos authkit local session bridge", () => {
   beforeEach(() => {
     process.env.MCPJAM_WORKOS_SESSION_SECRET = "test-workos-session-secret";
@@ -279,11 +296,18 @@ describe("workos authkit local session bridge", () => {
       );
 
       expect(res.status).toBe(200);
-      const setCookie = res.headers.get("set-cookie") ?? "";
-      expect(setCookie).toContain("__Host-mcpjam_workos_session=");
-      expect(setCookie).toContain("HttpOnly");
+      const sessionCookie = setCookieFor(res, "__Host-mcpjam_workos_session");
+      expect(sessionCookie).toContain("HttpOnly");
+      // The `__Host-` prefix is not decoration: a browser silently REJECTS a
+      // cookie carrying it without Secure and Path=/, or with any Domain at
+      // all. Dropped here, the session would vanish on the next page load —
+      // the exact failure this whole change exists to fix, reintroduced one
+      // attribute at a time.
+      expect(sessionCookie).toContain("Secure");
+      expect(sessionCookie).toContain("Path=/");
+      expect(sessionCookie).not.toContain("Domain=");
       // The refresh token must never reach the deployed browser in the clear.
-      expect(setCookie).not.toContain("refresh-token-1");
+      expect(sessionCookie).not.toContain("refresh-token-1");
     });
 
     // THE regression. Without this cookie on the app's own origin, AuthKit's
@@ -314,9 +338,15 @@ describe("workos authkit local session bridge", () => {
         }
       );
 
-      const setCookie = res.headers.get("set-cookie") ?? "";
-      expect(setCookie).toContain("workos-has-session=true");
-      expect(setCookie).toContain("Secure");
+      const hasSessionCookie = setCookieFor(res, "workos-has-session");
+      expect(hasSessionCookie).toContain("workos-has-session=true");
+      // Secure asserted on THIS cookie specifically: a deployed browser drops
+      // an insecure cookie on an https origin, and AuthKit would then skip its
+      // refresh and demote the user to a guest.
+      expect(hasSessionCookie).toContain("Secure");
+      // Readable by the page — this is the one cookie AuthKit inspects from
+      // JavaScript, so HttpOnly on it would break the flow it exists to drive.
+      expect(hasSessionCookie).not.toContain("HttpOnly");
     });
   });
 });


### PR DESCRIPTION
Follow-up to #4514, from review feedback.

- The cookie tests checked flags against the whole `Set-Cookie` header, which joins every cookie into one string — so `Secure` passed as long as *any* cookie had it, not the one that actually matters.
- Now checks each cookie's own entry, and also pins the `__Host-` rules (`Secure`, `Path=/`, no `Domain`). Browsers silently throw away a `__Host-` cookie that breaks those, which would bring back the exact sign-in bug #4514 fixed.
- Verified both assertions actually catch it: removing `Secure` and adding a `Domain` each turn the tests red, and both slipped through the old version.
- Tests only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cookie flag tests so each assertion targets the cookie's own `Set-Cookie` entry instead of the joined header, and pins the `__Host-` rules (`Secure`, `Path=/`, no `Domain`) that browsers enforce by silently dropping the cookie.

The old assertions passed `Secure` as long as any cookie in the response had it, leaving the session cookie's missing flag undetected. Tests only; no behaviour change.

<sup>Written for commit 51ec054f6c1ba9ecce1500522bc4980041784558. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

