### PR TITLE
fix(evals): attach the bearer to the Evaluate chain reads

### DIFF
--- a/.changeset/evaluate-chain-reads-carry-the-bearer.md
+++ b/.changeset/evaluate-chain-reads-carry-the-bearer.md
@@ -1,0 +1,17 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Evaluate (New) chain reads carry the user's bearer, so they stop 401ing as "could not be loaded"
+
+The decision summary and the stage-analytics funnel both rendered a service error on every run — "Couldn't load the decision summary", "Stage analytics could not be loaded … Bearer token required" — while the API answered those exact routes correctly to any client that sent a token.
+
+`authFetch` is the single owner of the `Authorization` header, and it attaches one only to paths named in `HOSTED_AUTH_PATH_PREFIXES` / `HOSTED_AUTH_PATH_PATTERNS`. That list grants `/api/v1/` **path by path on purpose**: the prefix that would cover these, `/api/v1/projects/`, would hand the user's bearer to every project-scoped public-API route that ever ships. Three eval-chain routes were never added to it, so their requests went out with no `Authorization` at all and the API returned its ordinary `401 Bearer token required` — which the clients map to `requestFailed`, whose copy reads as a backend outage rather than a missing header.
+
+Adds two anchored patterns covering `eval-runs/{id}/decision-summary`, `eval-runs/{id}/stage-analytics`, and `eval-suites/{id}/stage-analytics`.
+
+This is the third time this exact bug has shipped, and the second half of the fix is the tests. `/web/registry/*` shipped with no entry and every call went out unauthenticated; readiness needed a pattern because its scope sits mid-path; G4b's run-disclosure remembered, D9 and D5c did not. Nothing fails until runtime — no build error, no type error, no test — because the allowlist is a hand-maintained list that a new consumer has to remember to join.
+
+So the new suite spends 10 of its 14 cases proving the grant stayed narrow: sibling routes under the same project (`eval-runs/{id}`, `eval-runs/{id}/iterations`, `eval-suites/{id}`, `eval-suites/{id}/runs`, `eval-runs/{id}/insights`), paths that merely start the same way, one path segment too many, and a foreign origin on a chain path all still receive nothing. Verified load-bearing: reverting the patterns fails exactly the four positive cases and leaves the ten narrowness ones green.
+
+Not local-dev-specific — `shouldAttachHostedAuthorization` never branches on hosted mode and same-origin passes its origin check in production too, so both panels were broken wherever `evaluate-enabled` was on.

