### PR TITLE
Only signal a process group we can still prove is ours

### DIFF
--- a/mcpjam-inspector/server/utils/harness/local/README.md
+++ b/mcpjam-inspector/server/utils/harness/local/README.md
@@ -253,15 +253,23 @@ becomes exactly such an entry under a `hidepid` mount, and exempting the error
 then reports the tree gone while it is running.
 
 The trade is a fail-OPEN safety hole against a fail-CLOSED functional one. On a
-`hidepid` mount the probe will answer `unknown` often, so stops report unproven
-and the janitor retains records — noisy, but the termination itself is
-unaffected: an unprovable group escalates to `SIGKILL` exactly as a live one
-does, and only the reporting and the record retention change. That last part was
-briefly untrue — the `unknown` branch returned _above_ the escalation, so a
-child ignoring `SIGTERM` was never force-killed — which is why it is now pinned
-by a test rather than asserted in a comment. Given that this file exists
-because the same trade kept being made the wrong way round, it is made the other
-way here.
+`hidepid` mount the probe answers `unknown` often, so stops report unproven and
+the janitor retains records rather than reclaiming them. Given that this file
+exists because the same trade kept being made the wrong way round, it is made
+the other way here.
+
+An unprovable group is **not** force-killed either, and the reason is narrow.
+Every caller of `settleGroup` has already proven the ROOT is gone, so its pid is
+free for reuse; what makes `kill(-pid)` safe anyway is that a pid serving as a
+process-GROUP id is not reissued _while that group has members_ — a guarantee
+about a non-empty group, and `unknown` is exactly the failure to establish it.
+So the general rule that `unknown` gates reporting rather than action does not
+reach this signal: the action needs the very fact `unknown` is missing. `live`
+is different, and does escalate.
+
+This line has been written both ways within a day, so both directions are now
+pinned by tests, and each was checked to fail against the opposite behaviour
+rather than merely to pass against the current one.
 
 ### "Gone" and "cannot tell" are different answers
 

--- a/mcpjam-inspector/server/utils/harness/local/README.md
+++ b/mcpjam-inspector/server/utils/harness/local/README.md
@@ -264,12 +264,53 @@ free for reuse; what makes `kill(-pid)` safe anyway is that a pid serving as a
 process-GROUP id is not reissued _while that group has members_ — a guarantee
 about a non-empty group, and `unknown` is exactly the failure to establish it.
 So the general rule that `unknown` gates reporting rather than action does not
-reach this signal: the action needs the very fact `unknown` is missing. `live`
-is different, and does escalate.
+reach this signal: the action needs the very fact `unknown` is missing.
 
-This line has been written both ways within a day, so both directions are now
-pinned by tests, and each was checked to fail against the opposite behaviour
-rather than merely to pass against the current one.
+`live` is necessary but not sufficient, and the first version of this paragraph
+got that wrong — it read the rule as making a non-empty group's id proof that
+the group was ours. It is not. The rule is about the FUTURE of a group that
+still has a member: from that moment its id cannot be reissued underneath us. It
+says nothing about a group that emptied. Once ours emptied its id went free, and
+any unrelated process could have taken that pid, made itself a group leader and
+exited, leaving a live group wearing our recorded id with nothing of ours in it
+— which is what an ordinary shell pipeline whose first stage exits early, or a
+double-forking daemon, leaves behind. So `live` says a group with this id
+exists, not that it is ours.
+
+What makes it ours is an **anchor**: a moment at which the group was known to be
+ours _and_ non-empty. A stranger's group carrying our id can only have been
+created after ours emptied, so it cannot predate the anchor. Inside a single
+termination call there is one — the root was verified alive and carrying its
+recorded birth identity just before being signalled, and a leader belongs to its
+own group — and only the grace window separates it from the probe.
+
+Two paths have no anchor at all, and neither signals now:
+
+- `settleGroup` reached with the root already gone on its FIRST look. Nothing in
+  that call ever saw the tree; the group is reported, not signalled.
+- The janitor's dead-root branch. It only runs for a record whose owning
+  supervisor has provably exited, so arbitrary time has passed since anything of
+  ours was in that group. It reports `escaped` and keeps the record.
+
+That costs a real capability: a stray left behind by a harness that exited on
+its own is no longer swept at `stopSession`. It is reported and its record
+retained instead, which an operator can act on — the trade being that an
+unswept survivor you can see beats a `SIGKILL` delivered to whoever now holds
+the id. Restoring the sweep soundly needs per-MEMBER identity rather than a
+group signal: enumerate the group once at the instant the root exits, while its
+id provably still belongs to us, record each member's pid and birth identity,
+and then verify each with `isSameProcess` before signalling it individually.
+That is immune to pid reuse; it is also a new platform primitive plus supervisor
+plumbing, and is not implemented yet.
+
+Even the anchored signal is bounded rather than airtight: our group could empty
+and its id be reissued inside the grace window. That needs the pid space to wrap
+within a few seconds, and ruling it out needs the same per-member identity proof.
+It is stated here rather than papered over.
+
+These lines have been written both ways, so every direction is pinned by tests,
+and each was checked to fail against the opposite behaviour rather than merely
+to pass against the current one.
 
 ### "Gone" and "cannot tell" are different answers
 

--- a/mcpjam-inspector/server/utils/harness/local/__tests__/process-identity.test.ts
+++ b/mcpjam-inspector/server/utils/harness/local/__tests__/process-identity.test.ts
@@ -224,45 +224,130 @@ describe("terminating a tree we own", () => {
   );
 });
 
