### PR TITLE
UVH-FU6: a missing route stops looking like a missing run, and a provisional funnel refreshes itself

### DIFF
--- a/.changeset/route-404-and-provisional-refresh.md
+++ b/.changeset/route-404-and-provisional-refresh.md
@@ -1,0 +1,18 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/inspector": patch
+---
+
+A missing route and a missing run stop looking the same, and a provisional funnel refreshes itself
+
+**`PlatformApiError` now records where its `code` came from.** `STATUS_FALLBACK_CODES` assumes a wire code when an error response carries no `{ code }` envelope, and for 404 that assumption erases a distinction callers need: an API answering `{ code: "NOT_FOUND" }` means the resource does not exist, while a bare 404 with no envelope is usually the route not being there at all. Both arrived as `code: "NOT_FOUND"`, so a caller wanting to fall back on an undeployed endpoint — rather than render "no such thing" — had nothing to branch on. A discriminator built on the code could not have worked.
+
+`codeSource` is `"envelope"` or `"status"`, and it is one signal rather than a verdict: a proxy can strip a body from any status, so it is meant to be read alongside the status, not instead of it. Optional, so an error constructed anywhere else keeps its current shape.
+
+**The stage-analytics reader uses it for the dark ship.** A bare 404 is now `routeUnavailable`, not `notFound`. During a dark ship this is not cosmetic: the run detail was rendering an undeployed route as "this run was never measured" instead of falling back to the legacy funnel it should still have been showing.
+
+**A provisional document now refreshes itself.** A run's analytics are materialized `provisional` while a judge fanout is pending and replaced by a `final` document once it settles. The hook's effect keys on ids and the run's terminal status, neither of which moves at that instant, so a page open across the transition kept showing provisional numbers until someone reloaded.
+
+This is the rule the hook already implements — ask again exactly when the answer can still change — applied to the one transition it did not cover. Bounded and self-terminating rather than a poll: it re-asks only while the document itself says it is unsettled, backs off across four attempts, and stops at `final` or when the budget is spent, so a fanout that never settles costs a handful of reads rather than one per interval forever. A manual `refetch` never consumes the budget, and a re-triggered judge pass gets a fresh one.
+
+Mutation-checked in three directions: dropping the bare-404 branch and forcing `codeSource` to `"envelope"` each fail exactly the test that names it — with the enveloped-404 test beside it as an unchanged control — and removing the refresh effect fails the two tests that assert re-asking.

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-eval-run-stage-analytics.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-eval-run-stage-analytics.test.tsx
@@ -68,6 +68,79 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+describe("a provisional document is re-asked for until it settles", () => {
+  // A document is materialized `provisional` while a judge fanout is pending
+  // and REPLACED by a `final` one when that settles. The effect keys on ids and
+  // the run's terminal status, neither of which moves at that instant, so a
+  // page open across the transition showed provisional numbers until reload.
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const provisional = () =>
+    stageAnalyticsVariation({ materializationState: "provisional" });
+  const settled = () => stageAnalyticsVariation({ materializationState: "final" });
+
+  it("asks again while provisional, and serves the settled document", async () => {
+    fetchMock
+      .mockResolvedValueOnce(provisional())
+      .mockResolvedValue(settled());
+
+    const { latest } = renderHook();
+    await vi.waitFor(() => expect(latest().status).toBe("ready"));
+    expect(latest().document?.materializationState).toBe("provisional");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    await vi.waitFor(() =>
+      expect(latest().document?.materializationState).toBe("final"),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("STOPS once the document is final", async () => {
+    // The half that makes this a bounded re-ask rather than a poll. Without it
+    // every settled run would keep reading forever.
+    fetchMock.mockResolvedValue(settled());
+
+    const { latest } = renderHook();
+    await vi.waitFor(() => expect(latest().status).toBe("ready"));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after the budget rather than polling forever", async () => {
+    // A fanout that never settles must cost a handful of reads, not one per
+    // interval until the tab is closed.
+    fetchMock.mockResolvedValue(provisional());
+
+    const { latest } = renderHook();
+    await vi.waitFor(() => expect(latest().status).toBe("ready"));
+
+    // Stepped one delay at a time: each re-ask is only SCHEDULED once React
+    // has processed the previous response, so a single large jump would fire
+    // one timer and then find nothing pending — and would have "passed" this
+    // test by measuring the wrong thing.
+    for (const [index, delay] of [3_000, 8_000, 20_000, 45_000].entries()) {
+      await vi.advanceTimersByTimeAsync(delay);
+      await vi.waitFor(() =>
+        expect(fetchMock).toHaveBeenCalledTimes(index + 2),
+      );
+    }
+
+    // The initial read plus one per configured delay, and then nothing more,
+    // however long the fanout stays stuck.
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    await vi.advanceTimersByTimeAsync(600_000);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+});
+
 describe("useEvalRunStageAnalytics", () => {
   it("reads the run and reports ready with its document", async () => {
     fetchMock.mockResolvedValue(GOLDEN_STAGE_ANALYTICS);

--- a/mcpjam-inspector/client/src/hooks/use-eval-run-stage-analytics.ts
+++ b/mcpjam-inspector/client/src/hooks/use-eval-run-stage-analytics.ts
@@ -86,6 +86,24 @@ const TERMINAL_RUN_STATUSES = new Set([
   "timed_out",
 ]);
 
+/**
+ * How long to keep asking while the document says it is not settled yet.
+ *
+ * A document is materialized `provisional` when a judge fanout is still
+ * pending, and REPLACED by a `final` one once that settles. The effect keys on
+ * ids and the run's terminal status, neither of which changes at that moment —
+ * so a page open across the transition kept showing provisional numbers until
+ * someone reloaded it.
+ *
+ * This is the same rule the run-status re-ask already implements ("ask again
+ * exactly when the answer can still change"), applied to the one remaining
+ * transition it did not cover. Bounded and self-terminating rather than a
+ * poll: it stops at `final`, and it stops when the attempts run out, so a
+ * fanout that never settles costs a handful of reads and not one per interval
+ * forever. Backs off so a slow judge is not hammered.
+ */
+const PROVISIONAL_REFRESH_DELAYS_MS = [3_000, 8_000, 20_000, 45_000] as const;
+
 export function useEvalRunStageAnalytics({
   projectId,
   runId,
@@ -178,6 +196,33 @@ export function useEvalRunStageAnalytics({
     if (!active) return;
     setAttempt((n) => n + 1);
   }, [active]);
+
+  // Re-ask while the document itself says a judge pass is still coming.
+  //
+  // Keyed on the document's state rather than on a timer that runs regardless:
+  // when the read comes back `final` this effect has nothing to schedule and
+  // the loop ends on its own. `provisionalAttempt` counts only these automatic
+  // re-asks, so a manual `refetch` never consumes the budget.
+  const [provisionalAttempt, setProvisionalAttempt] = useState(0);
+  const provisional =
+    status === "ready" && document?.materializationState === "provisional";
+
+  useEffect(() => {
+    if (!active || !provisional) {
+      // Settled (or gone). Reset so a LATER provisional document — a
+      // re-triggered judge pass reopens one — gets the full budget again
+      // rather than inheriting a spent one.
+      setProvisionalAttempt(0);
+      return;
+    }
+    const delay = PROVISIONAL_REFRESH_DELAYS_MS[provisionalAttempt];
+    if (delay === undefined) return;
+    const timer = setTimeout(() => {
+      setProvisionalAttempt((n) => n + 1);
+      setAttempt((n) => n + 1);
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [active, provisional, provisionalAttempt]);
 
   // `idle` means "never asked", and while ACTIVE that is only ever true for a
   // single render: `active` is computed here, but the effect that sets

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/eval-stage-analytics-api.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/eval-stage-analytics-api.test.ts
@@ -152,6 +152,32 @@ describe("fetchEvalSuiteStageAnalytics", () => {
       expect((error as EvalStageAnalyticsError).kind).toBe("notFound");
     });
 
+    it("maps a BARE 404 to routeUnavailable, not to notFound", async () => {
+      // The dark-ship case, and the one a discriminator on `code` could never
+      // make: `STATUS_FALLBACK_CODES` maps any bodiless 404 to `NOT_FOUND`,
+      // the same code an API sends when it means the resource is missing. A
+      // deployment that never shipped this function answers a bare 404 from
+      // its router, and reading that as "no such thing" makes the run detail
+      // claim a run was never measured instead of falling back to the legacy
+      // funnel.
+      //
+      // The enveloped-404 test directly above is the control: same status,
+      // opposite answer, and the only thing separating them is whether the
+      // server sent a code of its own.
+      authFetchMock.mockResolvedValue(
+        new Response("<html>404 Not Found</html>", {
+          status: 404,
+          headers: { "content-type": "text/html" },
+        }),
+      );
+      const error = await fetchEvalSuiteStageAnalytics({
+        projectId: "p1",
+        suiteId: SUITE_ID,
+      }).catch((caught: unknown) => caught);
+
+      expect((error as EvalStageAnalyticsError).kind).toBe("routeUnavailable");
+    });
+
     it("maps a 501 to routeUnavailable", async () => {
       authFetchMock.mockResolvedValue(
         jsonResponse({ code: "NOT_IMPLEMENTED", message: "nope" }, 501),

--- a/mcpjam-inspector/client/src/lib/apis/eval-stage-analytics-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/eval-stage-analytics-api.ts
@@ -119,12 +119,28 @@ function client(): PlatformApiClient {
  * path shape but not this method. Everything else at 404 is the route's own
  * "Eval suite not found", which is a fact about the suite.
  */
-function isRouteUnavailable(status: number, code: string): boolean {
+function isRouteUnavailable(
+  status: number,
+  code: string,
+  codeSource?: "envelope" | "status",
+): boolean {
   return (
     code === "FEATURE_NOT_SUPPORTED" ||
     code === "NOT_IMPLEMENTED" ||
     status === 501 ||
-    status === 405
+    status === 405 ||
+    // A 404 the server did not put a code on. An API that MEANS "no such
+    // resource" answers `{ code: "NOT_FOUND" }`; a deployment that never
+    // shipped this function answers a bare 404 from its router, with no
+    // envelope at all. `STATUS_FALLBACK_CODES` maps both to `NOT_FOUND`, so
+    // `code` alone cannot separate them — which is why this reads
+    // `codeSource`, and why a discriminator built on the code was never
+    // going to work.
+    //
+    // Getting this wrong is not cosmetic during a dark ship: the run detail
+    // renders an undeployed route as "this run was never measured" instead of
+    // falling back to the legacy funnel it should still be showing.
+    (status === 404 && codeSource === "status")
   );
 }
 
@@ -161,7 +177,7 @@ export async function fetchEvalSuiteStageAnalytics(
     // said no".
     if (signal?.aborted) throw error;
     if (isPlatformApiError(error)) {
-      if (isRouteUnavailable(error.status, error.code)) {
+      if (isRouteUnavailable(error.status, error.code, error.codeSource)) {
         throw new EvalStageAnalyticsError(
           "routeUnavailable",
           "This deployment does not serve eval stage analytics.",
@@ -270,7 +286,7 @@ export async function fetchEvalRunStageAnalytics(
     // A caller's abort is the caller's, not a failure of the read.
     if (signal?.aborted) throw error;
     if (isPlatformApiError(error)) {
-      if (isRouteUnavailable(error.status, error.code)) {
+      if (isRouteUnavailable(error.status, error.code, error.codeSource)) {
         throw new EvalStageAnalyticsError(
           "routeUnavailable",
           "This deployment does not serve eval stage analytics.",

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -231,7 +231,7 @@ export class PlatformApiClient {
   constructor(options: PlatformApiClientOptions) {
     this.baseUrl = (options.baseUrl ?? DEFAULT_PLATFORM_API_BASE_URL).replace(
       /\/+$/,
-      "",
+      ""
     );
     this.getAuth = options.getAuth;
     // Native fetch must run with `this` bound to the global scope. Storing the
@@ -248,7 +248,7 @@ export class PlatformApiClient {
           Object.entries(options.extraHeaders).map(([name, value]) => [
             name.toLowerCase(),
             value,
-          ]),
+          ])
         )
       : undefined;
   }
@@ -262,51 +262,51 @@ export class PlatformApiClient {
   }
 
   listOrganizations(
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformOrganization>> {
     return this.request("GET", "/organizations", {}, options);
   }
 
   listProjects(
     params: { organizationId?: string } = {},
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformProject>> {
     return this.request(
       "GET",
       "/projects",
       { query: { organizationId: params.organizationId } },
-      options,
+      options
     );
   }
 
   createProject(
     params: { body: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformProject> {
     return this.request("POST", "/projects", { body: params.body }, options);
   }
 
   updateProject(
     params: { projectId: string; body: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformProject> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(params.projectId)}`,
       { body: params.body },
-      options,
+      options
     );
   }
 
   deleteProject(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<{ id: string; deleted: boolean }> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(params.projectId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -323,7 +323,7 @@ export class PlatformApiClient {
       cursor?: string;
       limit?: number;
     } = {},
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformDirectorySearchPage> {
     return this.request(
       "GET",
@@ -339,62 +339,64 @@ export class PlatformApiClient {
             params.connectableOnly === undefined
               ? undefined
               : params.connectableOnly
-                ? "true"
-                : "false",
+              ? "true"
+              : "false",
           ...pageQuery({ cursor: params.cursor, limit: params.limit }),
         },
       },
-      options,
+      options
     );
   }
 
   getRegistryDirectoryServer(
     params: { catalogServerId: string } | { name: string; source?: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformCatalogServer> {
     if ("catalogServerId" in params) {
       return this.request(
         "GET",
-        `/registry/directory-servers/${encodeURIComponent(params.catalogServerId)}`,
+        `/registry/directory-servers/${encodeURIComponent(
+          params.catalogServerId
+        )}`,
         {},
-        options,
+        options
       );
     }
     return this.request(
       "GET",
       `/registry/directory-servers/${encodeURIComponent(params.name)}`,
       { query: { source: params.source } },
-      options,
+      options
     );
   }
 
   listRegistryDirectorySources(
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformCatalogSourceStatus>> {
     return this.request("GET", "/registry/directory-sources", {}, options);
   }
 
   listRegistryServers(
     params: { projectId: string; scope?: "global" | "organization" | "all" },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformRegistryServer>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/registry/servers`,
       { query: { scope: params.scope } },
-      options,
+      options
     );
   }
 
   listRegistryConnections(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformRegistryConnection>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/registry/connections`,
       {},
-      options,
+      options
     );
   }
 
@@ -405,7 +407,7 @@ export class PlatformApiClient {
       endpointUrl?: string;
       expectedContentHash?: string;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformRegistryInstall> {
     // Explicit picks, not a rest spread — see `startClaudeReadinessRun`. The
     // route's body schema forbids additional properties.
@@ -420,7 +422,7 @@ export class PlatformApiClient {
       "POST",
       `/projects/${encodeURIComponent(projectId)}/registry/directory-installs`,
       { body },
-      options,
+      options
     );
   }
 
@@ -430,7 +432,7 @@ export class PlatformApiClient {
       registryServerId: string;
       expectedUpdatedAt?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformRegistryInstall> {
     const { projectId, registryServerId, expectedUpdatedAt } = params;
     const body: Record<string, unknown> = { registryServerId };
@@ -441,19 +443,21 @@ export class PlatformApiClient {
       "POST",
       `/projects/${encodeURIComponent(projectId)}/registry/installs`,
       { body },
-      options,
+      options
     );
   }
 
   uninstallRegistryServer(
     params: { projectId: string; registryServerId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<{ deleted?: boolean }> {
     return this.request(
       "DELETE",
-      `/projects/${encodeURIComponent(params.projectId)}/registry/installs/${encodeURIComponent(params.registryServerId)}`,
+      `/projects/${encodeURIComponent(
+        params.projectId
+      )}/registry/installs/${encodeURIComponent(params.registryServerId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -472,13 +476,13 @@ export class PlatformApiClient {
    */
   createServerConnection(
     params: { body: PlatformServerConnectionCreateBody },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformServerConnection> {
     return this.request(
       "POST",
       "/server-connections",
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -488,27 +492,27 @@ export class PlatformApiClient {
    * means the interval itself is too fast — honour `Retry-After`. */
   getServerConnection(
     params: { connectionRequestId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformServerConnection> {
     return this.request(
       "GET",
       `/server-connections/${encodeURIComponent(params.connectionRequestId)}`,
       {},
-      options,
+      options
     );
   }
 
   cancelServerConnection(
     params: { connectionRequestId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformServerConnection> {
     return this.request(
       "POST",
       `/server-connections/${encodeURIComponent(
-        params.connectionRequestId,
+        params.connectionRequestId
       )}/cancel`,
       {},
-      options,
+      options
     );
   }
 
@@ -520,39 +524,39 @@ export class PlatformApiClient {
    */
   retryServerConnectionValidation(
     params: { connectionRequestId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformServerConnection> {
     return this.request(
       "POST",
       `/server-connections/${encodeURIComponent(
-        params.connectionRequestId,
+        params.connectionRequestId
       )}/retry-validation`,
       {},
-      options,
+      options
     );
   }
 
   listProjectServers(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformProjectServer>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/servers`,
       {},
-      options,
+      options
     );
   }
 
   listServerGroups(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformServerGroup>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/server-groups`,
       {},
-      options,
+      options
     );
   }
 
@@ -561,39 +565,39 @@ export class PlatformApiClient {
       projectId: string;
       body: { name: string; description?: string; serverIds: string[] };
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformServerGroup> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/server-groups`,
       { body: params.body },
-      options,
+      options
     );
   }
 
   createProjectServer(
     params: { projectId: string; body: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformProjectServer> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/servers`,
       { body: params.body },
-      options,
+      options
     );
   }
 
   getProjectServer(
     params: { projectId: string; serverId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformProjectServer> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/servers/${encodeURIComponent(params.serverId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -603,41 +607,41 @@ export class PlatformApiClient {
       serverId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformProjectServer> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/servers/${encodeURIComponent(params.serverId)}`,
       { body: params.body },
-      options,
+      options
     );
   }
 
   deleteProjectServer(
     params: { projectId: string; serverId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<{ id: string; deleted: boolean }> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/servers/${encodeURIComponent(params.serverId)}`,
       { body: {} },
-      options,
+      options
     );
   }
 
   listEvalSuites(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformEvalSuite>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/eval-suites`,
       {},
-      options,
+      options
     );
   }
 
@@ -648,7 +652,7 @@ export class PlatformApiClient {
       limit?: number;
       before?: string;
     } = {},
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformChatSession>> {
     return this.request(
       "GET",
@@ -661,7 +665,7 @@ export class PlatformApiClient {
           before: params.before,
         },
       },
-      options,
+      options
     );
   }
 
@@ -698,7 +702,7 @@ export class PlatformApiClient {
       allowedTools?: string[];
       maxToolCalls?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformChatTurn> {
     // Built field by field rather than forwarded wholesale. The route's body
     // schema is STRICT, so any extra key a caller happens to carry on its own
@@ -748,7 +752,7 @@ export class PlatformApiClient {
             : {}),
         },
       },
-      options,
+      options
     );
   }
 
@@ -766,7 +770,7 @@ export class PlatformApiClient {
       afterMessageIndex?: number;
       limit?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformChatSessionDetail> {
     return this.request(
       "GET",
@@ -778,7 +782,7 @@ export class PlatformApiClient {
           limit: params.limit,
         },
       },
-      options,
+      options
     );
   }
 
@@ -798,7 +802,7 @@ export class PlatformApiClient {
       limit?: number;
       includeSpans?: boolean;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformChatSessionTrace> {
     return this.request(
       "GET",
@@ -818,7 +822,7 @@ export class PlatformApiClient {
               : String(params.includeSpans),
         },
       },
-      options,
+      options
     );
   }
 
@@ -849,7 +853,7 @@ export class PlatformApiClient {
       limit?: number;
       cursor?: string;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformSessionsPage> {
     return this.request(
       "GET",
@@ -866,33 +870,33 @@ export class PlatformApiClient {
           cursor: params.cursor,
         },
       },
-      options,
+      options
     );
   }
 
   listScenarios(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformScenarioSummary>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/scenarios`,
       {},
-      options,
+      options
     );
   }
 
   getScenario(
     params: { projectId: string; scenarioId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformScenarioDetail> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/scenarios/${encodeURIComponent(params.scenarioId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -906,7 +910,7 @@ export class PlatformApiClient {
 
   listClients(
     params: { projectId: string; includePrivateBacking?: boolean },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformClient>> {
     return this.request(
       "GET",
@@ -916,7 +920,7 @@ export class PlatformApiClient {
           ? { includePrivateBacking: "true" }
           : undefined,
       },
-      options,
+      options
     );
   }
 
@@ -935,19 +939,19 @@ export class PlatformApiClient {
       client: string;
       includePrivateBacking?: boolean;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformClientDetail> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/clients/${encodeURIComponent(params.client)}`,
       {
         query: params.includePrivateBacking
           ? { includePrivateBacking: "true" }
           : undefined,
       },
-      options,
+      options
     );
   }
 
@@ -958,13 +962,13 @@ export class PlatformApiClient {
    */
   createClient(
     params: { projectId: string; body: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformClientDetail> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/clients`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -981,15 +985,15 @@ export class PlatformApiClient {
       client: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformClientDetail> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/clients/${encodeURIComponent(params.client)}`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -1002,12 +1006,12 @@ export class PlatformApiClient {
       expectedConfigId: string;
       expectedImpact?: PlatformClientImpact;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformClientDetail> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/clients/${encodeURIComponent(params.client)}/servers`,
       {
         body: {
@@ -1021,21 +1025,21 @@ export class PlatformApiClient {
             : {}),
         },
       },
-      options,
+      options
     );
   }
 
   duplicateClient(
     params: { projectId: string; client: string; name?: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformClientDetail> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/clients/${encodeURIComponent(params.client)}/duplicate`,
       { body: params.name === undefined ? {} : { name: params.name } },
-      options,
+      options
     );
   }
 
@@ -1045,15 +1049,15 @@ export class PlatformApiClient {
       client: string;
       body?: Record<string, unknown>;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformClientDeleted> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/clients/${encodeURIComponent(params.client)}`,
       { body: params.body ?? {} },
-      options,
+      options
     );
   }
 
@@ -1062,28 +1066,28 @@ export class PlatformApiClient {
   /** @deprecated Use {@link listClients}. Calls the deprecated `/hosts` alias. */
   listHosts(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformHost>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/hosts`,
       {},
-      options,
+      options
     );
   }
 
   /** @deprecated Use {@link getClient}. Calls the deprecated `/hosts` alias. */
   getHost(
     params: { projectId: string; hostId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformHostDetail> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/hosts/${encodeURIComponent(params.hostId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -1096,13 +1100,13 @@ export class PlatformApiClient {
    */
   createHost(
     params: { projectId: string; body: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformHostDetail> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/hosts`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -1113,15 +1117,15 @@ export class PlatformApiClient {
       hostId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformHostDetail> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/hosts/${encodeURIComponent(params.hostId)}`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -1133,12 +1137,12 @@ export class PlatformApiClient {
       serverIds: string[];
       optionalServerIds?: string[];
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<{ hostId: string; hostConfigId: string }> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/hosts/${encodeURIComponent(params.hostId)}/servers`,
       {
         body: {
@@ -1148,22 +1152,22 @@ export class PlatformApiClient {
             : {}),
         },
       },
-      options,
+      options
     );
   }
 
   /** @deprecated Use {@link duplicateClient}. Calls the deprecated `/hosts` alias. */
   duplicateHost(
     params: { projectId: string; hostId: string; name?: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformHostDetail> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/hosts/${encodeURIComponent(params.hostId)}/duplicate`,
       { body: params.name === undefined ? {} : { name: params.name } },
-      options,
+      options
     );
   }
 
@@ -1174,15 +1178,15 @@ export class PlatformApiClient {
       hostId: string;
       body?: Record<string, unknown>;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformHostDeleted> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/hosts/${encodeURIComponent(params.hostId)}`,
       { body: params.body ?? {} },
-      options,
+      options
     );
   }
 
@@ -1198,7 +1202,7 @@ export class PlatformApiClient {
 
   listEnvironments(
     params: { projectId: string; includeArchived?: boolean },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformEnvironment>> {
     return this.request(
       "GET",
@@ -1206,7 +1210,7 @@ export class PlatformApiClient {
       {
         query: params.includeArchived ? { includeArchived: "true" } : undefined,
       },
-      options,
+      options
     );
   }
 
@@ -1220,29 +1224,29 @@ export class PlatformApiClient {
    */
   getEnvironmentCapabilities(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEnvironmentCapabilities> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/environments/capabilities`,
       {},
-      options,
+      options
     );
   }
 
   getEnvironment(
     params: { projectId: string; environmentId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEnvironment> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/environments/${encodeURIComponent(params.environmentId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -1254,27 +1258,27 @@ export class PlatformApiClient {
    */
   resolveEnvironment(
     params: { projectId: string; environmentId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEnvironmentResolved> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/environments/${encodeURIComponent(params.environmentId)}/resolve`,
       {},
-      options,
+      options
     );
   }
 
   createEnvironment(
     params: { projectId: string; body: PlatformEnvironmentCreateBody },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEnvironment> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/environments`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -1293,15 +1297,15 @@ export class PlatformApiClient {
    */
   ensureAdhocEnvironment(
     params: { projectId: string; body: PlatformAdhocEnvironmentBody },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformAdhocEnvironmentEnsured> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/environments/ensure-adhoc`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -1321,15 +1325,15 @@ export class PlatformApiClient {
       environmentId: string;
       body: PlatformEnvironmentNameBody;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEnvironment> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/environments/${encodeURIComponent(params.environmentId)}/name`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -1344,15 +1348,15 @@ export class PlatformApiClient {
       environmentId: string;
       body: PlatformEnvironmentUpdateBody;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEnvironment> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/environments/${encodeURIComponent(params.environmentId)}`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -1366,15 +1370,15 @@ export class PlatformApiClient {
       environmentId: string;
       expectedRevision: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEnvironment> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/environments/${encodeURIComponent(params.environmentId)}/archive`,
       { body: { expectedRevision: params.expectedRevision } },
-      options,
+      options
     );
   }
 
@@ -1390,15 +1394,15 @@ export class PlatformApiClient {
       environmentId: string;
       expectedRevision: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEnvironment> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/environments/${encodeURIComponent(params.environmentId)}/restore`,
       { body: { expectedRevision: params.expectedRevision } },
-      options,
+      options
     );
   }
 
@@ -1409,27 +1413,27 @@ export class PlatformApiClient {
 
   listProjectSkills(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformProjectSkill>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/skills`,
       {},
-      options,
+      options
     );
   }
 
   getProjectSkill(
     params: { projectId: string; skillId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformProjectSkillDetail> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/skills/${encodeURIComponent(params.skillId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -1440,13 +1444,13 @@ export class PlatformApiClient {
 
   listProjectPlugins(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformPlugin>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/plugins`,
       {},
-      options,
+      options
     );
   }
 
@@ -1458,13 +1462,13 @@ export class PlatformApiClient {
    */
   getPluginVersion(
     params: { pluginVersionId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPluginVersion> {
     return this.request(
       "GET",
       `/plugin-versions/${encodeURIComponent(params.pluginVersionId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -1475,39 +1479,39 @@ export class PlatformApiClient {
 
   listImages(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformImage>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/images`,
       {},
-      options,
+      options
     );
   }
 
   getImage(
     params: { projectId: string; imageId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformImage> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/images/${encodeURIComponent(params.imageId)}`,
       {},
-      options,
+      options
     );
   }
 
   createImage(
     params: { projectId: string; body: { name: string; blueprint: string } },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformImage> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/images`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -1517,15 +1521,15 @@ export class PlatformApiClient {
       imageId: string;
       body: { name?: string; blueprint?: string };
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformImage> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/images/${encodeURIComponent(params.imageId)}`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -1533,70 +1537,70 @@ export class PlatformApiClient {
    * invalid blueprint is a successful lint with structured errors. */
   validateImageBlueprint(
     params: { projectId: string; body: { blueprint: string } },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformImageBlueprintValidation> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/images/validate`,
       { body: params.body },
-      options,
+      options
     );
   }
 
   deleteImage(
     params: { projectId: string; imageId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformImageDeleted> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/images/${encodeURIComponent(params.imageId)}`,
       {},
-      options,
+      options
     );
   }
 
   listImageBuilds(
     params: { projectId: string; imageId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformImageBuild>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/images/${encodeURIComponent(params.imageId)}/builds`,
       {},
-      options,
+      options
     );
   }
 
   /** `POST …/build` — async (202); poll `listImageBuilds` for status. */
   buildImage(
     params: { projectId: string; imageId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformImageBuildStarted> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/images/${encodeURIComponent(params.imageId)}/build`,
       {},
-      options,
+      options
     );
   }
 
   promoteImage(
     params: { projectId: string; imageId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformImage> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/images/${encodeURIComponent(params.imageId)}/promote`,
       {},
-      options,
+      options
     );
   }
 
@@ -1604,28 +1608,28 @@ export class PlatformApiClient {
    * pinned image). */
   useImage(
     params: { projectId: string; imageId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformComputerAttached> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/images/${encodeURIComponent(params.imageId)}/use`,
       {},
-      options,
+      options
     );
   }
 
   /** Reset the caller's computer to its image (wipes mutable state). */
   resetComputer(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformComputerReset> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/computer/reset`,
       {},
-      options,
+      options
     );
   }
 
@@ -1635,13 +1639,13 @@ export class PlatformApiClient {
    */
   createEvalRun(
     params: { projectId: string; body: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalRunCreated> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/eval-runs`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -1693,16 +1697,18 @@ export class PlatformApiClient {
        */
       namedHostId?: string;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalRunDisclosure> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(params.suiteId)}/run-disclosure`,
       {
         query: {
-          caseIds: params.caseIds?.length ? params.caseIds.join(",") : undefined,
+          caseIds: params.caseIds?.length
+            ? params.caseIds.join(",")
+            : undefined,
           environmentId: params.environmentId,
           environmentIds: params.environmentIds?.length
             ? params.environmentIds.join(",")
@@ -1710,7 +1716,7 @@ export class PlatformApiClient {
           host: params.namedHostId,
         },
       },
-      options,
+      options
     );
   }
 
@@ -1726,15 +1732,15 @@ export class PlatformApiClient {
    */
   attachEvalSuiteEnvironment(
     params: { projectId: string; suiteId: string; environmentId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalSuiteEnvironmentAttached> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(params.suiteId)}/environments`,
       { body: { environmentId: params.environmentId } },
-      options,
+      options
     );
   }
 
@@ -1755,13 +1761,13 @@ export class PlatformApiClient {
    */
   createEvalRunGroup(
     params: { projectId: string; body: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalRunGroupCreated> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/eval-run-groups`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -1773,13 +1779,13 @@ export class PlatformApiClient {
    */
   createEvalSuite(
     params: { projectId: string; body: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalSuiteCreated> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/eval-suites`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -1804,27 +1810,27 @@ export class PlatformApiClient {
         verdictPolicyDefaults?: PlatformEvalVerdictPolicyDefaults;
       };
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformFileOwnedEvalSuiteSynced> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/eval-suites/from-file`,
       { body: params.body },
-      options,
+      options
     );
   }
 
   getEvalRun(
     params: { projectId: string; runId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalRun> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-runs/${encodeURIComponent(params.runId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -1851,15 +1857,15 @@ export class PlatformApiClient {
       cursor?: string;
       limit?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalRunDecisionSummary> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-runs/${encodeURIComponent(params.runId)}/decision-summary`,
       { query: { cursor: params.cursor, limit: params.limit } },
-      options,
+      options
     );
   }
 
@@ -1955,15 +1961,15 @@ export class PlatformApiClient {
    */
   requestEvalRunInsights(
     params: { projectId: string; runId: string; force?: boolean },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalRunInsightsRequested> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-runs/${encodeURIComponent(params.runId)}/insights`,
       { body: params.force ? { force: true } : {} },
-      options,
+      options
     );
   }
 
@@ -1986,12 +1992,12 @@ export class PlatformApiClient {
       model?: string;
       threshold?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalRunJudgeRequested> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-runs/${encodeURIComponent(params.runId)}/judge`,
       {
         body: {
@@ -2003,7 +2009,7 @@ export class PlatformApiClient {
             : {}),
         },
       },
-      options,
+      options
     );
   }
 
@@ -2013,15 +2019,15 @@ export class PlatformApiClient {
    */
   listEvalCheckRepos(
     params: { organizationId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalCheckRepos> {
     return this.request(
       "GET",
       `/organizations/${encodeURIComponent(
-        params.organizationId,
+        params.organizationId
       )}/eval-check-repos`,
       {},
-      options,
+      options
     );
   }
 
@@ -2040,12 +2046,12 @@ export class PlatformApiClient {
       repo: string;
       outagePolicy: "fail_open" | "fail_closed";
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalCheckRepoConnected> {
     return this.request(
       "POST",
       `/organizations/${encodeURIComponent(
-        params.organizationId,
+        params.organizationId
       )}/eval-check-repos`,
       {
         body: {
@@ -2055,7 +2061,7 @@ export class PlatformApiClient {
           outagePolicy: params.outagePolicy,
         },
       },
-      options,
+      options
     );
   }
 
@@ -2066,47 +2072,47 @@ export class PlatformApiClient {
       cursor?: string;
       limit?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformEvalIteration>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-runs/${encodeURIComponent(params.runId)}/iterations`,
       { query: { cursor: params.cursor, limit: params.limit } },
-      options,
+      options
     );
   }
 
   /** Full trace envelope (messages + analysis) for one iteration. */
   getEvalIterationTrace(
     params: { projectId: string; runId: string; iterationId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<unknown> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-runs/${encodeURIComponent(
-        params.runId,
+        params.runId
       )}/iterations/${encodeURIComponent(params.iterationId)}/trace`,
       {},
-      options,
+      options
     );
   }
 
   /** Cancel an in-flight run; returns the run in its (now cancelled) state. */
   cancelEvalRun(
     params: { projectId: string; runId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalRun> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-runs/${encodeURIComponent(params.runId)}/cancel`,
       {},
-      options,
+      options
     );
   }
 
@@ -2142,15 +2148,15 @@ export class PlatformApiClient {
       reason: string;
       expiresAt: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformGateWaiverWriteResult> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-runs/${encodeURIComponent(params.runId)}/gate-waivers`,
       { body: { reason: params.reason, expiresAt: params.expiresAt } },
-      options,
+      options
     );
   }
 
@@ -2163,15 +2169,15 @@ export class PlatformApiClient {
    */
   getGateWaiver(
     params: { projectId: string; runId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformGateWaiverRead> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-runs/${encodeURIComponent(params.runId)}/gate-waivers`,
       {},
-      options,
+      options
     );
   }
 
@@ -2184,17 +2190,17 @@ export class PlatformApiClient {
    */
   revokeGateWaiver(
     params: { projectId: string; runId: string; waiverId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformGateWaiverWriteResult> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-runs/${encodeURIComponent(
-        params.runId,
+        params.runId
       )}/gate-waivers/${encodeURIComponent(params.waiverId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -2216,8 +2222,11 @@ export class PlatformApiClient {
    * that can spend, and it defaults off.
    */
   startClaudeReadinessRun(
-    params: { projectId: string; serverId: string } & PlatformReadinessStartBody,
-    options?: RequestOptions,
+    params: {
+      projectId: string;
+      serverId: string;
+    } & PlatformReadinessStartBody,
+    options?: RequestOptions
   ): Promise<PlatformReadinessRunReceipt> {
     // Explicit picks, not a rest spread. The endpoint's body schema is
     // `strictObject`, and TypeScript's structural typing lets a caller hand a
@@ -2230,10 +2239,10 @@ export class PlatformApiClient {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/servers/${encodeURIComponent(
-        serverId,
+        serverId
       )}/readiness-runs/claude`,
       { body: pickReadinessStartBody(params) },
-      options,
+      options
     );
   }
 
@@ -2250,32 +2259,32 @@ export class PlatformApiClient {
       projectId: string;
       serverId: string;
     } & PlatformOpenAIReadinessStartBody,
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformReadinessRunReceipt> {
     // Explicit picks — see `startClaudeReadinessRun`.
     const { projectId, serverId, submissionMode } = params;
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/servers/${encodeURIComponent(
-        serverId,
+        serverId
       )}/readiness-runs/openai`,
       { body: { ...pickReadinessStartBody(params), submissionMode } },
-      options,
+      options
     );
   }
 
   /** Lane statuses, coverage and the observation axis. Poll this. */
   getReadinessRun(
     params: { projectId: string; runId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformReadinessRun> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/readiness-runs/${encodeURIComponent(params.runId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -2286,14 +2295,14 @@ export class PlatformApiClient {
       serverId?: string;
       limit?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformReadinessRun>> {
     const { projectId, ...query } = params;
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(projectId)}/readiness-runs`,
       { query },
-      options,
+      options
     );
   }
 
@@ -2306,15 +2315,15 @@ export class PlatformApiClient {
    */
   cancelReadinessRun(
     params: { projectId: string; runId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<{ runId: string; projectId: string; status: string }> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/readiness-runs/${encodeURIComponent(params.runId)}/cancel`,
       {},
-      options,
+      options
     );
   }
 
@@ -2331,15 +2340,15 @@ export class PlatformApiClient {
    */
   getReadinessReport(
     params: { projectId: string; runId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<unknown> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/readiness-runs/${encodeURIComponent(params.runId)}/report`,
       {},
-      options,
+      options
     );
   }
 
@@ -2358,10 +2367,16 @@ export class PlatformApiClient {
       protocolVersion?: string;
       engineVersion?: string;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformConformanceRunReceipt> {
-    const { projectId, serverId, suites, idempotencyKey, protocolVersion, engineVersion } =
-      params;
+    const {
+      projectId,
+      serverId,
+      suites,
+      idempotencyKey,
+      protocolVersion,
+      engineVersion,
+    } = params;
     const body: Record<string, unknown> = {};
     if (suites !== undefined) body.suites = suites;
     if (idempotencyKey !== undefined) body.idempotencyKey = idempotencyKey;
@@ -2370,24 +2385,24 @@ export class PlatformApiClient {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/servers/${encodeURIComponent(
-        serverId,
+        serverId
       )}/conformance-runs`,
       { body },
-      options,
+      options
     );
   }
 
   getConformanceRun(
     params: { projectId: string; runId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformConformanceRun> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/conformance-runs/${encodeURIComponent(params.runId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -2398,45 +2413,45 @@ export class PlatformApiClient {
       limit?: number;
       cursor?: string;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformConformanceRun>> {
     const { projectId, ...query } = params;
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(projectId)}/conformance-runs`,
       { query },
-      options,
+      options
     );
   }
 
   getConformanceReport(
     params: { projectId: string; runId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformConformanceReport> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/conformance-runs/${encodeURIComponent(params.runId)}/report`,
       {},
-      options,
+      options
     );
   }
 
   /** One row per authored step (status + reason + evidence) for one iteration. */
   getEvalRunSteps(
     params: { projectId: string; runId: string; iterationId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformEvalStepResult>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-runs/${encodeURIComponent(
-        params.runId,
+        params.runId
       )}/iterations/${encodeURIComponent(params.iterationId)}/steps`,
       {},
-      options,
+      options
     );
   }
 
@@ -2469,12 +2484,12 @@ export class PlatformApiClient {
       baseCommitSha?: string;
       previewChars?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformRunCompare> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-runs/${encodeURIComponent(params.runId)}/compare`,
       {
         query: {
@@ -2483,21 +2498,21 @@ export class PlatformApiClient {
           previewChars: params.previewChars,
         },
       },
-      options,
+      options
     );
   }
 
   listEvalSuiteRuns(
     params: { projectId: string; suiteId: string; limit?: number },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformEvalRun>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(params.suiteId)}/runs`,
       { query: { limit: params.limit } },
-      options,
+      options
     );
   }
 
@@ -2505,15 +2520,15 @@ export class PlatformApiClient {
 
   getEvalSuite(
     params: { projectId: string; suiteId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalSuiteDetail> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(params.suiteId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -2523,29 +2538,29 @@ export class PlatformApiClient {
       suiteId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalSuiteDetail> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(params.suiteId)}`,
       { body: params.body },
-      options,
+      options
     );
   }
 
   deleteEvalSuite(
     params: { projectId: string; suiteId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalSuiteDeleted> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(params.suiteId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -2555,45 +2570,45 @@ export class PlatformApiClient {
       suiteId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalSuiteDetail> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(params.suiteId)}/schedule`,
       { body: params.body },
-      options,
+      options
     );
   }
 
   listEvalCases(
     params: { projectId: string; suiteId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformEvalCase>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(params.suiteId)}/cases`,
       {},
-      options,
+      options
     );
   }
 
   getEvalCase(
     params: { projectId: string; suiteId: string; caseId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalCase> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(
-        params.suiteId,
+        params.suiteId
       )}/cases/${encodeURIComponent(params.caseId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -2603,15 +2618,15 @@ export class PlatformApiClient {
       suiteId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalCase> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(params.suiteId)}/cases`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -2626,15 +2641,15 @@ export class PlatformApiClient {
       suiteId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalCaseBatchResult> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(params.suiteId)}/cases/batch`,
       { body: params.body },
-      options,
+      options
     );
   }
 
@@ -2645,33 +2660,33 @@ export class PlatformApiClient {
       caseId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalCase> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(
-        params.suiteId,
+        params.suiteId
       )}/cases/${encodeURIComponent(params.caseId)}`,
       { body: params.body },
-      options,
+      options
     );
   }
 
   deleteEvalCase(
     params: { projectId: string; suiteId: string; caseId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalCaseDeleted> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(
-        params.suiteId,
+        params.suiteId
       )}/cases/${encodeURIComponent(params.caseId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -2681,56 +2696,56 @@ export class PlatformApiClient {
       suiteId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformEvalCasesGenerated> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(params.suiteId)}/cases/generate`,
       { body: params.body },
-      options,
+      options
     );
   }
 
   validateServer(
     params: ServerScope & { body?: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.serverOp(params, "validate", options);
   }
 
   doctorServer(
     params: ServerScope & { body?: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformDoctorReport> {
     return this.serverOp(params, "doctor", options);
   }
 
   exportServer(
     params: ServerScope & { body?: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.serverOp(params, "export", options);
   }
 
   listServerTools(
     params: ServerScope & { body?: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<Record<string, unknown>>> {
     return this.serverOp(params, "tools", options);
   }
 
   listServerResources(
     params: ServerScope & { body?: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<Record<string, unknown>>> {
     return this.serverOp(params, "resources", options);
   }
 
   listServerPrompts(
     params: ServerScope & { body?: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<Record<string, unknown>>> {
     return this.serverOp(params, "prompts", options);
   }
@@ -2744,7 +2759,7 @@ export class PlatformApiClient {
     params: ServerScope & {
       body: { toolName: string; parameters?: Record<string, unknown> };
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.serverOp(params, "tools/call", options);
   }
@@ -2770,11 +2785,13 @@ export class PlatformApiClient {
         viewport?: { width: number; height: number };
       };
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformWidgetRender> {
-    return this.serverOp(params, "widgets/render", options) as Promise<
-      PlatformWidgetRender
-    >;
+    return this.serverOp(
+      params,
+      "widgets/render",
+      options
+    ) as Promise<PlatformWidgetRender>;
   }
 
   /** `POST /projects/{p}/servers/{s}/prompts/get` — render one prompt. */
@@ -2785,7 +2802,7 @@ export class PlatformApiClient {
         arguments?: Record<string, string | number | boolean>;
       };
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.serverOp(params, "prompts/get", options);
   }
@@ -2793,7 +2810,7 @@ export class PlatformApiClient {
   /** `POST /projects/{p}/servers/{s}/resources/read` — read one resource. */
   readServerResource(
     params: ServerScope & { body: { uri: string } },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.serverOp(params, "resources/read", options);
   }
@@ -2808,7 +2825,7 @@ export class PlatformApiClient {
    */
   listServerSkills(
     params: ServerScope & { body?: Record<string, unknown> },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.serverOp(params, "skills", options);
   }
@@ -2822,7 +2839,7 @@ export class PlatformApiClient {
    */
   getServerSkill(
     params: ServerScope & { body: { uri: string } },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.serverOp(params, "skills/get", options);
   }
@@ -2833,7 +2850,7 @@ export class PlatformApiClient {
    */
   readServerSkillFile(
     params: ServerScope & { body: { skillUri: string; resourceUri: string } },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.serverOp(params, "skills/read-file", options);
   }
@@ -2846,13 +2863,13 @@ export class PlatformApiClient {
    */
   createTunnel(
     params: { projectId: string; name: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformTunnelGrant> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/tunnels`,
       { body: { name: params.name } },
-      options,
+      options
     );
   }
 
@@ -2863,15 +2880,15 @@ export class PlatformApiClient {
    */
   closeTunnel(
     params: { projectId: string; serverId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformTunnelClosed> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/tunnels/${encodeURIComponent(params.serverId)}/close`,
       {},
-      options,
+      options
     );
   }
 
@@ -2893,13 +2910,13 @@ export class PlatformApiClient {
 
   listJourneys(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformJourney>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/journeys`,
       {},
-      options,
+      options
     );
   }
 
@@ -2910,29 +2927,29 @@ export class PlatformApiClient {
       cursor?: string;
       limit?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformJourneyRun>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/journeys/${encodeURIComponent(params.journeyId)}/runs`,
       { query: pageQuery(params) },
-      options,
+      options
     );
   }
 
   getJourneyRun(
     params: { projectId: string; runId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformJourneyRun> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/journey-runs/${encodeURIComponent(params.runId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -2943,15 +2960,15 @@ export class PlatformApiClient {
       cursor?: string;
       limit?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformJourneyRunSession>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/journey-runs/${encodeURIComponent(params.runId)}/sessions`,
       { query: pageQuery(params) },
-      options,
+      options
     );
   }
 
@@ -2976,12 +2993,12 @@ export class PlatformApiClient {
       waveId?: string;
       environmentIds?: string[];
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformJourneyRunLaunched> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/journeys/${encodeURIComponent(params.journeyId)}/runs`,
       {
         body: {
@@ -2991,7 +3008,7 @@ export class PlatformApiClient {
             : {}),
         },
       },
-      options,
+      options
     );
   }
 
@@ -3008,15 +3025,15 @@ export class PlatformApiClient {
    */
   cancelJourneyRun(
     params: { projectId: string; runId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformJourneyRunCanceled> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/journey-runs/${encodeURIComponent(params.runId)}/cancel`,
       {},
-      options,
+      options
     );
   }
 
@@ -3032,27 +3049,27 @@ export class PlatformApiClient {
 
   listPersonas(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformPersona>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/personas`,
       {},
-      options,
+      options
     );
   }
 
   getPersona(
     params: { projectId: string; personaId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPersona> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/personas/${encodeURIComponent(params.personaId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -3071,14 +3088,14 @@ export class PlatformApiClient {
       avatarShape?: number;
       avatarPalette?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPersona> {
     const { projectId, ...body } = params;
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/personas`,
       { body },
-      options,
+      options
     );
   }
 
@@ -3092,16 +3109,16 @@ export class PlatformApiClient {
       avatarShape?: number;
       avatarPalette?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPersona> {
     const { projectId, personaId, ...body } = params;
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(projectId)}/personas/${encodeURIComponent(
-        personaId,
+        personaId
       )}`,
       { body },
-      options,
+      options
     );
   }
 
@@ -3113,29 +3130,29 @@ export class PlatformApiClient {
    */
   deletePersona(
     params: { projectId: string; personaId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPersonaDeleted> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/personas/${encodeURIComponent(params.personaId)}`,
       {},
-      options,
+      options
     );
   }
 
   getJourney(
     params: { projectId: string; journeyId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformJourney> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/journeys/${encodeURIComponent(params.journeyId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -3153,14 +3170,14 @@ export class PlatformApiClient {
       serverAttachmentId?: string;
       hostIds?: string[];
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformJourney> {
     const { projectId, ...body } = params;
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/journeys`,
       { body },
-      options,
+      options
     );
   }
 
@@ -3184,16 +3201,16 @@ export class PlatformApiClient {
       sessionsPerTarget?: number;
       maxTurns?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformJourney> {
     const { projectId, journeyId, ...body } = params;
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(projectId)}/journeys/${encodeURIComponent(
-        journeyId,
+        journeyId
       )}`,
       { body },
-      options,
+      options
     );
   }
 
@@ -3204,41 +3221,41 @@ export class PlatformApiClient {
    */
   archiveJourney(
     params: { projectId: string; journeyId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformJourneyArchived> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/journeys/${encodeURIComponent(params.journeyId)}`,
       {},
-      options,
+      options
     );
   }
 
   listSwarms(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformSwarm>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/swarms`,
       {},
-      options,
+      options
     );
   }
 
   getSwarm(
     params: { projectId: string; swarmId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformSwarm> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/swarms/${encodeURIComponent(params.swarmId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -3252,14 +3269,14 @@ export class PlatformApiClient {
       description?: string;
       environmentIds?: string[];
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformSwarm> {
     const { projectId, ...body } = params;
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/swarms`,
       { body },
-      options,
+      options
     );
   }
 
@@ -3273,16 +3290,16 @@ export class PlatformApiClient {
       sessionsPerTarget?: number;
       maxTurns?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformSwarm> {
     const { projectId, swarmId, ...body } = params;
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(projectId)}/swarms/${encodeURIComponent(
-        swarmId,
+        swarmId
       )}`,
       { body },
-      options,
+      options
     );
   }
 
@@ -3292,15 +3309,15 @@ export class PlatformApiClient {
    */
   archiveSwarm(
     params: { projectId: string; swarmId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformSwarmArchived> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/swarms/${encodeURIComponent(params.swarmId)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -3322,14 +3339,14 @@ export class PlatformApiClient {
       description?: string;
       existingPersonas?: Array<{ name: string; role: string }>;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformGenerationDrafts> {
     const { projectId, ...body } = params;
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/personas/generate`,
       { body },
-      options,
+      options
     );
   }
 
@@ -3348,14 +3365,14 @@ export class PlatformApiClient {
       journeyCount?: number;
       description?: string;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformGenerationDrafts> {
     const { projectId, ...body } = params;
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/journeys/generate`,
       { body },
-      options,
+      options
     );
   }
 
@@ -3369,81 +3386,81 @@ export class PlatformApiClient {
 
   getSwarmOverview(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformSwarmOverview> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/journeys-overview`,
       {},
-      options,
+      options
     );
   }
 
   getJourneyRunScorecard(
     params: { projectId: string; runId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformRunScorecard> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/journey-runs/${encodeURIComponent(params.runId)}/scorecard`,
       {},
-      options,
+      options
     );
   }
 
   listSwarmFindings(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformSwarmFinding>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/journey-findings`,
       {},
-      options,
+      options
     );
   }
 
   dismissSwarmFinding(
     params: { projectId: string; findingId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformFindingDismissed> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/journey-findings/${encodeURIComponent(params.findingId)}/dismiss`,
       {},
-      options,
+      options
     );
   }
 
   undismissSwarmFinding(
     params: { projectId: string; findingId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformFindingDismissed> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/journey-findings/${encodeURIComponent(params.findingId)}/undismiss`,
       {},
-      options,
+      options
     );
   }
 
   getWaveInsights(
     params: { projectId: string; waveId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformWaveInsights> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/waves/${encodeURIComponent(params.waveId)}/insights`,
       {},
-      options,
+      options
     );
   }
 
@@ -3458,15 +3475,15 @@ export class PlatformApiClient {
    */
   requestWaveInsights(
     params: { projectId: string; waveId: string; force?: boolean },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformWaveInsightsRequested> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/waves/${encodeURIComponent(params.waveId)}/insights`,
       { body: params.force ? { force: true } : {} },
-      options,
+      options
     );
   }
 
@@ -3477,15 +3494,15 @@ export class PlatformApiClient {
    */
   cancelWaveInsights(
     params: { projectId: string; waveId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformWaveInsightsCanceled> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/waves/${encodeURIComponent(params.waveId)}/insights`,
       {},
-      options,
+      options
     );
   }
 
@@ -3500,13 +3517,13 @@ export class PlatformApiClient {
    */
   getCapabilities(
     params: { projectId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformCapabilities> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/capabilities`,
       {},
-      options,
+      options
     );
   }
 
@@ -3531,7 +3548,7 @@ export class PlatformApiClient {
       description?: string;
       mode?: "project_members" | "invited_only" | "anyone_with_link";
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformScenario> {
     const { projectId, environmentId } = params;
     // Explicit picks, not a rest spread: TypeScript's structural typing lets a
@@ -3542,31 +3559,31 @@ export class PlatformApiClient {
         name: params.name,
         description: params.description,
         mode: params.mode,
-      }).filter(([, value]) => value !== undefined),
+      }).filter(([, value]) => value !== undefined)
     );
     return this.request(
       "PUT",
       `/projects/${encodeURIComponent(
-        projectId,
+        projectId
       )}/environments/${encodeURIComponent(environmentId)}/scenario`,
       // Bodyless when there is nothing to send — the common case, and what
       // existing callers already put on the wire.
       Object.keys(body).length > 0 ? { body } : {},
-      options,
+      options
     );
   }
 
   unpublishScenario(
     params: { projectId: string; environmentId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformScenarioDeleted> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/environments/${encodeURIComponent(params.environmentId)}/scenario`,
       {},
-      options,
+      options
     );
   }
 
@@ -3602,16 +3619,16 @@ export class PlatformApiClient {
       description?: string;
       mode?: "project_members" | "invited_only" | "anyone_with_link";
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformScenario> {
     const { projectId, environmentId, ...body } = params;
     return this.request(
       "PUT",
       `/projects/${encodeURIComponent(
-        projectId,
+        projectId
       )}/environments/${encodeURIComponent(environmentId)}/scenario`,
       { body },
-      options,
+      options
     );
   }
 
@@ -3625,13 +3642,13 @@ export class PlatformApiClient {
    */
   getUserTestingScenario(
     params: { projectId: string; scenarioId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformUserTestingScenarioDetail> {
     return this.request(
       "GET",
       this.userTestingPath(params.projectId, params.scenarioId),
       {},
-      options,
+      options
     );
   }
 
@@ -3650,14 +3667,14 @@ export class PlatformApiClient {
       description?: string;
       mode?: "project_members" | "invited_only" | "anyone_with_link";
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformUserTestingScenario> {
     const { projectId, scenarioId, ...body } = params;
     return this.request(
       "PATCH",
       this.userTestingPath(projectId, scenarioId),
       { body },
-      options,
+      options
     );
   }
 
@@ -3669,13 +3686,13 @@ export class PlatformApiClient {
       cursor?: string;
       limit?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformUserTestingSession>> {
     return this.request(
       "GET",
       `${this.userTestingPath(params.projectId, params.scenarioId)}/sessions`,
       { query: pageQuery(params) },
-      options,
+      options
     );
   }
 
@@ -3694,22 +3711,22 @@ export class PlatformApiClient {
       cursor?: string;
       limit?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformUserTestingSessionDetail> {
     return this.request(
       "GET",
       `${this.userTestingPath(
         params.projectId,
-        params.scenarioId,
+        params.scenarioId
       )}/sessions/${encodeURIComponent(params.sessionId)}`,
       { query: pageQuery(params) },
-      options,
+      options
     );
   }
 
   getUserTestingMetrics(
     params: { projectId: string; scenarioId: string; population?: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.request(
       "GET",
@@ -3717,7 +3734,7 @@ export class PlatformApiClient {
       {
         query: params.population ? { population: params.population } : {},
       },
-      options,
+      options
     );
   }
 
@@ -3729,53 +3746,53 @@ export class PlatformApiClient {
    */
   getUserTestingUsage(
     params: { projectId: string; scenarioId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.request(
       "GET",
       `${this.userTestingPath(params.projectId, params.scenarioId)}/usage`,
       {},
-      options,
+      options
     );
   }
 
   listUserTestingFindings(
     params: { projectId: string; scenarioId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<Record<string, unknown>>> {
     return this.request(
       "GET",
       `${this.userTestingPath(params.projectId, params.scenarioId)}/findings`,
       {},
-      options,
+      options
     );
   }
 
   /** Also how you learn the CURRENT window id, which the insights read takes. */
   getUserTestingSignals(
     params: { projectId: string; scenarioId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.request(
       "GET",
       `${this.userTestingPath(params.projectId, params.scenarioId)}/signals`,
       {},
-      options,
+      options
     );
   }
 
   getUserTestingInsights(
     params: { projectId: string; scenarioId: string; windowId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.request(
       "GET",
       `${this.userTestingPath(
         params.projectId,
-        params.scenarioId,
+        params.scenarioId
       )}/windows/${encodeURIComponent(params.windowId)}/insights`,
       {},
-      options,
+      options
     );
   }
 
@@ -3786,38 +3803,38 @@ export class PlatformApiClient {
    */
   requestUserTestingInsights(
     params: { projectId: string; scenarioId: string; force?: boolean },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformUserTestingInsightsRequested> {
     return this.request(
       "POST",
       `${this.userTestingPath(params.projectId, params.scenarioId)}/insights`,
       { body: params.force ? { force: true } : {} },
-      options,
+      options
     );
   }
 
   cancelUserTestingInsights(
     params: { projectId: string; scenarioId: string; windowId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.request(
       "DELETE",
       `${this.userTestingPath(params.projectId, params.scenarioId)}/insights`,
       { body: { windowId: params.windowId } },
-      options,
+      options
     );
   }
 
   dismissUserTestingFinding(
     params: { projectId: string; scenarioId: string; findingId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.userTestingFindingAction(params, "dismiss", options);
   }
 
   undismissUserTestingFinding(
     params: { projectId: string; scenarioId: string; findingId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.userTestingFindingAction(params, "undismiss", options);
   }
@@ -3835,16 +3852,16 @@ export class PlatformApiClient {
       scenarioId: string;
       guestExecution: PlatformGuestExecution;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.request(
       "PUT",
       `${this.userTestingPath(
         params.projectId,
-        params.scenarioId,
+        params.scenarioId
       )}/guest-execution`,
       { body: params.guestExecution },
-      options,
+      options
     );
   }
 
@@ -3854,16 +3871,16 @@ export class PlatformApiClient {
    */
   rotateUserTestingLink(
     params: { projectId: string; scenarioId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.request(
       "POST",
       `${this.userTestingPath(
         params.projectId,
-        params.scenarioId,
+        params.scenarioId
       )}/rotate-link`,
       {},
-      options,
+      options
     );
   }
 
@@ -3875,29 +3892,29 @@ export class PlatformApiClient {
       email: string;
       sendInviteEmail?: boolean;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     const { projectId, scenarioId, ...body } = params;
     return this.request(
       "PUT",
       `${this.userTestingPath(projectId, scenarioId)}/members`,
       { body },
-      options,
+      options
     );
   }
 
   removeUserTestingMember(
     params: { projectId: string; scenarioId: string; member: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.request(
       "DELETE",
       `${this.userTestingPath(
         params.projectId,
-        params.scenarioId,
+        params.scenarioId
       )}/members/${encodeURIComponent(params.member)}`,
       {},
-      options,
+      options
     );
   }
 
@@ -3908,46 +3925,48 @@ export class PlatformApiClient {
    */
   rebindUserTestingScenario(
     params: { projectId: string; scenarioId: string; environmentId: string },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.request(
       "POST",
       `${this.userTestingPath(params.projectId, params.scenarioId)}/rebind`,
       { body: { environmentId: params.environmentId } },
-      options,
+      options
     );
   }
 
   private userTestingPath(projectId: string, scenarioId: string): string {
     return `/projects/${encodeURIComponent(
-      projectId,
+      projectId
     )}/user-testing/scenarios/${encodeURIComponent(scenarioId)}`;
   }
 
   private userTestingFindingAction(
     params: { projectId: string; scenarioId: string; findingId: string },
     action: "dismiss" | "undismiss",
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.request(
       "POST",
       `${this.userTestingPath(
         params.projectId,
-        params.scenarioId,
+        params.scenarioId
       )}/findings/${encodeURIComponent(params.findingId)}/${action}`,
       {},
-      options,
+      options
     );
   }
 
   private sharePath(
     projectId: string,
     resourceType: string,
-    resourceId: string,
+    resourceId: string
   ): string {
-    return `/projects/${encodeURIComponent(projectId)}/shares/${encodeURIComponent(
-      resourceType,
-    )}/${encodeURIComponent(resourceId)}`;
+    return `/projects/${encodeURIComponent(
+      projectId
+    )}/shares/${encodeURIComponent(resourceType)}/${encodeURIComponent(
+      resourceId
+    )}`;
   }
 
   getShareSettings(
@@ -3956,13 +3975,13 @@ export class PlatformApiClient {
       resourceType: "scenario" | "conformanceRun" | "evalRun";
       resourceId: string;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.request(
       "GET",
       this.sharePath(params.projectId, params.resourceType, params.resourceId),
       {},
-      options,
+      options
     );
   }
 
@@ -3974,7 +3993,7 @@ export class PlatformApiClient {
       mode: "project_members" | "invited_only" | "anyone_with_link";
       allowGuestAccess?: boolean;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     const { projectId, resourceType, resourceId, mode, allowGuestAccess } =
       params;
@@ -3987,7 +4006,7 @@ export class PlatformApiClient {
           ...(allowGuestAccess !== undefined ? { allowGuestAccess } : {}),
         },
       },
-      options,
+      options
     );
   }
 
@@ -4001,23 +4020,27 @@ export class PlatformApiClient {
       resourceType: "scenario" | "conformanceRun" | "evalRun";
       resourceId: string;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<Record<string, unknown>> {
     return this.request(
       "POST",
-      `${this.sharePath(params.projectId, params.resourceType, params.resourceId)}/rotate-link`,
+      `${this.sharePath(
+        params.projectId,
+        params.resourceType,
+        params.resourceId
+      )}/rotate-link`,
       {},
-      options,
+      options
     );
   }
 
   private serverOp<T>(
     params: ServerScope & { body?: Record<string, unknown> },
     op: string,
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<T> {
     const path = `/projects/${encodeURIComponent(
-      params.projectId,
+      params.projectId
     )}/servers/${encodeURIComponent(params.serverId)}/${op}`;
     return this.request("POST", path, { body: params.body ?? {} }, options);
   }
@@ -4030,7 +4053,7 @@ export class PlatformApiClient {
     method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
     path: string,
     init: { query?: QueryParams; body?: unknown },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<T> {
     const url = resolvePlatformRequestUrl(`${this.baseUrl}${path}`);
     for (const [name, value] of Object.entries(init.query ?? {})) {
@@ -4070,9 +4093,9 @@ export class PlatformApiClient {
     const timeoutHandle = setTimeout(
       () =>
         controller.abort(
-          new Error(`Request timed out after ${this.timeoutMs}ms`),
+          new Error(`Request timed out after ${this.timeoutMs}ms`)
         ),
-      this.timeoutMs,
+      this.timeoutMs
     );
 
     // BOTH THE FETCH AND THE BODY READ ARE INSIDE THIS `try`, and that is the
@@ -4103,10 +4126,10 @@ export class PlatformApiClient {
           aborted
             ? `Request to ${path} timed out after ${this.timeoutMs}ms`
             : `Failed to reach the MCPJam API at ${url.origin}: ${errorMessage(
-                error,
+                error
               )}`,
           aborted ? "TIMEOUT" : "NETWORK_ERROR",
-          { status: 0, endpoint: path, cause: error },
+          { status: 0, endpoint: path, cause: error }
         );
       }
 
@@ -4122,13 +4145,13 @@ export class PlatformApiClient {
           throw new PlatformApiError(
             `Request to ${path} timed out after ${this.timeoutMs}ms`,
             "TIMEOUT",
-            { status: 0, endpoint: path, cause: error },
+            { status: 0, endpoint: path, cause: error }
           );
         }
         throw new PlatformApiError(
           `Failed to read the MCPJam API response (${response.status}) for ${path}`,
           "INTERNAL_ERROR",
-          { status: response.status, endpoint: path, cause: error },
+          { status: response.status, endpoint: path, cause: error }
         );
       }
     } finally {
@@ -4156,7 +4179,7 @@ export class PlatformApiClient {
       throw new PlatformApiError(
         `The MCPJam API returned a non-JSON response (${response.status}) for ${path}`,
         "INTERNAL_ERROR",
-        { status: response.status, endpoint: path, cause: parseError },
+        { status: response.status, endpoint: path, cause: parseError }
       );
     }
 
@@ -4167,16 +4190,20 @@ export class PlatformApiClient {
   private toApiError(
     response: Response,
     body: unknown,
-    path: string,
+    path: string
   ): PlatformApiError {
     const envelope =
       body && typeof body === "object" && !Array.isArray(body)
         ? (body as { code?: unknown; message?: unknown; details?: unknown })
         : undefined;
-    const code =
+    // Tracked, not just resolved: a caller cannot tell an assumed code from a
+    // server-sent one afterwards, and for 404 the difference decides whether
+    // the RESOURCE is missing or the ROUTE is. See `PlatformApiError.codeSource`.
+    const sentCode =
       typeof envelope?.code === "string" && envelope.code.length > 0
         ? envelope.code
-        : fallbackCodeForStatus(response.status);
+        : undefined;
+    const code = sentCode ?? fallbackCodeForStatus(response.status);
     const message =
       typeof envelope?.message === "string" && envelope.message.length > 0
         ? envelope.message
@@ -4193,6 +4220,7 @@ export class PlatformApiClient {
       details,
       retryAfter: parseRetryAfter(response.headers.get("retry-after")),
       endpoint: path,
+      codeSource: sentCode !== undefined ? "envelope" : "status",
     });
   }
 }
@@ -4213,7 +4241,7 @@ function fallbackCodeForStatus(status: number): string {
 
 function parseRetryAfter(
   header: string | null,
-  now: number = Date.now(),
+  now: number = Date.now()
 ): number | undefined {
   if (!header) return undefined;
   const seconds = Number(header);

--- a/sdk/src/platform/errors.ts
+++ b/sdk/src/platform/errors.ts
@@ -52,6 +52,8 @@ export type PlatformApiErrorOptions = SdkErrorOptions & {
   retryAfter?: number;
   /** Request path that failed, for diagnostics. */
   endpoint?: string;
+  /** See `PlatformApiError.codeSource`. Omit when the code was not wire-derived. */
+  codeSource?: "envelope" | "status";
 };
 
 export class PlatformApiError extends SdkError {
@@ -59,6 +61,25 @@ export class PlatformApiError extends SdkError {
   public readonly details?: Record<string, unknown>;
   public readonly retryAfter?: number;
   public readonly endpoint?: string;
+  /**
+   * Did `code` come from the response's own `{ code }` envelope, or was it
+   * ASSUMED from the HTTP status?
+   *
+   * The two are indistinguishable in `code` alone, and for 404 that ambiguity
+   * has a caller-visible cost: an API answering `{ code: "NOT_FOUND" }` is
+   * saying the resource does not exist, while a bare 404 with no envelope is
+   * usually the route not being there at all — an older deployment, a function
+   * not yet shipped. `STATUS_FALLBACK_CODES` maps both to `NOT_FOUND`, so a
+   * caller wanting to fall back on an undeployed endpoint (rather than render
+   * "no such thing") had nothing to branch on.
+   *
+   * `"status"` says the server offered no code of its own. It does NOT by
+   * itself mean the route is missing — a proxy can strip a body from any
+   * status — so treat it as one signal, alongside the status, not a verdict.
+   *
+   * Optional so an error constructed anywhere else keeps its current shape.
+   */
+  public readonly codeSource?: "envelope" | "status";
 
   constructor(message: string, code: string, options: PlatformApiErrorOptions) {
     super(message, code, options);
@@ -67,6 +88,7 @@ export class PlatformApiError extends SdkError {
     this.details = options.details;
     this.retryAfter = options.retryAfter;
     this.endpoint = options.endpoint;
+    this.codeSource = options.codeSource;
   }
 }
 


### PR DESCRIPTION
Fifth of the UVH follow-up PRs. Independent of #4524 and #4528 — all branch from `main`.

## 1. A routing 404 and a resource 404 were indistinguishable

`STATUS_FALLBACK_CODES` assumes a wire code when an error response carries no `{ code }` envelope. For 404 that erases a distinction callers need:

- An API answering `{ code: "NOT_FOUND" }` means **the resource does not exist**.
- A bare 404 with no envelope is usually **the route not being there at all** — an older deployment, a function not yet shipped.

Both arrived as `code: "NOT_FOUND"`. **A discriminator built on the code could never have worked** — which is worth stating plainly, because that was the obvious-looking fix.

`PlatformApiError.codeSource` now records `"envelope"` or `"status"`. It is deliberately one signal rather than a verdict: a proxy can strip a body from any status, so it is meant to be read alongside the status. Optional, so an error constructed anywhere else keeps its current shape.

The stage-analytics reader uses it — a bare 404 becomes `routeUnavailable`. **During a dark ship this is not cosmetic:** the run detail was rendering an undeployed route as "this run was never measured" instead of falling back to the legacy funnel it should still have been showing.

## 2. A provisional document never refreshed

A run's analytics are materialized `provisional` while a judge fanout is pending, and **replaced** by a `final` document once it settles. The hook's effect keys on ids and the run's terminal status — neither of which moves at that instant — so a page open across the transition kept showing provisional numbers until someone reloaded.

This applies the rule the hook already implements ("ask again exactly when the answer can still change") to the one transition it did not cover. **Bounded and self-terminating, not a poll:** it re-asks only while the document itself says it is unsettled, backs off across four attempts (3s → 45s), and stops at `final` or when the budget is spent — so a fanout that never settles costs a handful of reads rather than one per interval forever. A manual `refetch` never consumes the budget, and a re-triggered judge pass gets a fresh one.

## Testing

| Mutation | Tests that fail |
|---|---|
| Drop the bare-404 branch | exactly the bare-404 test |
| Force `codeSource` to `"envelope"` | exactly the bare-404 test |
| Remove the refresh effect | the two that assert re-asking |

The pre-existing enveloped-404 test sits directly above the new one as an unchanged control: same status, opposite answer, and the only thing separating them is whether the server sent a code of its own.

Two things I hit that are worth recording:

- **The bare-404 test first failed for an environmental reason.** `@mcpjam/sdk/platform` resolves to `dist`, not source, so the API-layer test reads the *built* SDK. It needed `npm run build -w @mcpjam/sdk` before it could see the change. Noted in the commit message for the next person.
- **The budget test initially passed nothing.** A single large `advanceTimersByTimeAsync` fires one timer and then finds nothing pending, because each re-ask is only scheduled after React processes the previous response. It now steps one delay at a time and asserts the count at each step.

Green: SDK 314 files / 6934 tests; client sweep 276 files / 2765 tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4jTtZJsDeaterEzKwpF2p)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error classification for stage-analytics 404s and adds timed refetch logic in a run-detail hook; wrong branching would affect dark-ship UX and API read volume, but behavior is bounded and covered by targeted tests.
> 
> **Overview**
> **Route vs resource 404.** `PlatformApiError` now exposes optional `codeSource` (`"envelope"` vs `"status"`) so callers can tell a server-sent `{ code: "NOT_FOUND" }` from a bodyless 404 where the SDK assumed `NOT_FOUND` from the status. The eval stage-analytics client uses that signal: bare 404s map to **`routeUnavailable`** instead of **`notFound`**, so dark-ship run detail can fall back to the legacy funnel instead of showing “never measured.”
> 
> **Provisional → final analytics.** `useEvalRunStageAnalytics` adds a bounded, backoff re-fetch (3s → 45s, four automatic attempts) while `materializationState` is `provisional`, stopping at `final` or when the budget is spent; manual `refetch` does not consume that budget.
> 
> Tests cover bare vs enveloped 404 mapping and provisional refresh behavior (settle, stop at final, budget cap). SDK `client.ts` also includes formatting-only churn alongside the `toApiError` change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d1062f0b8c48c99a553ff609ed7e0986e2104e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Distinguishes a missing route from a missing run in 404 responses, and makes a provisional analytics document refresh itself once the judge pass settles.

**Bug Fixes**
- `PlatformApiError` now records `codeSource` (`"envelope"` or `"status"`), so a bare 404 with no code envelope no longer collides with an API's own `NOT_FOUND`.
- The stage-analytics reader maps a bare 404 to `routeUnavailable` instead of `notFound`, so an undeployed route shows the legacy funnel instead of "this run was never measured".
- A `provisional` document now re-fetches on backoff (3s → 45s, four attempts) until it turns `final`; a manual `refetch` never consumes the budget.

<sup>Written for commit 8d1062f0b8c48c99a553ff609ed7e0986e2104e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

