### PR TITLE
UVH-FU8a: the judge pass reads the model-layer classification instead of guessing

### DIFF
--- a/.changeset/persist-the-model-layer-classification.md
+++ b/.changeset/persist-the-model-layer-classification.md
@@ -1,0 +1,15 @@
+---
+"@mcpjam/inspector": patch
+---
+
+The judge second pass reads the model-layer classification instead of guessing it
+
+`stepError` is transient runner state — an input to the first derivation, never persisted — so the judge second pass re-derived from strictly less evidence than the first, and dropped `providerError` and the `setup` category the moment a verdict landed. UVH-IN2 patched that by recovering the classification from the stored chain, on the stated grounds that the chain "already says it: `providerError` is written if and only if the model layer was classified as the failure".
+
+**That premise was false.** `categoryFor` returns `setup` for a model-call failure where *nothing* failed — "there was nothing to fail against" — and on that shape `applyProviderError` relabels no row at all. The witness was empty exactly when the fact was true, so the category vanished on the second pass with no missing row to point at.
+
+The classification is now written beside the chain that produced it, as a single `stageStepErrorSource` key, and read back directly. The chain scan stays as a fallback for iterations finalized before the marker shipped — it was always a faithful witness where it fired, only an incomplete one. `code` and `httpStatus` are still not recovered by either route: they are diagnostics, were never part of the classification, and persisting them would invite a reader to treat them as evidence.
+
+No contract or vocabulary change, and no backend change: iteration metadata is an open bag, and `REPORTED_STAGE_KEYS` gates only claim detection and quarantine stripping, not what may be stored.
+
+Mutation-checked on both halves, which took two passes. Removing the read fails the test that names it immediately; removing the *write* originally failed nothing, because the read-side tests hand the reader a metadata bag directly and pass whether or not anything ever writes one. `buildStageMetadata` is now asserted at the seam as well.

--- a/mcpjam-inspector/server/services/evals/__tests__/build-iteration-finish-params.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/build-iteration-finish-params.test.ts
@@ -482,6 +482,44 @@ describe("buildStageMetadata — the seam a setup abort finalizes through", () =
     expect(buildStageMetadata({ status: "failed", error: "boom" })).toEqual({});
   });
 
