### PR TITLE
ci: put dependency updates on rails

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,11 @@ version: 2
 updates:
   # --------------------------------------------------------------- workspace
   - package-ecosystem: npm
-    directory: "/"
+    directories:
+      - "/"
+      # Standalone: has its own committed manifest + lockfile and is NOT a root
+      # npm workspace, so the workspace entry above does not cover it.
+      - "/mcpjam-inspector/test-servers/mcp-check-fixture"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,78 @@
+# Dependabot configuration.
+#
+# Why this file exists: before it landed, this repo raised alerts but never
+# acted on them. Dependabot security updates were off and no config existed,
+# so a critical protobufjs RCE advisory sat open for 124 days (2026-04-16 →
+# 2026-08-18) and was cleared only because a human happened to look. Alerts
+# without update PRs are a reporting system, not a remediation one.
+#
+# Grouping is load-bearing, not cosmetic. There are ~400 open alerts; turning
+# security updates on WITHOUT groups opens a PR per advisory, and a flood of
+# several hundred PRs gets ignored in exactly the way the alerts did.
+
+version: 2
+updates:
+  # --------------------------------------------------------------- workspace
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      production-dependencies:
+        applies-to: version-updates
+        dependency-type: production
+        update-types: [minor, patch]
+      development-dependencies:
+        applies-to: version-updates
+        dependency-type: development
+        update-types: [minor, patch]
+      # Security updates group separately so an advisory PR is never queued
+      # behind a routine version bump.
+      security-production:
+        applies-to: security-updates
+        dependency-type: production
+      security-development:
+        applies-to: security-updates
+        dependency-type: development
+    # Deliberately NO `ignore` rules for electron / sharp majors. `ignore`
+    # suppresses SECURITY updates as well as version updates, so such a rule
+    # would have hidden the Electron 37 → 43 bump (#4081) that cleared 31
+    # advisories. Those packages are held back from AUTO-MERGE instead — see
+    # dependabot-auto-merge.yml — so a human reads them, never so they vanish.
+
+  # ------------------------------------------------------------ example apps
+  # Each example ships its own lockfile, so each is a separate Dependabot
+  # target. Together they are ~70% of open-alert volume while shipping nothing
+  # to users, which is why extracting them to a public examples repo is under
+  # discussion. Keep this block contiguous so it deletes in one cut.
+  - package-ecosystem: npm
+    directories:
+      - "/examples/conformance/basic"
+      - "/examples/evals/asana"
+      - "/examples/evals/brightdata"
+      - "/examples/mcp-apps/express-react-template"
+      - "/examples/mcp-apps/flashcards-supabase"
+      - "/examples/mcp-apps/reservation-app"
+      - "/examples/mcp-apps/sip-cocktails"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      example-dependencies:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: [minor, patch]
+      example-security:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  # --------------------------------------------------------- GitHub Actions
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,172 @@
+name: Dependabot Auto-merge
+
+# Takes exactly ONE action on every Dependabot PR:
+#   - MERGE  -> approve + `gh pr merge --auto --squash`, so it lands only
+#              after the required checks ("Build and Test", "Run Tests") pass.
+#   - HOLD   -> leave it open for a human and say, in one line, why.
+#
+# Scope is deliberately narrow. Auto-merging dependency PRs ships code into
+# deployed services and the desktop app, so only two classes qualify:
+# security updates, and patch/minor bumps of DEVELOPMENT dependencies. Every
+# major, every runtime version bump, and anything touching the Electron /
+# native packaging chain is held for a person.
+
+on:
+  # `pull_request_target`, NOT `pull_request`. Workflows that Dependabot
+  # triggers via `pull_request` run with a read-only GITHUB_TOKEN regardless
+  # of the `permissions:` block below, so `gh pr merge` would 403 — and that
+  # failure is easy to miss. `pull_request_target` runs in base-branch context
+  # with a writable token.
+  #
+  # `pull_request_target` is dangerous when a job checks out and EXECUTES the
+  # PR's code, because that code would run with those write permissions. This
+  # job never does: there is no `actions/checkout` step anywhere below, and
+  # none may be added. It reads metadata through the API and nothing else.
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  decide:
+    # Gate on the PR author, not `github.actor`, which is spoofable and is the
+    # human rather than the bot on a reopen — same reasoning as
+    # mintlify-triage.yml.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # enable auto-merge
+      pull-requests: write # approve / comment
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Metadata reaches the shell through `env:`, never through `${{ }}`
+      # interpolated directly into the script, so a crafted dependency name
+      # cannot break out into the runner shell.
+      - name: Decide the outcome
+        id: decide
+        env:
+          NAMES: ${{ steps.meta.outputs.dependency-names }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEP_TYPE: ${{ steps.meta.outputs.dependency-type }}
+          GHSA: ${{ steps.meta.outputs.ghsa-id }}
+        run: |
+          set -euo pipefail
+
+          # The desktop packaging chain. `electron-forge package` is NOT
+          # exercised by any required check — desktop-package-smoke.yml is
+          # path-filtered and advisory — so a green PR proves the app still
+          # builds, never that it still packages. These stay manual until
+          # that smoke job is a required check.
+          hold_desktop=false
+          IFS=',' read -ra pkgs <<<"$NAMES"
+          for raw in "${pkgs[@]}"; do
+            pkg="$(echo "$raw" | tr -d '[:space:]')"
+            case "$pkg" in
+              electron | sharp | @electron/* | @electron-forge/*)
+                hold_desktop=true
+                ;;
+            esac
+          done
+
+          if [ "$hold_desktop" = true ]; then
+            action=hold
+            reason="touches the Electron/native packaging chain, which no required check exercises"
+          elif [ "$UPDATE_TYPE" = "version-update:semver-major" ]; then
+            action=hold
+            reason="major version update"
+          elif [ -n "$GHSA" ]; then
+            action=merge
+            reason="security update ($GHSA)"
+          elif [ "$DEP_TYPE" = "direct:development" ] && \
+               { [ "$UPDATE_TYPE" = "version-update:semver-patch" ] || \
+                 [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; }; then
+            action=merge
+            reason="dev-dependency ${UPDATE_TYPE#version-update:semver-} update"
+          else
+            action=hold
+            reason="runtime dependency version update"
+          fi
+
+          echo "action=$action" >>"$GITHUB_OUTPUT"
+          echo "reason=$reason" >>"$GITHUB_OUTPUT"
+          echo "Decision: $action — $reason (names=$NAMES type=$DEP_TYPE update=$UPDATE_TYPE)"
+
+      # The approval is the second half of the MERGE decision, not a general
+      # bypass: the "Standard BC" ruleset on main requires 1 approving review,
+      # so without it an auto-merge queue never drains. It is posted by
+      # github-actions[bot], only in this workflow, only for the narrow classes
+      # decided above, and never by the PR author.
+      - name: Approve and queue for auto-merge
+        if: steps.decide.outputs.action == 'merge'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          REASON: ${{ steps.decide.outputs.reason }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/$REPO/pulls/$PR/reviews" \
+            -f event=APPROVE \
+            -f body="Auto-approved: $REASON. Queued for auto-merge; it lands only once the required checks pass." >/dev/null
+          gh pr merge "$PR" --repo "$REPO" --auto --squash
+
+      - name: Explain the hold
+        # Only on the first look. `synchronize` fires on every Dependabot
+        # rebase, and re-commenting each time would bury the PR in noise.
+        if: steps.decide.outputs.action == 'hold' && github.event.action != 'synchronize'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          REASON: ${{ steps.decide.outputs.reason }}
+        run: |
+          set -euo pipefail
+          gh pr comment "$PR" --repo "$REPO" \
+            --body "Held for human review: $REASON. Auto-merge covers security updates and patch/minor dev-dependency bumps only."
+
+      # A run that reaches no outcome must be loud. mintlify-triage.yml learned
+      # this the hard way: a step that soft-skips exits 0 and reports a green
+      # check having done nothing, which is strictly worse than a red X because
+      # nobody can tell it apart from a real decision.
+      - name: Enforce an outcome
+        # Not success(): a soft-skip exits 0. Not always(): `cancel-in-progress`
+        # means a superseded run has legitimately reached no outcome.
+        if: ${{ !cancelled() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          ACTION: ${{ steps.decide.outputs.action }}
+        run: |
+          set -euo pipefail
+          pr=$(gh api "repos/$REPO/pulls/$PR")
+          queued=$(jq -r '.auto_merge != null' <<<"$pr")
+          merged=$(jq -r '.merged' <<<"$pr")
+
+          case "$ACTION" in
+            merge)
+              if [ "$queued" = "true" ] || [ "$merged" = "true" ]; then
+                echo "Outcome: MERGE — auto-merge queued (or already landed)."
+              else
+                echo "::error title=Auto-merge never queued::PR #$PR was classified MERGE but has no auto-merge enabled. Check the approve/queue step — a silent 403 there is the likely cause, which would mean this workflow is running with a read-only token."
+                exit 1
+              fi
+              ;;
+            hold)
+              echo "Outcome: HOLD — left for human review."
+              ;;
+            *)
+              echo "::error title=No decision reached::The classify step produced no action for PR #$PR, so neither MERGE nor HOLD ran."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -43,11 +43,23 @@ jobs:
       pull-requests: write # approve / comment
 
     steps:
+      # Pinned to a full commit SHA, not a moving tag: this job holds
+      # `contents: write` and can approve PRs, so a compromised tag would
+      # inherit both. Update the pin deliberately.
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # `ghsa-id` is populated ONLY when `alert-lookup` is on, and the
+          # lookup needs a PAT or App token — GITHUB_TOKEN cannot read
+          # Dependabot alerts. So this is wired to an optional secret: without
+          # it the workflow still runs and security PRs simply fall through to
+          # the runtime-update hold (a human reads them, nothing is lost); add
+          # DEPENDABOT_ALERTS_TOKEN and security auto-merge lights up with no
+          # further edit. Without this wiring the security branch below would
+          # be dead code that silently never fires.
+          alert-lookup: ${{ secrets.DEPENDABOT_ALERTS_TOKEN != '' }}
+          github-token: ${{ secrets.DEPENDABOT_ALERTS_TOKEN || secrets.GITHUB_TOKEN }}
 
       # Metadata reaches the shell through `env:`, never through `${{ }}`
       # interpolated directly into the script, so a crafted dependency name
@@ -59,6 +71,7 @@ jobs:
           UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
           DEP_TYPE: ${{ steps.meta.outputs.dependency-type }}
           GHSA: ${{ steps.meta.outputs.ghsa-id }}
+          ALERT_LOOKUP: ${{ secrets.DEPENDABOT_ALERTS_TOKEN != '' }}
         run: |
           set -euo pipefail
 
@@ -95,6 +108,11 @@ jobs:
           else
             action=hold
             reason="runtime dependency version update"
+            if [ "$ALERT_LOOKUP" != "true" ]; then
+              # Be explicit rather than letting a security PR look like a
+              # routine bump: without the token we cannot tell them apart.
+              reason="$reason (security detection off — no DEPENDABOT_ALERTS_TOKEN)"
+            fi
           fi
 
           echo "action=$action" >>"$GITHUB_OUTPUT"
@@ -120,19 +138,32 @@ jobs:
             -f body="Auto-approved: $REASON. Queued for auto-merge; it lands only once the required checks pass." >/dev/null
           gh pr merge "$PR" --repo "$REPO" --auto --squash
 
-      - name: Explain the hold
-        # Only on the first look. `synchronize` fires on every Dependabot
-        # rebase, and re-commenting each time would bury the PR in noise.
-        if: steps.decide.outputs.action == 'hold' && github.event.action != 'synchronize'
+      - name: Hold for human review
+        if: steps.decide.outputs.action == 'hold'
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           REASON: ${{ steps.decide.outputs.reason }}
+          EVENT: ${{ github.event.action }}
         run: |
           set -euo pipefail
-          gh pr comment "$PR" --repo "$REPO" \
-            --body "Held for human review: $REASON. Auto-merge covers security updates and patch/minor dev-dependency bumps only."
+
+          # Dependabot rewrites an existing PR in place when a newer version
+          # lands, so a PR queued as a patch on `opened` can come back as a
+          # major on `synchronize`. Without this, the earlier queue survives
+          # the reclassification and merges the thing we just decided to hold.
+          if [ "$(gh api "repos/$REPO/pulls/$PR" --jq '.auto_merge != null')" = "true" ]; then
+            gh pr merge "$PR" --repo "$REPO" --disable-auto
+            echo "Disabled a previously queued auto-merge after reclassification."
+          fi
+
+          # Comment only on the first look: `synchronize` fires on every
+          # Dependabot rebase and re-commenting would bury the PR in noise.
+          if [ "$EVENT" != "synchronize" ]; then
+            gh pr comment "$PR" --repo "$REPO" \
+              --body "Held for human review: $REASON. Auto-merge covers security updates and patch/minor dev-dependency bumps only."
+          fi
 
       # A run that reaches no outcome must be loud. mintlify-triage.yml learned
       # this the hard way: a step that soft-skips exits 0 and reports a green
@@ -163,6 +194,10 @@ jobs:
               fi
               ;;
             hold)
+              if [ "$queued" = "true" ]; then
+                echo "::error title=Held PR still queued::PR #$PR was classified HOLD but auto-merge is still enabled, so it will merge without review. The disable step above did not take effect."
+                exit 1
+              fi
               echo "Outcome: HOLD — left for human review."
               ;;
             *)

--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -1,0 +1,89 @@
+name: Desktop Package Smoke
+
+# Closes a blind spot: `electron-forge package` is exercised nowhere before a
+# release. mac-release.yml / windows-release.yml are `workflow_call` targets
+# reached only through release.yml, which is `workflow_dispatch` and publishes
+# real artifacts — so until this job existed, a dependency bump could go green
+# on "Build and Test" + "Run Tests" and still break packaging, discovered only
+# at release time. Electron 37 → 43 (#4081) merged with exactly that gap open.
+#
+# Path-filtered and advisory for now: it is NOT in the required-checks ruleset.
+# Promoting it to required is what would let the Electron/native packaging
+# chain come off the auto-merge hold list in dependabot-auto-merge.yml.
+
+on:
+  pull_request:
+    paths:
+      - "package-lock.json"
+      - "mcpjam-inspector/package.json"
+      - "mcpjam-inspector/forge.config.ts"
+      - "mcpjam-inspector/src/main.ts"
+      - "mcpjam-inspector/src/preload.ts"
+      - "mcpjam-inspector/vite.main.config.ts"
+      - "mcpjam-inspector/vite.preload.config.ts"
+      - "mcpjam-inspector/vite.renderer.config.mts"
+      - ".github/workflows/desktop-package-smoke.yml"
+
+concurrency:
+  group: desktop-package-smoke-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "24.14.0"
+
+jobs:
+  package:
+    name: Desktop Package Smoke
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      # forge's extraResource points at dist/client, .env.production and
+      # sdk/dist, so the app build has to precede packaging — same order
+      # mac-release.yml uses. NODE_OPTIONS is not optional: without it the
+      # main-process Vite bundle OOMs at node's ~4GB default heap.
+      - name: Build application
+        run: npm run build -w @mcpjam/inspector
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+
+      # `package`, not `make`: this proves the .app assembles (vite main /
+      # preload / renderer builds, asar packing, the fuses plugin) without
+      # spending release-length time on DMG and installer makers.
+      #
+      # No signing secrets are needed. forge.config.ts degrades osxSign and
+      # osxNotarize to `undefined` when MAC_CODESIGN_IDENTITY is unset, so this
+      # produces an unsigned bundle instead of failing — which also means the
+      # job runs on PRs from forks.
+      - name: Package application
+        run: npm run electron:package -w @mcpjam/inspector
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+
+      # A green step that produced nothing is the failure mode worth guarding:
+      # forge has exited 0 without writing out/ before.
+      - name: Assert the app bundle exists
+        working-directory: mcpjam-inspector
+        run: |
+          set -euo pipefail
+          app=$(find out -maxdepth 2 -name "*.app" -print -quit)
+          if [ -z "$app" ]; then
+            echo "::error title=No .app produced::electron-forge package exited 0 but wrote no bundle under mcpjam-inspector/out/."
+            ls -la out 2>/dev/null || echo "(out/ does not exist)"
+            exit 1
+          fi
+          echo "Packaged: $app"
+          du -sh "$app"

--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -22,6 +22,12 @@ on:
       - "mcpjam-inspector/vite.main.config.ts"
       - "mcpjam-inspector/vite.preload.config.ts"
       - "mcpjam-inspector/vite.renderer.config.mts"
+      # Packaging inputs forge reads directly: extraResource (.env.production),
+      # the icons and entitlements under assets/, and the module forge.config
+      # imports for the Sentry build surface.
+      - "mcpjam-inspector/.env.production"
+      - "mcpjam-inspector/assets/**"
+      - "mcpjam-inspector/shared/sentry-config.ts"
       - ".github/workflows/desktop-package-smoke.yml"
 
 concurrency:
@@ -79,7 +85,10 @@ jobs:
         working-directory: mcpjam-inspector
         run: |
           set -euo pipefail
-          app=$(find out -maxdepth 2 -name "*.app" -print -quit)
+          # `|| true`: with `set -e` a failing find (no out/ at all — exactly
+          # the case this step exists to report) would abort the step before
+          # the diagnostic below ever printed.
+          app=$(find out -maxdepth 2 -name "*.app" -print -quit 2>/dev/null || true)
           if [ -z "$app" ]; then
             echo "::error title=No .app produced::electron-forge package exited 0 but wrote no bundle under mcpjam-inspector/out/."
             ls -la out 2>/dev/null || echo "(out/ does not exist)"


### PR DESCRIPTION
Dependency updates have no mechanism today. Security updates are **off**, there is no `dependabot.yml`, and the result was measurable: a critical `protobufjs` RCE advisory sat open **124 days** (2026-04-16 → 2026-08-18) and cleared only because someone happened to look. Alerts without update PRs are a reporting system, not a remediation one.

Three files, designed to land in this order.

## 1. `.github/dependabot.yml`

Grouped weekly updates for the workspace, the seven example projects that carry their own lockfiles, and GitHub Actions.

**Grouping is load-bearing, not cosmetic.** With ~400 open alerts, enabling security updates *ungrouped* opens a PR per advisory — and several hundred PRs get ignored in exactly the way the alerts did.

**No `ignore` rules for `electron`/`sharp` majors**, deliberately. `ignore` suppresses *security* updates as well as version updates, so such a rule would have hidden the Electron 37 → 43 bump (#4081) that cleared 31 advisories. Those packages are kept off the **auto-merge** list instead — read by a human, never invisible.

## 2. `.github/workflows/dependabot-auto-merge.yml`

One outcome per PR: approve + `gh pr merge --auto --squash` (lands only after "Build and Test" and "Run Tests" pass), or hold with a one-line reason.

| Auto-merged | Held for a human |
| --- | --- |
| Security updates | Any major |
| Patch/minor **dev** dependencies | Runtime version bumps |
| | `electron`, `sharp`, `@electron/*`, `@electron-forge/*` |

Two mechanics worth reviewing closely:

**`pull_request_target`, not `pull_request`.** Dependabot-triggered `pull_request` workflows get a read-only `GITHUB_TOKEN` regardless of the `permissions:` block, so `gh pr merge` would 403. `pull_request_target` runs in base-branch context with a writable token. That trigger is only safe because **the job never checks out or executes PR code** — there is no `actions/checkout` step, and the comment says none may be added. Metadata reaches the shell via `env:`, never interpolated into the script, so a crafted dependency name cannot break out.

**It approves.** The "Standard BC" ruleset requires 1 approving review, so without an approval the auto-merge queue never drains. Same pattern `mintlify-triage.yml` uses, narrowly job-gated, posted by `github-actions[bot]`. Confirmed working in this repo — `github-actions[bot]` approved #4523.

A no-decision run fails loudly rather than reporting green, which is the lesson `mintlify-triage.yml` learned the hard way (its lines 74-83).

## 3. `.github/workflows/desktop-package-smoke.yml`

`electron-forge package` on `macos-latest`, path-filtered to files that can break packaging.

Nothing exercises packaging before a release today: `mac-release.yml` / `windows-release.yml` are `workflow_call` targets reachable only through a `workflow_dispatch` that publishes real artifacts. So a green PR proves the app **builds**, never that it **packages** — Electron 37 → 43 merged with exactly that gap open. Needs no signing secrets (`forge.config.ts` degrades `osxSign`/`osxNotarize` to `undefined` when `MAC_CODESIGN_IDENTITY` is unset), so it runs on fork PRs too, and it asserts an `.app` actually exists rather than trusting a green exit.

Advisory, not required, for now. **Promoting it to a required check is what would let the Electron chain come off the auto-merge hold list.**

## Verification

- All three parse; `actionlint` clean on both workflows
- The seven configured example directories match the seven lockfiles on disk exactly (no missing, no extras)
- Referenced check names match `lint.yml` (`Build and Test`) and `test.yml` (`Run Tests`)

## After merge

Enable Dependabot security updates in repo settings — **after** this lands, so the first wave arrives grouped. That setting is the actual fix; these files just make it safe to turn on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New `pull_request_target` workflow can approve and auto-merge PRs with write permissions (mitigated by no checkout and narrow bot-only rules); misconfiguration of `DEPENDABOT_ALERTS_TOKEN` or hold logic could merge or block the wrong dependency classes.
> 
> **Overview**
> Adds **Dependabot** with weekly, **grouped** npm updates for the root workspace (plus `mcp-check-fixture`), seven example lockfile trees, and GitHub Actions—aimed at turning alerts into bounded PR volume instead of hundreds of one-off advisories. It deliberately avoids `ignore` rules on `electron`/`sharp` so security bumps stay visible; risky packages are gated in auto-merge instead.
> 
> Introduces **`dependabot-auto-merge.yml`**: on Dependabot PRs only, either **approve + queue squash auto-merge** (after existing **Build and Test** / **Run Tests**) for security fixes and patch/minor **dev** deps, or **hold** with a comment for majors, runtime bumps, and Electron/native packaging deps. Uses `pull_request_target` without checkout, optional `DEPENDABOT_ALERTS_TOKEN` for GHSA detection, and fails the job if merge/hold outcomes don’t match reality (e.g. stale auto-merge after reclassification).
> 
> Adds **`desktop-package-smoke.yml`**: path-filtered macOS job that builds and runs `electron-forge package`, then asserts a `.app` exists—advisory coverage for packaging before release; promoting it to required is the path to relaxing Electron holds in auto-merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bece9bbaf41f78951acd8364124f75fbf59d9a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns on grouped Dependabot updates with auto-merge policies that keep risk low, and adds a desktop packaging smoke test so dependency bumps can't break packaging silently.

- Configures weekly grouped updates for the workspace, seven example lockfiles, the `mcp-check-fixture` test server, and GitHub Actions.
- Auto-merges security updates and patch/minor dev-dependency bumps; holds majors, runtime bumps, and `electron`/`sharp`/`@electron/*`/`@electron-forge/*` for human review, and disables any auto-merge queued before a reclassification.
- Security detection is wired to an optional `DEPENDABOT_ALERTS_TOKEN`; absent, security PRs hold with an explicit note, and the metadata action is pinned to a commit SHA.
- Runs on `pull_request_target` but never checks out or executes PR code, so the writable token can't be abused.
- Adds a macOS `electron-forge package` smoke test, path-filtered to packaging inputs, and asserts an `.app` bundle exists.
- After merge, enable Dependabot security updates in repo settings so the first wave arrives already grouped.

<sup>Written for commit 2bece9bbaf41f78951acd8364124f75fbf59d9a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

