### PR TITLE
UVH-FU1: the emulated engine says which side of the handover it died on

### DIFF
--- a/.changeset/engine-error-phase-emulated-path.md
+++ b/.changeset/engine-error-phase-emulated-path.md
@@ -1,0 +1,15 @@
+---
+"@mcpjam/inspector": patch
+---
+
+The emulated engine says which side of the model handover it died on
+
+Provider-error attribution reads `MCPJamEngineErrorEvent.phase` to decide whether a failed turn was ours or the provider's. `runChatEngineLoop` set it at none of its three emit sites, so `failedLayerForEngineError`'s no-phase default answered for the entire emulated path: every failure on it resolved to `model`. On the hosted eval path `model` becomes a `providerError`, which WITHDRAWS the trial's failures — so an Inspector bug did not merely get mislabelled, it deleted the evidence of whatever else the trial had found.
+
+The outer catch is the one that matters. It opens before any preparation and covers the trace-payload `structuredClone`, message scrubbing, the guest-IP hash, tool narrowing, `emitTurnStart`, pending-approval processing and the MRTR resume pre-phase — all of which can throw without a model ever being contacted. It now reports from a `modelInvoked` flag mirroring the harness's, set at the handover rather than on a successful response, so a provider that rejects the request outright still reads as the model's failure while a preparation bug reads as ours. The two inner emitters are strictly post-response and say `"stream"` outright; neither needs a flag to know it.
+
+**Two comments were wrong, and both understated the gap.** `failedLayerForEngineError` claimed the over-broad-catch problem "holds for the chat engine and not for the harness" — the chat engine's catch is exactly as broad, it just had no phase to report — and justified its default with "every emitter that omits a phase today is a real stream failure", when this engine's three emitters were the counter-example. A test carried the same premise. The default is unchanged and still `model`, but it now governs only emitters outside the two in-repo engines, and the reason given for it is no longer a fiction.
+
+**The new test sits below the existing mock boundary, deliberately.** `provider-error-plumbing.test.ts` `vi.mock`s `driveHostedEvalTurn`, so it starts above the code this fixes and would pass with the bug fully present; `provider-error-attribution.test.ts` unit-tests the decision without ever running an engine. The new suite drives the real engine through its public entry point and reads the events it emits. Its first draft was itself vacuous — an incomplete `logger` mock threw inside the non-OK-response site, so that case fell through to the outer catch and asserted the right string from the wrong place — so it now pins the emitting site by `httpStatus`, not just the answer.
+
+Mutation-checked three ways: dropping the outer emitter's phase fails the three tests that route through it; dropping the response site's fails exactly the one that names it; and marking the handover on success instead of at the request flips the transport-failure case to `setup`, failing only the test that states the timing rule.

--- a/mcpjam-inspector/server/services/evals/__tests__/provider-error-attribution.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/provider-error-attribution.test.ts
@@ -30,9 +30,15 @@ describe("the hosted path reads the engine's reported phase", () => {
   });
 
   it("still says model when the engine reports no phase at all", () => {
-    // The compatibility floor. Every emitter that omits a phase today is a
-    // real stream failure, and defaulting the other way would un-attribute
-    // the outages this work was built for.
+    // The compatibility floor, and the comment here used to justify it with
+    // something false: "every emitter that omits a phase today is a real
+    // stream failure". `runChatEngineLoop`'s three emitters all omitted one,
+    // so this branch was answering for the entire emulated path — including
+    // failures thrown before the model was ever contacted.
+    //
+    // Both engines report a phase now, so this governs only emitters outside
+    // them, where a stream failure really is the likelier reading. The value
+    // is unchanged; the reason for it is no longer a fiction.
     expect(failedLayerForEngineError({})).toBe("model");
     expect(failedLayerForEngineError(undefined)).toBe("model");
   });

--- a/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
+++ b/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
@@ -305,16 +305,29 @@ export const MAX_WIDGET_FOLLOWUP_TURNS = 3;
  * this was called.
  *
  * The first version of this decision lived inline and assumed every engine
