### PR TITLE
Local terminal: self-repair spawn-helper, surface open errors, embed in Playground rail

### DIFF
--- a/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Cloud,
   FileText,
@@ -13,6 +13,7 @@ import { track } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import { LoggerView } from "@/components/logger-view";
 import { ComputerStatusChip } from "@/components/computer/ComputerStatusChip";
+import { ComputerTerminal } from "@/components/computer/ComputerTerminal";
 import { ComputerTerminalPane } from "@/components/computer/ComputerTerminalPane";
 import { PaneMessage } from "@/components/computer/PaneMessage";
 import { useComputerTerminal } from "@/components/computer/useComputerTerminal";
@@ -22,6 +23,9 @@ import {
   type ComputerEngineState,
 } from "@/hooks/useComputerEngine";
 import { useHarnessWorkdir } from "@/stores/harness-workdir-store";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
+import { mintLocalTerminalNonce } from "@/lib/local-computer-consent";
+import { LOCAL_TERMINAL_WS_PATH } from "@/lib/computer-terminal-connection";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
 
 /**
@@ -155,7 +159,7 @@ function RightRailTabbed({
             until the idle sweep, and switching back reconnects with a fresh
             token mint. */}
         {isLocalShell ? (
-          <LocalShellBody engine={engine} />
+          <LocalShellBody engine={engine} projectId={projectId} />
         ) : (
           <CloudShellBody
             engine={engine}
@@ -186,9 +190,49 @@ function RailEngineChip({ engine }: { engine: "local" | "cloud" }) {
   );
 }
 
-/** The Shell body for the local engine: no cloud controller, no reserve. */
-function LocalShellBody({ engine }: { engine: ComputerEngineState }) {
+/**
+ * The Shell body for the local engine: no cloud controller, no reserve — the
+ * same bare `ComputerTerminal` the Computer tab's local face mounts, behind
+ * the same explicit "Open terminal" gesture the cloud body uses. Explicit
+ * because a PTY is a real shell on the user's machine: both rail bodies stay
+ * mounted across Logs ⇄ Shell toggles, so mounting eagerly would open a shell
+ * the moment the Playground loads, without the user asking for one.
+ */
+function LocalShellBody({
+  engine,
+  projectId,
+}: {
+  engine: ComputerEngineState;
+  projectId: string | null;
+}) {
   const { consent, localTerminalAvailable } = engine;
+  const themeMode = usePreferencesStore((state) => state.themeMode);
+  const [terminalOpen, setTerminalOpen] = useState(false);
+
+  // A fresh nonce per (re)connect — single-use by construction, so the
+  // reconnect button in `ComputerTerminal` must mint again rather than replay.
+  const consentToken = consent.token;
+  const mintToken = useCallback(
+    () => mintLocalTerminalNonce({ projectId: projectId ?? "", consentToken }),
+    [projectId, consentToken],
+  );
+
+  const canOpenTerminal =
+    consent.granted && localTerminalAvailable && !!projectId;
+  const showTerminal = terminalOpen && canOpenTerminal;
+
+  // One `computer_terminal_opened` per opened SESSION, keyed like the Computer
+  // tab's local face: a project switch remounts the terminal (new shell, new
+  // workspace) and must be counted even though this component didn't remount.
+  const lastReportedRef = useRef<string | null>(null);
+  useEffect(() => {
+    const key = showTerminal ? `open:${projectId}` : null;
+    if (lastReportedRef.current === key) return;
+    lastReportedRef.current = key;
+    if (key === null) return;
+    track("computer_terminal_opened", { location: "playground_rail_local" });
+  }, [showTerminal, projectId]);
+
   return (
     <>
       <div className="flex shrink-0 items-center justify-between gap-2 px-3 py-2">
@@ -197,6 +241,12 @@ function LocalShellBody({ engine }: { engine: ComputerEngineState }) {
             already names the machine. */}
         {engine.toggleVisible ? (
           <RailEngineChip engine={engine.engine} />
+        ) : null}
+        {!terminalOpen && canOpenTerminal ? (
+          <Button size="sm" onClick={() => setTerminalOpen(true)}>
+            <TerminalSquare className="mr-1.5 h-3.5 w-3.5" />
+            Open terminal
+          </Button>
         ) : null}
       </div>
       <div className="min-h-0 flex-1 px-3 pb-3">
@@ -209,10 +259,26 @@ function LocalShellBody({ engine }: { engine: ComputerEngineState }) {
               allow agent commands here.
             </span>
           </PaneMessage>
-        ) : localTerminalAvailable ? (
+        ) : showTerminal ? (
+          // `uploadEnabled={false}` for the same reason as the Computer tab's
+          // local pane: the drag-and-drop upload posts to the CLOUD box's
+          // upload route, and writing dropped files onto the user's real
+          // filesystem is a separate consent question.
+          <ComputerTerminal
+            // Keyed by project: `ComputerTerminal` connects from a MOUNT-ONLY
+            // effect, so a project switch must remount into the new project's
+            // workspace (and journal under it).
+            key={projectId}
+            mintToken={mintToken}
+            themeMode={themeMode === "dark" ? "dark" : "light"}
+            wsPath={LOCAL_TERMINAL_WS_PATH}
+            uploadEnabled={false}
+            className="h-full"
+          />
+        ) : canOpenTerminal ? (
           <PaneMessage dashed>
             <span data-testid="rail-local-terminal-pointer">
-              Open the terminal for this machine from the Computer tab.
+              Open the terminal to use a shell on this machine.
             </span>
           </PaneMessage>
         ) : (

--- a/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundRightRail.test.tsx
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundRightRail.test.tsx
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 /**
  * The rail's Shell tab is engine-aware: the CLOUD controller
  * (`useComputerTerminal`, which reserves/wakes a real cloud box on open) must
  * never be mounted while the project's computer engine is local. These suites
  * pin exactly that — plus the indicator chip and the local body's three states
- * (unconsented / terminal available / terminal unavailable).
+ * (unconsented / open-terminal prompt / terminal unavailable).
  */
 
 const engineState = vi.hoisted(() => ({
@@ -72,6 +72,20 @@ vi.mock("@/components/computer/ComputerStatusChip", () => ({
 
 vi.mock("@/components/computer/ComputerTerminalPane", () => ({
   ComputerTerminalPane: () => <div data-testid="cloud-terminal-pane" />,
+}));
+
+// The bare terminal the LOCAL body mounts (xterm won't run under jsdom).
+vi.mock("@/components/computer/ComputerTerminal", () => ({
+  ComputerTerminal: () => <div data-testid="local-terminal" />,
+}));
+
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: (selector: (s: { themeMode: string }) => unknown) =>
+    selector({ themeMode: "light" }),
+}));
+
+vi.mock("@/lib/local-computer-consent", () => ({
+  mintLocalTerminalNonce: vi.fn(),
 }));
 
 vi.mock("@/stores/harness-workdir-store", () => ({
@@ -200,14 +214,22 @@ describe("PlaygroundRightRail — local engine body", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("points at the Computer tab's terminal when one is available", () => {
+  it("offers Open terminal and mounts the LOCAL pane on click — never the cloud controller", () => {
     engineState.engine = "local";
     engineState.granted = true;
     engineState.localTerminalAvailable = true;
     renderRail();
+    // Idle until asked: a PTY is a real shell on the user's machine, and both
+    // rail bodies stay mounted, so nothing may spawn one on Playground load.
     expect(
       screen.getByTestId("rail-local-terminal-pointer"),
     ).toBeInTheDocument();
+    expect(screen.queryByTestId("local-terminal")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /open terminal/i }));
+    expect(screen.getByTestId("local-terminal")).toBeInTheDocument();
+    expect(screen.queryByTestId("cloud-terminal-pane")).not.toBeInTheDocument();
+    expect(terminalSpies.useComputerTerminal).not.toHaveBeenCalled();
   });
 
   it("degrades honestly when the local terminal isn't available", () => {

--- a/mcpjam-inspector/server/routes/web/local-computer-terminal.ts
+++ b/mcpjam-inspector/server/routes/web/local-computer-terminal.ts
@@ -314,14 +314,24 @@ export function createLocalComputerTerminalWsHandler(
             });
             ws.send(JSON.stringify({ type: "ready", sessionId }));
           } catch (error) {
+            const reason =
+              error instanceof Error ? error.message : String(error);
             logger.warn("[local-computer-terminal] PTY open failed", {
-              error: error instanceof Error ? error.message : String(error),
+              error: reason,
             });
             if (!closed) {
+              // Include the underlying reason: this machine belongs to the
+              // person reading the pane, and a bare "failed" turned a
+              // one-line diagnosis (`posix_spawnp failed.`) into a
+              // server-log hunt. Bounded so a pathological message can't
+              // flood the status line.
+              const detail = reason.trim().slice(0, 200);
               ws.send(
                 JSON.stringify({
                   type: "error",
-                  message: "Failed to open a terminal on this machine.",
+                  message: detail
+                    ? `Failed to open a terminal on this machine. (${detail})`
+                    : "Failed to open a terminal on this machine.",
                 })
               );
               ws.close(CLOSE_UNAVAILABLE, "PTY open failed");

--- a/mcpjam-inspector/server/utils/computers/local-pty.ts
+++ b/mcpjam-inspector/server/utils/computers/local-pty.ts
@@ -18,6 +18,9 @@
  * is unavailable (hosted, kill switch off, no bash), because a terminal on a
  * machine that may not execute bash would be a second, ungated execution path.
  */
+import { chmodSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
 import { logger } from "../logger.js";
 import { isLocalComputerEngineAvailable } from "./local-machine.js";
 
@@ -58,8 +61,46 @@ let loadPromise: Promise<LocalPtyModuleLoad> | null = null;
  * native addon will not appear mid-process, and retrying per connection would
  * pay the resolution cost on every socket).
  */
+/**
+ * npm's published node-pty prebuilds have shipped `spawn-helper` without its
+ * execute bit (npm preserves the mode packed into the tarball). On macOS
+ * node-pty exec's that helper for every PTY, so the module LOADS fine — the
+ * availability probe passes — and every spawn then dies with the bare
+ * `posix_spawnp failed.`. The repair is a one-bit chmod on a file inside our
+ * own node_modules, so do it once at load rather than leaving every affected
+ * install to diagnose it. Best-effort: any failure here falls through to the
+ * spawn error, which the WS handler surfaces to the terminal pane.
+ */
+function repairSpawnHelperMode(): void {
+  if (process.platform !== "darwin") return;
+  try {
+    const require = createRequire(import.meta.url);
+    const root = path.dirname(require.resolve("node-pty/package.json"));
+    for (const helper of [
+      path.join(root, "prebuilds", `darwin-${process.arch}`, "spawn-helper"),
+      path.join(root, "build", "Release", "spawn-helper"),
+    ]) {
+      try {
+        const mode = statSync(helper).mode;
+        if ((mode & 0o111) === 0) {
+          chmodSync(helper, mode | 0o111);
+          logger.info("[local-pty] restored execute bit on spawn-helper", {
+            helper,
+          });
+        }
+      } catch {
+        // Candidate absent (other build layout) or chmod refused — the spawn
+        // error stays the source of truth.
+      }
+    }
+  } catch {
+    // node-pty itself not resolvable — the import below reports that.
+  }
+}
+
 export function loadLocalPtyModule(): Promise<LocalPtyModuleLoad> {
   if (!loadPromise) {
+    repairSpawnHelperMode();
     // `as string` widens the specifier for TYPE resolution only — node-pty is
     // optional, so `tsc` must not fail when it isn't installed (and must not
     // fight the package's own types when it is). The cast is erased before


### PR DESCRIPTION
Three follow-ups from dogfooding the local computer engine (companion to #4515):

## 1. Self-repair the node-pty spawn-helper exec bit (server/utils/computers/local-pty.ts)

npm's published node-pty 1.1.0 macOS prebuild can arrive with `spawn-helper` missing its execute bit (npm preserves the mode packed into the tarball — reproduced on a clean install). node-pty exec's that helper for every PTY, so the module **loads** fine — the availability probe passes, the mint succeeds — and every spawn then dies with a bare `posix_spawnp failed.`. The worst shape of failure: everything reports healthy and the terminal errors at open.

The loader now restores the bit before importing node-pty (darwin only, both the `prebuilds/darwin-<arch>` and `build/Release` layouts, best-effort with full fallthrough to the spawn error).

## 2. Surface the PTY open error to the pane (server/routes/web/local-computer-terminal.ts)

"Failed to open a terminal on this machine." now includes the underlying reason, bounded to 200 chars — e.g. `(posix_spawnp failed.)`. This machine belongs to the person reading the pane; a bare "failed" turned a one-line diagnosis into a server-log hunt. The client already renders the WS error message as the status detail, so no client change needed.

## 3. Embed the local terminal in the Playground rail (PlaygroundRightRail.tsx)

The rail's local Shell body previously pointed at the Computer tab. It now mounts the real terminal — the same bare `ComputerTerminal` the Computer tab's local face uses (same nonce mint, same WS path, per-project remount, `uploadEnabled={false}` for the same consent reason) — behind the same explicit **Open terminal** gesture as the cloud body. Idle until asked: both rail bodies stay mounted across Logs ⇄ Shell toggles, so nothing may spawn a shell on the user's machine at Playground load. Still never mounts the cloud controller (no reserve behind the user's back); opens tracked as `computer_terminal_opened` with `location: "playground_rail_local"`.

## Testing

- `local-pty.test.ts` + `local-computer-terminal.test.ts`: 31/31 pass; `PlaygroundRightRail.test.tsx`: 14/14 pass (pointer test rewritten as open-and-mount, cloud-controller-never-called assertions kept).
- `npm run typecheck:client` clean.
- Self-repair verified end-to-end on a real affected install: stripped the exec bit, loaded the module, bit restored (`-rw-r--r--` → `-rwxr-xr-x`) and the shell spawns.
- Rail terminal verified live in dev: consent → Playground → Shell → Open terminal → interactive zsh in the project workspace; session survives Logs ⇄ Shell toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSsaUHWwK68vbX9zhMoDyr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch local PTY spawning and chmod in node_modules on macOS, plus another UI entry point for an interactive shell—still behind existing consent and explicit open, but execution-sensitive.
> 
> **Overview**
> Follow-up dogfooding for the **local computer** engine: fixes a macOS **node-pty** install quirk, improves open failures in the UI, and lets the Playground **Shell** rail run a local PTY without sending users to the Computer tab.
> 
> On **darwin**, `loadLocalPtyModule` now **restores the execute bit** on `node-pty`'s `spawn-helper` before import when npm ships it non-executable — so availability can stay green while every spawn was failing with `posix_spawnp failed.`
> 
> When PTY open still fails, the local terminal WebSocket **error message includes the underlying reason** (trimmed to 200 chars), e.g. `(posix_spawnp failed.)`, instead of a generic failure string.
> 
> The Playground right rail's **local Shell** body no longer only points at the Computer tab: after consent it shows an explicit **Open terminal** control, then mounts the same **`ComputerTerminal`** path as the Computer tab (local nonce mint, `LOCAL_TERMINAL_WS_PATH`, project-keyed remount, uploads off). The terminal stays **idle until clicked** so a real shell is not spawned on Playground load; opens are tracked as `computer_terminal_opened` with `location: "playground_rail_local"`. Tests cover open-and-mount and that the cloud terminal controller is never used for local.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adcdb54e2181a143c19ae80573118262ff3979fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes local terminal failures diagnosable and embeds a real terminal in the Playground rail.

**Bug Fixes**

- The loader restores `node-pty`'s missing `spawn-helper` execute bit before import on macOS, so every spawn no longer dies with a bare `posix_spawnp failed.` while the availability probe passes.
- The terminal open error now includes the underlying reason, bounded to 200 chars, e.g. `(posix_spawnp failed.)`, instead of sending the reader to server logs.

**New Features**

- The Playground rail's local Shell body mounts the same `ComputerTerminal` as the Computer tab behind an explicit **Open terminal** button; it stays idle until asked so no shell spawns on Playground load, and the cloud controller is never mounted for local engines.

<sup>Written for commit adcdb54e2181a143c19ae80573118262ff3979fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