+  test("records the model-layer classification beside the chain it produced", () => {
+    // The WRITE half of the persisted attribution. Without it the judge second
+    // pass has to infer the classification from the chain, and the chain does
+    // not always carry it: a model-call failure where nothing failed gets a
+    // `setup` category with no row relabelled.
+    //
+    // Asserted here rather than only where it is read, because a test that
+    // hands the reader a hand-built metadata bag passes whether or not this
+    // function ever writes one.
+    const metadata = buildStageMetadata({
+      stageCase: authoredCase,
+      status: "failed",
+      error: "provider outage",
+      stepError: { source: "model" },
+    });
+    expect(metadata.stageStepErrorSource).toBe("model");
+  });
+
+  test("writes no classification marker when the failure was not the model's", () => {
+    // `setup` is our own layer and needs no marker: it changes no derivation
+    // the second pass would otherwise get wrong, and writing it would invite a
+    // reader to treat the absence of a marker as meaningful.
+    expect(
+      buildStageMetadata({
+        stageCase: authoredCase,
+        status: "failed",
+        error: "our own preparation broke",
+        stepError: { source: "setup" },
+      }).stageStepErrorSource,
+    ).toBeUndefined();
+    expect(
+      buildStageMetadata({
+        stageCase: authoredCase,
+        status: "completed",
+      }).stageStepErrorSource,
+    ).toBeUndefined();
+  });
+
   test("an authored case that captured nothing reports a setup abort", () => {
     const metadata = buildStageMetadata({
       stageCase: authoredCase,

--- a/mcpjam-inspector/server/services/evals/__tests__/judge-second-pass.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/judge-second-pass.test.ts
@@ -1146,6 +1146,67 @@ describe("the second pass keeps its contract with the run and the first pass", (
   });
 });
 
+describe("the marker carries what the chain cannot", () => {
+  // The case the chain-scan recovery could never see, and the reason the
+  // classification is now persisted rather than inferred.
+  //
+  // `categoryFor` returns `setup` for a model-call failure where NOTHING
+  // failed — "there was nothing to fail against". On that shape
+  // `applyProviderError` relabels no row, so a recovery that looks for a
+  // `providerError` row finds an empty chain and concludes the provider was
+  // fine. The category then vanishes on the second pass with no missing row to
+  // point at.
+  const reachedAndPassed = {
+    status: "completed",
+    traceComplete: true,
+    stageCase: {
+      mode: "model_driven",
+      expectsToolCall: false,
+      expectsWidgetRender: false,
+      assertionCount: 0,
+    },
+    spans: [{ id: "s1", name: "tools/call", category: "tool", status: "ok" }],
+  };
+
+  const derive = (metadata: Record<string, unknown>) =>
+    deriveIterationPayload({
+      iteration: { ...reachedAndPassed, metadata },
+      mode: "advisory",
+      judgeVerdict: { status: "scored", verdict: "pass", score: 0.9 },
+      attributionVerdict: undefined,
+    } as never).stage;
+
+  // Nothing failed, and nothing blamed on the provider — exactly what the
+  // first pass writes for this shape.
+  const CLEAN_CHAIN = [
+    { stage: "connection", state: "passed", reason: "observed" },
+  ];
+
+  it("keeps the setup category when NO row records providerError", () => {
+    const stage = derive({
+      stageResults: CLEAN_CHAIN,
+      stageStepErrorSource: "model",
+    });
+    expect(stage.failureCategory).toBe("setup");
+  });
+
+  it("and the chain alone cannot recover it — the reason the marker exists", () => {
+    // Same chain, marker absent. This is what the second pass saw before, and
+    // it is why the old recovery's "if and only if" premise was false.
+    expect(stepErrorFromStoredChain(CLEAN_CHAIN)).toBeUndefined();
+    const stage = derive({ stageResults: CLEAN_CHAIN });
+    expect(stage.failureCategory).toBeUndefined();
+  });
+
+  it("does not invent a provider failure from a marker saying otherwise", () => {
+    expect(
+      derive({ stageResults: CLEAN_CHAIN, stageStepErrorSource: "setup" })
+        .failureCategory,
+    ).toBeUndefined();
+  });
+});
+
+
 describe("stepErrorFromStoredChain", () => {
   // `stepError` is an INPUT to the first derivation and is never persisted, so
   // the judge pass re-derived without it and dropped `providerError` and the

--- a/mcpjam-inspector/server/services/evals/finalize-iteration.ts
+++ b/mcpjam-inspector/server/services/evals/finalize-iteration.ts
@@ -92,7 +92,7 @@ type PolicyBlockRecord = { reason?: unknown };
  * summary reason when multiple policy blocks occur.
  */
 function getIterationPolicyReason(
-  policyBlocks: ReadonlyArray<PolicyBlockRecord>
+  policyBlocks: ReadonlyArray<PolicyBlockRecord>,
 ): string | undefined {
   const reason = policyBlocks[0]?.reason;
   return typeof reason === "string" ? reason : undefined;
@@ -233,6 +233,26 @@ export function buildStageMetadata(args: {
 }): Record<string, unknown> {
   const { stageCase, status, error } = args;
   if (!stageCase) return {};
+  /**
+   * The classification itself, recorded beside the chain it produced.
+   *
+   * `stepError` is transient runner state, so a re-derivation that does not
+   * receive it derives from strictly less evidence than the first pass did.
+   * The judge second pass used to recover it by looking for a `providerError`
+   * row, on the stated grounds that the chain "already says it" — but it does
+   * not always: `categoryFor` returns `setup` for a model-call failure where
+   * NOTHING failed, and in that case no row is relabelled at all. The
+   * re-derivation then lost the category with no row missing to show for it.
+   *
+   * One key, written only for the classification that has a consequence.
+   * `code` and `httpStatus` stay out: they are diagnostics, were never part of
+   * the classification, and persisting them would invite a reader to treat
+   * them as evidence.
+   */
+  const stepErrorSource =
+    args.stepError?.source === "model"
+      ? { stageStepErrorSource: "model" as const }
+      : {};
   const metadata = stageDerivationToMetadata(
     deriveStageResults({
       authored: stageCase,
@@ -255,12 +275,15 @@ export function buildStageMetadata(args: {
       policy: args.policy,
     }),
   );
-  return attachStageMeasurements(metadata, args.spans);
+  return {
+    ...attachStageMeasurements(metadata, args.spans),
+    ...stepErrorSource,
+  };
 }
 
 /** A predicate row the score projection can key a criterion off. */
 function isHostedPredicateResult(
-  value: unknown
+  value: unknown,
 ): value is HostedPredicateResultLike {
   if (typeof value !== "object" || value === null) return false;
   const row = value as { predicate?: unknown; passed?: unknown };
@@ -273,7 +296,7 @@ function isHostedPredicateResult(
 
 /** Read only the matcher fields the projection needs, typed rather than cast. */
 function narrowEvaluation(
-  evaluation: Record<string, unknown>
+  evaluation: Record<string, unknown>,
 ): HostedEvaluationLike {
   const list = (key: string): readonly unknown[] | undefined => {
     const value = evaluation[key];
@@ -363,7 +386,7 @@ function buildScoreMetadata(args: {
 } {
   if (args.mode === "off") return { keys: {} };
   const predicateResults = (args.predicateResults ?? []).filter(
-    isHostedPredicateResult
+    isHostedPredicateResult,
   );
   const { scores, evaluationConfig } = buildHostedScoreContract({
     ...(predicateResults.length ? { predicateResults } : {}),
@@ -429,7 +452,7 @@ function buildScoreMetadata(args: {
         ...(typeof args.stageMetadata.stageAnalyzerVersion === "number"
           ? { stageAnalyzerVersion: args.stageMetadata.stageAnalyzerVersion }
           : {}),
-      }
+      },
     );
     // The emitter is only REACHED on disagreement, so a spy on it counts
     // mismatches rather than comparisons — that is what makes
@@ -460,7 +483,11 @@ function readUserValueRow(
   for (const row of rows) {
     if (typeof row !== "object" || row === null) continue;
     const candidate = row as Partial<StageResultRow>;
-    if (candidate.stage === "userValue" && candidate.state && candidate.reason) {
+    if (
+      candidate.stage === "userValue" &&
+      candidate.state &&
+      candidate.reason
+    ) {
       return { state: candidate.state, reason: candidate.reason };
     }
   }
@@ -497,12 +524,14 @@ function buildSelectionToolCatalogMetadata(args: {
   // and folding them in could fill the catalog's cap before the turn that
   // actually caused the failure is ever considered.
   const failingPrompts = prompts.filter(
-    (p) => (p.missing?.length ?? 0) > 0 || (p.unexpected?.length ?? 0) > 0
+    (p) => (p.missing?.length ?? 0) > 0 || (p.unexpected?.length ?? 0) > 0,
   );
   const expectedToolNames = failingPrompts
     .flatMap((p) => p.missing ?? [])
     .map((t) => t.toolName)
-    .filter((name): name is string => typeof name === "string" && name.length > 0);
+    .filter(
+      (name): name is string => typeof name === "string" && name.length > 0,
+    );
   // `unexpected` names FIRST, then the rest of the turn's actual calls:
   // `buildSelectionToolCatalog`'s cap is shared across both roles, and for
   // an `unexpectedToolCall` failure (e.g. `maxExtraToolCalls: 0`, six
@@ -517,11 +546,15 @@ function buildSelectionToolCatalogMetadata(args: {
   const unexpectedToolNames = failingPrompts
     .flatMap((p) => p.unexpected ?? [])
     .map((t) => t.toolName)
-    .filter((name): name is string => typeof name === "string" && name.length > 0);
+    .filter(
+      (name): name is string => typeof name === "string" && name.length > 0,
+    );
   const otherActualToolNames = failingPrompts
     .flatMap((p) => p.actualToolCalls ?? [])
     .map((t) => t.toolName)
-    .filter((name): name is string => typeof name === "string" && name.length > 0);
+    .filter(
+      (name): name is string => typeof name === "string" && name.length > 0,
+    );
   const actualToolNames = [...unexpectedToolNames, ...otherActualToolNames];
   if (expectedToolNames.length === 0 && actualToolNames.length === 0) {
     return {};
@@ -712,10 +745,7 @@ export function buildIterationFinishParams(args: {
     selectionTools,
   } = args;
   const gradingMode = args.gradingMode ?? resolveGradingEngineMode();
-  const persistedSpans = [
-    ...(setupSpans ?? []),
-    ...(spans ?? []),
-  ];
+  const persistedSpans = [...(setupSpans ?? []), ...(spans ?? [])];
   const stageMetadata = buildStageMetadata({
     ...(stageCase ? { stageCase } : {}),
     spans,
@@ -761,14 +791,13 @@ export function buildIterationFinishParams(args: {
   // would silently switch D7's catalog capture back OFF for the cohort that
   // has progressed furthest. The predicate is what keeps "dual_write and
   // above" in one place.
-  const selectionToolCatalogMetadata =
-    isDualWrite(gradingMode)
-      ? buildSelectionToolCatalogMetadata({
-          stageMetadata,
-          prompts,
-          selectionTools,
-        })
-      : {};
+  const selectionToolCatalogMetadata = isDualWrite(gradingMode)
+    ? buildSelectionToolCatalogMetadata({
+        stageMetadata,
+        prompts,
+        selectionTools,
+      })
+    : {};
 
   // THE FLIP, and the ONE DIRECTION IT MAY MOVE.
   //
@@ -1033,8 +1062,8 @@ export async function finalizeEvalIteration(
     iterationStatus === "cancelled"
       ? "eval_cancelled"
       : isCycleFailure
-        ? "eval_failed"
-        : "eval_completed";
+      ? "eval_failed"
+      : "eval_completed";
 
   // PR 13: emit per-iteration browser-eval observability from the runner-local
   // arrays (covers both the stream + non-stream paths via this shared choke
@@ -1089,8 +1118,7 @@ export async function finalizeEvalIteration(
   // before any turn landed. With turns already written, re-sending
   // would overwrite turn 0 (W1 always writes at promptIndex: 0) and
   // orphan turns 1..N. See persist-eval-trace.ts for the contract.
-  const useW1Fallback =
-    fanout.persisted === false && fanout.turnsWritten === 0;
+  const useW1Fallback = fanout.persisted === false && fanout.turnsWritten === 0;
   if (fanout.persisted === false) {
     logger.warn(
       useW1Fallback
@@ -1136,8 +1164,7 @@ export async function finalizeEvalIteration(
               : {}),
             ...(widgetSnapshots?.length
               ? {
-                  widgetSnapshots:
-                    sanitizeForConvexTransport(widgetSnapshots),
+                  widgetSnapshots: sanitizeForConvexTransport(widgetSnapshots),
                 }
               : {}),
             // PR 6b: browser artifacts already uploaded + sanitized above;

--- a/mcpjam-inspector/server/services/evals/judge-second-pass.ts
+++ b/mcpjam-inspector/server/services/evals/judge-second-pass.ts
@@ -405,23 +405,30 @@ function isPredicateRow(value: unknown): value is StoredPredicateRow {
 }
 
 /**
- * Recover the FIRST derivation's verdict about the model layer from the chain
- * it wrote.
+ * Recover the FIRST derivation's verdict about the model layer.
  *
- * `stepError` is transient runner state — an INPUT to that derivation, never
- * persisted — so the judge second pass re-derived without it and silently
- * dropped `providerError` and the `setup` category the moment a verdict
- * arrived. A run our own provider killed went back to being filed against the
- * server, which is exactly what that reason exists to prevent.
+ * `stepError` is transient runner state — an INPUT to that derivation — so a
+ * second pass that does not receive it derives from strictly less evidence
+ * than the first, and silently drops `providerError` and the `setup` category
+ * the moment a verdict arrives. A run our own provider killed goes back to
+ * being filed against the server, which is what that reason exists to prevent.
  *
- * Read from the stored chain rather than from a new persisted field, because
- * the chain already says it: `providerError` is written if and only if the
- * model layer was classified as the failure, so its presence is a faithful
- * witness of that input. Nothing is invented here.
+ * PREFERRED SOURCE: `metadata.stageStepErrorSource`, written beside the chain
+ * at finalize time. An earlier revision recovered it from the chain alone, on
+ * the stated grounds that "`providerError` is written if and only if the model
+ * layer was classified as the failure". THAT WAS NOT TRUE. `categoryFor`
+ * returns `setup` for a model-call failure where NOTHING failed — there was
+ * nothing to fail against — and on that shape no row is relabelled at all. The
+ * witness was empty exactly when the fact was true, and the category vanished
+ * with no missing row to show for it.
  *
- * `code` and `httpStatus` are not recoverable and are not recovered. They are
- * diagnostics for a reader and were explicitly never part of the
- * classification, so their absence changes no verdict.
+ * The chain scan REMAINS as a fallback, for iterations finalized before the
+ * marker shipped. It is still a faithful witness where it fires; it was only
+ * ever incomplete.
+ *
+ * `code` and `httpStatus` are not recovered by either route. They are
+ * diagnostics for a reader, were never part of the classification, and their
+ * absence changes no verdict.
  */
 export function stepErrorFromStoredChain(
   stageResults: unknown,
@@ -501,7 +508,10 @@ export function deriveIterationPayload(args: {
   // failed.
   const traceUsable = iteration.traceComplete !== false;
 
-  const recoveredStepError = stepErrorFromStoredChain(metadata.stageResults);
+  const recoveredStepError =
+    metadata.stageStepErrorSource === "model"
+      ? ({ source: "model" } as const)
+      : stepErrorFromStoredChain(metadata.stageResults);
 
   const stage = traceUsable
     ? buildStageMetadata({
@@ -510,8 +520,8 @@ export function deriveIterationPayload(args: {
         ...(iteration.prompts?.length ? { prompts: iteration.prompts } : {}),
         ...(iteration.messages?.length ? { messages: iteration.messages } : {}),
         ...(predicateRows.length ? { predicateResults: predicateRows } : {}),
-        // UVH-IN2: recovered from the stored chain, because `stepError` is
-        // transient runner state this pass never receives.
+        // UVH-IN2: read back from the marker the first pass persisted, because
+        // `stepError` is transient runner state this pass never receives.
         ...(recoveredStepError ? { stepError: recoveredStepError } : {}),
         ...(iteration.toolSignals
           ? { toolSignals: iteration.toolSignals }


### PR DESCRIPTION
The persistence half of the attribution work. Self-contained: **no contract change, no version bump, no backend change, no deploy ordering.** The positional half is a separate PR for exactly that reason.

## The false premise

`stepError` is transient runner state — an input to the first derivation, never persisted — so the judge second pass re-derived from strictly less evidence than the first, and dropped `providerError` and the `setup` category the moment a verdict landed. UVH-IN2 patched that by recovering the classification from the stored chain, defending the choice in the docblock:

> Read from the stored chain rather than from a new persisted field, because the chain already says it: `providerError` is written **if and only if** the model layer was classified as the failure.

**That is not true.** `categoryFor` returns `setup` for a model-call failure where *nothing* failed — its own comment says "there was nothing to fail against" — and on that shape `applyProviderError` relabels no row at all.

So the witness was empty exactly when the fact was true. The `setup` category vanished on the second pass with **no missing row to point at**, which is why nothing caught it.

## The fix

The classification is written beside the chain that produced it, as one `stageStepErrorSource` key, and read back directly. The chain scan **stays as a fallback** for iterations finalized before the marker shipped — it was always a faithful witness where it fired, only an incomplete one.

`code` and `httpStatus` are still not recovered by either route. They are diagnostics, were never part of the classification, and persisting them would invite a reader to treat them as evidence.

## Why no backend change

Verified rather than assumed: iteration `metadata` is `v.any()`, and `REPORTED_STAGE_KEYS` in the backend gates only (a) whether *any* stage claim was made and (b) which keys are stripped when a chain is quarantined. It is not an exhaustive validator, so an extra key passes through and survives the round trip.

## Testing, and a mutation that initially failed nothing

| Mutation | Tests that fail |
|---|---|
| Judge pass ignores the marker (back to the proxy) | exactly the test that names it |
| `buildStageMetadata` stops writing the marker | **originally: nothing** |

The second one is worth spelling out. The read-side tests hand the reader a metadata bag directly, so they pass whether or not anything ever *writes* one — the same seam problem as #4524, where a test above the boundary passed with the bug fully present. `buildStageMetadata` is now asserted at the seam too, and the mutation fails.

## One thing that is not mine

`server/utils/harness` has **11 failing tests on clean `main`** right now (Claude Code bridge bootstrap, codex skill parity), from the harness PRs that just landed. I verified the same 11 fail with my changes stashed. Untouched here, flagging in case it is news.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4jTtZJsDeaterEzKwpF2p)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval failure attribution on judge re-derivation; scope is iteration metadata and inspector eval services, with regression tests and a backward-compatible chain fallback.
> 
> **Overview**
> Fixes **judge second-pass** stage re-derivation losing model-layer failure attribution when transient `stepError` is not available.
> 
> **Write path:** `buildStageMetadata` now persists `stageStepErrorSource: "model"` beside the stage chain when the runner classified the fatal error as the model layer. It does **not** write a marker for `setup` or successful runs, so absence stays unambiguous.
> 
> **Read path:** `deriveIterationPayload` prefers that metadata key and only falls back to scanning `stageResults` for a `providerError` reason (legacy iterations). The old chain-only recovery was incomplete: some model failures yield `failureCategory: "setup"` with **no** `providerError` row, so the category disappeared after a judge verdict.
> 
> Tests pin both the finalize **write** seam and the second-pass **read** behavior (including the clean-chain case the scan cannot see). No API or backend contract change—extra iteration metadata only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fc39e3482178e7c2017efb75a03c53d9e0f2a35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The judge second pass now reads the model-layer classification from a persisted marker instead of re-deriving it from the stored chain. The chain recovery was based on a false premise: `providerError` is not written for a model-call failure where nothing failed, so the second pass silently dropped the `setup` category.

- Writes one `stageStepErrorSource` key at finalize time when the source is `model`, and reads it back on the second pass.
- Keeps the chain scan as a fallback for iterations finalized before the marker shipped.
- Does not recover `code` or `httpStatus`; they are diagnostics, not classification evidence.
- No backend or contract change: iteration metadata is an open bag, and `REPORTED_STAGE_KEYS` only gates claim detection and quarantine stripping.
- Removing the write originally failed no tests, so `buildStageMetadata` now asserts the marker at the seam.

<sup>Written for commit 0fc39e3482178e7c2017efb75a03c53d9e0f2a35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

