### PR TITLE
ci: stop Dependabot PRs from carrying false failures, and unblock the production group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,12 +36,34 @@ updates:
       desktop-packaging-security:
         applies-to: security-updates
         patterns: ["electron", "sharp", "@electron/*", "@electron-forge/*"]
+      # @xmldom/xmldom is pre-1.0, where a "minor" is allowed to break —
+      # and 0.8 → 0.9 does: `ErrorHandlerFunction` no longer accepts
+      # `warning`, and its `Document` no longer structurally matches the
+      # DOM one. Dependabot classifies that as `semver-minor`, so it landed
+      # inside the production group and took 34 unrelated bumps down with
+      # it (#4556 failed every check on three type errors in
+      # sdk/src/xaa/mint/saml.ts and sdk/src/openai-readiness/package/
+      # svg-xml-node.ts). Its own group keeps one breaking 0.x bump from
+      # gating the group that carries the security-relevant updates.
+      # DELETE this carve-out once the 0.9 migration lands.
+      xmldom:
+        applies-to: version-updates
+        patterns: ["@xmldom/xmldom"]
+      xmldom-security:
+        applies-to: security-updates
+        patterns: ["@xmldom/xmldom"]
       production-dependencies:
         applies-to: version-updates
         dependency-type: production
         update-types: [minor, patch]
         exclude-patterns:
-          ["electron", "sharp", "@electron/*", "@electron-forge/*"]
+          [
+            "electron",
+            "sharp",
+            "@electron/*",
+            "@electron-forge/*",
+            "@xmldom/xmldom",
+          ]
       development-dependencies:
         applies-to: version-updates
         dependency-type: development
@@ -54,7 +76,13 @@ updates:
         applies-to: security-updates
         dependency-type: production
         exclude-patterns:
-          ["electron", "sharp", "@electron/*", "@electron-forge/*"]
+          [
+            "electron",
+            "sharp",
+            "@electron/*",
+            "@electron-forge/*",
+            "@xmldom/xmldom",
+          ]
       security-development:
         applies-to: security-updates
         dependency-type: development

--- a/.github/workflows/pr-mcp-preview.yml
+++ b/.github/workflows/pr-mcp-preview.yml
@@ -52,9 +52,13 @@ env:
 jobs:
   upsert-mcp-preview:
     # Same fork-PR exclusion as pr-preview.yml — external PRs don't get
-    # access to Cloudflare secrets.
+    # access to Cloudflare secrets. Dependabot PRs are excluded for the
+    # same reason: GitHub gives Dependabot-triggered runs the Dependabot
+    # secret store, not the Actions one, so the Cloudflare credentials
+    # arrive empty and the job can only ever fail.
     if: >
       github.event.action != 'closed' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -203,8 +207,11 @@ jobs:
           echo "- MCP endpoint: \`${DEPLOYMENT_URL%/}/mcp\`" >> "$GITHUB_STEP_SUMMARY"
 
   destroy-mcp-preview:
+    # Mirrors upsert-mcp-preview's exclusions: nothing was ever created for
+    # a Dependabot or fork PR, so there is nothing to tear down.
     if: >
       github.event.action == 'closed' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -54,9 +54,18 @@ env:
 
 jobs:
   upsert-preview:
+    # Dependabot PRs are excluded for the same reason as fork PRs: GitHub
+    # hands Dependabot-triggered runs the Dependabot secret store, not the
+    # Actions one, so RAILWAY_API_TOKEN and BACKEND_PREVIEW_DISPATCH_TOKEN
+    # arrive empty and the job dies on `BACKEND_PREVIEW_DISPATCH_TOKEN
+    # cannot access MCPJam/mcpjam-backend (HTTP 401)`. That is not a
+    # failure anyone can fix on the PR — it made every Dependabot PR show a
+    # red X that had nothing to do with the bump, which is how a real
+    # breakage hides in plain sight.
     if: >
       github.event_name == 'pull_request' &&
       github.event.action != 'closed' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     # Newer pushes cancel older upsert/sync runs for the same PR. Prevents
     # the "commit A's sync clobbers commit B's env vars" race the audit
@@ -630,9 +639,13 @@ jobs:
             });
 
   destroy-preview:
+    # Must mirror upsert-preview's exclusions exactly: a PR that never got
+    # an environment has nothing to destroy, and the teardown would fail on
+    # the same empty token.
     if: >
       github.event_name == 'pull_request' &&
       github.event.action == 'closed' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     # Same group as upsert so closing a PR cancels any in-flight upsert
     # for that PR; destroy runs last.


