### PR TITLE
search_sessions: drop the transcript coverage disclosure (backfill complete)

### DIFF
--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -7557,7 +7557,6 @@ export const searchSessionsOperation: PlatformOperation<
   description:
     "Search conversation sessions in a project across every surface (Playground, user testing, evals, swarms), ranked by relevance. " +
     "scope=titles (default) searches session titles and opening messages; scope=transcripts searches what was said inside the conversations. " +
-    "Older sessions (created before 2026-08-14) are EXCLUDED from transcript search — they cannot match at all; use scope=titles to find them. " +
     "Every result carries a link to open the session.",
   readOnly: true,
   permalink: responsePermalinks((result) =>


### PR DESCRIPTION
The prod transcript backfill ran to `done` on 2026-09-01 — 380 batches, 59,231 transcripts, zero errors on every counter — so the operation description's coverage sentence ("Older sessions (created before 2026-08-14) are EXCLUDED from transcript search…") is no longer true and must go: an agent reading a stale warning will route around a gap that no longer exists.

Verified end-to-end before this PR: a **2026-06-08** Playground session is a transcript-scope hit via `mcpjam cloud sessions search --scope transcripts`, with matchPreview and working deep link.

One-sentence deletion; SDK operation tests (82) and worker README/partition tests (24) green. Pairs with MCPJam/mcpjam-backend#1221 which retires the backend's FORWARD-ONLY comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the MCP operation description; no search logic or API behavior is modified.
> 
> **Overview**
> Updates the **`search_sessions`** platform operation description so agents no longer see a warning that **transcript scope** cannot match sessions created before **2026-08-14**.
> 
> That sentence is removed because prod transcript backfill finished; **scope=transcripts** now covers older sessions. The rest of the description (surfaces, **scope=titles** vs **scope=transcripts**, permalinks) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70957abe721cf84d0f9b253b83d6ea210fa0cb0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the stale transcript-coverage warning from the `searchSessions` operation description. The prod transcript backfill completed on 2026-09-01 (59,231 transcripts, zero errors), so the claim that sessions created before 2026-08-14 cannot be transcript-searched is no longer true. Verified a 2026-06-08 session is a transcript-scope hit end-to-end via the CLI.

<sup>Written for commit 70957abe721cf84d0f9b253b83d6ea210fa0cb0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

