### PR TITLE
UVH-FU10: drop the landed UVH stack pattern from the CI branch filters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - "claude/mcp-benchmarks-v2-b0tw4b-**"
-      - "claude/uvc-mcp-eval-reporting-gyycwl**"
   push:
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,16 +5,16 @@ on:
     # `branches` filters on the PR's BASE. A stacked PR is based on the branch
     # below it rather than on main, so with `main` alone every PR above the
     # root of a stack merges without these tests having run against it once.
-    # Drop each stack pattern once that stack has landed.
+    # Add a pattern while a stack is in flight; drop it once that stack lands.
     #
-    # The UVH pattern was added after this bit us: a test in the stack asserted
-    # a label's wording verbatim, a later PR in the same stack changed that
-    # wording, and the break sat unnoticed because every PR above the root was
-    # green on previews and review bots alone.
+    # Worth keeping the reason: this bit us on the UVH stack, where a test
+    # asserted a label's wording verbatim, a later PR in the same stack changed
+    # that wording, and the break sat unnoticed because every PR above the root
+    # was green on previews and review bots alone. That stack has landed and
+    # its pattern is gone; the lesson is why the mechanism stays.
     branches:
       - main
       - "claude/mcp-benchmarks-v2-b0tw4b-**"
-      - "claude/uvc-mcp-eval-reporting-gyycwl**"
   push:
     branches: [main]
 


### PR DESCRIPTION
Housekeeping, doing what the comment next to the code says to do.

`pull_request.branches` filters on a PR's **base**, so a stack in flight needs its own pattern or every PR above the root merges without `lint.yml` / `test.yml` having run against it. The comment sitting directly above the list says: *"Drop each stack pattern once that stack has landed."*

The UVH stack has landed — all twelve PRs merged, and the follow-up PRs (#4524, #4528, #4529 and this one) target `main` directly. The pattern now only widens the filter for branches nothing is based on.

**Verified rather than assumed:** no open PR in this repo has a `claude/uvc-mcp-eval-reporting-gyycwl*` base branch, so nothing loses CI by this change. Both workflow files still parse, with `branches` resolving to `['main', 'claude/mcp-benchmarks-v2-b0tw4b-**']`.

## One comment change

`test.yml`'s explanation of *why* the mechanism exists was written about the UVH stack specifically — a test asserting a label's wording verbatim, a later PR in the same stack changing that wording, the break sitting unnoticed because every PR above the root was green on previews and review bots alone. That lesson is worth keeping, but as written it described a pattern this PR removes. It is now past-tensed.

## One thing I left alone

`claude/mcp-benchmarks-v2-b0tw4b-**` looks equally stale — one remote branch survives (`…-in4`) and no open PR is based on it. I have not touched it: that is not my stack to declare landed. Flagging it here so someone who knows can decide.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4jTtZJsDeaterEzKwpF2p)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger narrowing only; low risk if no open PRs still use the removed base branch (as verified in the PR description).
> 
> **Overview**
> **Removes** the `claude/uvc-mcp-eval-reporting-gyycwl**` entry from `pull_request.branches` in both `lint.yml` and `test.yml`, now that the UVH stack has merged. PRs targeting `main` (or the remaining MCP benchmarks stack pattern) still get build/lint and tests; nothing should lose CI unless something still bases on the dropped branch name.
> 
> In `test.yml`, the inline comment is **updated** so stack maintenance reads “add while in flight, drop when landed,” and the UVH incident story is **past-tensed**—the pattern is gone but the rationale for extra branch patterns on stacked PRs stays documented.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4474aad5acf5f025c590c447d8d50be3f3899ba1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `claude/uvc-mcp-eval-reporting-gyycwl**` branch filter from `lint.yml` and `test.yml` now that the UVH stack has landed. Previously the filter let PRs based on active stack branches run CI; it no longer matches any open PR, so removing it changes nothing for current work.

Also updates the comment in `test.yml` to explain the mechanism in general terms instead of referencing the landed UVH stack specifically. The `mcp-benchmarks-v2` pattern is left untouched.

<sup>Written for commit 4474aad5acf5f025c590c447d8d50be3f3899ba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