### PR DESCRIPTION
Two operational fixes found while triaging this morning's Dependabot batch.

## 1. Preview deploys failed on every Dependabot PR

`upsert-preview` was red on all 24 open Dependabot PRs. The cause is structural, not per-PR: GitHub hands Dependabot-triggered runs the **Dependabot** secret store rather than the Actions one (`Secret source: Dependabot` in the job log), so `RAILWAY_API_TOKEN` and `BACKEND_PREVIEW_DISPATCH_TOKEN` arrive empty and the job dies on `BACKEND_PREVIEW_DISPATCH_TOKEN cannot access MCPJam/mcpjam-backend (HTTP 401)`. `upsert-mcp-preview` fails the same way on its Cloudflare credentials.

Neither check is required, so nothing was blocked — but a permanent red X on every dependency PR is how a real breakage hides in plain sight. This review started with "why is everything failing", and the answer was "it isn't".

Dependabot is now excluded from the preview jobs exactly the way fork PRs already are, with the teardown jobs mirrored so nothing is orphaned.

## 2. One breaking 0.x bump gated 34 production updates

#4556 (production group, 35 updates) fails every check. All of it traces to `@xmldom/xmldom` 0.8.13 → 0.9.12, which is pre-1.0 — a "minor" there is allowed to break, and this one does:

```
sdk/src/openai-readiness/package/svg-xml-node.ts(46,9): error TS2353: 'warning' does not exist in type 'ErrorHandlerFunction'
sdk/src/xaa/mint/saml.ts(248,7): error TS2353: 'warning' does not exist in type 'ErrorHandlerFunction'
sdk/src/xaa/mint/saml.ts(257,3): error TS2740: Type 'Document' is missing ... URL, alinkColor, all, anchors, and 193 more
```

Dependabot classifies it `semver-minor`, so it grouped with 34 unrelated bumps — including the security-relevant `@noble/hashes`, `ajv` and `zod` — and sank them all.

xmldom now gets its own version and security groups, so the 0.9 migration arrives as its own reviewable PR. That is what changing SAML XML parsing deserves, rather than a drive-by inside a 35-package bump. The carve-out is marked for deletion once that migration lands.

## After this merges

Comment `@dependabot recreate` on #4556; it should regroup without xmldom and go green.

## Not addressed here

`Inspector Tests` shards are **not** in the required set (`Build and Test`, `Run Tests` are). jsdom 30 (#4565, now closed) passed both required checks while failing `Inspector Tests 2/4` — so a PR can read green in the merge queue with a red test shard. Worth fixing before any policy that auto-merges majors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvkSUhykCecmn8t8HnMf6k

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/Dependabot configuration and do not alter application runtime behavior or secret handling for normal PRs.
> 
> **Overview**
> **Dependabot PRs no longer run Railway/Cloudflare preview jobs**, which were failing with empty secrets because GitHub serves the Dependabot secret store on those runs—not Actions secrets. `pr-preview.yml` and `pr-mcp-preview.yml` now skip `upsert-*` and mirror the same filter on `destroy-*`, like fork PRs already did.
> 
> **`@xmldom/xmldom` is carved out of the bulk production/security Dependabot groups** into dedicated `xmldom` and `xmldom-security` groups, with `@xmldom/xmldom` added to `exclude-patterns` on `production-dependencies` and `security-production`. That stops a breaking 0.8→0.9 “minor” from blocking ~34 unrelated bumps (including security updates) until the SDK SAML/XML migration lands; comments note deleting the carve-out after migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48d015354bb2a1442ac2fc28ace6223bdbfd3b9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes preview deploys so Dependabot PRs stop carrying a permanent red X from empty secrets, and isolates `@xmldom/xmldom` so its breaking 0.9 bump stops gating the production Dependabot group.

- Preview jobs now exclude Dependabot PRs the same way they exclude fork PRs, since Dependabot-triggered runs get the Dependabot secret store and `RAILWAY_API_TOKEN`, `BACKEND_PREVIEW_DISPATCH_TOKEN`, and the Cloudflare credentials always arrive empty.
- Teardown jobs mirror the exclusion so nothing is orphaned.
- `@xmldom/xmldom` is pre-1.0, so 0.8→0.9 is a breaking "minor"; Dependabot grouped it with 34 unrelated production bumps and the whole group failed on its type errors.
- It now has its own version and security groups so the 0.9 migration gets its own reviewable PR; the carve-out is marked for deletion once that lands.
- After merging, comment `@dependabot recreate` on #4556 so it regroups without xmldom.

<sup>Written for commit 48d015354bb2a1442ac2fc28ace6223bdbfd3b9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

