### PR TITLE
Update enterprise auth policy copy

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -1167,7 +1167,7 @@ export function ProtocolTab({
           <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">
             <div className="min-w-0">
               <span className="text-[12px] font-medium">
-                Enterprise-managed authorization
+                Default all project servers to enterprise managed auth
               </span>
               <p className="text-[11px] leading-snug text-muted-foreground">
                 Route every HTTP server connection through your IdP (XAA) by
@@ -1187,7 +1187,7 @@ export function ProtocolTab({
               checked={policyOn}
               onCheckedChange={setPolicyOn}
               disabled={readOnly}
-              aria-label="Enterprise-managed authorization"
+              aria-label="Default all project servers to enterprise managed auth"
             />
           </div>
         )}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.enterprisePolicy.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.enterprisePolicy.test.tsx
@@ -36,7 +36,7 @@ describe("ProtocolTab — enterprise-managed authorization policy switch", () =>
   it("toggling on writes the policy under mcpProfile.extensions", () => {
     const { getDraft } = renderTab(emptyHostConfigInputV2());
     const toggle = screen.getByRole("switch", {
-      name: /enterprise-managed authorization/i,
+      name: /default all project servers to enterprise managed auth/i,
     });
     expect(toggle).toHaveAttribute("aria-checked", "false");
 
@@ -53,7 +53,7 @@ describe("ProtocolTab — enterprise-managed authorization policy switch", () =>
     };
     const { getDraft } = renderTab(draft);
     const toggle = screen.getByRole("switch", {
-      name: /enterprise-managed authorization/i,
+      name: /default all project servers to enterprise managed auth/i,
     });
     expect(toggle).toHaveAttribute("aria-checked", "true");
 
@@ -72,7 +72,7 @@ describe("ProtocolTab — enterprise-managed authorization policy switch", () =>
     const { getDraft, rerender, onDraftChange } = renderTab(draft);
     const toggle = () =>
       screen.getByRole("switch", {
-        name: /enterprise-managed authorization/i,
+        name: /default all project servers to enterprise managed auth/i,
       });
     fireEvent.click(toggle()); // on
     // Re-render with the updated draft (the parent does this in production)
@@ -100,7 +100,7 @@ describe("ProtocolTab — enterprise-managed authorization policy switch", () =>
     };
     renderTab(draft);
     const toggle = screen.getByRole("switch", {
-      name: /enterprise-managed authorization/i,
+      name: /default all project servers to enterprise managed auth/i,
     });
     expect(toggle).toHaveAttribute("aria-checked", "false");
     expect(
@@ -128,7 +128,7 @@ describe("ProtocolTab — enterprise-managed authorization policy switch", () =>
       renderTab(emptyHostConfigInputV2());
       expect(
         screen.queryByRole("switch", {
-          name: /enterprise-managed authorization/i,
+          name: /default all project servers to enterprise managed auth/i,
         })
       ).toBeNull();
     } finally {
@@ -147,7 +147,7 @@ describe("ProtocolTab — enterprise-managed authorization policy switch", () =>
       renderTab(draft);
       expect(
         screen.getByRole("switch", {
-          name: /enterprise-managed authorization/i,
+          name: /default all project servers to enterprise managed auth/i,
         })
       ).toHaveAttribute("aria-checked", "true");
     } finally {

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/tabs.readOnly.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/tabs.readOnly.test.tsx
@@ -157,7 +157,7 @@ describe("Client editor tabs — readOnly prop wiring", () => {
       />
     );
     const emaSwitch = screen.getByRole("switch", {
-      name: /enterprise-managed authorization/i,
+      name: /default all project servers to enterprise managed auth/i,
     });
     expect(emaSwitch).toBeDisabled();
   });
@@ -171,7 +171,7 @@ describe("Client editor tabs — readOnly prop wiring", () => {
       />
     );
     const emaSwitch = screen.getByRole("switch", {
-      name: /enterprise-managed authorization/i,
+      name: /default all project servers to enterprise managed auth/i,
     });
     expect(emaSwitch).not.toBeDisabled();
   });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the enterprise auth policy switch label from "Enterprise-managed authorization" to "Default all project servers to enterprise managed auth" so the UI wording matches the actual behavior. Updates the switch's `aria-label` and related test expectations accordingly.

<sup>Written for commit 0d65636a9acef0240afefdf3d4382746d2e57dfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