--- a/mcpjam-inspector/client/src/lib/__tests__/session-token.eval-chain.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/session-token.eval-chain.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The hosted bearer on the Evaluate (New) chain reads — and, just as
+ * importantly, off everything beside them.
+ *
+ * Third instance of one failure mode: `/web/registry/*` shipped with no
+ * `HOSTED_AUTH_PATH_PREFIXES` entry, readiness needed a pattern because its
+ * scope sits mid-path, and then D9's decision summary and D5c's stage
+ * analytics shipped with neither. All three go out through `authFetch`, which
+ * is the ONE owner of the bearer, so a route the list does not name sends no
+ * `Authorization` at all and the API answers "Bearer token required".
+ *
+ * That 401 is what makes this worth pinning rather than eyeballing: both
+ * panels render it as service copy ("could not be loaded"), which reads as a
+ * backend outage. The API is fine; the header never left the browser.
+ *
+ * As with readiness, the half of this file that matters most is the second
+ * half — proof the grant stayed as narrow as the id segments in the middle,
+ * rather than becoming the `/api/v1/projects/` prefix nobody wants.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/apis/web/context", () => ({
+  getApiAuthorizationHeader: vi.fn(async () => "Bearer hosted-bearer"),
+}));
+
+vi.mock("@/lib/convex-site-url", () => ({
+  getConvexSiteUrl: () => "https://outstanding-fennec-304.convex.site",
+}));
+
+describe("authFetch bearer on the eval chain routes", () => {
+  let sessionToken: typeof import("../session-token");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    delete (window as any).__MCP_SESSION_TOKEN__;
+    vi.mocked(global.fetch).mockReset();
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+    sessionToken = await import("../session-token");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function headersOf(call: number): Record<string, string> {
+    const init = vi.mocked(global.fetch).mock.calls[call]?.[1] as RequestInit;
+    return (init?.headers ?? {}) as Record<string, string>;
+  }
+
+  for (const path of [
+    // D9 — the canonical decision summary the run view renders.
+    "/api/v1/projects/proj_1/eval-runs/run_1/decision-summary",
+    // D5c — stage analytics, both the suite page and the run-scoped reader.
+    "/api/v1/projects/proj_1/eval-suites/suite_1/stage-analytics",
+    "/api/v1/projects/proj_1/eval-runs/run_1/stage-analytics",
+  ]) {
+    it(`attaches the bearer to ${path}`, async () => {
+      await sessionToken.authFetch(path, { method: "GET" });
+      expect(headersOf(0).Authorization).toBe("Bearer hosted-bearer");
+    });
+  }
+
+  it("attaches it with a query string, which both paged reads carry", async () => {
+    await sessionToken.authFetch(
+      "/api/v1/projects/proj_1/eval-suites/suite_1/stage-analytics?limit=25&cursor=abc",
+      { method: "GET" },
+    );
+    expect(headersOf(0).Authorization).toBe("Bearer hosted-bearer");
+  });
+
+  for (const path of [
+    // The blanket prefix these patterns exist to avoid: a sibling
+    // project-scoped route must NOT inherit the UI's bearer.
+    "/api/v1/projects/proj_1/eval-runs/run_1",
+    "/api/v1/projects/proj_1/eval-runs/run_1/iterations",
+    "/api/v1/projects/proj_1/eval-suites/suite_1",
+    "/api/v1/projects/proj_1/eval-suites/suite_1/runs",
+    // Paths that merely start the same way.
+    "/api/v1/projects/proj_1/eval-runs/run_1/decision-summary-export",
+    "/api/v1/projects/proj_1/eval-suites/suite_1/stage-analytics-raw",
+    // One segment too many under either read.
+    "/api/v1/projects/proj_1/eval-runs/run_1/decision-summary/page/2",
+    "/api/v1/projects/proj_1/eval-suites/suite_1/stage-analytics/overall",
+    // The run-scoped suffix is a closed set, not a wildcard.
+    "/api/v1/projects/proj_1/eval-runs/run_1/insights",
+  ]) {
+    it(`does NOT attach the bearer to ${path}`, async () => {
+      await sessionToken.authFetch(path, { method: "GET" });
+      expect(headersOf(0).Authorization).toBeUndefined();
+    });
+  }
+
+  it("does not attach the bearer to a foreign origin on a chain path", async () => {
+    await sessionToken.authFetch(
+      "https://evil.example.com/api/v1/projects/proj_1/eval-runs/run_1/decision-summary",
+      { method: "GET" },
+    );
+    expect(headersOf(0).Authorization).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -399,6 +399,16 @@ const HOSTED_AUTH_PATH_PATTERNS = [
   // module header on why a pattern, not a prefix, is what keeps the grant as
   // narrow as the id segments in the middle.
   /^\/api\/v1\/projects\/[^/]+\/eval-suites\/[^/]+\/run-disclosure$/,
+  // The Evaluate (New) chain reads: D9's decision summary and D5c's stage
+  // analytics, suite-paged and run-scoped. Same anchored bearer-scope grant as
+  // the disclosure above, and needed for the same reason — both go out through
+  // `authFetch`, so without an entry here they ship no `Authorization` at all
+  // and the route answers "Bearer token required". That 401 surfaces as
+  // `requestFailed`/service copy ("could not be loaded"), which reads as a
+  // backend outage rather than a missing header, so the panels look broken
+  // while the API is fine.
+  /^\/api\/v1\/projects\/[^/]+\/eval-runs\/[^/]+\/(decision-summary|stage-analytics)$/,
+  /^\/api\/v1\/projects\/[^/]+\/eval-suites\/[^/]+\/stage-analytics$/,
 ];
 
 function pathMatchesHostedPrefix(pathname: string): boolean {


### PR DESCRIPTION
## What this fixes

Both Evaluate (New) chain panels rendered a service error on every run, while the API answered those exact routes correctly to any client that sent a token:

- run view → **"Couldn't load the decision summary — The read did not complete."** (and `LOAD FAILED` in the Run History verdict column)
- suite view → **"Stage analytics could not be loaded, so this run's chain is not measured here. Bearer token required"**

That last string is the tell. `Bearer token required` is the API's response to a request carrying **no** `Authorization` header at all — the same thing an anonymous `curl` gets.

## Root cause

`authFetch` is the single owner of the `Authorization` header — both API clients deliberately strip their own and delegate, so `authFetch` keeps its 401 refresh-and-retry. It attaches a bearer only to paths named in `HOSTED_AUTH_PATH_PREFIXES` / `HOSTED_AUTH_PATH_PATTERNS`.

That list grants `/api/v1/` **path by path on purpose**, and the module header says why: the prefix that would cover these, `/api/v1/projects/`, would hand the user's bearer to every project-scoped public-API route that ever ships.

Three eval-chain routes were never added to it:

| route | owner |
|---|---|
| `/api/v1/projects/{id}/eval-runs/{id}/decision-summary` | D9 |
| `/api/v1/projects/{id}/eval-suites/{id}/stage-analytics` | D5c |
| `/api/v1/projects/{id}/eval-runs/{id}/stage-analytics` | UVH |

So `shouldAttachHostedAuthorization` returned false, the requests went out unauthenticated, and the API returned its ordinary 401. The clients map that to `requestFailed`, whose copy reads as a backend outage rather than a missing header — which is why both panels looked broken while the API was fine.

**Not local-dev-specific.** `shouldAttachHostedAuthorization` never branches on `HOSTED_MODE`, and `isHostedAuthAllowedOrigin` returns true for same-origin, which production is. Both panels were broken wherever `evaluate-enabled` was on; the flag's narrow scope is the only reason nobody hit it.

## The change

Two anchored patterns, matching the shape of the `run-disclosure` entry directly above them. Both anchor at each end and match one path segment per id.

## Tests — and why most of them are negative

**This is the third time this exact bug has shipped.** The existing readiness test file records the first in its own header: "`/web/registry/*` shipped without a `HOSTED_AUTH_PATH_PREFIXES` entry and every call went out unauthenticated." Readiness then needed a pattern because its scope sits mid-path. G4b's run-disclosure remembered to add one, with a comment saying exactly why. D9 and D5c did not.

Nothing catches it: no build error, no type error, no test. The allowlist is a hand-maintained list a new consumer has to remember to join, and the only symptom is a runtime 401 wearing outage copy. That is the same failure shape as a completeness check written as a predicate over names — it silently exempts whatever it did not anticipate.

So 10 of the 14 new cases exist to prove the grant stayed narrow, and still receive nothing:

- sibling project-scoped routes — `eval-runs/{id}`, `eval-runs/{id}/iterations`, `eval-suites/{id}`, `eval-suites/{id}/runs`, `eval-runs/{id}/insights`
- paths that merely start the same way — `…/decision-summary-export`, `…/stage-analytics-raw`
- one path segment too many — `…/decision-summary/page/2`, `…/stage-analytics/overall`
- a foreign origin on a chain path

**Verified load-bearing rather than assumed**: reverting the two patterns fails exactly the 4 positive cases and leaves the 10 narrowness ones green.

All 7 `session-token.*` suites pass (74 tests), plus `client/src/lib/apis/__tests__/` (143 tests across 16 files).

## Formatting

`session-token.ts` fails default prettier v2.8.8 **on `origin/main` already** — verified by stashing the change and re-checking the base at its real repo path, not by trusting a warning. No `--write`, so no untouched lines were reformatted. The new test file passes clean.

## Relationship to the backend PR

Independent, and neither blocks the other. This makes the panels *load*; MCPJam/mcpjam-backend#1212 fixes what one of them then *says* — a validator disagreement that excluded every trial where the agent recovered from a tool error. Both were found on the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfgRLmB8FHScZ5DSPEKvUW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which public API paths receive the user's bearer; mistakes could over-attach credentials, though the new patterns are tightly anchored and heavily covered by negative tests.
> 
> **Overview**
> **Fixes Evaluate (New) decision summary and stage analytics panels** that always showed “could not be loaded” / “Bearer token required” because `authFetch` never sent `Authorization` on those URLs.
> 
> Adds **two anchored regex entries** to `HOSTED_AUTH_PATH_PATTERNS` in `session-token.ts` so the hosted bearer is attached only for `eval-runs/{id}/decision-summary`, `eval-runs/{id}/stage-analytics`, and `eval-suites/{id}/stage-analytics` (including query strings)—same narrow, path-by-path approach as `run-disclosure`, not a blanket `/api/v1/projects/` prefix.
> 
> Adds **`session-token.eval-chain.test.ts`**: four cases that the bearer is sent on those reads, plus ten that sibling routes, lookalike paths, extra segments, and foreign origins still get **no** bearer. Includes a patch changeset for `@mcpjam/inspector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da46c91b56568d014482c2c4a41271f950418f55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Evaluate (New) chain reads so they carry the user's bearer token, replacing the misleading "could not be loaded" service errors with actual data.

Previously, these three routes were missing from the hosted auth allowlist, so `authFetch` sent no `Authorization` header and the API returned a 401 that the client displayed as a backend outage. The fix adds two anchored patterns covering `eval-runs/{id}/decision-summary`, `eval-runs/{id}/stage-analytics`, and `eval-suites/{id}/stage-analytics`.

Adds a test suite that confirms the bearer is attached to those exact routes and not to sibling or similar routes, so the allowlist stays narrow.

<sup>Written for commit da46c91b56568d014482c2c4a41271f950418f55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

