### PR TITLE
test: BehaviorTab expects the approval switch enabled for claude-code

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/BehaviorTab.harness.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/BehaviorTab.harness.test.tsx
@@ -47,15 +47,20 @@ describe("BehaviorTab harness gray-out", () => {
     ).not.toHaveAttribute("readonly");
   });
 
-  it("disables approval / visibility until their proxy phase lands", () => {
+  it("leaves approval EDITABLE for claude-code now that its proxy phase landed", () => {
+    // The adapter bridge's `canUseTool` gates every surface — built-ins,
+    // host-executed tools, and (under `approvalPermissionMode: "allow-reads"`)
+    // the MCP tools the in-sandbox client calls — so `requireToolApproval` is
+    // enforced for claude-code (#4531) and the switch must not gray out or
+    // carry the old "refused rather than run unapproved" note.
     renderBehaviorTab({ harness: "claude-code" });
 
     expect(
       screen.getByRole("switch", { name: /require tool approval/i }),
-    ).toBeDisabled();
+    ).toBeEnabled();
     expect(
-      screen.getByRole("switch", { name: /respect tool visibility/i }),
-    ).toBeDisabled();
+      screen.queryByText(/refused rather than run unapproved/i),
+    ).not.toBeInTheDocument();
   });
 
   it("shows progressive discovery as off for harness hosts even if an old draft says on", () => {


### PR DESCRIPTION
## Why

`test.yml` has been red on main since #4531 merged, which is holding the release (Soundcheck verdict: Hold — CI isn't green for 8a5fe93).

#4531 intentionally flipped `requireToolApproval` for claude-code to `ENFORCED` — the adapter bridge's `canUseTool` now gates MCP-server tools under `approvalPermissionMode: "allow-reads"` — and updated the capability-table unit test, but missed this component-level test, which still asserted the approval switch stays grayed out ("until their proxy phase lands").

## What

Replace the stale assertion with the new reality: for a claude-code host the **Require tool approval** switch is enabled and the old "refused rather than run unapproved" note is gone. Tool visibility staying gated for claude-code is already covered by its own test in this file, so the bundled visibility assertion isn't duplicated.

## Verification

`npx vitest run client/src/components/hosts/redesigned/focus/__tests__/BehaviorTab.harness.test.tsx` — 6/6 pass (was 5/6 on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rmkL1Ux7fRn2P3YshkCCY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change aligning expectations with already-shipped claude-code approval behavior; no runtime logic modified.
> 
> **Overview**
> Updates the **BehaviorTab** harness test to match post-#4531 behavior for **claude-code** hosts: **Require tool approval** is now expected to be **enabled** (not grayed out), and the stale “refused rather than run unapproved” copy is expected to be **absent**.
> 
> The test is renamed and its comments explain that approval is enforced via the adapter bridge’s `canUseTool` gating. The bundled assertion that **respect tool visibility** stays disabled for claude-code is removed here because that case is already covered by a dedicated test in the same file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2464d7722b5cada5b34da3011680fba6478a3fb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the claude-code harness test to expect the require tool approval switch to be enabled, matching the behavior change from #4531. The test was still asserting the old grayed-out state, leaving `test.yml` red on main and blocking the release.

<sup>Written for commit 2464d7722b5cada5b34da3011680fba6478a3fb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

