### PR TITLE
Do not report an unprovable termination as a pid-reuse mismatch

### DIFF
--- a/mcpjam-inspector/server/utils/harness/local/README.md
+++ b/mcpjam-inspector/server/utils/harness/local/README.md
@@ -323,6 +323,17 @@ timeout, an unreadable `/proc`, or a platform with no primitive answers
 which meant a probe failure could report a live tree as stopped and let a second
 Inspector window reclaim a healthy instance's sessions.
 
+The distinction has to survive into what the janitor REPORTS, too, which is a
+step it kept skipping. An unsettled termination was announced as `not-owned`
+whether the pid genuinely belonged to somebody else or the answer was merely
+unprovable — and the two want opposite follow-ups: a real mismatch is terminal
+and the record should sit there for a human to look at, while an unprovable one
+is transient and the next sweep should just try again. `skipped-unprovable`,
+which every other blind spot in the file already used, now covers it. Gating the
+group signal on an ownership anchor is what made this bite: `unknown` went from
+a rare probe failure to the routine answer for a tree whose root exited on its
+own.
+
 ### A zombie is a dead process
 
 `/proc/<pid>/stat` still exists after a process exits, until something reaps it.

--- a/mcpjam-inspector/server/utils/harness/local/__tests__/process-registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/local/__tests__/process-registry.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../process-identity.js";
 import {
   forgetProcess,
+  janitorOutcomeForUnsettled,
   listProcessRecords,
   mintSupervisorNonce,
   reclaimAbandonedProcesses,
@@ -184,6 +185,24 @@ describe("the durable record", () => {
     );
     expect(stored).toHaveLength(1);
     expect(stored[0]!.rootPid).toBe(11);
+  });
+});
+
+describe("reporting an unsettled termination", () => {
+  it("keeps 'could not prove' apart from 'not ours'", () => {
+    // The janitor said `not-owned` for both, which announces a pid-reuse
+    // mismatch that was never established. They want opposite follow-ups: a
+    // real mismatch is terminal and the record should stay for a human to look
+    // at, while an unprovable answer is transient and the next sweep should
+    // just try again. Every other blind spot in this file already says
+    // `skipped-unprovable`.
+    //
+    // This stopped being academic when the group signal was gated on an
+    // ownership anchor: `unknown` became a routine answer for a tree whose
+    // root exited on its own, not just a rare probe failure.
+    expect(janitorOutcomeForUnsettled("unknown")).toBe("skipped-unprovable");
+    expect(janitorOutcomeForUnsettled("not-owned")).toBe("not-owned");
+    expect(janitorOutcomeForUnsettled("escaped")).toBe("escaped");
   });
 });
 