- * error was a stream failure. That holds for the chat engine and not for the
- * harness: `runHarnessTurn` wraps its whole turn — preparation included — in
- * one try, so a missing `projectId`, a missing auth bearer, or disabled broker
- * credential delivery arrives looking exactly like a provider outage. Calling
- * those `model` files our own setup bug as the provider's, which is the
- * mis-attribution this work exists to remove, moved one layer over.
+ * error was a stream failure. `runHarnessTurn` wraps its whole turn —
+ * preparation included — in one try, so a missing `projectId`, a missing auth
+ * bearer, or disabled broker credential delivery arrives looking exactly like
+ * a provider outage. Calling those `model` files our own setup bug as the
+ * provider's, which is the mis-attribution this work exists to remove, moved
+ * one layer over.
  *
- * `model` stays the answer for an engine that reports no phase at all: every
- * emitter that omits it today is a real stream failure, and defaulting the
- * other way would un-attribute the outages this work was built for.
+ * TWO EARLIER CLAIMS HERE WERE WRONG, and both said the same comfortable
+ * thing — that the gap was narrower than it was:
+ *
+ *   - "that holds for the chat engine": it did not. `runChatEngineLoop`'s
+ *     outer catch covers its own preparation just as broadly — the
+ *     trace-payload `structuredClone`, message scrubbing, tool narrowing,
+ *     `emitTurnStart`. It was simply never given a phase to report.
+ *   - "every emitter that omits it today is a real stream failure": that
+ *     engine's three emitters ALL omitted it, so every emulated-path failure,
+ *     preparation bugs included, resolved here to `model`. On the hosted path
+ *     that also WITHDREW the eval failures a provider outage excuses.
+ *
+ * Both engines now report a phase, so the default below governs only emitters
+ * outside them. It stays `model` deliberately: with the in-repo emitters
+ * truthful, an unknown emitter is far likelier to be a stream failure, and
+ * flipping it would un-attribute the outages this work was built for.
  */
 export function failedLayerForEngineError(
   event: { phase?: "setup" | "stream" } | undefined,

--- a/mcpjam-inspector/server/utils/__tests__/engine-error-phase.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/engine-error-phase.test.ts
@@ -1,0 +1,192 @@
+/**
+ * The emulated engine must say WHICH SIDE of the model handover it died on.
+ *
+ * `MCPJamEngineErrorEvent.phase` is what stops an Inspector bug being filed as
+ * a provider outage: `failedLayerForEngineError` maps `"setup"` → our layer and
+ * everything else → `"model"`, and on the hosted eval path `model` becomes a
+ * `providerError` that WITHDRAWS the trial's failures. Getting it wrong does
+ * not just mislabel a row; it deletes evidence.
+ *
+ * `runChatEngineLoop` used to set `phase` at none of its three emit sites, so
+ * every emulated-path failure resolved to `model` — including anything thrown
+ * in preparation, which its outer `try` covers just as broadly as the harness's
+ * does (trace-payload `structuredClone`, message scrubbing, tool narrowing,
+ * `emitTurnStart`). The comment justifying the default said "every emitter that
+ * omits a phase today is a real stream failure"; this engine's emitters were
+ * the counter-example.
+ *
+ * ── why this file exists at all ──────────────────────────────────────────────
+ *
+ * `provider-error-attribution.test.ts` unit-tests the decision, and
+ * `provider-error-plumbing.test.ts` covers the runner hops — but the latter
+ * `vi.mock`s `driveHostedEvalTurn`, so its boundary sits ABOVE the code under
+ * test here. A test written up there passes with this bug fully present. So
+ * these drive the real engine through its public entry point and read the
+ * events it actually emits.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  executeToolCallsFromMessages,
+  hasUnresolvedToolCalls,
+} from "@/shared/http-tool-calls";
+import { handleMCPJamFreeChatModel } from "../mcpjam-stream-handler";
+import { failedLayerForEngineError } from "../../services/evals/drive-hosted-eval-turn";
+
+let lastExecution: Promise<void> | null = null;
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    createUIMessageStream: vi.fn(({ execute, onFinish }) => {
+      const writer = { write: vi.fn() };
+      lastExecution = Promise.resolve(execute({ writer })).then(async () => {
+        await onFinish?.();
+      });
+      return { getReader: vi.fn() };
+    }),
+    createUIMessageStreamResponse: vi
+      .fn()
+      .mockReturnValue(
+        new Response("{}", {
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      ),
+  };
+});
+
+vi.mock("@/shared/http-tool-calls", () => ({
+  hasUnresolvedToolCalls: vi.fn(),
+  executeToolCallsFromMessages: vi.fn(),
+}));
+
+vi.mock("../mcpjam-tool-helpers", () => ({
+  serializeToolsForConvex: vi.fn(() => []),
+}));
+
+// `captureOriginErrorToSentry` matters as much as `logger` here: the non-OK
+// response site reaches it through `error-origin-capture`, and a mock missing
+// it throws a vitest module error INSIDE that site. That throw escapes to the
+// outer catch, which emits `"stream"` of its own accord — so the 502 case
+// below passed while never once running the code it names. Same shape as the
+// vacuous tests this suite exists to stop.
+vi.mock("../logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    event: vi.fn(),
+    systemEvent: vi.fn(),
+  },
+  captureOriginErrorToSentry: vi.fn(),
+}));
+
+vi.mock("@sentry/node", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+type EngineErrorEvent = {
+  phase?: "setup" | "stream";
+  message?: string;
+  httpStatus?: number;
+  stepIndex?: number;
+};
+
+async function runTurn(overrides: Record<string, unknown> = {}): Promise<{
+  events: EngineErrorEvent[];
+}> {
+  const events: EngineErrorEvent[] = [];
+  await handleMCPJamFreeChatModel({
+    messages: [{ role: "user", content: "Hi." }] as any,
+    modelId: "openai/gpt-oss-120b",
+    systemPrompt: "You are helpful",
+    tools: {},
+    mcpClientManager: {
+      getAllToolsMetadata: vi.fn().mockReturnValue({}),
+      listServers: vi.fn().mockReturnValue([]),
+    } as any,
+    heartbeatIntervalMs: 0,
+    onEngineError: (event: EngineErrorEvent) => events.push(event),
+    ...overrides,
+  } as any);
+  await lastExecution;
+  return { events };
+}
+
+describe("the emulated engine reports which side of the handover it died on", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastExecution = null;
+    process.env.CONVEX_HTTP_URL = "https://test-convex.example.com";
+    vi.mocked(hasUnresolvedToolCalls).mockReturnValue(false);
+    vi.mocked(executeToolCallsFromMessages).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.CONVEX_HTTP_URL;
+  });
+
+  it("calls a failure BEFORE the handover setup, and never contacts the model", async () => {
+    // `onStreamWriterReady` is the first statement inside the outer `try`, so
+    // throwing here reproduces the whole class — a bug in our own preparation —
+    // without reaching into the engine's internals to stage it.
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy;
+
+    const { events } = await runTurn({
+      onStreamWriterReady: () => {
+        throw new Error("preparation blew up before the model was asked");
+      },
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(events).toHaveLength(1);
+    expect(events[0].phase).toBe("setup");
+    // The claim that matters: our bug is not filed as the provider's.
+    expect(failedLayerForEngineError(events[0])).toBe("setup");
+  });
+
+  it("calls a transport failure AT the handover stream, not setup", async () => {
+    // The flag flips when the request leaves, not when a response arrives, so
+    // a provider that refuses the connection outright is still the model's
+    // failure rather than ours.
+    global.fetch = vi.fn().mockRejectedValue(new Error("ECONNRESET"));
+
+    const { events } = await runTurn();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].phase).toBe("stream");
+    expect(failedLayerForEngineError(events[0])).toBe("model");
+  });
+
+  it("calls a non-OK backend response stream", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response("Bad Gateway", { status: 502 }));
+
+    const { events } = await runTurn();
+
+    expect(events).toHaveLength(1);
+    // Pin the SITE, not just the answer. `"stream"` is what the outer catch
+    // says too, so without this the test passes whether or not the response
+    // site was ever reached — which is exactly how it passed before the
+    // logger mock above was completed. `httpStatus` is site (1)'s alone.
+    expect(events[0]).toMatchObject({ httpStatus: 502, stepIndex: 0 });
+    expect(events[0].phase).toBe("stream");
+    expect(failedLayerForEngineError(events[0])).toBe("model");
+  });
+
+  it("leaves no emitter in this engine without a phase", async () => {
+    // A guard against the next site being added phase-less: the default is
+    // `model`, so an omission is silent and re-opens exactly this bug.
+    global.fetch = vi.fn().mockRejectedValue(new Error("ECONNRESET"));
+    const { events } = await runTurn();
+    for (const event of events) {
+      expect(event.phase).toBeDefined();
+    }
+  });
+});

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -425,17 +425,22 @@ export interface MCPJamEngineErrorEvent {
   /**
    * WHICH LAYER was running when this fired — not what the message says.
    *
-   * `"setup"` means the turn died before the model stream began: the harness
-   * catches its own pre-stream preparation (no `projectId`, no auth bearer,
-   * broker credential delivery disabled, a sandbox it could not reserve) in
-   * the same block that catches a stream failure, and reports both here.
-   * A consumer that assumed every engine error was a provider failure would
-   * file our own setup bug as the provider's outage.
+   * `"setup"` means the turn died before the model stream began. Both engines
+   * catch their own pre-stream preparation in the same block that catches a
+   * stream failure — the harness its missing `projectId` / auth bearer /
+   * sandbox, this file its trace-payload clone, message scrubbing and tool
+   * narrowing — and report both here. A consumer that assumed every engine
+   * error was a provider failure would file our own setup bug as the
+   * provider's outage.
    *
-   * Derived from a flag the emitter already holds — whether the turn's trace
-   * ever started — never from reading the message. Omitted by emitters that
-   * cannot distinguish the two, and a consumer must treat that as unknown
-   * rather than as either answer.
+   * Derived from a flag the emitter already holds — whether the turn handed
+   * over to the model — never from reading the message.
+   *
+   * BOTH in-repo engines now populate it: `runHarnessTurn` from its own
+   * `modelInvoked`, and `runChatEngineLoop` from its (this file's two inner
+   * emitters are post-response and say `"stream"` outright). It stays
+   * optional for emitters outside those two, and a consumer must treat
+   * absence as unknown rather than as either answer.
    */
   phase?: "setup" | "stream";
   /**
@@ -944,6 +949,16 @@ interface StepContext {
   // processOneStep, processStream/tool-execution catch, outer
   // agentic-loop catch). Optional.
   onEngineError?: (event: MCPJamEngineErrorEvent) => void;
+  /**
+   * Fired at the HANDOVER to the model, immediately before the `/stream`
+   * request leaves. Lets `runChatEngineLoop`'s outer catch — a different
+   * function, so it cannot see this one's locals — say whether a turn that
+   * threw had reached the model yet.
+   *
+   * A callback rather than a returned flag because the interesting case is
+   * the one where this function THROWS and returns nothing at all.
+   */
+  onModelHandover?: () => void;
   // Typed mid-stream failure telemetry; threaded from runChatEngineLoop
   // (already oncePerTurn-wrapped and fallback-resolved there).
   failureReporter: StreamFailureReporter;
@@ -2393,6 +2408,7 @@ async function processOneStep(
     onToolResult,
     // PR 5b-followup-2 structured-error callback.
     onEngineError,
+    onModelHandover,
     failureReporter,
     // Browser-rendered MCP App eval PR 2: advertised-tool narrowing hook.
     prepareAdvertisedTools,
@@ -2541,6 +2557,11 @@ async function processOneStep(
     convexHeaders[GUEST_IP_HASH_HEADER] = ipHash;
   }
   let res: Response;
+  // Everything above this line is ours; everything at or below it is the
+  // model's turn. Marked HERE, at the handover, not once a response comes
+  // back: a provider that rejects the request outright still failed as the
+  // model, while a throw in the preparation above genuinely is ours.
+  onModelHandover?.();
   try {
     res = await fetch(`${process.env.CONVEX_HTTP_URL}${endpointPath}`, {
       method: "POST",
@@ -2713,6 +2734,9 @@ async function processOneStep(
       promptIndex: traceTurn.promptIndex,
       stepIndex,
       normalized,
+      // A response is in hand, so this is unambiguously the model's leg —
+      // no flag needed to know it.
+      phase: "stream",
     });
     return { shouldContinue: false, didEmitFinish: false };
   }
@@ -3209,6 +3233,10 @@ async function processOneStep(
         promptIndex: traceTurn.promptIndex,
         stepIndex,
         normalized: stepNormalized,
+        // The enclosing `try` opens on tool wrapping and execution, which is
+        // reached only after the stream responded. Nothing pre-request can
+        // land here.
+        phase: "stream",
       });
       return { shouldContinue: false, didEmitFinish: false };
     }
@@ -3534,6 +3562,24 @@ export async function runChatEngineLoop(
       }
     }
 