-describe("escalating when the group cannot be read", () => {
+/**
+ * A root that exits on SIGTERM, with a descendant in its group that ignores it.
+ *
+ * The descendant announces itself only AFTER installing its handler, and the
+ * root relays its pid only after that — without the handshake, the SIGTERM
+ * that starts termination can land before the handler is registered and kill
+ * the descendant by default action, which quietly turns these tests into
+ * something that measures nothing.
+ */
+const DESERTING_ROOT = [
+  "const{spawn}=require('node:child_process');",
+  "const k=spawn(process.execPath,['-e',",
+  JSON.stringify(
+    "process.on('SIGTERM',function(){});console.log('ready');" +
+      "setInterval(()=>{},1000)",
+  ),
+  "],{stdio:['ignore','pipe','ignore']});",
+  "k.stdout.once('data',function(){console.log(k.pid)});",
+  "process.on('SIGTERM',function(){process.exit(0)});",
+  "setInterval(()=>{},1000);",
+].join("");
+
+/** Poll until `pid` is provably gone, or give up. */
+async function waitForGone(pid: number, timeoutMs = 6_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if ((await probeProcess(pid)).state === "gone") return true;
+    if (Date.now() >= deadline) return false;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+describe("a group that cannot be enumerated", () => {
   it.skipIf(!supportsOwnershipProof())(
-    "still SIGKILLs a group it could not enumerate",
+    "reports unknown and does NOT signal a group it cannot prove",
     async () => {
-      // The regression: `settleGroup` returned `unknown` BEFORE the escalation,
-      // so a descendant that ignored SIGTERM survived with no SIGKILL ever
-      // sent whenever the group probe could not enumerate. Not knowing whether
-      // a survivor exists is a reason to make sure, not to walk away.
+      // Shaped so that ONLY `settleGroup` could do the killing: the root exits
+      // on SIGTERM, so the grace loop returns through `settleGroup("graceful")`
+      // before the main flow's own SIGKILL is ever reached. A descendant that
+      // ignores SIGTERM is therefore still alive at that point, and whether it
+      // dies tells us exactly what `settleGroup` did.
+      //
+      // It must NOT die here. Every caller of `settleGroup` has already proven
+      // the root gone, so its pid is reusable; `kill(-pid)` is only safe
+      // because a group id is not reissued while the group has members, and
+      // `unknown` is the failure to establish that. Signalling anyway risks a
+      // stranger's group.
       const { spawn } = await import("node:child_process");
-      const child = spawn(
-        process.execPath,
-        ["-e", "process.on('SIGTERM',function(){});setInterval(()=>{},1000)"],
-        { detached: true, stdio: "ignore" },
+      const root = spawn(process.execPath, ["-e", DESERTING_ROOT], {
+        detached: true,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      const pid = root.pid!;
+      const descendant = Number(
+        await new Promise<string>((resolve) => {
+          root.stdout!.once("data", (d: Buffer) =>
+            resolve(d.toString().trim()),
+          );
+        }),
       );
-      const pid = child.pid!;
+      expect(descendant).toBeGreaterThan(0);
       try {
         const identity = await readProcessBirthIdentity(pid);
         const outcome = await terminateOwnedProcessGroup({
           pid,
           birthIdentity: identity!,
-          graceMs: 200,
+          graceMs: 2_000,
           pollMs: 25,
           // Always unprovable, as an unreadable /proc would be.
           probeGroup: async () => "unknown",
         });
         expect(outcome.outcome).toBe("unknown");
-        // ...and the tree is gone anyway, because the kill still happened.
-        const deadline = Date.now() + 4_000;
-        let probe = await probeProcess(pid);
-        while (probe.state !== "gone" && Date.now() < deadline) {
-          await new Promise((r) => setTimeout(r, 25));
-          probe = await probeProcess(pid);
-        }
-        expect(probe.state).toBe("gone");
+        // The root cooperated and is gone...
+        expect(await waitForGone(pid)).toBe(true);
+        // ...and the descendant was left alone rather than signalled on an
+        // unverifiable group id.
+        expect((await probeProcess(descendant)).state).toBe("alive");
       } finally {
-        try {
-          process.kill(-pid, "SIGKILL");
-        } catch {
-          /* already gone */
+        for (const victim of [descendant, pid]) {
+          try {
+            process.kill(victim, "SIGKILL");
+          } catch {
+            /* already gone */
+          }
+        }
+      }
+    },
+  );
+
+  it.skipIf(!supportsOwnershipProof())(
+    "DOES force-kill a group it can prove still has a member",
+    async () => {
+      // The counterpart: `live` proves the group is non-empty, which is exactly
+      // the fact that makes its id un-reissuable and the signal ours to send.
+      const { spawn } = await import("node:child_process");
+      const root = spawn(process.execPath, ["-e", DESERTING_ROOT], {
+        detached: true,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      const pid = root.pid!;
+      const descendant = Number(
+        await new Promise<string>((resolve) => {
+          root.stdout!.once("data", (d: Buffer) =>
+            resolve(d.toString().trim()),
+          );
+        }),
+      );
+      try {
+        const identity = await readProcessBirthIdentity(pid);
+        const outcome = await terminateOwnedProcessGroup({
+          pid,
+          birthIdentity: identity!,
+          graceMs: 2_000,
+          pollMs: 25,
+        });
+        expect(["forced", "graceful"]).toContain(outcome.outcome);
+        expect(await waitForGone(descendant)).toBe(true);
+      } finally {
+        for (const victim of [descendant, pid]) {
+          try {
+            process.kill(victim, "SIGKILL");
+          } catch {
+            /* already gone */
+          }
         }
       }
     },

--- a/mcpjam-inspector/server/utils/harness/local/__tests__/process-identity.test.ts
+++ b/mcpjam-inspector/server/utils/harness/local/__tests__/process-identity.test.ts
@@ -246,6 +246,20 @@ const DESERTING_ROOT = [
   "setInterval(()=>{},1000);",
 ].join("");
 
+/**
+ * A detached group leader that spawns one long-lived grandchild, reports its
+ * pid and then idles. Killing the leader leaves the GROUP live with its leader
+ * gone — the shape in which a recorded pgid can no longer be tied to us.
+ */
+const LEADER_WITH_SURVIVOR = [
+  "const{spawn}=require('node:child_process');",
+  "const k=spawn(process.execPath,['-e',",
+  JSON.stringify("setInterval(()=>{},1000)"),
+  "],{stdio:'ignore'});",
+  "console.log(k.pid);",
+  "setInterval(()=>{},1000);",
+].join("");
+
 /** Poll until `pid` is provably gone, or give up. */
 async function waitForGone(pid: number, timeoutMs = 6_000): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
@@ -348,6 +362,64 @@ describe("a group that cannot be enumerated", () => {
           } catch {
             /* already gone */
           }
+        }
+      }
+    },
+  );
+});
+
+describe("a live group whose root was already gone", () => {
+  it.skipIf(!supportsOwnershipProof())(
+    "reports it rather than signalling a group nothing ties to this tree",
+    async () => {
+      // `live` proves a group with this id EXISTS. It does not prove the group
+      // is ours, and the difference is the whole finding: the pid-reuse rule
+      // ("an id in use as a process-group id is not reissued while that group
+      // has members") is a promise about a group that still has one. A group
+      // that emptied released its id, and an unrelated process could have
+      // taken that pid, led a new group with it and exited — leaving a live
+      // group under our id with nothing of ours in it.
+      //
+      // The other paths through `settleGroup` have an anchor: they proved the
+      // root alive and carrying its recorded birth identity moments earlier,
+      // and a leader belongs to its own group. This path has none — the root
+      // was gone on the very first probe — so it must not signal.
+      const { spawn } = await import("node:child_process");
+      const root = spawn(process.execPath, ["-e", LEADER_WITH_SURVIVOR], {
+        detached: true,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      const pid = root.pid!;
+      const survivor = Number(
+        await new Promise<string>((resolve) => {
+          root.stdout!.once("data", (d: Buffer) =>
+            resolve(d.toString().trim()),
+          );
+        }),
+      );
+      expect(survivor).toBeGreaterThan(0);
+      // Read the identity while the root still has one, then kill ONLY the
+      // root so the call below finds it gone on its first look.
+      const identity = await readProcessBirthIdentity(pid);
+      process.kill(pid, "SIGKILL");
+      expect(await waitForGone(pid)).toBe(true);
+
+      try {
+        const outcome = await terminateOwnedProcessGroup({
+          pid,
+          birthIdentity: identity!,
+          graceMs: 2_000,
+          pollMs: 25,
+        });
+        // Not `forced`: nothing was killed, and nothing may be reported
+        // stopped either.
+        expect(outcome.outcome).toBe("unknown");
+        expect((await probeProcess(survivor)).state).toBe("alive");
+      } finally {
+        try {
+          process.kill(survivor, "SIGKILL");
+        } catch {
+          /* already gone */
         }
       }
     },

--- a/mcpjam-inspector/server/utils/harness/local/__tests__/process-identity.test.ts
+++ b/mcpjam-inspector/server/utils/harness/local/__tests__/process-identity.test.ts
@@ -260,6 +260,67 @@ const LEADER_WITH_SURVIVOR = [
   "setInterval(()=>{},1000);",
 ].join("");
 
+/**
+ * Spawn one of the fixtures above, wait for it to name its descendant, run the
+ * body, and kill both whatever happens.
+ *
+ * The spawn and the handshake belong INSIDE the guarded region: a rejected
+ * handshake or a failed assertion before the `try` would leak a detached group
+ * leader and its child, each holding a `setInterval`, for the life of the host.
+ * Nothing reaps a detached leader.
+ */
+async function withDetachedTree(
+  script: string,
+  body: (pid: number, descendant: number) => Promise<void>,
+): Promise<void> {
+  const { spawn } = await import("node:child_process");
+  const root = spawn(process.execPath, ["-e", script], {
+    detached: true,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const pid = root.pid!;
+  let descendant = 0;
+  try {
+    descendant = Number(
+      await new Promise<string>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error("the fixture never announced its descendant")),
+          10_000,
+        );
+        root.once("error", reject);
+        root.stdout!.once("data", (d: Buffer) => {
+          clearTimeout(timer);
+          resolve(d.toString().trim());
+        });
+      }),
+    );
+    expect(descendant).toBeGreaterThan(0);
+    await body(pid, descendant);
+  } finally {
+    if (descendant > 0) {
+      try {
+        process.kill(descendant, "SIGKILL");
+      } catch {
+        /* already gone */
+      }
+    } else {
+      // The handshake never named it. The root has not been signalled yet, so
+      // it is still alive and its group id is provably still ours — the only
+      // way to reach a descendant we cannot name.
+      try {
+        process.kill(-pid, "SIGKILL");
+      } catch {
+        /* already gone */
+      }
+    }
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
 /** Poll until `pid` is provably gone, or give up. */
 async function waitForGone(pid: number, timeoutMs = 6_000): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
@@ -285,21 +346,7 @@ describe("a group that cannot be enumerated", () => {
       // because a group id is not reissued while the group has members, and
       // `unknown` is the failure to establish that. Signalling anyway risks a
       // stranger's group.
-      const { spawn } = await import("node:child_process");
-      const root = spawn(process.execPath, ["-e", DESERTING_ROOT], {
-        detached: true,
-        stdio: ["ignore", "pipe", "ignore"],
-      });
-      const pid = root.pid!;
-      const descendant = Number(
-        await new Promise<string>((resolve) => {
-          root.stdout!.once("data", (d: Buffer) =>
-            resolve(d.toString().trim()),
-          );
-        }),
-      );
-      expect(descendant).toBeGreaterThan(0);
-      try {
+      await withDetachedTree(DESERTING_ROOT, async (pid, descendant) => {
         const identity = await readProcessBirthIdentity(pid);
         const outcome = await terminateOwnedProcessGroup({
           pid,
@@ -315,37 +362,19 @@ describe("a group that cannot be enumerated", () => {
         // ...and the descendant was left alone rather than signalled on an
         // unverifiable group id.
         expect((await probeProcess(descendant)).state).toBe("alive");
-      } finally {
-        for (const victim of [descendant, pid]) {
-          try {
-            process.kill(victim, "SIGKILL");
-          } catch {
-            /* already gone */
-          }
-        }
-      }
+      });
     },
   );
 
   it.skipIf(!supportsOwnershipProof())(
     "DOES force-kill a group it can prove still has a member",
     async () => {
-      // The counterpart: `live` proves the group is non-empty, which is exactly
-      // the fact that makes its id un-reissuable and the signal ours to send.
-      const { spawn } = await import("node:child_process");
-      const root = spawn(process.execPath, ["-e", DESERTING_ROOT], {
-        detached: true,
-        stdio: ["ignore", "pipe", "ignore"],
-      });
-      const pid = root.pid!;
-      const descendant = Number(
-        await new Promise<string>((resolve) => {
-          root.stdout!.once("data", (d: Buffer) =>
-            resolve(d.toString().trim()),
-          );
-        }),
-      );
-      try {
+      // The counterpart. `live` alone would not earn this: it says a group
+      // with our id exists, not that the group is ours. What earns it is the
+      // anchor — this call proved the root alive and carrying its recorded
+      // birth identity moments before, and a leader belongs to its own group,
+      // so a stranger could not have created this one in between.
+      await withDetachedTree(DESERTING_ROOT, async (pid, descendant) => {
         const identity = await readProcessBirthIdentity(pid);
         const outcome = await terminateOwnedProcessGroup({
           pid,
@@ -355,15 +384,7 @@ describe("a group that cannot be enumerated", () => {
         });
         expect(["forced", "graceful"]).toContain(outcome.outcome);
         expect(await waitForGone(descendant)).toBe(true);
-      } finally {
-        for (const victim of [descendant, pid]) {
-          try {
-            process.kill(victim, "SIGKILL");
-          } catch {
-            /* already gone */
-          }
-        }
-      }
+      });
     },
   );
 });
@@ -384,27 +405,13 @@ describe("a live group whose root was already gone", () => {
       // root alive and carrying its recorded birth identity moments earlier,
       // and a leader belongs to its own group. This path has none — the root
       // was gone on the very first probe — so it must not signal.
-      const { spawn } = await import("node:child_process");
-      const root = spawn(process.execPath, ["-e", LEADER_WITH_SURVIVOR], {
-        detached: true,
-        stdio: ["ignore", "pipe", "ignore"],
-      });
-      const pid = root.pid!;
-      const survivor = Number(
-        await new Promise<string>((resolve) => {
-          root.stdout!.once("data", (d: Buffer) =>
-            resolve(d.toString().trim()),
-          );
-        }),
-      );
-      expect(survivor).toBeGreaterThan(0);
-      // Read the identity while the root still has one, then kill ONLY the
-      // root so the call below finds it gone on its first look.
-      const identity = await readProcessBirthIdentity(pid);
-      process.kill(pid, "SIGKILL");
-      expect(await waitForGone(pid)).toBe(true);
+      await withDetachedTree(LEADER_WITH_SURVIVOR, async (pid, survivor) => {
+        // Read the identity while the root still has one, then kill ONLY the
+        // root so the call below finds it gone on its first look.
+        const identity = await readProcessBirthIdentity(pid);
+        process.kill(pid, "SIGKILL");
+        expect(await waitForGone(pid)).toBe(true);
 
-      try {
         const outcome = await terminateOwnedProcessGroup({
           pid,
           birthIdentity: identity!,
@@ -415,13 +422,7 @@ describe("a live group whose root was already gone", () => {
         // stopped either.
         expect(outcome.outcome).toBe("unknown");
         expect((await probeProcess(survivor)).state).toBe("alive");
-      } finally {
-        try {
-          process.kill(survivor, "SIGKILL");
-        } catch {
-          /* already gone */
-        }
-      }
+      });
     },
   );
 });

--- a/mcpjam-inspector/server/utils/harness/local/__tests__/process-registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/local/__tests__/process-registry.test.ts
@@ -262,23 +262,33 @@ describe("the janitor", () => {
         stdio: ["ignore", "pipe", "ignore"],
       });
       const pid = leader.pid!;
-      const survivor = Number(
-        await new Promise<string>((resolve) => {
-          leader.stdout!.once("data", (d: Buffer) =>
-            resolve(d.toString().trim()),
-          );
-        }),
-      );
-      expect(survivor).toBeGreaterThan(0);
-      // Kill the ROOT only. The group outlives it.
-      process.kill(pid, "SIGKILL");
-      for (let i = 0; i < 200; i++) {
-        if ((await probeProcess(pid)).state === "gone") break;
-        await new Promise((r) => setTimeout(r, 25));
-      }
-      expect((await probeProcess(pid)).state).toBe("gone");
-
+      // Everything from here is guarded: a rejected handshake or a failed
+      // assertion outside the `try` would leak a detached leader and its
+      // child, and nothing reaps a detached group leader.
+      let survivor = 0;
       try {
+        survivor = Number(
+          await new Promise<string>((resolve, reject) => {
+            const timer = setTimeout(
+              () => reject(new Error("the fixture never announced its child")),
+              10_000,
+            );
+            leader.once("error", reject);
+            leader.stdout!.once("data", (d: Buffer) => {
+              clearTimeout(timer);
+              resolve(d.toString().trim());
+            });
+          }),
+        );
+        expect(survivor).toBeGreaterThan(0);
+        // Kill the ROOT only. The group outlives it.
+        process.kill(pid, "SIGKILL");
+        for (let i = 0; i < 200; i++) {
+          if ((await probeProcess(pid)).state === "gone") break;
+          await new Promise((r) => setTimeout(r, 25));
+        }
+        expect((await probeProcess(pid)).state).toBe("gone");
+
         // A WELL-FORMED record: the group id is exactly the recorded root pid,
         // which is what the removed gate vouched for. That is what makes this
         // discriminating — the old code signalled precisely here.
@@ -304,8 +314,23 @@ describe("the janitor", () => {
         // The point of the test: the group was not signalled.
         expect((await probeProcess(survivor)).state).toBe("alive");
       } finally {
+        if (survivor > 0) {
+          try {
+            process.kill(survivor, "SIGKILL");
+          } catch {
+            /* already gone */
+          }
+        } else {
+          // Never named: the root has not been signalled, so its group id is
+          // provably still ours and this is the only way to reach the child.
+          try {
+            process.kill(-pid, "SIGKILL");
+          } catch {
+            /* already gone */
+          }
+        }
         try {
-          process.kill(survivor, "SIGKILL");
+          process.kill(pid, "SIGKILL");
         } catch {
           /* already gone */
         }

--- a/mcpjam-inspector/server/utils/harness/local/__tests__/process-registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/local/__tests__/process-registry.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
+  probeProcess,
   supportsOwnershipProof,
   readProcessBirthIdentity,
 } from "../process-identity.js";
@@ -54,6 +55,20 @@ function record(
     ...overrides,
   };
 }
+
+/**
+ * A detached group leader that spawns one long-lived grandchild, reports its
+ * pid and then idles. Killing the leader leaves the GROUP live with its leader
+ * gone — the shape that makes a recorded pgid unprovable.
+ */
+const LEADER_WITH_SURVIVOR = [
+  "const{spawn}=require('node:child_process');",
+  "const k=spawn(process.execPath,['-e',",
+  JSON.stringify("setInterval(()=>{},1000)"),
+  "],{stdio:'ignore'});",
+  "console.log(k.pid);",
+  "setInterval(()=>{},1000);",
+].join("");
 
 beforeAll(async () => {
   base = await realpath(await mkdtemp(join(tmpdir(), "mcpjam-registry-")));
@@ -176,11 +191,11 @@ describe("the janitor", () => {
   it.skipIf(!canOwnProcesses)(
     "keeps a record whose group it could not vouch for while survivors remain",
     async () => {
-      // A malformed `processGroupIdentity` is a reason not to SIGNAL the
-      // group; it is an even stronger reason not to throw away the only
-      // durable handle on a tree nobody has looked at. The earlier version
-      // skipped the signal and then deleted the record anyway, leaving the
-      // survivors unreapable.
+      // A record the janitor cannot make sense of must not lose its handle:
+      // an earlier version deleted it anyway, leaving the survivors
+      // unreapable. (The `processGroupIdentity` gate this once gated a signal
+      // on is gone — see the test below — but a malformed record still has to
+      // keep its survivors visible.)
       const { spawn } = await import("node:child_process");
       // A group leader that spawns a grandchild, then dies: the group outlives
       // it, which is exactly the case the check exists for.
@@ -223,6 +238,79 @@ describe("the janitor", () => {
         /* already gone */
       }
       await forgetProcess("s-unvouched");
+    },
+  );
+
+  it.skipIf(!canOwnProcesses)(
+    "reports survivors of a dead root without signalling their group",
+    async () => {
+      // The janitor reaches this branch only for a record whose owning
+      // supervisor has PROVABLY exited, so arbitrary time has passed since
+      // anything of ours was last in that group.
+      //
+      // A pid in use as a process-group id is not reissued while that group
+      // has members — but that is a promise about a group that still has one,
+      // not about one that emptied. If this tree finished normally its id went
+      // free, and any unrelated process could since have taken that pid, led a
+      // new group with it and exited, leaving a live group under our recorded
+      // id (an ordinary shell pipeline whose first stage exits early does
+      // exactly this). Nothing here can tell those apart, so the survivors are
+      // reported and the record kept, and NO signal is sent.
+      const { spawn } = await import("node:child_process");
+      const leader = spawn(process.execPath, ["-e", LEADER_WITH_SURVIVOR], {
+        detached: true,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      const pid = leader.pid!;
+      const survivor = Number(
+        await new Promise<string>((resolve) => {
+          leader.stdout!.once("data", (d: Buffer) =>
+            resolve(d.toString().trim()),
+          );
+        }),
+      );
+      expect(survivor).toBeGreaterThan(0);
+      // Kill the ROOT only. The group outlives it.
+      process.kill(pid, "SIGKILL");
+      for (let i = 0; i < 200; i++) {
+        if ((await probeProcess(pid)).state === "gone") break;
+        await new Promise((r) => setTimeout(r, 25));
+      }
+      expect((await probeProcess(pid)).state).toBe("gone");
+
+      try {
+        // A WELL-FORMED record: the group id is exactly the recorded root pid,
+        // which is what the removed gate vouched for. That is what makes this
+        // discriminating — the old code signalled precisely here.
+        await recordProcess(
+          record({
+            sessionId: "s-live-group",
+            rootPid: pid,
+            processGroupIdentity: String(pid),
+          }),
+        );
+        const results = await reclaimAbandonedProcesses({
+          liveNonce: "sup_live",
+        });
+        expect(results).toContainEqual({
+          sessionId: "s-live-group",
+          outcome: "escaped",
+        });
+        expect(
+          (await listProcessRecords()).find(
+            (r) => r.sessionId === "s-live-group",
+          ),
+        ).toBeDefined();
+        // The point of the test: the group was not signalled.
+        expect((await probeProcess(survivor)).state).toBe("alive");
+      } finally {
+        try {
+          process.kill(survivor, "SIGKILL");
+        } catch {
+          /* already gone */
+        }
+        await forgetProcess("s-live-group");
+      }
     },
   );
 

--- a/mcpjam-inspector/server/utils/harness/local/__tests__/supervisor.test.ts
+++ b/mcpjam-inspector/server/utils/harness/local/__tests__/supervisor.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+  probeProcess,
   readProcessBirthIdentity,
   supportsOwnershipProof,
 } from "../process-identity.js";
@@ -217,6 +218,21 @@ describe("a root that exits while its tree does not", () => {
   it.skipIf(!canOwnProcesses)(
     "retains ownership when the root exits naturally before stop",
     async () => {
+      // The root here is gone before `stopSession` ever looks, so nothing in
+      // the stop ties the surviving group to this tree: the id could have been
+      // released and reissued at any point since the root exited, and an
+      // unrelated leader that has since exited would leave a live group
+      // wearing it. So the stop reports the survivor rather than SIGKILLing a
+      // group it cannot prove is ours, and KEEPS the record, which is the only
+      // durable handle on it. This test previously expected the sweep.
+      //
+      // Restoring the sweep soundly needs per-MEMBER identity, not a group
+      // signal: enumerate the group once at the moment the root exits — while
+      // its id provably still belongs to us — and record each member's pid and
+      // birth identity, then at stop verify each with `isSameProcess` and
+      // signal only those that still match. That is immune to pid reuse, but
+      // it is a new platform primitive plus supervisor plumbing, deliberately
+      // not folded in here.
       const sup = supervisor();
       const handle = await sup.spawnSupervised(
         request("s-natural-desert", "natural-deserter.js"),
@@ -237,15 +253,22 @@ describe("a root that exits while its tree does not", () => {
       ).toBeDefined();
 
       await expect(sup.stopSession("s-natural-desert")).resolves.toEqual({
-        stopped: true,
-        escaped: 0,
+        stopped: false,
+        escaped: 1,
       });
-      expect(await waitForExit(descendant)).toBe(true);
+      // Not signalled, and still visible: an unswept survivor the operator can
+      // still see beats a SIGKILL delivered to whoever now holds the id.
+      expect((await probeProcess(descendant)).state).toBe("alive");
       expect(
         (await listProcessRecords()).find(
           (record) => record.sessionId === "s-natural-desert",
         ),
-      ).toBeUndefined();
+      ).toBeDefined();
+      try {
+        process.kill(descendant, "SIGKILL");
+      } catch {
+        /* already gone */
+      }
     },
   );
 });

--- a/mcpjam-inspector/server/utils/harness/local/process-identity.ts
+++ b/mcpjam-inspector/server/utils/harness/local/process-identity.ts
@@ -357,9 +357,9 @@ async function probeLinuxGroup(pgid: number): Promise<GroupProbe> {
       // against a fail-CLOSED functional one (on a hidepid mount the probe
       // answers `unknown` a lot, so stops report unproven and the janitor
       // retains records) — and this file exists because that trade keeps being
-      // made the wrong way round. The termination itself is unaffected:
-      // `settleGroup` escalates to SIGKILL on `unknown` exactly as it does on
-      // `live`, so only the reporting and the record retention change.
+      // made the wrong way round. An unprovable group is not force-killed
+      // either, because that signal needs a fact `unknown` does not supply;
+      // see `settleGroup`.
       if (code !== "ENOENT" && code !== "ESRCH") blind = true;
       continue;
     }
@@ -501,14 +501,31 @@ export async function terminateOwnedProcessGroup(args: {
     const probeGroup = args.probeGroup ?? probeProcessGroup;
     const before = await probeGroup(args.pid, platform);
     if (before === "empty") return { outcome: goneOutcome };
-    // `live` AND `unknown` both escalate. Not knowing whether a descendant is
-    // still down there is a reason to MAKE SURE, not a reason to walk away:
-    // returning early on `unknown` left a child that ignored SIGTERM running
-    // with no SIGKILL ever sent, because the only escalation sat below this
-    // point. The signal is ownership-safe in both cases by the rule the
-    // janitor also relies on — a pid still serving as a process-GROUP id is
-    // not handed out as a new process's pid while that group has members, so
-    // it can only reach the group whose root we proved was ours.
+    if (before === "unknown") {
+      // No signal here, and the reason is narrow enough to be worth spelling
+      // out, because this line has been written both ways.
+      //
+      // Every caller of `settleGroup` has already proven the ROOT is gone, so
+      // its pid is free for reuse. What makes `kill(-pid)` safe anyway is that
+      // a pid serving as a process-GROUP id is not handed out to a new process
+      // WHILE THAT GROUP HAS MEMBERS — which is a guarantee about a non-empty
+      // group, and `unknown` is precisely the failure to establish that. An
+      // unprovable group may be empty and its id already reissued, so the
+      // signal could land on a stranger's group.
+      //
+      // So the general rule ("`unknown` gates reporting, not action") does not
+      // reach here: this action needs the very fact `unknown` is missing. The
+      // caller keeps the record, reports the tree unproven rather than
+      // stopped, and the janitor retries when the probe can see again.
+      return {
+        outcome: "unknown",
+        reason:
+          "the process group could not be enumerated, so a survivor could be " +
+          "neither ruled out nor signalled without risking a reused group id",
+      };
+    }
+    // `live` is different: it proves the group has a member, which is exactly
+    // the fact that makes the id un-reissuable and the signal ours to send.
     signalProcessGroup(args.pid, "SIGKILL", platform);
     await new Promise((r) => setTimeout(r, Math.min(args.graceMs, 500)));
     const after = await probeGroup(args.pid, platform);

--- a/mcpjam-inspector/server/utils/harness/local/process-identity.ts
+++ b/mcpjam-inspector/server/utils/harness/local/process-identity.ts
@@ -484,13 +484,46 @@ export async function terminateOwnedProcessGroup(args: {
    * A descendant that ignores SIGTERM keeps running while the leader exits, so
    * "the root's pid is gone" is not "the tree is gone" — and reporting
    * `graceful` on the root alone is how a session gets announced as stopped
-   * over a live vendor process. Signalling the group here is justified by the
-   * same rule the janitor relies on: a pid still in use as a process-GROUP id
-   * is not handed out as a new process's pid while that group has members, so
-   * this can only reach the group we already proved we own.
+   * over a live vendor process.
+   *
+   * ── What the pid-reuse rule actually gives ──────────────────────────────
+   * A pid still in use as a process-GROUP id is not handed out as a new
+   * process's pid WHILE THAT GROUP HAS MEMBERS. That is a guarantee about the
+   * FUTURE of a non-empty group: from any moment the group has a member, its
+   * id cannot be reissued underneath us.
+   *
+   * It is NOT a statement about the past, and reading it as one is the bug
+   * this signal shipped with. If the group ever emptied, its id was free, and
+   * an unrelated process could have taken that pid, made itself a group leader
+   * (`setsid`/`setpgid`), forked, and exited — leaving a LIVE group carrying
+   * our recorded id with nothing of ours in it. That is not exotic: it is what
+   * an ordinary shell pipeline whose first stage exits early, or any
+   * double-forking daemon, leaves behind. So a point-in-time `live` says a
+   * group with this id exists; it does not say the group is ours.
+   *
+   * ── What makes the signal ours to send ─────────────────────────────────
+   * An ANCHOR: a moment at which we knew this group was ours AND non-empty.
+   * A stranger's group with our id can only have been created after our group
+   * emptied, so it cannot predate the anchor. Inside a single termination call
+   * we have one — the root was verified alive and carrying its recorded birth
+   * identity before we signalled it, and a leader is a member of its own group
+   * — and only the grace window separates it from these probes.
+   *
+   * When the root was ALREADY gone the first time we looked, there is no such
+   * anchor: arbitrary time may have passed since anything of ours was in that
+   * group, which is exactly the janitor's situation after an Inspector
+   * restart. Then the live group is reported, not signalled.
+   *
+   * Not closed, and not claimed: even with the anchor, our group could empty
+   * and its id be reissued inside the grace window. That needs the pid space
+   * to wrap within a few seconds, and ruling it out needs a per-member
+   * identity proof no cheap platform primitive offers — enumeration gives
+   * states, not lineage. It is bounded here rather than eliminated.
    */
   const settleGroup = async (
     goneOutcome: "already-gone" | "graceful" | "forced",
+    /** Was the root proven alive and OURS earlier in this same call? */
+    anchored: boolean,
   ): Promise<
     | { outcome: "already-gone" }
     | { outcome: "graceful" }
@@ -524,8 +557,20 @@ export async function terminateOwnedProcessGroup(args: {
           "neither ruled out nor signalled without risking a reused group id",
       };
     }
-    // `live` is different: it proves the group has a member, which is exactly
-    // the fact that makes the id un-reissuable and the signal ours to send.
+    if (!anchored) {
+      // A live group carries our recorded id, and nothing ties it to our tree:
+      // the root was gone before this call looked even once, so the group may
+      // have emptied and the id been reissued long ago. Report it; the caller
+      // keeps its record and the survivors stay visible.
+      return {
+        outcome: "unknown",
+        reason:
+          "a live process group carries this id, but the root was already " +
+          "gone when the stop began, so the group cannot be tied to this tree",
+      };
+    }
+    // Anchored and `live`: the group had a member of ours moments ago and has
+    // one now, so this is the tree we set out to terminate.
     signalProcessGroup(args.pid, "SIGKILL", platform);
     await new Promise((r) => setTimeout(r, Math.min(args.graceMs, 500)));
     const after = await probeGroup(args.pid, platform);
@@ -540,7 +585,7 @@ export async function terminateOwnedProcessGroup(args: {
   };
 
   const initial = await probeProcess(args.pid, platform);
-  if (initial.state === "gone") return settleGroup("already-gone");
+  if (initial.state === "gone") return settleGroup("already-gone", false);
   if (initial.state === "unknown") {
     // We could not look. Reporting "already-gone" here would let a caller
     // announce a stopped session over a tree that may still be running.
@@ -558,7 +603,7 @@ export async function terminateOwnedProcessGroup(args: {
   while (Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, pollMs));
     if ((await probeProcess(args.pid, platform)).state === "gone") {
-      return settleGroup("graceful");
+      return settleGroup("graceful", true);
     }
   }
 
@@ -568,7 +613,7 @@ export async function terminateOwnedProcessGroup(args: {
   // one `false` — and a probe failure reported here as `graceful` is a caller
   // announcing a stopped session over a tree that may still be running.
   const afterGrace = await probeProcess(args.pid, platform);
-  if (afterGrace.state === "gone") return settleGroup("graceful");
+  if (afterGrace.state === "gone") return settleGroup("graceful", true);
   if (afterGrace.state === "unknown") {
     return { outcome: "unknown", reason: afterGrace.reason };
   }
@@ -583,14 +628,14 @@ export async function terminateOwnedProcessGroup(args: {
   while (Date.now() < killDeadline) {
     await new Promise((r) => setTimeout(r, pollMs));
     if ((await probeProcess(args.pid, platform)).state === "gone") {
-      return settleGroup("forced");
+      return settleGroup("forced", true);
     }
   }
   // The polls above only ever conclude "gone". Ask once more so the difference
   // between "SIGKILL was delivered and the root is STILL there" and "the last
   // few probes could not look" survives into the answer.
   const settled = await probeProcess(args.pid, platform);
-  if (settled.state === "gone") return settleGroup("forced");
+  if (settled.state === "gone") return settleGroup("forced", true);
   if (settled.state === "unknown") {
     return { outcome: "unknown", reason: settled.reason };
   }

--- a/mcpjam-inspector/server/utils/harness/local/process-registry.ts
+++ b/mcpjam-inspector/server/utils/harness/local/process-registry.ts
@@ -31,7 +31,6 @@ import { createLocalStateMutationLock } from "./local-state-lock.js";
 import {
   probeProcess,
   probeProcessGroup,
-  signalProcessGroup,
   supportsOwnershipProof,
   terminateOwnedProcessGroup,
   type ProcessBirthIdentity,
@@ -329,34 +328,36 @@ export function reclaimAbandonedProcesses(args: {
       }
       if (rootProbe.state === "gone") {
         // The ROOT is gone, but a descendant it spawned can still be running:
-        // the process group outlives its leader. Signal the recorded group
-        // before dropping the record, otherwise this is the moment the only
-        // durable handle on those survivors is thrown away.
+        // the process group outlives its leader. Look before dropping the
+        // record, otherwise this is the moment the only durable handle on
+        // those survivors is thrown away.
         //
-        // Safe despite the root's pid being free: a pid still in use as a
-        // process-group id is not handed out as a new process's pid while the
-        // group has members, so this can only reach the group we recorded. If
-        // the group is already empty the signal is a harmless ESRCH.
-        // Only signal a group the record itself vouches for: a malformed
-        // `processGroupIdentity` is not a licence to signal an arbitrary pid.
-        const vouched = record.processGroupIdentity === String(record.rootPid);
-        if (vouched) {
-          signalProcessGroup(record.rootPid, "SIGKILL", platform);
-          // Give the survivors a moment before confirming.
-          await new Promise((r) => setTimeout(r, 200));
-        }
-        // Confirmed in BOTH cases. Being unable to vouch for the group is a
-        // reason not to SIGNAL it; it is an even stronger reason not to throw
-        // away the only durable handle on a tree nobody has looked at. (This
-        // path is unreachable on win32, where the group probe always answers
-        // `unknown` — ownership proof gates it above.)
+        // LOOK, but do not signal. An earlier version sent SIGKILL to the
+        // recorded group here, on the grounds that a pid in use as a
+        // process-group id is not reissued while that group has members, so
+        // the signal "can only reach the group we recorded". That rule is
+        // about the FUTURE of a non-empty group; it says nothing about a group
+        // that emptied. This record was written by a supervisor that has since
+        // exited — that is the precondition for reaching this line — so
+        // arbitrary time has passed, and if the tree finished normally its id
+        // went free long ago. Any unrelated process could then have taken that
+        // pid, led a new group with it and exited, leaving a live group under
+        // our recorded id: an ordinary shell pipeline does exactly that. There
+        // is no observation left that ties this group to our tree, so the
+        // honest move is to report the survivors and keep the handle rather
+        // than SIGKILL a stranger's process group.
+        //
+        // `terminateOwnedProcessGroup` below still signals, because it gets
+        // its anchor by proving the root alive and ours first; see the note on
+        // `settleGroup`. (This path is unreachable on win32, where the group
+        // probe always answers `unknown` — ownership proof gates it above.)
         const group = await probeProcessGroup(record.rootPid, platform);
         if (group === "live") {
           survivors.push(record);
           results.push({ sessionId: record.sessionId, outcome: "escaped" });
           logger.warn(
             "[local-harness] descendants outlived their root; record kept",
-            { sessionId: record.sessionId, vouched },
+            { sessionId: record.sessionId },
           );
           continue;
         }

--- a/mcpjam-inspector/server/utils/harness/local/supervisor.ts
+++ b/mcpjam-inspector/server/utils/harness/local/supervisor.ts
@@ -545,6 +545,25 @@ export class LocalHarnessSupervisor {
           pid,
         });
       }
+      if (outcome.outcome === "unknown") {
+        logger.warn("[local-harness] tree not proven stopped; will retry", {
+          sessionId: request.sessionId,
+          pid,
+          reason: outcome.reason,
+        });
+      }
+      // The latch means "a kill is in flight, or the tree is settled" — not
+      // "a kill was attempted once". `escaped` and `unknown` settle nothing,
+      // and leaving it latched is how a descendant gets stranded for the rest
+      // of this process's life: the abort listener and the wall-clock timer
+      // both funnel through here, and `stopSession` may never come. Reopening
+      // it lets the next trigger try again, which matters most for `unknown`,
+      // where the answer may simply be that the probe could not look yet.
+      //
+      // `not-owned` stays latched: retrying cannot help and must not signal.
+      if (outcome.outcome === "escaped" || outcome.outcome === "unknown") {
+        entry.killed = false;
+      }
     };
 
     const onAbort = () => {


### PR DESCRIPTION
Follow-up to #4532, which merged about ninety seconds before the first of these fixes was ready. It started as one behaviour change and grew by two rounds of review; the scope now is **every group signal in the local harness**, which is three sites.

## 1. `unknown` is not a licence to signal (the original fix)

`main` escalates to `SIGKILL` when the process-group probe answers `unknown`, on the reasoning that not knowing whether a descendant is down there is a reason to make sure. Every caller of `settleGroup` has already proven the root gone, so its pid is free for reuse; what makes `kill(-pid)` safe anyway is a guarantee about a **non-empty** group, and `unknown` is precisely the failure to establish it. So on an unreadable `/proc` or a `ps` timeout, an already-empty group whose id has since been reissued gets signalled.

The module's general rule — `unknown` gates *reporting*, not *action* — does not reach this signal, because the action needs the very fact `unknown` is missing.

## 2. `live` is not proof of ownership either

Codex was right that the fix above didn't go far enough, and that the comment I wrote justifying the surviving branch asserted something false.

"A pid in use as a group id is not reissued while that group has members" constrains the **future** of a non-empty group. It says nothing about a group that emptied. Once ours emptied its id went free, and an unrelated process could take that pid, lead a new group with it and exit, leaving a live group wearing our recorded id with nothing of ours in it — which is what an ordinary shell pipeline whose first stage exits early, or a double-forking daemon, leaves behind. A point-in-time `live` says a group with this id exists, not that it is ours.

In place of a continuity proof this uses an **anchor**: a moment at which the group was known to be ours *and* non-empty. A stranger's group carrying our id can only have been created after ours emptied, so it cannot predate the anchor. Two paths had none, and neither signals now:

- `settleGroup` reached with the root already gone on its first look — nothing in that call ever saw the tree.
- **The janitor's dead-root branch**, which carried the same justification verbatim and is the more reachable of the two: it runs only for a record whose owning supervisor has provably exited, so arbitrary time has passed since anything of ours was in that group. It now reports `escaped` and keeps the record.

The anchored path — root verified alive and carrying its recorded birth identity moments earlier, and a leader belongs to its own group — still escalates. After this, `signalProcessGroup` has no callers outside `process-identity.ts`.

## 3. An unproven kill is now retried

`killTree` latched `entry.killed = true` on entry and never cleared it, so the latch meant "a kill was attempted once" rather than "a kill is in flight, or the tree is settled". The abort listener and the wall-clock timer both funnel through it, so the first unproven outcome stranded the descendant for the rest of the process's life. `escaped` and `unknown` now reopen it; `not-owned` stays latched. `unknown` is logged rather than passing in silence.

This matters more after (2), which makes `unknown` a normal outcome for a tree whose root exited on its own rather than only a probe failure.

## What this costs, stated plainly

A stray left behind by a harness that exited on its own is **no longer swept** at `stopSession`. It is reported and its record retained instead — an unswept survivor an operator can see, rather than a `SIGKILL` delivered to whoever now holds the id. One existing test asserted the sweep and now asserts the report.

Restoring it soundly needs per-**member** identity rather than a group signal: enumerate the group once at the instant the root exits, while its id provably still belongs to us; record each member's pid and birth identity; verify each with `isSameProcess` before signalling it individually. That is immune to pid reuse, and it is a new platform primitive plus supervisor plumbing — deliberately not folded in here.

Also not closed, and not claimed: even anchored, the group could empty and its id be reissued inside the grace window. That needs the pid space to wrap within a few seconds, and ruling it out needs the same per-member proof. Documented rather than papered over.

## Tests

Every direction is pinned, and **each was checked to fail against the opposite behaviour and against nothing else** rather than merely to pass against the current one.

That check has earned its keep. The test shipped with the original escalation passed either way: its only spawned process was the root, which ignored `SIGTERM`, so the kill came from the main flow's own `SIGKILL` after the grace window and never from `settleGroup` at all. The fixtures are now two-process trees whose root exits on `SIGTERM`, so the grace loop returns through `settleGroup` *before* the main-flow kill and the descendant's fate isolates that branch. They also need a readiness handshake to mean anything — the descendant announces itself only after installing its `SIGTERM` handler, because otherwise the signal that starts termination can arrive first and kill it by default action.

Mutation results: reverting the `settleGroup` anchor gate fails exactly the unanchored-settle and natural-exit tests; restoring the janitor signal fails exactly the janitor test.

The fixtures were also leaking. Spawn and handshake sat outside the `try`, so a rejected handshake or a failed assertion before it left a detached leader and its child running for the life of the host, since nothing reaps a detached group leader. A `withDetachedTree` helper now owns spawn, handshake and cleanup together, with a timeout so a silent fixture rejects instead of hanging.

## Verification

- 343 tests in `server/utils/harness/local`, 815 across `server/utils/harness`.
- `npm run test:checks` exit 0; `tsc` reports no errors under `harness/local`.
- `prettier --check` passes on every file touched here. `grants.ts` and `supervised-provider.ts` still fail it; that drift is pre-existing on `main` and neither is touched. `process-registry.ts` *is* touched, and its only prettier complaint is a union-type layout at lines 40–46 that this PR does not go near — reformatting it here would bury the diff.