### PR TITLE
harness: pre-seed the adapter's skills write so MCPJam's skill passes stop colliding with it

### DIFF
--- a/mcpjam-inspector/server/utils/harness/__tests__/preseed-adapter-skills.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/preseed-adapter-skills.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect } from "vitest";
+import { writeSkills } from "@ai-sdk/harness/utils";
+import {
+  handOffLegacySkillDirs,
+  preseedAdapterSkills,
+  type PreseedSession,
+} from "../preseed-adapter-skills";
+
+const ROOT = "/home/user/.claude/skills";
+const ADAPTER_MANIFEST = `${ROOT}/.ai-sdk-harness-skills.json`;
+const MCPJAM_MANIFEST = `${ROOT}/.mcpjam-skills.json`;
+
+/**
+ * In-memory sandbox session interpreting exactly the shell the library's
+ * `writeSkills` issues (`mkdir -p`, `mv -f`, `rm -rf --`, `test ! -e`) plus
+ * this module's own `rm -rf --`. Paths arrive single-quoted.
+ */
+function makeSession(initial: {
+  files?: Record<string, string>;
+  dirs?: string[];
+}) {
+  const files = new Map<string, string>(Object.entries(initial.files ?? {}));
+  const dirs = new Set<string>(initial.dirs ?? []);
+  const commands: string[] = [];
+
+  const tokens = (command: string): string[] => {
+    const out: string[] = [];
+    for (const m of command.matchAll(/'([^']*)'|(\S+)/g)) {
+      out.push(m[1] ?? m[2]);
+    }
+    return out;
+  };
+  const exists = (path: string): boolean => {
+    if (dirs.has(path) || files.has(path)) return true;
+    for (const p of files.keys()) if (p.startsWith(`${path}/`)) return true;
+    for (const d of dirs) if (d.startsWith(`${path}/`)) return true;
+    return false;
+  };
+  const removeTree = (path: string): void => {
+    dirs.delete(path);
+    for (const d of [...dirs]) if (d.startsWith(`${path}/`)) dirs.delete(d);
+    for (const p of [...files.keys()])
+      if (p === path || p.startsWith(`${path}/`)) files.delete(p);
+  };
+
+  const session: PreseedSession = {
+    readTextFile: async ({ path }) => files.get(path) ?? null,
+    writeTextFile: async ({ path, content }) => {
+      files.set(path, content);
+    },
+    run: async ({ command }) => {
+      commands.push(command);
+      const argv = tokens(command);
+      const ok = { exitCode: 0, stdout: "", stderr: "" };
+      if (argv[0] === "mkdir" && argv[1] === "-p") {
+        dirs.add(argv[2]);
+        return ok;
+      }
+      if (argv[0] === "mv" && argv[1] === "-f") {
+        const content = files.get(argv[2]);
+        if (content === undefined)
+          return { exitCode: 1, stdout: "", stderr: "mv: missing source" };
+        files.set(argv[3], content);
+        files.delete(argv[2]);
+        return ok;
+      }
+      if (argv[0] === "rm" && argv[1] === "-rf" && argv[2] === "--") {
+        for (const path of argv.slice(3)) removeTree(path);
+        return ok;
+      }
+      if (argv[0] === "test" && argv[1] === "!" && argv[2] === "-e") {
+        return exists(argv[3])
+          ? { exitCode: 1, stdout: "", stderr: "" }
+          : ok;
+      }
+      throw new Error(`fake session: unrecognized command: ${command}`);
+    },
+  };
+  return { session, files, dirs, commands };
+}
+
+const PAYLOAD = [
+  { name: "find-skills", description: '"Find skills"', content: "body A" },
+  { name: "frontend-design", description: '"Design"', content: "body B" },
+];
+
+/** The library sandbox type is nominally distinct; cast like the module does. */
+const asLibSandbox = (session: PreseedSession) =>
+  session as unknown as Parameters<typeof writeSkills>[0]["sandbox"];
+
+describe("preseedAdapterSkills", () => {
+  it("writes each SKILL.md and a complete adapter manifest", async () => {
+    const { session, files } = makeSession({});
+    await preseedAdapterSkills({
+      session,
+      skillsBase: ROOT,
+      payload: PAYLOAD,
+      trailingNewline: true,
+    });
+    expect(files.get(`${ROOT}/find-skills/SKILL.md`)).toContain("body A");
+    expect(files.get(`${ROOT}/frontend-design/SKILL.md`)).toContain("body B");
+    const manifest = JSON.parse(files.get(ADAPTER_MANIFEST)!) as {
+      state: string;
+      skills: Array<{ name: string; hash: string }>;
+    };
+    expect(manifest.state).toBe("complete");
+    expect(manifest.skills.map((s) => s.name).sort()).toEqual([
+      "find-skills",
+      "frontend-design",
+    ]);
+    for (const skill of manifest.skills) {
+      expect(skill.hash).toMatch(/^[a-f0-9]{64}$/);
+    }
+  });
+
+  it("makes the Claude adapter's own turn-time write a hash-unchanged no-op", async () => {
+    const { session, commands } = makeSession({});
+    await preseedAdapterSkills({
+      session,
+      skillsBase: ROOT,
+      payload: PAYLOAD,
+      trailingNewline: true,
+    });
+    const before = commands.length;
+    // Exactly how `writeClaudeCodeSkills` invokes the library (messages don't
+    // affect the projected hash; `trailingNewline: true` does).
+    const result = await writeSkills({
+      sandbox: asLibSandbox(session),
+      rootDir: ROOT,
+      skills: PAYLOAD,
+      invalidSkillNameMessage: ({ name }) =>
+        `Invalid Claude Code skill name: ${name}`,
+      invalidSkillFilePathMessage: ({ skillName, filePath }) =>
+        `Invalid Claude Code skill file path for ${skillName}: ${filePath}`,
+      trailingNewline: true,
+    });
+    expect(result.changed).toBe(false);
+    expect(result.unchanged.sort()).toEqual(["find-skills", "frontend-design"]);
+    const after = commands.slice(before);
+    expect(after.filter((c) => c.startsWith("rm "))).toEqual([]);
+  });
+
+  it("makes the Codex adapter's own turn-time write a no-op (default options)", async () => {
+    const { session } = makeSession({});
+    const codexRoot = "/home/user/.agents/skills";
+    await preseedAdapterSkills({
+      session,
+      skillsBase: codexRoot,
+      payload: PAYLOAD,
+      trailingNewline: false,
+    });
+    // Exactly how `writeCodexSkills` invokes the library.
+    const result = await writeSkills({
+      sandbox: asLibSandbox(session),
+      rootDir: codexRoot,
+      skills: PAYLOAD,
+      invalidSkillNameMessage: ({ name }) => `Invalid Codex skill name: ${name}`,
+      invalidSkillFilePathMessage: ({ skillName, filePath }) =>
+        `Invalid Codex skill file path for ${skillName}: ${filePath}`,
+    });
+    expect(result.changed).toBe(false);
+  });
+
+  it("refuses a foreign colliding dir with the adapter's own error", async () => {
+    const { session } = makeSession({
+      files: { [`${ROOT}/frontend-design/SKILL.md`]: "hand-placed" },
+    });
+    await expect(
+      preseedAdapterSkills({
+        session,
+        skillsBase: ROOT,
+        payload: PAYLOAD,
+        trailingNewline: true,
+      }),
+    ).rejects.toThrow(/not owned by the AI SDK harness/);
+  });
+});
+
+describe("handOffLegacySkillDirs", () => {
+  const mcpjamManifest = (names: string[]) =>
+    JSON.stringify({
+      schemaVersion: 1,
+      skillsHash: "f70b9b65",
+      skills: Object.fromEntries(
+        names.map((name, i) => [`id${i}`, { skillId: `id${i}`, name }]),
+      ),
+    });
+
+  it("removes only delivered, MCPJam-managed dirs the adapter does not own", async () => {
+    const { session, files } = makeSession({
+      files: {
+        [MCPJAM_MANIFEST]: mcpjamManifest(["find-skills", "frontend-design"]),
+        [`${ROOT}/find-skills/SKILL.md`]: "legacy",
+        [`${ROOT}/frontend-design/SKILL.md`]: "legacy",
+        [`${ROOT}/hand-placed/SKILL.md`]: "user data",
+      },
+    });
+    const { removed } = await handOffLegacySkillDirs({
+      session,
+      skillsBase: ROOT,
+      deliveredNames: ["find-skills", "frontend-design", "hand-placed"],
+    });
+    expect(removed.sort()).toEqual(["find-skills", "frontend-design"]);
+    expect(files.has(`${ROOT}/find-skills/SKILL.md`)).toBe(false);
+    // Not in MCPJam's manifest ⇒ user data, never removed.
+    expect(files.get(`${ROOT}/hand-placed/SKILL.md`)).toBe("user data");
+  });
+
+  it("leaves dirs the adapter manifest already owns", async () => {
+    const { session, files } = makeSession({
+      files: {
+        [MCPJAM_MANIFEST]: mcpjamManifest(["find-skills"]),
+        [ADAPTER_MANIFEST]: JSON.stringify({
+          version: 1,
+          state: "complete",
+          skills: [{ name: "find-skills", hash: "a".repeat(64) }],
+        }),
+        [`${ROOT}/find-skills/SKILL.md`]: "adapter-owned",
+      },
+    });
+    const { removed } = await handOffLegacySkillDirs({
+      session,
+      skillsBase: ROOT,
+      deliveredNames: ["find-skills"],
+    });
+    expect(removed).toEqual([]);
+    expect(files.get(`${ROOT}/find-skills/SKILL.md`)).toBe("adapter-owned");
+  });
+
+  it("does nothing without an MCPJam manifest", async () => {
+    const { session, commands } = makeSession({
+      files: { [`${ROOT}/find-skills/SKILL.md`]: "x" },
+    });
+    const { removed } = await handOffLegacySkillDirs({
+      session,
+      skillsBase: ROOT,
+      deliveredNames: ["find-skills"],
+    });
+    expect(removed).toEqual([]);
+    expect(commands).toEqual([]);
+  });
+
+  it("legacy box end-to-end: hand-off then pre-seed then adapter no-op", async () => {
+    const { session, files } = makeSession({
+      files: {
+        [MCPJAM_MANIFEST]: mcpjamManifest(["find-skills", "frontend-design"]),
+        [`${ROOT}/find-skills/SKILL.md`]: "legacy",
+        [`${ROOT}/frontend-design/SKILL.md`]: "legacy",
+      },
+    });
+    await handOffLegacySkillDirs({
+      session,
+      skillsBase: ROOT,
+      deliveredNames: PAYLOAD.map((s) => s.name),
+    });
+    await preseedAdapterSkills({
+      session,
+      skillsBase: ROOT,
+      payload: PAYLOAD,
+      trailingNewline: true,
+    });
+    expect(files.get(`${ROOT}/find-skills/SKILL.md`)).toContain("body A");
+    const result = await writeSkills({
+      sandbox: asLibSandbox(session),
+      rootDir: ROOT,
+      skills: PAYLOAD,
+      trailingNewline: true,
+    });
+    expect(result.changed).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/preseed-adapter-skills.ts
+++ b/mcpjam-inspector/server/utils/harness/preseed-adapter-skills.ts
@@ -1,0 +1,195 @@
+/**
+ * Ownership pre-seed for the adapter's on-box skills write.
+ *
+ * Since the stable `@ai-sdk/harness` line, the ADAPTER re-writes its skills at
+ * the start of EVERY prompt turn (`writeClaudeCodeSkills` in `doPromptTurn`,
+ * same for Codex) through `writeSkills`, which tracks ownership in a
+ * `.ai-sdk-harness-skills.json` manifest and REFUSES any pre-existing skill
+ * dir that manifest does not list. That collides with MCPJam's own skill
+ * passes, all of which run earlier (in `onSandboxSession`) and create or
+ * rewrite exactly those dirs:
+ *
+ *   - `materializeSkillFiles` / `materializePinnedSkillFiles` write a skill's
+ *     supporting files (signed-URL blobs the `skills` param cannot carry),
+ *     creating the dir before the adapter ever writes it → the adapter's
+ *     "already exists and is not owned" refusal fails the whole turn;
+ *   - `materializeSkillFrontmatter` re-writes SKILL.md with preserved extra
+ *     frontmatter, which an adapter write in the SAME turn would clobber;
+ *   - boxes from before the stable line hold dirs MCPJam managed (delivered or
+ *     adopted) that the adapter manifest has never seen, so a current project
+ *     skill becomes permanently undeliverable there.
+ *
+ * The fix is to run the adapter's OWN write first, from `onSandboxSession`:
+ * same payload, same options, same `@ai-sdk/harness` `writeSkills` ⇒ the same
+ * per-skill content hash lands in the adapter manifest, so the adapter's
+ * turn-time call sees every skill unchanged and touches nothing. Dirs are
+ * adapter-owned before any MCPJam pass targets them, and what those passes add
+ * survives because `writeSkills` never touches a hash-unchanged skill.
+ *
+ * VERSION LOCKSTEP: the no-op depends on this package's `@ai-sdk/harness`
+ * hashing byte-identically to the copy nested inside each harness adapter
+ * (all 1.0.96 today). If they drift, nothing breaks loudly — the adapter
+ * re-writes each skill once per session and MCPJam's supporting files for it
+ * are lost until the next session — but the drift should be closed, not
+ * tolerated. `__tests__/preseed-adapter-skills.test.ts` asserts the no-op
+ * against this package's copy; verify the nested versions on adapter bumps.
+ */
+import { writeSkills } from "@ai-sdk/harness/utils";
+import { shellQuote } from "./shell-quote.js";
+import type { HarnessSkillPayload } from "./runtime-skills.js";
+import { logger } from "../logger.js";
+
+/** Minimal structural view of the harness sandbox session (dual-`ai` boundary:
+ *  the live session object comes from an adapter's nested `@ai-sdk/harness`
+ *  copy, nominally distinct from this package's — structurally identical). */
+export interface PreseedSession {
+  readTextFile(args: {
+    path: string;
+    abortSignal?: AbortSignal;
+  }): PromiseLike<string | null>;
+  writeTextFile(args: {
+    path: string;
+    content: string;
+    abortSignal?: AbortSignal;
+  }): PromiseLike<unknown>;
+  run(args: {
+    command: string;
+    abortSignal?: AbortSignal;
+  }): PromiseLike<{ exitCode: number; stdout: string; stderr: string }>;
+}
+
+/** The adapter core's ownership manifest (`writeSkills` reads/writes it). */
+const ADAPTER_MANIFEST_BASENAME = ".ai-sdk-harness-skills.json";
+/** MCPJam's managed-dirs manifest (see `reconcile-skill-dirs.ts`). */
+const MCPJAM_MANIFEST_BASENAME = ".mcpjam-skills.json";
+
+async function readManifestNames(
+  session: PreseedSession,
+  path: string,
+  extract: (parsed: unknown) => string[],
+): Promise<Set<string> | null> {
+  let raw: string | null;
+  try {
+    raw = await session.readTextFile({ path });
+  } catch {
+    return null; // unreadable ≠ empty: the caller must not treat this as "owns nothing"
+  }
+  if (!raw) return new Set();
+  try {
+    return new Set(extract(JSON.parse(raw)));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Hand legacy MCPJam-managed skill dirs over to the adapter: remove any dir
+ * that (a) is being delivered this turn, (b) MCPJam's manifest claims as
+ * managed, and (c) the adapter's manifest does not own. The pre-seed that
+ * follows re-writes it in the same breath, adapter-owned.
+ *
+ * Only MCPJam-managed dirs are eligible — a hand-placed dir that merely shares
+ * a delivered skill's name is user data, and deleting it is not ours to do;
+ * the pre-seed's own "not owned" refusal surfaces that collision instead.
+ *
+ * Best-effort: an unreadable manifest or a failed removal logs and returns —
+ * the pre-seed's refusal is the loud backstop.
+ */
+export async function handOffLegacySkillDirs(args: {
+  session: PreseedSession;
+  skillsBase: string;
+  deliveredNames: string[];
+  signal?: AbortSignal;
+}): Promise<{ removed: string[] }> {
+  const { session, skillsBase } = args;
+  const mcpjamManaged = await readManifestNames(
+    session,
+    `${skillsBase}/${MCPJAM_MANIFEST_BASENAME}`,
+    (parsed) => {
+      const skills = (parsed as { skills?: Record<string, { name?: unknown }> })
+        ?.skills;
+      return Object.values(skills ?? {})
+        .map((entry) => entry?.name)
+        .filter((name): name is string => typeof name === "string");
+    },
+  );
+  if (mcpjamManaged === null || mcpjamManaged.size === 0) {
+    return { removed: [] };
+  }
+  const adapterOwned = await readManifestNames(
+    session,
+    `${skillsBase}/${ADAPTER_MANIFEST_BASENAME}`,
+    (parsed) => {
+      const skills = (parsed as { skills?: Array<{ name?: unknown }> })?.skills;
+      return (Array.isArray(skills) ? skills : [])
+        .map((entry) => entry?.name)
+        .filter((name): name is string => typeof name === "string");
+    },
+  );
+  if (adapterOwned === null) return { removed: [] };
+
+  const toRemove = args.deliveredNames.filter(
+    (name) => mcpjamManaged.has(name) && !adapterOwned.has(name),
+  );
+  if (toRemove.length === 0) return { removed: [] };
+
+  const command = `rm -rf -- ${toRemove
+    .map((name) => shellQuote(`${skillsBase}/${name}`))
+    .join(" ")}`;
+  try {
+    const result = await session.run({
+      command,
+      ...(args.signal ? { abortSignal: args.signal } : {}),
+    });
+    if (result.exitCode !== 0) {
+      logger.warn("[preseed-adapter-skills] legacy hand-off rm failed", {
+        skillsBase,
+        exitCode: result.exitCode,
+        stderr: result.stderr?.slice(0, 500),
+      });
+      return { removed: [] };
+    }
+  } catch (error) {
+    logger.warn("[preseed-adapter-skills] legacy hand-off errored", {
+      skillsBase,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { removed: [] };
+  }
+  logger.info("[preseed-adapter-skills] handed legacy dirs to adapter", {
+    skillsBase,
+    removed: toRemove,
+  });
+  return { removed: toRemove };
+}
+
+/**
+ * Run the adapter's skills write ahead of it. Options MUST mirror the
+ * adapter's own `writeSkills` invocation exactly (the per-adapter divergence —
+ * Claude Code passes `trailingNewline: true`, Codex the default — travels on
+ * `HarnessRuntimeAdapter.skillsWriteOptions`); the payload is the same object
+ * handed to `HarnessAgent`'s `skills` param, so the projected content hash is
+ * identical and the adapter's turn-time write is a no-op.
+ *
+ * Throws on a genuinely foreign colliding dir — the same "already exists and
+ * is not owned" refusal the adapter itself would raise a moment later, just
+ * before MCPJam's passes have touched anything.
+ */
+export async function preseedAdapterSkills(args: {
+  session: PreseedSession;
+  skillsBase: string;
+  payload: HarnessSkillPayload[];
+  trailingNewline: boolean;
+  signal?: AbortSignal;
+}): Promise<void> {
+  await writeSkills({
+    // Dual-`ai` boundary cast, same as the adapters in `registry.ts`.
+    sandbox: args.session as unknown as Parameters<
+      typeof writeSkills
+    >[0]["sandbox"],
+    rootDir: args.skillsBase,
+    skills: args.payload,
+    trailingNewline: args.trailingNewline,
+    ...(args.signal ? { abortSignal: args.signal } : {}),
+  });
+}

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -234,6 +234,14 @@ type HarnessRuntimeAdapterBase = {
    *  turn-end adoption) must address the dirs the ADAPTER wrote, so the root
    *  travels with the adapter instead of being hardcoded per pass. */
   skillsBaseDir: string;
+  /** The options THIS adapter's runtime passes to `writeSkills` for its
+   *  turn-time on-box write, mirrored exactly so the `onSandboxSession`
+   *  pre-seed (see `preseed-adapter-skills.ts`) produces the identical
+   *  projected content hash and the adapter's own write becomes a no-op.
+   *  Claude Code passes `trailingNewline: true`; Codex takes the default.
+   *  Verified against the installed packages' `writeClaudeCodeSkills` /
+   *  `writeCodexSkills` — re-verify on adapter bumps. */
+  skillsWriteOptions: { trailingNewline: boolean };
   /** Shape the runtime skills into this adapter's `skills` param, and report
    *  which skills that actually amounts to (a runtime may reject a name outright
    *  — Codex throws mid-`doStart`, which would fail the whole turn). The caller
@@ -948,6 +956,8 @@ const claudeCodeAdapter: HarnessRuntimeAdapter = {
   mcpDelivery: HARNESS_MCP_DELIVERY["claude-code"],
   supportsSkills: true,
   skillsBaseDir: CLAUDE_CODE_SKILLS_BASE,
+  // Mirrors `writeClaudeCodeSkills` in `@ai-sdk/harness-claude-code`.
+  skillsWriteOptions: { trailingNewline: true },
   prepareSkills: prepareClaudeCodeSkills,
   // No native plugin-unit install: this adapter delivers a plugin's COMPONENTS
   // (skills param + `.mcp.json`), which is not the same contract.
@@ -1049,6 +1059,8 @@ const codexAdapter: HarnessRuntimeAdapter = {
   // adapter in `__tests__/codex-skill-parity.test.ts`.
   supportsSkills: true,
   skillsBaseDir: CODEX_SKILLS_BASE,
+  // Mirrors `writeCodexSkills` in `@ai-sdk/harness-codex` (library default).
+  skillsWriteOptions: { trailingNewline: false },
   prepareSkills: prepareCodexSkills,
   // Codex has no plugin-install interface in the installed harness — MCPJam
   // still projects a plugin's components (skills param, host-executed MCP

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -111,6 +111,10 @@ import { materializePinnedSkillFiles } from "./pinned-harness-skills.js";
 import { selectHarnessSkillSource } from "./skill-delivery.js";
 import { materializeSkillFrontmatter } from "./materialize-skill-frontmatter.js";
 import {
+  handOffLegacySkillDirs,
+  preseedAdapterSkills,
+} from "./preseed-adapter-skills.js";
+import {
   reconcileSkillDirs,
   appendManagedSkills,
 } from "./reconcile-skill-dirs.js";
@@ -1749,6 +1753,35 @@ export async function runHarnessTurn(
               skillsBase: harnessAdapter.skillsBaseDir,
               ...(abortSignal ? { signal: abortSignal } : {}),
             }).catch(() => {});
+            // OWNERSHIP PRE-SEED (stable adapter line). The adapter re-writes
+            // its skills at the start of EVERY prompt turn via `writeSkills`,
+            // which refuses any pre-existing dir absent from its own
+            // `.ai-sdk-harness-skills.json` — and the materialize passes below
+            // create exactly those dirs. Running the SAME write here first
+            // (same payload, same options ⇒ same content hash) makes the
+            // adapter's turn-time call a hash-unchanged no-op: dirs become
+            // adapter-owned BEFORE supporting files/frontmatter land in them,
+            // and stay untouched after. Legacy dirs MCPJam managed before the
+            // adapter manifest existed are handed off (removed) first; the
+            // pre-seed re-writes them in the same breath. A genuinely foreign
+            // colliding dir still throws the adapter's own "not owned" error —
+            // just here, before any MCPJam pass has touched the box.
+            if (preparedSkills && preparedSkills.payload.length > 0) {
+              await handOffLegacySkillDirs({
+                session,
+                skillsBase: harnessAdapter.skillsBaseDir,
+                deliveredNames: deliveredSkills.map((s) => s.name),
+                ...(abortSignal ? { signal: abortSignal } : {}),
+              });
+              await preseedAdapterSkills({
+                session,
+                skillsBase: harnessAdapter.skillsBaseDir,
+                payload: preparedSkills.payload,
+                trailingNewline:
+                  harnessAdapter.skillsWriteOptions.trailingNewline,
+                ...(abortSignal ? { signal: abortSignal } : {}),
+              });
+            }
             // PINNED MODE: supporting files ride INLINE on the pinned
             // artifacts (P0.2 host-channel plugin skills) — never the live
             // file query. Env-channel entries are SKILL.md-only under P0.3.
@@ -1764,8 +1797,10 @@ export async function runHarnessTurn(
                 ...(abortSignal ? { signal: abortSignal } : {}),
               }).catch(() => {});
             }
-            // Materialize supporting files AFTER reconcile (the adapter wrote each
-            // SKILL.md; reconcile removed stale managed dirs). Fetched here rather
+            // Materialize supporting files AFTER the pre-seed (each SKILL.md is
+            // written and adapter-owned; reconcile removed stale managed dirs),
+            // so the files land in dirs the adapter's turn-time write will not
+            // refuse or clobber. Fetched here rather
             // than at turn start to keep the zero-file fast path free. Fully
             // fail-soft; guest/swarm scope uses the execution-scoped file query.
             //
@@ -1959,10 +1994,11 @@ export async function runHarnessTurn(
 
       // Re-write SKILL.md WITH preserved extra frontmatter (allowed-tools /
       // license / …) for skills that carry it. The adapter's `skills` param
-      // structurally can't deliver those fields, and the adapter writes its
-      // own (extras-less) SKILL.md during createSession — AFTER
-      // `onSandboxSession` — so this must run here, post-createSession, or a
-      // fresh start (exactly when the adapter writes) would clobber it.
+      // structurally can't deliver those fields. The `onSandboxSession`
+      // pre-seed wrote each (extras-less) SKILL.md and made the adapter's own
+      // per-prompt write a hash-unchanged no-op, so this rewrite survives the
+      // turn; it runs post-createSession only to keep it off the session-start
+      // critical path.
       // Fail-soft (never fails the turn); zero session calls when no skill
       // has extras; same gating as the onSandboxSession skill passes.
       if (deliveredSkills.length > 0 && sandboxFileSession) {


### PR DESCRIPTION
## What

Fixes the every-turn harness failure `Cannot write harness skill 'X': <dir> already exists and is not owned by the AI SDK harness`, plus two adjacent casualties of the same upstream change.

Since the stable `@ai-sdk/harness` line (#4530), the adapter re-writes its skills at the start of **every prompt turn** via `writeSkills`, which tracks ownership in an on-box `.ai-sdk-harness-skills.json` and refuses any pre-existing skill dir that manifest does not list. All of MCPJam's own skill passes run earlier (in `onSandboxSession`) and create exactly those dirs:

- `materializeSkillFiles` pre-created a dir for any skill with supporting files → the adapter refused it and the **whole turn failed, every turn**;
- `materializeSkillFrontmatter`'s extras rewrite (allowed-tools / license) was clobbered by the adapter's write on a skill's first-delivery turn;
- boxes from before the stable line hold dirs MCPJam managed (delivered or **adopted**) that the adapter manifest has never seen → a current project skill was **permanently undeliverable** there.

## How

Run the adapter's **own** write first, from `onSandboxSession` (`preseed-adapter-skills.ts`):

- Same payload, same options (new per-adapter `skillsWriteOptions` mirrors each runtime's invocation: Claude Code `trailingNewline: true`, Codex default), same `@ai-sdk/harness` `writeSkills` ⇒ the identical per-skill content hash lands in the adapter manifest, so the adapter's turn-time call sees every skill **unchanged and touches nothing**.
- Dirs are adapter-owned before any MCPJam pass targets them; supporting files and frontmatter rewrites survive because `writeSkills` never touches a hash-unchanged skill.
- A hand-off pass first removes legacy dirs that `.mcpjam-skills.json` claims but the adapter manifest does not own — never a hand-placed dir; that still surfaces the adapter's own refusal, just before any MCPJam pass has touched the box.

Why not the alternatives: supporting files are signed-URL blobs with quota metering, so they can't ride the UTF-8 `skills` payload; and there is no seam between the adapter's `doPromptTurn` write and the CLI reading the dir, so reordering was impossible.

**Version lockstep:** the no-op depends on our `@ai-sdk/harness` (already a direct dep) hashing byte-identically to the copy nested in each adapter — all `1.0.96` today. Drift degrades to a rewrite-per-session (supporting files lost until next session), not a turn failure; the module doc says to re-verify on adapter bumps.

## Testing

- New `__tests__/preseed-adapter-skills.test.ts` (8 tests) against the real library `writeSkills` over an in-memory sandbox session, including **parity asserts**: after the pre-seed, invoking `writeSkills` exactly the way each adapter does returns `changed: false` with no `rm` issued.
- All 38 harness suites pass (480 tests); no new type errors vs baseline.
- Verified live on a real E2B computer: the previously always-failing `frontend-design` (has supporting files) delivery now completes and the turn streams a model response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox skill lifecycle ordering and can delete MCPJam-managed legacy dirs; correctness depends on `@ai-sdk/harness` hash parity with nested adapter copies on version bumps.
> 
> **Overview**
> Fixes harness turns failing with **“skill dir already exists and is not owned by the AI SDK harness”** after stable `@ai-sdk/harness` started re-writing skills every prompt via `writeSkills` and its `.ai-sdk-harness-skills.json` manifest.
> 
> During **`onSandboxSession`**, after reconcile and **before** supporting-file / pinned-file materialization, the turn now **hands off** legacy dirs listed in `.mcpjam-skills.json` but not adapter-owned (never hand-placed user dirs), then **pre-seeds** the same `writeSkills` call the adapter will use (payload + per-adapter `skillsWriteOptions`, e.g. Claude `trailingNewline: true`). That registers adapter ownership so the adapter’s per-turn write is a hash no-op and MCPJam’s extra files and frontmatter rewrites are not refused or clobbered.
> 
> Adds **`preseed-adapter-skills.ts`**, wires **`skillsWriteOptions`** on Claude Code and Codex in **`registry.ts`**, and **`__tests__/preseed-adapter-skills.test.ts`** asserting manifest writes, legacy cleanup, foreign-dir refusal, and post-pre-seed `writeSkills` parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94e80908278c675cd1849ecb20ce3bb882308632. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the every-turn harness failure `Cannot write harness skill 'X': <dir> already exists and is not owned by the AI SDK harness` and the clobbering of MCPJam's frontmatter rewrites by pre-seeding the adapter's own skills write from `onSandboxSession`, so its turn-time write becomes a hash-unchanged no-op.

- Runs the adapter's own `@ai-sdk/harness` `writeSkills` with the same payload and options, so the identical content hash lands in the adapter manifest and the turn-time call touches nothing.
- Supporting-file dirs and extras rewrites survive because `writeSkills` never modifies a hash-unchanged skill.
- A hand-off pass removes legacy dirs `.mcpjam-skills.json` claims but the adapter manifest doesn't own, restoring pre-stable boxes; a hand-placed foreign dir still surfaces the adapter's own refusal.
- The no-op requires `@ai-sdk/harness` to hash byte-identically to the copy nested in each adapter (all `1.0.96`); drift degrades to a rewrite-per-session, not a turn failure.

<sup>Written for commit 94e80908278c675cd1849ecb20ce3bb882308632. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