+    /**
+     * Has this turn handed over to the model yet?
+     *
+     * The `try` below covers the WHOLE turn, preparation included — the
+     * trace-payload clone, message scrubbing, the guest-IP hash, tool
+     * narrowing, `emitTurnStart`, pending-approval processing and the MRTR
+     * resume pre-phase all sit inside it. Without this flag its catch cannot
+     * tell an Inspector bug from a provider outage, and the consumer's
+     * no-phase default (`model`) then files ours as theirs — silently
+     * WITHDRAWING the eval failures a provider outage is supposed to excuse.
+     *
+     * Mirrors the harness's `modelInvoked` (`harness/run-harness-turn.ts`),
+     * including its timing rule: set at the handover, not on a successful
+     * response, so a provider rejecting the request outright still reads as
+     * the model's failure.
+     */
+    let modelInvoked = false;
+
     try {
       onStreamWriterReady?.(safeWriter);
 
@@ -3697,6 +3743,9 @@ export async function runChatEngineLoop(
           // the two `processOneStep` error sites (non-OK Convex
           // response + processStream/tool catch).
           onEngineError,
+          onModelHandover: () => {
+            modelInvoked = true;
+          },
           failureReporter,
           // Browser-rendered MCP App eval PR 2: advertised-tool narrowing.
           prepareAdvertisedTools,
@@ -3834,6 +3883,9 @@ export async function runChatEngineLoop(
           rawText: errorText,
           promptIndex: traceTurn.promptIndex,
           normalized: loopNormalized,
+          // The only one of this file's three emitters that can fire on
+          // either side of the handover. See `modelInvoked`.
+          phase: modelInvoked ? "stream" : "setup",
         });
       }
     } finally {


### PR DESCRIPTION
First of the UVH follow-up PRs. Verifying the late review findings against `main` (rather than against the branches they were written for) turned up 11 real defects in shipped code. This is the most consequential one.

## What was wrong

Provider-error attribution reads `MCPJamEngineErrorEvent.phase` to decide whether a failed turn was ours or the provider's. **`runChatEngineLoop` set it at none of its three emit sites**, so `failedLayerForEngineError`'s no-phase default answered for the entire emulated path: every failure on it resolved to `model`.

On the hosted eval path `model` becomes a `providerError`, and a `providerError` **withdraws** the trial's failures. So an Inspector bug did not merely get mislabelled — it deleted the evidence of whatever else that trial had found.

The outer catch is the one that matters. It opens before any preparation and covers the trace-payload `structuredClone`, message scrubbing, the guest-IP hash, tool narrowing, `emitTurnStart`, pending-approval processing and the MRTR resume pre-phase — none of which reach a model.

## The fix

- The outer emitter now reports from a `modelInvoked` flag mirroring the harness's (`harness/run-harness-turn.ts`), **set at the handover rather than on a successful response**, so a provider that rejects the request outright still reads as the model's failure while a preparation bug reads as ours.
- The two inner emitters are strictly post-response — one holds `res.status`, the other sits in a `try` that opens on tool execution — so they say `"stream"` outright and need no flag.
- Aborted turns take the other branch of the catch and are unaffected.

## Two comments were wrong

Both understated the gap, and both are corrected here:

- `failedLayerForEngineError` claimed the over-broad-catch problem *"holds for the chat engine and not for the harness"*. The chat engine's catch is exactly as broad; it simply had no phase to report.
- It justified its default with *"every emitter that omits a phase today is a real stream failure"*. This engine's three emitters were the counter-example. A test in `provider-error-attribution.test.ts` carried the same premise.

**The default value is unchanged** — still `model` — because with the in-repo emitters truthful, an unknown emitter really is likelier to be a stream failure. Only the reason given for it changes, and it is no longer a fiction.

## Testing

The new suite deliberately sits **below** the existing mock boundary. `provider-error-plumbing.test.ts` `vi.mock`s `driveHostedEvalTurn`, so it starts above the code this fixes and would pass with the bug fully present; `provider-error-attribution.test.ts` unit-tests the decision without ever running an engine. `engine-error-phase.test.ts` drives the real engine through its public entry point and reads the events it emits.

Worth flagging: **its own first draft was vacuous.** An incomplete `logger` mock threw inside the non-OK-response site, so that case fell through to the outer catch and asserted the right string from the wrong place. It now pins the emitting site by `httpStatus`, not just the answer.

Mutation-checked three ways:

| Mutation | Tests that fail |
|---|---|
| Outer emitter loses its phase (the shipped bug) | the 3 that route through it |
| Response site loses its phase | exactly the 1 that names it |
| Handover marked on success, not at the request | exactly the 1 that states the timing rule |

Full server suite green: 162 files, 2313 passed, 21 skipped. No prettier churn — both touched source files were already unformatted on `main`, and CI does not gate on it, so only the new file is formatted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4jTtZJsDeaterEzKwpF2p)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval failure attribution and provider-error withdrawal behavior on the emulated path; incorrect phase timing could still misclassify setup vs model failures.
> 
> **Overview**
> **Fixes mis-attribution on the emulated eval path** where every engine error looked like a provider failure because `runChatEngineLoop` never set `MCPJamEngineErrorEvent.phase`. Hosted evals map missing/`stream` phase to `model`, which can become a `providerError` and **withdraw** trial failures — so Inspector prep bugs could erase unrelated eval evidence, not just mislabel it.
> 
> The emulated engine now mirrors the harness: a **`modelInvoked` flag** (via new **`onModelHandover`**, fired immediately before the Convex `/stream` `fetch`) drives the **outer** `onEngineError` site to emit `phase: "setup"` vs `"stream"`. The two **inner** sites (non-OK HTTP response and post-response tool/stream failures) always emit **`phase: "stream"`**.
> 
> Comments and tests are updated to reflect that the chat engine’s outer catch was always as broad as the harness’s; the no-phase default stays **`model`** but only for emitters outside the two in-repo engines. New **`engine-error-phase.test.ts`** exercises the real handler entry point below existing mocks that stub `driveHostedEvalTurn`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87aa4a95c8920d2e4bc8c709b080bd5519493f2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes emulated-engine error attribution so our preparation bugs are no longer filed as provider outages — which was silently deleting the eval failures a provider outage is supposed to excuse.

- `runChatEngineLoop` never set `phase` at its three error emit sites, so every emulated-path failure defaulted to `model`, including bugs thrown before the model was contacted.
- The outer catch now reports from a `modelInvoked` flag set at the handover to the model; the two post-response emitters say `"stream"` outright.
- Corrected two comments that understated the gap. The default stays `model`: both engines now report truthfully, so it only governs emitters outside them.
- New `engine-error-phase.test.ts` drives the real engine through its public entry point, below the mock boundary where existing tests would have passed with the bug present.

<sup>Written for commit 87aa4a95c8920d2e4bc8c709b080bd5519493f2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