--- a/mcpjam-inspector/server/utils/harness/local/process-registry.ts
+++ b/mcpjam-inspector/server/utils/harness/local/process-registry.ts
@@ -236,6 +236,30 @@ export interface JanitorResult {
 }
 
 /**
+ * Report an unsettled termination in the janitor's own vocabulary.
+ *
+ * `unknown` is "could not prove", not "somebody else's pid". Folding it into
+ * `not-owned` announces a pid-reuse mismatch that was never established, and
+ * the two want opposite follow-ups: a real mismatch is terminal and the record
+ * should stay put for a human to look at, while an unprovable answer is
+ * transient and the next sweep should simply try again. Every other place the
+ * janitor cannot see already says `skipped-unprovable`; this one did not.
+ *
+ * Exported because the `unknown` arm cannot be produced from the janitor's own
+ * entry point — reaching `terminateOwnedProcessGroup` at all requires the root
+ * to probe alive and match its recorded identity, and there is no seam to make
+ * the group probe fail from there. A named function is the only way to assert
+ * the mapping rather than assume it.
+ */
+export function janitorOutcomeForUnsettled(
+  outcome: "not-owned" | "escaped" | "unknown",
+): JanitorOutcome {
+  if (outcome === "escaped") return "escaped";
+  if (outcome === "unknown") return "skipped-unprovable";
+  return "not-owned";
+}
+
+/**
  * Delete a session's disposable state directory.
  *
  * Re-checks containment under the local harness state root before removing
@@ -406,7 +430,7 @@ export function reclaimAbandonedProcesses(args: {
       survivors.push(record);
       results.push({
         sessionId: record.sessionId,
-        outcome: outcome.outcome === "escaped" ? "escaped" : "not-owned",
+        outcome: janitorOutcomeForUnsettled(outcome.outcome),
       });
     }
 


### PR DESCRIPTION
Follow-up to #4557, which merged while the review that found this was still running. Codex (P2) and CodeRabbit landed the same finding on it independently, a few minutes apart, and both are right.

## The bug

The janitor mapped every unsettled `terminateOwnedProcessGroup` outcome that wasn't `escaped` onto `not-owned`:

```ts
outcome: outcome.outcome === "escaped" ? "escaped" : "not-owned",
```

So `unknown` — "could not prove" — was announced as an **established pid-reuse mismatch**. It isn't one, and the two want opposite follow-ups:

- A real `not-owned` is terminal. The pid belongs to somebody else, retrying can't change that, and the record should sit there for a human to look at.
- An `unknown` is transient. Nothing was established, and the next sweep should simply try again when the probe can see.

`skipped-unprovable` is the accurate answer, and it isn't a new concept — every *other* blind spot in this file already reports it. This one site just never got the memo.

## Why now

#4557 is what made it bite. Gating the group signal on an ownership anchor turned `unknown` from a rare probe failure (an unreadable `/proc`, a `ps` timeout) into the **routine** outcome for a tree whose root exited on its own. A misreport that used to need a broken procfs now happens on the common path, so `reclaimOrphans()` would have started claiming pid reuse as a matter of course.

## On the named function

The mapping is a function rather than an inline ternary, and the reason is testability rather than taste: the `unknown` arm **cannot be produced from the janitor's own entry point**. Reaching `terminateOwnedProcessGroup` at all requires the root to probe alive *and* match its recorded identity, and there's no seam to make the group probe fail from there. Naming it is the only way to assert the mapping instead of assuming it — and "assumed instead of asserted" is exactly what shipped the bug this PR follows.

## Verification

- 344 tests in `server/utils/harness/local`, 816 across `server/utils/harness`.
- The new test was mutation-checked: collapsing `unknown` back into `not-owned` fails exactly that one test and nothing else.
- `npm run test:checks` exit 0; no `tsc` errors under `harness/local`.
- `prettier --check` passes on every line touched here. `process-registry.ts` still reports drift, but the only thing it would change is a union-type layout at lines 40–46 that this PR does not go near; that drift is pre-existing on `main` and reformatting it here would bury a 26-line diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01APkiUt1ywuLr5o21LFXnjM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes crash-recovery janitor outcomes for process trees; misclassification could either hide real pid reuse or spuriously freeze records, though the fix narrows a known false `not-owned` path after ownership-anchor gating.
> 
> **Overview**
> Fixes a janitor reporting bug where any unsettled `terminateOwnedProcessGroup` result that was not `escaped` was labeled **`not-owned`**, so **`unknown`** (“could not prove”) was treated like an established pid-reuse mismatch.
> 
> The janitor now routes those outcomes through **`janitorOutcomeForUnsettled`**: **`unknown` → `skipped-unprovable`** (retry on the next sweep), **`not-owned`** and **`escaped`** unchanged. That aligns this path with the rest of the registry, which already uses `skipped-unprovable` for blind spots.
> 
> Adds a focused unit test for the mapping (the `unknown` arm is not reachable from the full janitor path without this export) and documents the distinction in the local harness README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f4ff03cc90529b41df746e6ab6873b192a2aa5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the janitor's reporting of unsettled process terminations so `unknown` outcomes are labeled `skipped-unprovable` instead of `not-owned`.

- Adds a regression test asserting the mapping for `unknown`, `not-owned`, and `escaped`.
- Updates the local harness README to explain why the distinction matters.

<sup>Written for commit 8f4ff03cc90529b41df746e6ab6873b192a2aa5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

