### PR TITLE
UVH-FU5: two claims that stayed on screen after they stopped being true

### DIFF
--- a/.changeset/stale-analyzer-warning-and-precision-cap.md
+++ b/.changeset/stale-analyzer-warning-and-precision-cap.md
@@ -1,0 +1,17 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Two claims that stayed on screen after they stopped being true
+
+**A chat session kept warning "Derived by a newer analyzer" forever.** `analyzerVersionAhead` is stamped by the backend at the moment a chain arrives, and raising a version constant does not rewrite stored rows — so a session derived during a window when this build lagged its producer carried that amber warning permanently, long after the build caught up.
+
+The version it was derived at sits on the same object, so the warning is now derived from it rather than read out of storage. Self-healing for any future window and needing no migration: the claim goes false the moment it stops being true. This mirrors what the SDK's own `assembleChain` already does for eval runs, and what `checkStageOutcomes` was fixed to do backend-side. The stored boolean survives only as a fallback for rows written before the version was recorded, so nothing that was flagged loses its warning.
+
+The existing test asserted the defect: its fixture is stamped at analyzer 5 with the stored flag set, and against a build at 8 it expected the warning to show. That is how the stale flag survived review, and it is why the replacement test now pins both directions — warns when genuinely ahead, stops warning once caught up.
+
+**The judge's score line could print two different numbers as equal.** `showAgainst` grows precision until every pairwise-distinct value is distinguishable, capped at six decimals — past that a judge score is float noise. But the cap fell through to the six-decimal rendering *anyway*, so values differing beyond it rendered identically: "scored 0.7 against a 0.7 threshold" for numbers that were never equal. That is the exact contradiction the function's own docblock says it exists to prevent, reintroduced at its boundary.
+
+Values still colliding at the cap are now marked approximate (`≈0.7`). Marked per value, not blanket — a number the reader can trust should not be made to look uncertain — and genuinely equal values are left unmarked, because they *are* equal and a marker would make a true statement look doubtful. The six-decimal policy is unchanged.
+
+Both mutation-checked: reverting the derivation fails the warn-when-ahead and stop-when-caught-up tests in opposite directions; reverting the cap fails only the test that names it, and a blanket marker fails only the test that says which values get one.

--- a/mcpjam-inspector/client/src/components/shared/user-value-chain/SessionUserValueChain.tsx
+++ b/mcpjam-inspector/client/src/components/shared/user-value-chain/SessionUserValueChain.tsx
@@ -32,6 +32,7 @@
 import { AlertTriangle, Check, Circle, Loader2, Minus, X } from "lucide-react";
 import {
   FAILURE_CATEGORY_LABELS,
+  STAGE_ANALYZER_VERSION,
   STAGE_REASON_LABELS,
   STAGE_STATE_LABELS,
   USER_VALUE_STAGE_LABELS,
@@ -164,12 +165,37 @@ function ChainNotice({
         "text-[11px] leading-snug",
         tone === "warning"
           ? "text-amber-600 dark:text-amber-400"
-          : "text-muted-foreground"
+          : "text-muted-foreground",
       )}
     >
       {children}
     </p>
   );
