### PR TITLE
ci: give the desktop packaging chain its own Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,22 +23,43 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
+      # The desktop packaging chain gets its own groups. dependabot-auto-merge
+      # holds any PR that TOUCHES electron/sharp/@electron*, so leaving these
+      # packages inside the general groups holds the entire group hostage: the
+      # first weekly sync's 29-update dev group (#4558) was held for one
+      # packaging package while 28 auto-mergeable bumps sat behind it. Carving
+      # them out keeps the hold blast radius to exactly the packages it is for.
+      desktop-packaging:
+        applies-to: version-updates
+        patterns: ["electron", "sharp", "@electron/*", "@electron-forge/*"]
+        update-types: [minor, patch]
+      desktop-packaging-security:
+        applies-to: security-updates
+        patterns: ["electron", "sharp", "@electron/*", "@electron-forge/*"]
       production-dependencies:
         applies-to: version-updates
         dependency-type: production
         update-types: [minor, patch]
+        exclude-patterns:
+          ["electron", "sharp", "@electron/*", "@electron-forge/*"]
       development-dependencies:
         applies-to: version-updates
         dependency-type: development
         update-types: [minor, patch]
+        exclude-patterns:
+          ["electron", "sharp", "@electron/*", "@electron-forge/*"]
       # Security updates group separately so an advisory PR is never queued
       # behind a routine version bump.
       security-production:
         applies-to: security-updates
         dependency-type: production
+        exclude-patterns:
+          ["electron", "sharp", "@electron/*", "@electron-forge/*"]
       security-development:
         applies-to: security-updates
         dependency-type: development
+        exclude-patterns:
+          ["electron", "sharp", "@electron/*", "@electron-forge/*"]
     # Deliberately NO `ignore` rules for electron / sharp majors. `ignore`
     # suppresses SECURITY updates as well as version updates, so such a rule
     # would have hidden the Electron 37 → 43 bump (#4081) that cleared 31


### PR DESCRIPTION
## Why

dependabot-auto-merge holds any PR that touches `electron`/`sharp`/`@electron*` (the desktop packaging chain no required check exercises). With those packages inside the general Dependabot groups, one packaging package holds the entire group hostage: the first weekly sync's 29-update dev group (#4558) was held for a single packaging bump while 28 auto-mergeable dev-dependency bumps sat behind it.

## What

- New `desktop-packaging` (version-updates) and `desktop-packaging-security` (security-updates) groups containing exactly `electron`, `sharp`, `@electron/*`, `@electron-forge/*`.
- The four general workspace groups get matching `exclude-patterns`.

The general dev group can now actually auto-merge; the desktop chain still arrives as PRs a human reads — nothing is ignored or hidden, consistent with the no-`ignore`-rules stance in the file.

After this merges, the next Dependabot sync (or `@dependabot recreate` on #4558) regroups the open PRs accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvkSUhykCecmn8t8HnMf6k

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Dependabot configuration; no application runtime, auth, or data-path changes.
> 
> **Overview**
> **Dependabot grouping** is adjusted so `electron`, `sharp`, `@electron/*`, and `@electron-forge/*` no longer ride in the general workspace dependency groups.
> 
> Adds dedicated **`desktop-packaging`** (minor/patch version updates) and **`desktop-packaging-security`** groups for those packages only. The four existing workspace groups—production/development and their security counterparts—now **`exclude-patterns`** the same set so routine bumps can auto-merge without one packaging update blocking the whole batch.
> 
> Desktop packaging updates still surface as PRs and stay subject to manual review via **dependabot-auto-merge** holds; nothing is added to **`ignore`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f94fcbe68d99ea1d6fa25300518ed1c12d0e6a6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits the desktop packaging chain (`electron`, `sharp`, `@electron/*`, `@electron-forge/*`) into dedicated `desktop-packaging` and `desktop-packaging-security` Dependabot groups and excludes those packages from the four general workspace groups. Previously, one packaging bump in a general group held up auto-merge for all the other updates in that group; now the general dev group can auto-merge while desktop packaging PRs still require human review. After merge, the next Dependabot sync regroups existing open PRs.

<sup>Written for commit f94fcbe68d99ea1d6fa25300518ed1c12d0e6a6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

