### PR TITLE
fix(oauth): stop reporting target server request failures

### DIFF
--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-step-reporting.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-step-reporting.test.ts
@@ -139,6 +139,22 @@ describe("OAuth debugger step-failure reporting", () => {
     expect(updateState).toHaveBeenCalledWith(serverFault);
   });
 
+  it("ignores an authenticated request failure from the server under test", () => {
+    const { wrapped, updateState } = wrappedUpdateState(
+      vi.fn(),
+      "authenticated_request",
+    );
+    const serverFailure = {
+      error:
+        "Authenticated request failed: 503 Service Temporarily Unavailable: <html>temporarily unavailable</html>",
+    };
+
+    wrapped(serverFailure);
+
+    expect(reportCaught).not.toHaveBeenCalled();
+    expect(updateState).toHaveBeenCalledWith(serverFailure);
+  });
+
   it("still reports a real failure that follows a warning", () => {
     const { wrapped } = wrappedUpdateState();
 
@@ -171,6 +187,8 @@ describe("OAuth debugger step-failure reporting", () => {
 
     expect(updateState).toHaveBeenCalledTimes(2);
     expect(updateState).toHaveBeenNthCalledWith(1, { error: "boom" });
-    expect(updateState).toHaveBeenNthCalledWith(2, { authorizationCode: "abc" });
+    expect(updateState).toHaveBeenNthCalledWith(2, {
+      authorizationCode: "abc",
+    });
   });
 });

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
   createOAuthStateMachine,
   getBrowserDebugDynamicRegistrationMetadata,
+  isAuthenticatedRequestFailure,
   isLoopbackOAuthUrl,
   type OAuthFlowState,
   type OAuthProtocolVersion,