+}
+
+/**
+ * Does this derivation come from an analyzer NEWER than the build rendering it?
+ *
+ * DERIVED, not trusted. `analyzerVersionAhead` is stamped by the backend at the
+ * moment a chain arrives, and raising a version constant does not rewrite
+ * stored rows — so a session derived while this build lagged its producer kept
+ * claiming to be newer FOREVER, long after the claim stopped being true.
+ *
+ * The version it was derived at is on the same object, so compare that instead.
+ * Self-healing for any future window and needs no migration: the claim goes
+ * false the moment it stops being true. Mirrors what the SDK's own
+ * `assembleChain` already does for eval runs, down to reporting both numbers.
+ *
+ * The stored boolean survives only as a FALLBACK, for rows written before the
+ * version was recorded — nothing that was flagged loses its warning.
+ */
+export function analyzerVersionAhead(
+  derivation: ChatSessionStageDerivation | null | undefined,
+): boolean {
+  if (!derivation) return false;
+  const reported = derivation.stageAnalyzerVersion;
+  if (typeof reported === "number") return reported > STAGE_ANALYZER_VERSION;
+  return derivation.analyzerVersionAhead === true;
 }
 
 export function SessionUserValueChain({
@@ -186,6 +212,7 @@ export function SessionUserValueChain({
   className?: string;
 }) {
   const presentation = chainPresentation(derivation);
+  const versionAhead = analyzerVersionAhead(derivation);
 
   return (
     <section
@@ -264,7 +291,7 @@ export function SessionUserValueChain({
                 .
               </p>
             ) : null}
-            {derivation.analyzerVersionAhead ? (
+            {versionAhead ? (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <p className="flex items-center gap-1 text-[11px] text-amber-600 dark:text-amber-400">

--- a/mcpjam-inspector/client/src/components/shared/user-value-chain/__tests__/SessionUserValueChain.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/user-value-chain/__tests__/SessionUserValueChain.test.tsx
@@ -9,7 +9,10 @@
 
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { STAGE_REASON_LABELS } from "@mcpjam/sdk/contract";
+import {
+  STAGE_ANALYZER_VERSION,
+  STAGE_REASON_LABELS,
+} from "@mcpjam/sdk/contract";
 import { SessionUserValueChain } from "../SessionUserValueChain";
 import type {
   ChatSessionStageDerivation,
@@ -225,10 +228,48 @@ describe("a newer analyzer is flagged, not discarded", () => {
   it("keeps the rows and warns", () => {
     const { container } = render(
       <SessionUserValueChain
-        derivation={derivation({ analyzerVersionAhead: true })}
+        derivation={derivation({
+          stageAnalyzerVersion: STAGE_ANALYZER_VERSION + 1,
+        })}
       />
     );
     expect(container.querySelectorAll("[data-stage]")).toHaveLength(6);
+    expect(document.body.textContent).toContain("Derived by a newer analyzer");
+  });
+
+  it("STOPS warning once this build has caught up", () => {
+    // The defect this replaces. `analyzerVersionAhead` is stamped when a chain
+    // arrives, and raising the constant does not rewrite stored rows — so a
+    // session derived during a window when this build lagged kept claiming to
+    // be newer forever. The fixture is stamped at 5 and the stored flag says
+    // "ahead"; against a build at 8 that claim is simply false.
+    //
+    // The previous version of this test asserted the warning DID show here,
+    // which is how the stale flag survived review.
+    render(
+      <SessionUserValueChain
+        derivation={derivation({
+          stageAnalyzerVersion: 5,
+          analyzerVersionAhead: true,
+        })}
+      />
+    );
+    expect(document.body.textContent).not.toContain(
+      "Derived by a newer analyzer"
+    );
+  });
+
+  it("still trusts the stored flag when no version was recorded", () => {
+    // The fallback, for rows written before the version was on the object.
+    // Nothing that was flagged loses its warning.
+    render(
+      <SessionUserValueChain
+        derivation={derivation({
+          stageAnalyzerVersion: undefined,
+          analyzerVersionAhead: true,
+        })}
+      />
+    );
     expect(document.body.textContent).toContain("Derived by a newer analyzer");
   });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/judge-second-pass.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/judge-second-pass.test.ts
@@ -592,6 +592,45 @@ describe("judgeEvidenceFromVerdict", () => {
     expect(line).toContain("0.6999 partial floor");
   });
 
+  test("admits the rounding rather than claiming two values are equal", () => {
+    // The cap's own blind spot. Precision stops growing at six decimals — past
+    // that a judge score is float noise — but it used to fall through to the
+    // six-decimal rendering ANYWAY, printing two different numbers identically.
+    // "scored 0.7 against a 0.7 threshold" for values that were never equal is
+    // the exact contradiction the whole function exists to prevent.
+    const [line] = (
+      judgeEvidenceFromVerdict({
+        status: "scored",
+        verdict: "fail",
+        score: 0.70000001,
+        threshold: 0.70000002,
+      }) as { reasons: string[] }
+    ).reasons;
+
+    // Both are marked, because each is indistinguishable from the other...
+    expect(line).toBe(
+      "LLM judge scored \u22480.7 against a \u22480.7 threshold",
+    );
+    // ...and crucially the line no longer ASSERTS they are the same number.
+    expect(line).not.toBe("LLM judge scored 0.7 against a 0.7 threshold");
+  });
+
+  test("marks only the values that actually collide", () => {
+    // A blanket marker would make a number the reader CAN trust look uncertain.
+    // The floor here is distinguishable at six decimals; the other two are not.
+    const [line] = (
+      judgeEvidenceFromVerdict({
+        status: "scored",
+        verdict: "fail",
+        score: 0.70000001,
+        threshold: 0.70000002,
+        partialFloor: 0.5,
+      }) as { reasons: string[] }
+    ).reasons;
+    expect(line).toContain("0.5 partial floor");
+    expect(line).not.toContain("\u22480.5");
+  });
+
   test("still reads equal when the score IS the threshold", () => {
     // The other half: growing precision must not manufacture a difference
     // where none exists. A score exactly on its threshold should say so.

--- a/mcpjam-inspector/server/services/evals/judge-second-pass.ts
+++ b/mcpjam-inspector/server/services/evals/judge-second-pass.ts
@@ -219,22 +219,41 @@ function judgeReasonsFrom(verdict: JudgeVerdictMetadata): string[] {
  * compared only score-to-boundary, so a threshold of 0.7001 and a floor of
  * 0.6999 both rendered `0.7` while the score sat far from either — erasing the
  * partial band's configured width in a line whose whole job is to show it.
+ *
+ * AND WHEN SIX IS NOT ENOUGH, the line says so rather than asserting a false
+ * equality. The cap used to fall through to the six-decimal rendering anyway,
+ * so two values differing past it printed identically — "scored 0.7 against a
+ * 0.7 threshold" for numbers that were never equal, which is the exact defect
+ * every paragraph above is about, reintroduced at the boundary. Values still
+ * colliding at the cap are marked approximate. Equal values are not: they ARE
+ * equal, and `≈` would make a true statement look uncertain.
  */
+const APPROX = "\u2248";
+
 function showAgainst(
   score: number,
   bounds: readonly number[],
 ): (n: number) => string {
   const at = (n: number, digits: number) => String(Number(n.toFixed(digits)));
   const values = [score, ...bounds];
+  const collidesAt = (digits: number) =>
+    values.some((a, i) =>
+      values.slice(i + 1).some((b) => a !== b && at(a, digits) === at(b, digits)),
+    );
   // Six is the floor of usefulness, not an arbitrary cap: past it a judge
   // score is float noise, and a line no one can read explains nothing.
   for (let digits = 2; digits <= 6; digits += 1) {
-    const collides = values.some((a, i) =>
-      values.slice(i + 1).some((b) => a !== b && at(a, digits) === at(b, digits)),
-    );
-    if (!collides) return (n: number) => at(n, digits);
+    if (!collidesAt(digits)) return (n: number) => at(n, digits);
   }
-  return (n: number) => at(n, 6);
+  // Past the cap the numbers cannot be told apart on screen, so the honest
+  // rendering admits the rounding instead of claiming two of them are the
+  // same. Marked per VALUE, not blanket: only one that shares its rendering
+  // with a DIFFERENT value is uncertain.
+  return (n: number) => {
+    const shown = at(n, 6);
+    const ambiguous = values.some((v) => v !== n && at(v, 6) === shown);
+    return ambiguous ? `${APPROX}${shown}` : shown;
+  };
 }
 
 function readJudgeVerdict(


### PR DESCRIPTION
Fourth of the UVH follow-up PRs. Independent of #4524 — both branch from `main`.

Two unrelated surfaces, one shared shape: something on screen asserting a fact that had since become false.

## 1. A chat session warned "Derived by a newer analyzer" forever

`analyzerVersionAhead` is stamped by the backend at the moment a chain arrives, and raising a version constant does not rewrite stored rows. So a session derived during a window when this build lagged its producer carried that amber warning **permanently**, long after the build caught up.

The version it was derived at sits on the same object, so the warning is now derived from it rather than read out of storage — self-healing for any future window, no migration needed. This is the same move the SDK's own `assembleChain` already makes for eval runs, and the one `checkStageOutcomes` was fixed to make backend-side. The stored boolean survives only as a **fallback** for rows written before the version was recorded, so nothing that was flagged loses its warning.

**The existing test asserted the defect.** Its fixture is stamped at analyzer 5 with the stored flag set, and against a build at 8 it expected the warning to show. That is how the stale flag survived review in the first place. The replacement pins both directions — warns when genuinely ahead, stops warning once caught up — plus the fallback.

### A planned change that turned out not to be a defect

I had this scoped as a backend fix too: `markStagePending` carries `analyzerVersionAhead` forward across re-marks. Reading it in context, that is **correct** — the function deliberately preserves the previous *result* so a reader between generations sees the last measured chain rather than a blank, and the version it carries accurately describes that result. The defect was only that nothing recomputed the claim, which is a read-time question. No backend change ships.

## 2. The judge's score line could print two different numbers as equal

`showAgainst` grows precision until every pairwise-distinct value is distinguishable, capped at six decimals — past that a judge score is float noise, which is a reasonable policy. But the cap **fell through to that rendering anyway**, so values differing beyond it printed identically: `scored 0.7 against a 0.7 threshold` for numbers that were never equal.

That is the exact contradiction the function's own docblock says it exists to prevent, reintroduced at its own boundary.

Values still colliding at the cap are now marked approximate (`≈0.7`). Marked **per value, not blanket** — a number the reader can trust should not be made to look uncertain — and genuinely equal values stay unmarked, because they *are* equal and a marker would make a true statement look doubtful. The six-decimal policy is unchanged.

## Scope I deliberately dropped

The tooltip initially also named both versions (`version 10; this build knows 8`), mirroring the SDK's CLI and HTML reporters. Radix tooltip content only mounts on hover and nothing in that file asserts tooltip text, so I could not verify the string. Rather than ship unverifiable copy I reverted it — the fix is the derivation.

## Testing

Three mutations, each discriminating:

| Mutation | Tests that fail |
|---|---|
| Trust the stored flag again | warn-when-ahead **and** stop-when-caught-up, in opposite directions |
| Cap falls through to plain six decimals | exactly the test that names it |
| Blanket `≈` instead of per-value | exactly the test that says which values get one |

Regression sweep green: 58 files, 815 tests across the evals and user-value-chain suites. Both touched source files were already prettier-dirty on `main`; the diffs are confined to the intended hunks with no reformatting churn.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4jTtZJsDeaterEzKwpF2p)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-time display logic and judge evidence string formatting only; no auth, persistence, or grading verdict changes.
> 
> **Overview**
> Fixes two UI copy bugs where the screen kept asserting facts that were no longer true.
> 
> **User value chain:** The “Derived by a newer analyzer” amber notice no longer trusts the persisted `analyzerVersionAhead` flag alone. A new `analyzerVersionAhead()` helper compares `stageAnalyzerVersion` to the build’s `STAGE_ANALYZER_VERSION`, so warnings clear once the client catches up; legacy rows without a version still use the stored boolean.
> 
> **Judge evidence:** When `showAgainst` hits its six-decimal cap and distinct scores/thresholds would render the same, colliding values are prefixed with `≈` per number (not blanket), so lines like “scored 0.7 against a 0.7 threshold” are not shown for unequal floats. Truly equal values stay unmarked.
> 
> Tests cover warn/stop-when-caught-up/fallback for the chain panel and approximate vs trusted numbers in `judgeEvidenceFromVerdict`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d5a3893460bc40d93ba1639ba24759a512d4bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stale "Derived by a newer analyzer" warning so it disappears once the build catches up, and fixes the judge's score line from printing two different numbers as equal at the six-decimal cap.

- The warning is now derived from the recorded analyzer version; the stored boolean only serves as a fallback for rows written before the version was recorded.
- Values that still collide at the cap render as approximate (≈), marked per value — genuinely equal values stay unmarked.

<sup>Written for commit d5d5a3893460bc40d93ba1639ba24759a512d4bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

