### PR TITLE
feat(cli): --api-header, so the CLI can reach a deployment behind an edge authenticator

### DIFF
--- a/.changeset/platform-api-header.md
+++ b/.changeset/platform-api-header.md
@@ -1,0 +1,28 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/cli": minor
+---
+
+Let the CLI reach a deployment behind an edge authenticator.
+
+`PlatformApiClient` gains `extraHeaders`, and the CLI exposes it as a repeatable
+`--api-header "Name: value"` plus `MCPJAM_API_HEADERS` (newline-separated). Until
+now the platform client built its header set from scratch on every request and
+accepted no additions, so `mcpjam cloud …` could not authenticate to anything
+sitting behind Cloudflare Access, a WAF, or a corporate proxy — which is every
+staging deployment, every PR preview, and self-hosted installs behind a company
+egress. The existing `--header` flag never helped: it injects into the MCP
+*target server* connection, not the MCPJam API.
+
+The headers the client derives from its own contract cannot be overridden.
+`authorization`, `idempotency-key` and `content-type` are refused by name at the
+CLI boundary, and the client additionally applies extras *before* its own
+headers, so a caller reaching the transport another way still cannot swap the
+credential or the retry key. Names are lower-cased so one header cannot arrive
+under two spellings, and a value containing a line break is rejected as header
+injection rather than passed to `fetch`.
+
+Flag and environment combine rather than one winning: CI supplies a machine
+credential through the environment (keeping it out of `ps` and shell history)
+while a developer adds a one-off header on the command line. On a name given in
+both, the flag wins.

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -15,6 +15,8 @@ import {
 export interface PlatformClientOptions {
   apiKey?: string;
   apiUrl?: string;
+  /** Repeatable `Name: value` headers for an edge authenticator in front. */
+  apiHeader?: string[];
   timeoutMs?: number;
 }
 
@@ -74,6 +76,85 @@ function resolveExplicitApiUrl(
   return undefined;
 }
 
+/**
+ * Headers this client derives from its own contract. A caller that supplies
+ * one is not customizing a request — it is trying to replace the credential,
+ * the retry key, or the body's own description, and each would break a
+ * guarantee something else depends on. Rejected loudly at the boundary rather
+ * than dropped quietly, so the caller learns the flag did nothing.
+ *
+ * `PlatformApiClient` also spreads extras BEFORE its own headers, so this list
+ * is the readable half of a defence the transport enforces regardless.
+ */
+const RESERVED_HEADER_NAMES = new Set([
+  "authorization",
+  "idempotency-key",
+  "content-type",
+]);
+
+/** RFC 7230 token. Anything else cannot be a header name. */
+const HEADER_NAME_RE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+/**
+ * Parse one `Name: value` header. Split on the FIRST colon only — values
+ * legitimately contain colons (a URL, a timestamp), and splitting on all of
+ * them would corrupt them silently.
+ */
+function parseHeader(raw: string, source: string): [string, string] {
+  const separator = raw.indexOf(":");
+  if (separator < 1) {
+    throw usageError(
+      `${source} must be "Name: value" — got ${JSON.stringify(raw)}`,
+    );
+  }
+  const name = raw.slice(0, separator).trim();
+  const value = raw.slice(separator + 1).trim();
+  if (!HEADER_NAME_RE.test(name)) {
+    throw usageError(`${source} has an invalid header name ${JSON.stringify(name)}`);
+  }
+  if (value.length === 0) {
+    throw usageError(`${source} has an empty value for ${JSON.stringify(name)}`);
+  }
+  // A newline in a value is header injection, not a header. Native fetch
+  // rejects it too, but a named error beats a runtime TypeError.
+  if (/[\r\n]/.test(value)) {
+    throw usageError(`${source} value for ${JSON.stringify(name)} contains a line break`);
+  }
+  const lower = name.toLowerCase();
+  if (RESERVED_HEADER_NAMES.has(lower)) {
+    throw usageError(
+      `${source} cannot set ${JSON.stringify(name)} — it is derived from the credential and request`,
+    );
+  }
+  return [lower, value];
+}
+
+/**
+ * Extra request headers for a deployment behind an edge authenticator.
+ *
+ * Flag and env COMBINE rather than one winning: CI supplies the machine
+ * credential through the environment (so it stays out of `ps` and shell
+ * history) while a developer adds a one-off header on the command line, and
+ * needing both is the normal case rather than a conflict. A name given twice
+ * takes the flag's value, since that is the more specific of the two.
+ */
+export function resolvePlatformExtraHeaders(
+  options: Pick<PlatformClientOptions, "apiHeader">,
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> | undefined {
+  const headers: Record<string, string> = {};
+  for (const line of (env.MCPJAM_API_HEADERS ?? "").split("\n")) {
+    if (line.trim().length === 0) continue;
+    const [name, value] = parseHeader(line, "MCPJAM_API_HEADERS");
+    headers[name] = value;
+  }
+  for (const raw of options.apiHeader ?? []) {
+    const [name, value] = parseHeader(raw, "--api-header");
+    headers[name] = value;
+  }
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
 export function resolvePlatformBaseUrl(
   options: Pick<PlatformClientOptions, "apiUrl">,
   env: NodeJS.ProcessEnv = process.env,
@@ -105,6 +186,7 @@ export function buildPlatformClient(
 } {
   const env = deps.env ?? process.env;
   const credential = resolvePlatformCredential(options, deps);
+  const extraHeaders = resolvePlatformExtraHeaders(options, env);
 
   // When the stored OAuth login is the credential, its tokens belong to the
   // deployment it was created against — default to that deployment's API URL
@@ -124,6 +206,7 @@ export function buildPlatformClient(
       ? { timeoutMs: options.timeoutMs }
       : {}),
     userAgent: `mcpjam-cli/${packageJson.version}`,
+    ...(extraHeaders ? { extraHeaders } : {}),
   });
   return { client, credentialKind: credential.kind, baseUrl: resolvedBaseUrl };
 }

--- a/cli/src/lib/platform-command.ts
+++ b/cli/src/lib/platform-command.ts
@@ -42,6 +42,7 @@ import { CliError, usageError, writeResult } from "./output.js";
 export type PlatformOptions = {
   apiKey?: string;
   apiUrl?: string;
+  apiHeader?: string[];
 };
 
 export type CloudClientContext = {
@@ -133,6 +134,10 @@ export function addPlatformOptions(command: Command): Command {
     .option(
       "--api-url <url>",
       "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)"
+    )
+    .option(
+      "--api-header <header...>",
+      'Extra request header for a deployment behind an edge authenticator, as "Name: value" (repeatable; also MCPJAM_API_HEADERS, newline-separated)'
     );
 }
 

--- a/cli/tests/platform-extra-headers.test.ts
+++ b/cli/tests/platform-extra-headers.test.ts
@@ -1,0 +1,140 @@
+/**
+ * `--api-header` / `MCPJAM_API_HEADERS` — the flag that lets the CLI reach a
+ * deployment behind Cloudflare Access, a WAF, or a corporate proxy.
+ *
+ * The parsing tests matter less than the refusals. A header flag that can set
+ * `authorization` is a way to smuggle a credential past the per-deployment
+ * token rules in `platform-client`, and one that accepts a line break is header
+ * injection. Both are rejected here, by name, so the failure teaches.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CliError } from "../src/lib/output.js";
+import { resolvePlatformExtraHeaders } from "../src/lib/platform-client.js";
+
+const rejects = (
+  fn: () => unknown,
+  contains: string,
+  message: string
+): void => {
+  assert.throws(
+    fn,
+    (error: unknown) => {
+      assert.ok(error instanceof CliError, `${message}: not a CliError`);
+      assert.match(String((error as CliError).message), new RegExp(contains));
+      return true;
+    },
+    message
+  );
+};
+
+test("parses repeatable flags into lower-cased names", () => {
+  assert.deepEqual(
+    resolvePlatformExtraHeaders(
+      { apiHeader: ["CF-Access-Client-Id: abc", "CF-Access-Client-Secret: xyz"] },
+      {}
+    ),
+    { "cf-access-client-id": "abc", "cf-access-client-secret": "xyz" }
+  );
+});
+
+test("splits on the FIRST colon so values may contain colons", () => {
+  assert.deepEqual(
+    resolvePlatformExtraHeaders(
+      { apiHeader: ["X-Origin: https://staging.example.com:8443/path"] },
+      {}
+    ),
+    { "x-origin": "https://staging.example.com:8443/path" }
+  );
+});
+
+test("reads MCPJAM_API_HEADERS, one header per line, ignoring blanks", () => {
+  assert.deepEqual(
+    resolvePlatformExtraHeaders(
+      {},
+      { MCPJAM_API_HEADERS: "CF-Access-Client-Id: abc\n\nX-Extra: 1\n" }
+    ),
+    { "cf-access-client-id": "abc", "x-extra": "1" }
+  );
+});
+
+test("combines env and flag, and the flag wins a collision", () => {
+  // CI supplies the machine credential through the environment; a developer
+  // adds one more header on the command line. Needing both is the normal case.
+  assert.deepEqual(
+    resolvePlatformExtraHeaders(
+      { apiHeader: ["X-Shared: from-flag", "X-Only-Flag: 1"] },
+      { MCPJAM_API_HEADERS: "X-Shared: from-env\nX-Only-Env: 1" }
+    ),
+    { "x-shared": "from-flag", "x-only-flag": "1", "x-only-env": "1" }
+  );
+});
+
+test("is undefined when neither source supplies anything", () => {
+  assert.equal(resolvePlatformExtraHeaders({}, {}), undefined);
+  assert.equal(
+    resolvePlatformExtraHeaders({ apiHeader: [] }, { MCPJAM_API_HEADERS: "  " }),
+    undefined
+  );
+});
+
+test("refuses to set the credential, in any casing, from either source", () => {
+  for (const name of ["authorization", "Authorization", "AUTHORIZATION"]) {
+    rejects(
+      () => resolvePlatformExtraHeaders({ apiHeader: [`${name}: Bearer sk_x`] }, {}),
+      "cannot set",
+      `flag accepted ${name}`
+    );
+    rejects(
+      () =>
+        resolvePlatformExtraHeaders({}, { MCPJAM_API_HEADERS: `${name}: Bearer sk_x` }),
+      "cannot set",
+      `env accepted ${name}`
+    );
+  }
+});
+
+test("refuses the other headers the client derives for itself", () => {
+  for (const name of ["Idempotency-Key", "Content-Type"]) {
+    rejects(
+      () => resolvePlatformExtraHeaders({ apiHeader: [`${name}: x`] }, {}),
+      "cannot set",
+      `accepted ${name}`
+    );
+  }
+});
+
+test("refuses a line break in a value (header injection)", () => {
+  rejects(
+    () =>
+      resolvePlatformExtraHeaders(
+        { apiHeader: ["X-A: one\r\nAuthorization: Bearer sk_x"] },
+        {}
+      ),
+    "line break",
+    "accepted CRLF"
+  );
+});
+
+test("refuses malformed headers with a message naming the source", () => {
+  rejects(
+    () => resolvePlatformExtraHeaders({ apiHeader: ["no-colon-here"] }, {}),
+    "--api-header",
+    "accepted a header with no colon"
+  );
+  rejects(
+    () => resolvePlatformExtraHeaders({}, { MCPJAM_API_HEADERS: "bad header: v" }),
+    "MCPJAM_API_HEADERS",
+    "accepted a space in the name"
+  );
+  rejects(
+    () => resolvePlatformExtraHeaders({ apiHeader: ["X-Empty:   "] }, {}),
+    "empty value",
+    "accepted an empty value"
+  );
+  rejects(
+    () => resolvePlatformExtraHeaders({ apiHeader: [": novalue"] }, {}),
+    "Name: value",
+    "accepted an empty name"
+  );
+});

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -6,7 +6,7 @@ icon: "book"
 
 Complete flag tables for every `mcpjam` command. For guides and recipes, see the individual command pages.
 
-Account-bound Cloud commands live under `mcpjam cloud`. Local MCP testing stays at the top level (`mcpjam server`, `mcpjam oauth login`, …). Credential flags `--api-key` / `--api-url` are declared on `mcpjam cloud` and work before or after descendants. Hosted `readiness` stays at the root and still takes leaf `--api-key`. See [Migrating to CLI 4.0](/cli/migration).
+Account-bound Cloud commands live under `mcpjam cloud`. Local MCP testing stays at the top level (`mcpjam server`, `mcpjam oauth login`, …). Credential flags `--api-key` / `--api-url` / `--api-header` are declared on `mcpjam cloud` and work before or after descendants. Hosted `readiness` stays at the root and still takes leaf `--api-key`. See [Migrating to CLI 4.0](/cli/migration).
 
 ## Global flags
 
@@ -494,6 +494,7 @@ On a conflict, re-run `get` and retry with the fresh value.
 |------|-------------|
 | `--api-key <key>` | MCPJam `sk_` API key (overrides `MCPJAM_API_KEY`) |
 | `--api-url <url>` | MCPJam API base URL (defaults to `https://app.mcpjam.com/api/v1`) |
+| `--api-header <header...>` | Extra request header as `"Name: value"`, repeatable — for a deployment behind Cloudflare Access, a WAF, or a corporate proxy. Also `MCPJAM_API_HEADERS`, one per line. Cannot set `authorization`, `idempotency-key`, or `content-type`. |
 
 ### `cloud clients templates`
 
@@ -624,6 +625,7 @@ All `environments` commands require an `sk_` API key (via `--api-key` or the `MC
 |------|-------------|
 | `--api-key <key>` | MCPJam `sk_` API key (overrides `MCPJAM_API_KEY`) |
 | `--api-url <url>` | MCPJam API base URL (defaults to `https://app.mcpjam.com/api/v1`) |
+| `--api-header <header...>` | Extra request header as `"Name: value"`, repeatable — for a deployment behind Cloudflare Access, a WAF, or a corporate proxy. Also `MCPJAM_API_HEADERS`, one per line. Cannot set `authorization`, `idempotency-key`, or `content-type`. |
 
 ### The revision workflow
 
@@ -780,6 +782,7 @@ knowledge:
 |------|-------------|
 | `--api-key <key>` | MCPJam `sk_` API key (overrides `MCPJAM_API_KEY`) |
 | `--api-url <url>` | MCPJam API base URL (defaults to `https://app.mcpjam.com/api/v1`) |
+| `--api-header <header...>` | Extra request header as `"Name: value"`, repeatable — for a deployment behind Cloudflare Access, a WAF, or a corporate proxy. Also `MCPJAM_API_HEADERS`, one per line. Cannot set `authorization`, `idempotency-key`, or `content-type`. |
 
 ### `cloud images list`
 
@@ -887,6 +890,7 @@ All `skills` commands require an `sk_` API key (via `--api-key` or the `MCPJAM_A
 |------|-------------|
 | `--api-key <key>` | MCPJam `sk_` API key (overrides `MCPJAM_API_KEY`) |
 | `--api-url <url>` | MCPJam API base URL (defaults to `https://app.mcpjam.com/api/v1`) |
+| `--api-header <header...>` | Extra request header as `"Name: value"`, repeatable — for a deployment behind Cloudflare Access, a WAF, or a corporate proxy. Also `MCPJAM_API_HEADERS`, one per line. Cannot set `authorization`, `idempotency-key`, or `content-type`. |
 
 ### `cloud skills list`
 
@@ -979,6 +983,7 @@ All `readiness` hosted commands require an `sk_` API key (via `--api-key` or the
 |------|-------------|
 | `--api-key <key>` | MCPJam `sk_` API key (overrides `MCPJAM_API_KEY`) |
 | `--api-url <url>` | MCPJam API base URL (defaults to `https://app.mcpjam.com/api/v1`) |
+| `--api-header <header...>` | Extra request header as `"Name: value"`, repeatable — for a deployment behind Cloudflare Access, a WAF, or a corporate proxy. Also `MCPJAM_API_HEADERS`, one per line. Cannot set `authorization`, `idempotency-key`, or `content-type`. |
 
 ### `readiness start claude`
 
@@ -1053,6 +1058,7 @@ All `eval` commands accept the shared platform flags below.
 |------|-------------|
 | `--api-key <key>` | MCPJam `sk_` API key (overrides `MCPJAM_API_KEY`) |
 | `--api-url <url>` | MCPJam API base URL (defaults to `https://app.mcpjam.com/api/v1`) |
+| `--api-header <header...>` | Extra request header as `"Name: value"`, repeatable — for a deployment behind Cloudflare Access, a WAF, or a corporate proxy. Also `MCPJAM_API_HEADERS`, one per line. Cannot set `authorization`, `idempotency-key`, or `content-type`. |
 
 ### `cloud eval create`
 

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -155,6 +155,18 @@ export interface PlatformApiClientOptions {
   timeoutMs?: number;
   /** Optional User-Agent; ignored by browsers (forbidden header). */
   userAgent?: string;
+  /**
+   * Extra headers sent on every request — for a deployment that sits behind an
+   * edge authenticator (Cloudflare Access, a WAF, a corporate proxy) which
+   * demands its own credential BEFORE the platform's bearer is ever seen.
+   *
+   * Applied FIRST, so the headers this client derives from its own contract
+   * always win: `authorization` stays the credential `getAuth` resolved,
+   * `idempotency-key` stays the retry key the caller passed, and
+   * `content-type` stays what the body actually is. A caller cannot swap the
+   * credential or the dedupe key through this door, whatever it passes.
+   */
+  extraHeaders?: Record<string, string>;
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -214,6 +226,7 @@ export class PlatformApiClient {
   private readonly fetchFn: typeof fetch;
   private readonly timeoutMs: number;
   private readonly userAgent?: string;
+  private readonly extraHeaders?: Record<string, string>;
 
   constructor(options: PlatformApiClientOptions) {
     this.baseUrl = (options.baseUrl ?? DEFAULT_PLATFORM_API_BASE_URL).replace(
@@ -227,6 +240,17 @@ export class PlatformApiClient {
     this.fetchFn = options.fetch ?? fetch.bind(globalThis);
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.userAgent = options.userAgent;
+    // Lower-cased at construction so `request` cannot end up with two spellings
+    // of one header — HTTP names are case-insensitive, but a plain object's
+    // keys are not, and `{Authorization, authorization}` would send both.
+    this.extraHeaders = options.extraHeaders
+      ? Object.fromEntries(
+          Object.entries(options.extraHeaders).map(([name, value]) => [
+            name.toLowerCase(),
+            value,
+          ]),
+        )
+      : undefined;
   }
 
   getMe(options?: RequestOptions): Promise<PlatformMe> {
@@ -4015,7 +4039,10 @@ export class PlatformApiClient {
       }
     }
 
+    // Spread FIRST: every assignment below is a contract header this client
+    // owns, and each must survive whatever the caller supplied.
     const headers: Record<string, string> = {
+      ...(this.extraHeaders ?? {}),
       authorization: `Bearer ${await this.getAuth()}`,
     };
     if (init.body !== undefined) {

--- a/sdk/tests/platform/client-extra-headers.test.ts
+++ b/sdk/tests/platform/client-extra-headers.test.ts
@@ -1,0 +1,110 @@
+/**
+ * `extraHeaders` — the edge-authenticator door, and the lock on it.
+ *
+ * The point of these tests is not that a custom header arrives. It is that a
+ * custom header can NEVER become the credential, the retry key, or the body's
+ * description, however it is spelled. The CLI rejects those names at its own
+ * boundary, but the CLI is not the only caller of this client, so the transport
+ * has to hold the line by itself.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { PlatformApiClient } from "../../src/platform/index.js";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+const ok = () =>
+  new Response(JSON.stringify({ id: "u_1" }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+function makeClient(
+  fetchMock: FetchMock,
+  extraHeaders?: Record<string, string>
+): PlatformApiClient {
+  return new PlatformApiClient({
+    baseUrl: "https://api.example.com/api/v1",
+    getAuth: () => "sk_real_credential",
+    fetch: fetchMock as unknown as typeof fetch,
+    ...(extraHeaders ? { extraHeaders } : {}),
+  });
+}
+
+const headersOf = (fetchMock: FetchMock): Record<string, string> =>
+  fetchMock.mock.calls[0][1].headers as Record<string, string>;
+
+describe("PlatformApiClient extraHeaders", () => {
+  it("sends the extra headers alongside the credential", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok());
+    await makeClient(fetchMock, {
+      "CF-Access-Client-Id": "id.access",
+      "CF-Access-Client-Secret": "shhh",
+    }).getMe();
+
+    const headers = headersOf(fetchMock);
+    expect(headers["cf-access-client-id"]).toBe("id.access");
+    expect(headers["cf-access-client-secret"]).toBe("shhh");
+    expect(headers.authorization).toBe("Bearer sk_real_credential");
+  });
+
+  it("cannot replace the credential, whatever case it uses", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok());
+    await makeClient(fetchMock, {
+      Authorization: "Bearer sk_attacker_token",
+      AUTHORIZATION: "Bearer sk_attacker_token_2",
+    }).getMe();
+
+    const headers = headersOf(fetchMock);
+    expect(headers.authorization).toBe("Bearer sk_real_credential");
+    // Not merely overridden — the attacker's value is nowhere on the request.
+    expect(JSON.stringify(headers)).not.toContain("sk_attacker_token");
+  });
+
+  it("cannot forge a second spelling of a header it already set", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok());
+    await makeClient(fetchMock, { "CF-Access-Client-Id": "one" }).getMe();
+
+    // Lower-cased at construction, so a caller's `Name` and the client's
+    // `name` can never both reach fetch as separate keys.
+    const names = Object.keys(headersOf(fetchMock));
+    expect(names).toEqual(names.map((n) => n.toLowerCase()));
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("cannot replace the idempotency key on a write", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok());
+    await makeClient(fetchMock, {
+      "Idempotency-Key": "attacker-key",
+    }).createProject({ body: { name: "p" } }, { idempotencyKey: "caller-key" });
+
+    expect(headersOf(fetchMock)["idempotency-key"]).toBe("caller-key");
+  });
+
+  it("cannot mislabel a JSON body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok());
+    await makeClient(fetchMock, { "Content-Type": "text/plain" }).createProject({
+      body: { name: "p" },
+    });
+
+    expect(headersOf(fetchMock)["content-type"]).toBe("application/json");
+  });
+
+  it("leaves content-type alone on a request that HAS no body", async () => {
+    // Nothing to mislabel, so nothing is defended: the client only claims
+    // `content-type` when it is describing a body it actually sent. Pinned so
+    // the asymmetry is a decision on record rather than a surprise later.
+    const fetchMock = vi.fn().mockResolvedValue(ok());
+    await makeClient(fetchMock, { "Content-Type": "text/plain" }).getMe();
+
+    expect(headersOf(fetchMock)["content-type"]).toBe("text/plain");
+  });
+
+  it("changes nothing when no extra headers are given", async () => {
+    const withNone = vi.fn().mockResolvedValue(ok());
+    const withEmpty = vi.fn().mockResolvedValue(ok());
+    await makeClient(withNone).getMe();
+    await makeClient(withEmpty, {}).getMe();
+
+    expect(headersOf(withEmpty)).toEqual(headersOf(withNone));
+  });
+});


### PR DESCRIPTION
`@mcpjam/cli` cannot authenticate to any deployment that sits behind an edge authenticator. `PlatformApiClient` builds its header set from scratch on every request (`sdk/src/platform/client.ts`) and `PlatformApiClientOptions` accepts no additions, so there is no way to present a Cloudflare Access service token, a WAF credential, or a corporate-proxy header. There is no proxy escape hatch either — nothing in `cli/src` or `sdk/src/platform` reads `HTTPS_PROXY`, and Node's native `fetch` ignores it without an explicit dispatcher.

The existing `--header` flag looks like the answer and is not: it injects into the **MCP target server** connection (`cli/src/lib/server-config.ts`), never the MCPJam API.

**What that blocks today:** `staging.mcpjam.com` (behind Access — an unauthenticated request 302s to `dark-sun-f05b.cloudflareaccess.com`), every PR preview, and self-hosted installs behind a company egress. It is also why there is no CLI in the staging smoke lane: `post-deploy-smoke.yml` authenticates its `curl`s with `CF-Access-Client-Id`/`-Secret`, but the CLI has no way to send the same two headers.

## The change

`extraHeaders?: Record<string, string>` on `PlatformApiClientOptions`, surfaced as a repeatable `--api-header "Name: value"` plus `MCPJAM_API_HEADERS` (newline-separated).

```bash
mcpjam cloud eval run --suite my-suite --wait \
  --api-url https://staging.mcpjam.com/api/v1 \
  --api-header "CF-Access-Client-Id: $CF_ID" \
  --api-header "CF-Access-Client-Secret: $CF_SECRET"
```

## Security: the door has a lock, and the lock is tested

A header flag that can set `authorization` is a way to smuggle a credential past the per-deployment token rules in `platform-client` — the ones that stop a staging login from ever sending its token to prod. So:

- **`authorization`, `idempotency-key`, `content-type` are refused by name** at the CLI boundary, in any casing, from flag *and* environment. Refused loudly rather than dropped silently, so a caller learns the flag did nothing instead of wondering why the header vanished.
- **The client independently spreads extras BEFORE its own assignments**, so a caller reaching `PlatformApiClient` some other way still cannot swap the credential or the retry key. The two defences are deliberately redundant: the CLI is not this client's only caller.
- **Names are lower-cased at construction.** HTTP header names are case-insensitive; object keys are not. Without this, `{Authorization, authorization}` sends both.
- **CR/LF in a value is rejected as header injection** rather than handed to `fetch`.
- A `Name: value` string **splits on the first colon only** — values legitimately contain colons (a URL, a timestamp).

Flag and environment **combine** rather than one winning: CI supplies the machine credential through the environment, keeping it out of `ps` and shell history, while a developer adds a one-off header on the command line. Needing both is the normal case, not a conflict. On a name given in both, the flag wins as the more specific of the two.

## Verification

17 new tests (7 SDK, 10 CLI). Each guard was checked by mutation, not assumed:

| Mutation | Result |
|---|---|
| Client spreads extras **last** instead of first | fails exactly "cannot replace the credential, whatever case it uses" |
| CLI drops the reserved-name check | fails exactly the two refusal tests |

Plus a real end-to-end over the wire: the CLI's own resolver output through the built SDK against a local HTTP server, which received `cf-access-client-id`, `cf-access-client-secret`, **and** `authorization: Bearer <the real credential>` — the extras present, the credential intact.

One test documents an asymmetry rather than hiding it: on a request with **no body**, a caller-supplied `content-type` does pass through. There is nothing to mislabel, and pinning it makes that a decision on record.

Also verified: `--api-key`/`--api-url` behaviour unchanged (existing `platform-client` / `platform-command` / `cloud-flag-conventions` suites green, 24 tests), SDK and CLI typecheck clean, `docs/cli/reference.mdx` updated in all six credential tables.

**Pre-existing failure, not from this PR:** `sdk/tests/platform/operations-compose.test.ts > carries versionPins through to the ensure-adhoc body` fails on `main` at `dc627325c` too — confirmed by stashing this branch's changes and re-running. It belongs to #4444 (`--compose-server`).

## Why this is a product feature, not a test fixture

The same missing capability blocks three separate audiences: our own CI (no CLI coverage against a deployed environment), developers (cannot point the CLI at a PR preview), and enterprise customers (self-hosted or corporate-proxied installs). It is also the prerequisite for ever putting `eval run` into the staging smoke lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCybKeA3ocU8VdN3SykM98

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds configurable headers on the platform API client next to bearer auth; mistakes could break or weaken requests, but reserved-name checks and header merge order are tested and documented.
> 
> **Overview**
> **`mcpjam cloud …` can now send extra HTTP headers on MCPJam API calls**, not just on MCP server probes. That unblocks staging, PR previews, and self-hosted installs behind Cloudflare Access, WAFs, or corporate proxies—where the existing `--header` flag never applied because it only targets the MCP connection.
> 
> **SDK:** `PlatformApiClientOptions` adds `extraHeaders`, merged **before** the client sets `authorization`, `idempotency-key`, and `content-type`, with header names normalized to lowercase at construction.
> 
> **CLI:** Repeatable `--api-header "Name: value"` and newline-separated `MCPJAM_API_HEADERS` are wired through `resolvePlatformExtraHeaders` into `buildPlatformClient`, and registered on shared `mcpjam cloud` platform options. Env and flag values **merge** (flag wins on duplicate names). Parsing rejects reserved header names, invalid names, empty values, and CRLF in values.
> 
> Docs and a minor changeset for `@mcpjam/sdk` and `@mcpjam/cli` are included, plus dedicated CLI/SDK tests for parsing, merging, and override resistance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 963c41263864f24f5d04ddb6fd679a64607da987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `extraHeaders` to `PlatformApiClient` plus a repeatable `--api-header "Name: value"` flag and `MCPJAM_API_HEADERS` (newline-separated), so the CLI can authenticate to deployments behind Cloudflare Access, a WAF, or a corporate proxy. Before this, the platform client built its headers from scratch with no additions, and the existing `--header` flag only applied to the MCP target server connection.

**Security**

- `authorization`, `idempotency-key`, and `content-type` are refused by name at the CLI boundary, in any casing, from flag and env.
- The client spreads extras before its own headers, so the credential and retry key can never be swapped through this door.
- Header names are lower-cased at construction to prevent duplicate spellings; CR/LF in a value is rejected as header injection.
- Flag and env combine, with the flag winning on a name collision.
- `Name: value` strings split on the first colon only.

<sup>Written for commit 963c41263864f24f5d04ddb6fd679a64607da987. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