@@ -162,9 +163,9 @@ export function createDebugRequestExecutor(): OAuthRequestExecutor {
     if (!proxyResponse.ok) {
       const reason = await readProxyError(proxyResponse);
       throw new Error(
-        `Backend debug proxy error: ${proxyResponse.status} ${proxyResponse.statusText}${
-          reason ? `: ${reason}` : ""
-        }`,
+        `Backend debug proxy error: ${proxyResponse.status} ${
+          proxyResponse.statusText
+        }${reason ? `: ${reason}` : ""}`,
       );
     }
 
@@ -272,6 +273,12 @@ const UNREPORTED_STEP_FAILURES = new Set([
   AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER,
 ]);
 
+function isUnreportedStepFailure(error: string): boolean {
+  return (
+    UNREPORTED_STEP_FAILURES.has(error) || isAuthenticatedRequestFailure(error)
+  );
+}
+
 /**
  * Wrap the caller's `updateState` so every NEW step failure is reported.
  *
@@ -287,7 +294,8 @@ const UNREPORTED_STEP_FAILURES = new Set([
  *
  * `Warning: `-prefixed messages are skipped entirely — those are advisories the
  * flow recovers from (an optional metadata field the server left out), not step
- * failures. So are the messages in `UNREPORTED_STEP_FAILURES`.
+ * failures. So are target-server failures identified by
+ * `isUnreportedStepFailure`.
  */
 function withStepFailureReporting(
   updateState: InspectorOAuthStateMachineConfig["updateState"],
@@ -299,7 +307,7 @@ function withStepFailureReporting(
     const error = updates.error;
     if (
       typeof error === "string" &&
-      (error.startsWith("Warning: ") || UNREPORTED_STEP_FAILURES.has(error))
+      (error.startsWith("Warning: ") || isUnreportedStepFailure(error))
     ) {
       // Not ours to act on: the message is already on screen, and reporting
       // these buries real step failures under server-under-test nits.
@@ -309,7 +317,11 @@ function withStepFailureReporting(
       updateState(updates);
       return;
     }
-    if (typeof error === "string" && error !== "" && error !== lastReportedError) {
+    if (
+      typeof error === "string" &&
+      error !== "" &&
+      error !== lastReportedError
+    ) {
       lastReportedError = error;
       reportCaught(new Error(sanitizeStepError(error)), {
         source: "oauth_debugger_step",

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -477,6 +477,10 @@ export { runOAuthStateMachine } from "./oauth/state-machines/runner.js";
 // instead of re-typing the message — it is the server under test violating
 // RFC 8414, which a host may want to treat differently from its own errors.
 export { AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER } from "./oauth/state-machines/shared/required-metadata.js";
+// The debug proxy's own failures use a different error shape. This classifier
+// lets browser hosts keep a target server's authenticated-request rejection in
+// the debugger without sending it to their own exception tracker.
+export { isAuthenticatedRequestFailure } from "./oauth/state-machines/shared/response-error.js";
 // OAuth client emulation (HP-43): profile → generic machine knobs. Pure and
 // client-name-free — per-client profiles live in the private backend.
 export { deriveOAuthEmulation } from "./oauth/emulation/derive.js";

--- a/sdk/src/oauth/state-machines/shared/response-error.ts
+++ b/sdk/src/oauth/state-machines/shared/response-error.ts
@@ -10,6 +10,21 @@ import { sanitizeTraceErrorMessage } from "../trace-redaction.js";
  */
 const MAX_REASON_CHARS = 300;
 
+const AUTHENTICATED_REQUEST_FAILURE_PREFIX = "Authenticated request failed";
+
+/**
+ * Whether a debugger step error is the server under test rejecting the
+ * authenticated MCP request.
+ *
+ * The debug proxy reports its own failures separately. This prefix is only
+ * produced after that proxy successfully returns the target server's HTTP
+ * response, so consumers can keep the failure visible without filing it as an
+ * MCPJam defect.
+ */
+export function isAuthenticatedRequestFailure(error: string): boolean {
+  return error.startsWith(`${AUTHENTICATED_REQUEST_FAILURE_PREFIX}: `);
+}
+
 /**
  * Take one candidate field as a reason, or `undefined` if it carries no text.
  *
@@ -166,17 +181,17 @@ interface FailedResponse {
  */
 function describeResponseFailure(
   label: string,
-  response: FailedResponse,
+  response: FailedResponse
 ): string {
   const safeStatusText = toSingleLine(
     sanitizeTraceErrorMessage(response.statusText ?? "", {
       maxLength: MAX_REASON_CHARS,
-    }),
+    })
   );
   const reason = extractResponseErrorReason(response.body);
   const safeReason = reason
     ? toSingleLine(
-        sanitizeTraceErrorMessage(reason, { maxLength: MAX_REASON_CHARS }),
+        sanitizeTraceErrorMessage(reason, { maxLength: MAX_REASON_CHARS })
       )
     : undefined;
   return `${label}: ${response.status}${
@@ -192,9 +207,12 @@ function describeResponseFailure(
  * 2026-07-28 with `tools/list`), so they all report it the same way.
  */
 export function describeAuthenticatedRequestFailure(
-  response: FailedResponse,
+  response: FailedResponse
 ): string {
-  return describeResponseFailure("Authenticated request failed", response);
+  return describeResponseFailure(
+    AUTHENTICATED_REQUEST_FAILURE_PREFIX,
+    response
+  );
 }
 
 /**

--- a/sdk/tests/oauth/response-error.test.ts
+++ b/sdk/tests/oauth/response-error.test.ts
@@ -2,6 +2,7 @@ import {
   describeAuthenticatedRequestFailure,
   describeTokenRequestFailure,
   extractResponseErrorReason,
+  isAuthenticatedRequestFailure,
 } from "../../src/oauth/state-machines/shared/response-error.js";
 
 describe("extractResponseErrorReason", () => {
@@ -86,6 +87,26 @@ describe("extractResponseErrorReason", () => {
 });
 
 describe("describeAuthenticatedRequestFailure", () => {
+  it("marks its output as a target-server failure", () => {
+    const message = describeAuthenticatedRequestFailure({
+      status: 503,
+      statusText: "Service Temporarily Unavailable",
+      body: "<html><body>temporarily unavailable</body></html>",
+    });
+
+    expect(isAuthenticatedRequestFailure(message)).toBe(true);
+    expect(
+      isAuthenticatedRequestFailure(
+        "Backend debug proxy error: 503 Service Temporarily Unavailable"
+      )
+    ).toBe(false);
+    expect(
+      isAuthenticatedRequestFailure(
+        "Token request failed: 503 Service Temporarily Unavailable"
+      )
+    ).toBe(false);
+  });
+
   it("appends the server's reason to the status line", () => {
     expect(
       describeAuthenticatedRequestFailure({

--- a/sdk/tests/platform/operations-compose.test.ts
+++ b/sdk/tests/platform/operations-compose.test.ts
@@ -1057,6 +1057,7 @@ describe("compose skill selection", () => {
       suite: "Smoke",
       compose: {
         host: "Claude Code",
+        hostServers: true,
         skills: {
           mode: "explicit",
           skillIds: ["skill-a", "skill-b"],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stops the OAuth debugger from reporting a target server's authenticated-request failures to Sentry, so server-under-test errors stay visible in the debugger without being filed as MCPJam defects.

- Adds `isAuthenticatedRequestFailure` to classify the prefix produced by `describeAuthenticatedRequestFailure`.
- Exports `isAuthenticatedRequestFailure` from `sdk/src/browser.ts` so hosts can opt in to reporting these failures themselves.
- Skips these failures in the debugger adapter's step-failure reporting, alongside the existing `UNREPORTED_STEP_FAILURES`.

<sup>Written for commit 779dd14ebb48b46746636c9bde996182d90589f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

