### PR TITLE
Skills UX simplification: one library, one button, one rule

### DIFF
--- a/mcpjam-inspector/client/src/components/SkillsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SkillsTab.tsx
@@ -549,7 +549,7 @@ export function SkillsTab({
                         onChange={(next) => setSource(next)}
                         options={[
                           { value: "local", label: "Local" },
-                          { value: "cloud", label: "Cloud" },
+                          { value: "cloud", label: "Library" },
                         ]}
                         className="mr-1"
                       />
@@ -675,7 +675,7 @@ export function SkillsTab({
                         >
                           {selectedItem.origin === "cloud"
                             ? selectedItem.sharing === "project"
-                              ? "Shared"
+                              ? "Project"
                               : "Personal"
                             : "Local"}
                         </Badge>

--- a/mcpjam-inspector/client/src/components/SkillsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SkillsTab.tsx
@@ -149,8 +149,13 @@ export function SkillsTab({
    */
   const { isAuthenticated } = useConvexAuth();
   const { canManageMembers: canManageShared } = useProjectMembers({
-    isAuthenticated: isAuthenticated && isCloudMode,
-    projectId: isCloudMode && projectId ? projectId : null,
+    // Gated on the store being on this surface at all, not merely on cloud
+    // mode. With `cloudSkillsEnabled` off there is no library, no Publish
+    // button, and nothing this answer could change — and the same rule already
+    // keeps `listSkills` from firing. A standing project-members subscription
+    // for a tab showing only server skills is the same mistake in another API.
+    isAuthenticated: isAuthenticated && isCloudMode && !cloudUnavailable,
+    projectId: isCloudMode && !cloudUnavailable && projectId ? projectId : null,
   });
   const [skills, setSkills] = useState<SkillListItem[]>([]);
   const [selectedSkillName, setSelectedSkillName] = useState<string>("");

--- a/mcpjam-inspector/client/src/components/SkillsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SkillsTab.tsx
@@ -20,7 +20,10 @@ import {
   Pencil,
   Laptop,
 } from "lucide-react";
+import { useConvexAuth } from "convex/react";
+import { toast } from "sonner";
 import { track } from "@/lib/analytics";
+import { useProjectMembers } from "@/hooks/useProjects";
 import { EmptyState } from "./ui/empty-state";
 import {
   listSkills,
@@ -132,6 +135,23 @@ export function SkillsTab({
         : { kind: "local" },
     [isCloudMode, projectId]
   );
+  /**
+   * Whether this member may publish a skill to the project library.
+   *
+   * Backend `projectSkills:promoteSkillToProject` requires project admin
+   * (`canManageProjectMembers`) — the same authority `canManageMembers`
+   * resolves — so a non-admin's Publish click was always going to be refused.
+   * It used to be offered anyway, and the refusal went to the devtools
+   * console: the button appeared to do nothing at all.
+   *
+   * Fails closed while the query loads, which is the safe direction: a button
+   * that appears a moment late beats one that refuses on click.
+   */
+  const { isAuthenticated } = useConvexAuth();
+  const { canManageMembers: canManageShared } = useProjectMembers({
+    isAuthenticated: isAuthenticated && isCloudMode,
+    projectId: isCloudMode && projectId ? projectId : null,
+  });
   const [skills, setSkills] = useState<SkillListItem[]>([]);
   const [selectedSkillName, setSelectedSkillName] = useState<string>("");
   const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
@@ -399,7 +419,12 @@ export function SkillsTab({
       });
       await fetchSkills();
     } catch (err) {
+      // The person who clicked is the one who needs to know it failed, and
+      // they are not reading the console. `webPost` throws a `WebApiError`
+      // carrying the server's own message.
+      const message = err instanceof Error ? err.message : String(err);
       console.error("Error promoting skill:", err);
+      toast.error(`Couldn't publish "${selectedItem.name}": ${message}`);
     }
   };
 
@@ -558,7 +583,7 @@ export function SkillsTab({
                       onClick={() => setIsUploadDialogOpen(true)}
                       variant="ghost"
                       size="sm"
-                      title="Upload skill"
+                      title={isCloudMode ? "Add to library" : "Upload skill"}
                       disabled={cloudUnavailable}
                     >
                       <Plus className="h-3 w-3 cursor-pointer" />
@@ -644,7 +669,9 @@ export function SkillsTab({
                           disabled={cloudUnavailable}
                         >
                           <Plus className="h-3 w-3 mr-2" />
-                          Upload your first skill
+                          {isCloudMode
+                            ? "Add your first skill"
+                            : "Upload your first skill"}
                         </Button>
                       </div>
                     ))}
@@ -776,14 +803,18 @@ export function SkillsTab({
                           <Pencil className="h-4 w-4" />
                         </Button>
                       )}
+                    {/* Publishing is admin-only on the backend, so a member
+                        who cannot publish is not offered the button — see
+                        `canManageShared`. */}
                     {selectedItem?.origin === "cloud" &&
-                      selectedItem.sharing === "user" && (
+                      selectedItem.sharing === "user" &&
+                      canManageShared && (
                         <Button
                           onClick={handlePromote}
                           variant="ghost"
                           size="icon"
                           className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                          title="Promote to project (share with all members)"
+                          title="Publish to project library"
                         >
                           <Globe className="h-4 w-4" />
                         </Button>

--- a/mcpjam-inspector/client/src/components/__tests__/SkillsTab.cloud-gate.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/SkillsTab.cloud-gate.test.tsx
@@ -40,9 +40,13 @@ vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 
 // The tab resolves the publish permission from Convex; these suites are about
 // the tab's chrome, not about that resolution (see SkillsTab.promote-gate).
-vi.mock("convex/react", () => ({ useConvexAuth: () => ({ isAuthenticated: false }) }));
+vi.mock("convex/react", () => ({ useConvexAuth: () => ({ isAuthenticated: true }) }));
+const useProjectMembersMock = vi.fn(() => ({
+  canManageMembers: false,
+  isLoading: false,
+}));
 vi.mock("@/hooks/useProjects", () => ({
-  useProjectMembers: () => ({ canManageMembers: false, isLoading: false }),
+  useProjectMembers: (...args: unknown[]) => useProjectMembersMock(...args),
 }));
 
 import { SkillsTab } from "../SkillsTab";
@@ -69,6 +73,22 @@ describe("SkillsTab — cloud store gate", () => {
     ).not.toBeInTheDocument();
     // A list behind the flag is a request the backend gates anyway.
     expect(listSkills).not.toHaveBeenCalled();
+    // Same rule, other API: with no library on the surface there is no Publish
+    // button and nothing this answer could change, so the tab must not hold a
+    // standing project-members subscription for it either.
+    expect(useProjectMembersMock).toHaveBeenCalledWith({
+      isAuthenticated: false,
+      projectId: null,
+    });
+  });
+
+  it("does ask who the viewer is once the store is on the surface", async () => {
+    render(<SkillsTab projectId="project-1" cloudSkillsEnabled />);
+
+    expect(useProjectMembersMock).toHaveBeenCalledWith({
+      isAuthenticated: true,
+      projectId: "project-1",
+    });
   });
 
   it("shows the project store and lists it when enabled", async () => {

--- a/mcpjam-inspector/client/src/components/__tests__/SkillsTab.cloud-gate.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/SkillsTab.cloud-gate.test.tsx
@@ -38,6 +38,13 @@ vi.mock("../skills/ServerSkillsSection", () => ({
 
 vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 
+// The tab resolves the publish permission from Convex; these suites are about
+// the tab's chrome, not about that resolution (see SkillsTab.promote-gate).
+vi.mock("convex/react", () => ({ useConvexAuth: () => ({ isAuthenticated: false }) }));
+vi.mock("@/hooks/useProjects", () => ({
+  useProjectMembers: () => ({ canManageMembers: false, isLoading: false }),
+}));
+
 import { SkillsTab } from "../SkillsTab";
 
 beforeEach(() => {
@@ -55,10 +62,10 @@ describe("SkillsTab — cloud store gate", () => {
     expect(screen.getByTestId("server-skills")).toBeInTheDocument();
     expect(screen.queryByText("No skills available")).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /upload your first skill/i })
+      screen.queryByRole("button", { name: /add your first skill/i })
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /upload skill/i })
+      screen.queryByRole("button", { name: /add to library/i })
     ).not.toBeInTheDocument();
     // A list behind the flag is a request the backend gates anyway.
     expect(listSkills).not.toHaveBeenCalled();
@@ -69,7 +76,7 @@ describe("SkillsTab — cloud store gate", () => {
 
     expect(screen.getByTestId("server-skills")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /upload skill/i })
+      screen.getByRole("button", { name: /add to library/i })
     ).toBeInTheDocument();
     expect(listSkills).toHaveBeenCalled();
   });

--- a/mcpjam-inspector/client/src/components/__tests__/SkillsTab.list-summary.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/SkillsTab.list-summary.test.tsx
@@ -48,6 +48,13 @@ vi.mock("../skills/ServerSkillsSection", () => ({
 
 vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 
+// The tab resolves the publish permission from Convex; these suites are about
+// the tab's chrome, not about that resolution (see SkillsTab.promote-gate).
+vi.mock("convex/react", () => ({ useConvexAuth: () => ({ isAuthenticated: false }) }));
+vi.mock("@/hooks/useProjects", () => ({
+  useProjectMembers: () => ({ canManageMembers: false, isLoading: false }),
+}));
+
 import { SkillsTab } from "../SkillsTab";
 
 beforeEach(() => {
@@ -80,7 +87,7 @@ describe("SkillsTab — what the header and the placeholder claim", () => {
     await waitFor(() => expect(listSkills).toHaveBeenCalled());
     expect(screen.queryByText("No skills available")).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /upload your first skill/i })
+      screen.queryByRole("button", { name: /add your first skill/i })
     ).not.toBeInTheDocument();
     expect(await screen.findByText("2")).toBeInTheDocument();
   });
@@ -89,7 +96,7 @@ describe("SkillsTab — what the header and the placeholder claim", () => {
     render(<SkillsTab projectId="project-1" cloudSkillsEnabled />);
 
     expect(
-      await screen.findByRole("button", { name: /upload your first skill/i })
+      await screen.findByRole("button", { name: /add your first skill/i })
     ).toBeInTheDocument();
   });
 
@@ -102,7 +109,7 @@ describe("SkillsTab — what the header and the placeholder claim", () => {
     // An unanswered listing is not an empty one — offering to upload here would
     // flash away the moment the rows land.
     expect(
-      screen.queryByRole("button", { name: /upload your first skill/i })
+      screen.queryByRole("button", { name: /add your first skill/i })
     ).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/__tests__/SkillsTab.promote-gate.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/SkillsTab.promote-gate.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Who is offered "Publish to project library", and what happens when it fails.
+ *
+ * The globe button was rendered for every personal skill, but the backend
+ * (`projectSkills:promoteSkillToProject`) requires project admin — the same
+ * `canManageProjectMembers` authority `canManageMembers` resolves. A member
+ * who clicked it got a rejected request whose only trace was a `console.error`
+ * line: the button looked broken rather than forbidden.
+ *
+ * Two fixes, both pinned here: don't offer what the server will refuse, and
+ * when a promote a user IS allowed to attempt fails anyway (revoked mid-
+ * session, a lost network, an owner check the client can't see), say so where
+ * the person who clicked is looking.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    canManageMembers: false,
+    promoteSkill: vi.fn(async () => undefined),
+    toastError: vi.fn(),
+  },
+}));
+
+const PERSONAL_SKILL = {
+  name: "refunds",
+  description: "Handle refunds",
+  path: "Library",
+  skillId: "skill-refunds",
+  sharing: "user" as const,
+  isOwner: true,
+  origin: "cloud" as const,
+  provenance: "authored" as const,
+};
+
+vi.mock("@/lib/apis/mcp-skills-api", () => ({
+  listSkills: vi.fn(async () => [PERSONAL_SKILL]),
+  getSkill: vi.fn(async () => ({
+    name: "refunds",
+    description: "Handle refunds",
+    content: "# Refunds",
+    path: "Library",
+  })),
+  deleteSkill: vi.fn(),
+  listSkillFiles: vi.fn(async () => []),
+  readSkillFile: vi.fn(async () => ({
+    path: "SKILL.md",
+    content: "# Refunds",
+    mimeType: "text/markdown",
+  })),
+  promoteSkill: (...args: unknown[]) => mocks.promoteSkill(...args),
+}));
+
+vi.mock("@/lib/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/config")>();
+  return { ...actual, HOSTED_MODE: true };
+});
+
+vi.mock("../skills/ServerSkillsSection", () => ({
+  ServerSkillsSection: () => <div data-testid="server-skills" />,
+}));
+
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
+vi.mock("sonner", () => ({
+  toast: { error: (...args: unknown[]) => mocks.toastError(...args) },
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true }),
+}));
+
+vi.mock("@/hooks/useProjects", () => ({
+  useProjectMembers: () => ({
+    canManageMembers: mocks.canManageMembers,
+    isLoading: false,
+  }),
+}));
+
+import { SkillsTab } from "../SkillsTab";
+
+/** Render the tab and open the one personal skill it lists. */
+async function openTheSkill() {
+  render(<SkillsTab projectId="project-1" cloudSkillsEnabled />);
+  fireEvent.click(await screen.findByText("refunds"));
+  // The header renders once the detail load lands.
+  await screen.findByText("Personal");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.canManageMembers = false;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SkillsTab — publishing a personal skill to the library", () => {
+  it("withholds the button from a member who cannot publish", async () => {
+    await openTheSkill();
+
+    expect(
+      screen.queryByRole("button", { name: /publish to project library/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers it to an admin", async () => {
+    mocks.canManageMembers = true;
+    await openTheSkill();
+
+    expect(
+      await screen.findByRole("button", {
+        name: /publish to project library/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces a rejected publish to the person who clicked", async () => {
+    mocks.canManageMembers = true;
+    mocks.promoteSkill.mockRejectedValueOnce(
+      new Error("Only project admins can publish a skill"),
+    );
+    await openTheSkill();
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /publish to project library/i,
+      }),
+    );
+
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalled());
+    expect(mocks.toastError.mock.calls[0][0]).toContain("refunds");
+    expect(mocks.toastError.mock.calls[0][0]).toContain(
+      "Only project admins can publish a skill",
+    );
+  });
+
+  it("says nothing when the publish succeeds", async () => {
+    mocks.canManageMembers = true;
+    await openTheSkill();
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /publish to project library/i,
+      }),
+    );
+
+    await waitFor(() => expect(mocks.promoteSkill).toHaveBeenCalled());
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/components/__tests__/SkillsTab.source-toggle.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/SkillsTab.source-toggle.test.tsx
@@ -34,6 +34,13 @@ vi.mock("../skills/ServerSkillsSection", () => ({
 
 vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 
+// The tab resolves the publish permission from Convex; these suites are about
+// the tab's chrome, not about that resolution (see SkillsTab.promote-gate).
+vi.mock("convex/react", () => ({ useConvexAuth: () => ({ isAuthenticated: false }) }));
+vi.mock("@/hooks/useProjects", () => ({
+  useProjectMembers: () => ({ canManageMembers: false, isLoading: false }),
+}));
+
 import { SkillsTab } from "../SkillsTab";
 
 afterEach(() => {

--- a/mcpjam-inspector/client/src/components/__tests__/SkillsTab.source-toggle.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/SkillsTab.source-toggle.test.tsx
@@ -40,11 +40,11 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe("SkillsTab — the Local/Cloud browse toggle", () => {
+describe("SkillsTab — the Local/Library browse toggle", () => {
   it("is offered when the project store is released to this user", () => {
     render(<SkillsTab projectId="project-1" cloudSkillsEnabled />);
 
-    expect(screen.getByText("Cloud")).toBeInTheDocument();
+    expect(screen.getByText("Library")).toBeInTheDocument();
     expect(screen.getByText("Local")).toBeInTheDocument();
   });
 
@@ -53,13 +53,13 @@ describe("SkillsTab — the Local/Cloud browse toggle", () => {
     // than not offering it: the failure arrives after the user has committed.
     render(<SkillsTab projectId="project-1" cloudSkillsEnabled={false} />);
 
-    expect(screen.queryByText("Cloud")).not.toBeInTheDocument();
+    expect(screen.queryByText("Library")).not.toBeInTheDocument();
   });
 
   it("is withheld with no project to address, however the flags read", () => {
     render(<SkillsTab cloudSkillsEnabled />);
 
-    expect(screen.queryByText("Cloud")).not.toBeInTheDocument();
+    expect(screen.queryByText("Library")).not.toBeInTheDocument();
   });
 
   it("treats an empty project id as no project, not as one named \"\"", () => {
@@ -68,6 +68,6 @@ describe("SkillsTab — the Local/Cloud browse toggle", () => {
     // nothing the backend would accept.
     render(<SkillsTab projectId="" cloudSkillsEnabled />);
 
-    expect(screen.queryByText("Cloud")).not.toBeInTheDocument();
+    expect(screen.queryByText("Library")).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -6,7 +6,6 @@ import {
   useMemo,
   useEffect,
 } from "react";
-import { HOSTED_MODE } from "@/lib/config";
 import { useSkillsEnabled } from "@/hooks/useSkillsEnabled";
 import type { SkillsSource } from "@/lib/apis/mcp-skills-api";
 import type {
@@ -448,12 +447,19 @@ export function ChatInput({
   environmentServersOverridden = false,
   onResetEnvironmentServers,
 }: ChatInputProps) {
-  // Cloud skill source for the `/` picker: in hosted mode, list/load skills
-  // from the project's Convex/Computer source (Playground carries projectId via
-  // `clientSelector`). Gated behind the `skills-enabled` flag until QA completes
-  // (flag off ⇒ no cloud source, so the picker lists no cloud skills). Local
-  // mode keeps the default (filesystem) path. Memoized so the popover's fetch
-  // effects don't re-run every render.
+  // The project LIBRARY half of the `/` picker: list/load skills from the
+  // project's Convex source (Playground carries the id via `clientSelector`).
+  //
+  // NOT gated on `HOSTED_MODE` any more. It was, back when the picker showed
+  // one source or the other and hosted was the only mode with a library to
+  // show — which meant a local user's own project skills were unreachable from
+  // chat, though they are exactly what the library exists for. The picker now
+  // merges both halves (see SkillsPopoverSection), so this is simply "is there
+  // a library to read": a Convex project id exists in both modes, and an
+  // unsynced project has none, which keeps the half off by itself.
+  //
+  // Still gated behind the `skills-enabled` flag until QA completes. Memoized
+  // so the popover's fetch effects don't re-run every render.
   const skillsEnabled = useSkillsEnabled();
   // Skills over MCP (SEP-2640): the selected servers ARE the candidate
   // providers. `connected: true` because a server only reaches
@@ -481,7 +487,7 @@ export function ChatInput({
 
   const skillsSource = useMemo<SkillsSource | undefined>(
     () =>
-      HOSTED_MODE && skillsEnabled && clientSelector?.cloudProjectId
+      skillsEnabled && clientSelector?.cloudProjectId
         ? { kind: "cloud", projectId: clientSelector.cloudProjectId }
         : undefined,
     [clientSelector?.cloudProjectId, skillsEnabled]

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skill-upload-dialog.sharing.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skill-upload-dialog.sharing.test.tsx
@@ -198,6 +198,38 @@ describe("SkillUploadDialog — which tier an upload lands in", () => {
     expect(mocks.uploadSkillFolder.mock.calls[0][3]).toBe("project");
   });
 
+  it("re-asks on reopen instead of answering with the last session's role", async () => {
+    // A reconnect is a re-load of a question already asked; a REOPEN is a new
+    // question. An admin demoted between two opens would otherwise reopen to
+    // an enabled button and upload `sharing: 'project'` before the new query
+    // landed, and the server would refuse it.
+    mocks.canManageMembers = true;
+    const { rerender } = render(
+      <SkillUploadDialog open onOpenChange={vi.fn()} source={CLOUD} />,
+    );
+    expect(
+      screen.getByText(/will be added to the project library/i),
+    ).toBeInTheDocument();
+
+    rerender(
+      <SkillUploadDialog open={false} onOpenChange={vi.fn()} source={CLOUD} />,
+    );
+
+    // Reopened while the fresh role query is still in flight.
+    mocks.canManageMembers = false;
+    mocks.roleLoading = true;
+    rerender(<SkillUploadDialog open onOpenChange={vi.fn()} source={CLOUD} />);
+
+    expect(
+      screen.getByText(/Checking your role in this project/i),
+    ).toBeInTheDocument();
+    await pickSkillFolder();
+    expect(
+      screen.getByRole("button", { name: /add to library/i }),
+    ).toBeDisabled();
+    expect(mocks.uploadSkillFolder).not.toHaveBeenCalled();
+  });
+
   it("refuses to reuse a 'decision' taken while the dialog was closed", async () => {
     // The query is SKIPPED when the dialog is closed, so `canManageMembers`
     // reads false and `isLoading` reads false — a non-answer that looks

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skill-upload-dialog.sharing.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skill-upload-dialog.sharing.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Where an uploaded skill lands, and who decides.
+ *
+ * The dialog used to ask: a "Share with the project" checkbox, unchecked by
+ * default, whose small print admitted that ticking it "requires admin". A
+ * non-admin who ticked it committed the whole upload before the backend
+ * refused it, and an admin — the one person for whom the project library is
+ * the obvious destination — had to opt in every time.
+ *
+ * So the tier is RESOLVED, not asked: `canManageMembers` is the same backend
+ * authority (`canManageProjectMembers`) that gates `createSkill`'s
+ * `sharing: 'project'`, and it fails closed. The dialog states the outcome
+ * instead of offering a decision the user may not be allowed to make.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    canManageMembers: false,
+    uploadSkillFolder: vi.fn(async () => ({
+      name: "refunds",
+      description: "Handle refunds",
+      content: "",
+      path: "Library",
+    })),
+  },
+}));
+
+vi.mock("@/lib/apis/mcp-skills-api", () => ({
+  uploadSkillFolder: (...args: unknown[]) => mocks.uploadSkillFolder(...args),
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true }),
+}));
+
+const useProjectMembers = vi.fn(() => ({
+  canManageMembers: mocks.canManageMembers,
+  isLoading: false,
+}));
+vi.mock("@/hooks/useProjects", () => ({
+  useProjectMembers: (...args: unknown[]) => useProjectMembers(...args),
+}));
+
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
+import { SkillUploadDialog } from "../skill-upload-dialog";
+
+const CLOUD = { kind: "cloud" as const, projectId: "proj-1" };
+
+/** A one-file skill folder the dialog will accept. */
+const SKILL_MD = "---\nname: refunds\ndescription: Handle refunds\n---\n\nBody";
+
+function skillFolder(): File[] {
+  const file = new File([SKILL_MD], "SKILL.md", { type: "text/markdown" });
+  Object.defineProperty(file, "webkitRelativePath", {
+    value: "refunds/SKILL.md",
+  });
+  // jsdom's Blob has no `text()`; the dialog reads the frontmatter with it.
+  Object.defineProperty(file, "text", { value: async () => SKILL_MD });
+  return [file];
+}
+
+/** Pick a folder through the file input and wait for the parse to land. */
+async function pickSkillFolder() {
+  // Queried off the document: Radix portals the dialog outside `container`.
+  const input = document.querySelector(
+    'input[type="file"]',
+  ) as HTMLInputElement;
+  Object.defineProperty(input, "files", { value: skillFolder() });
+  fireEvent.change(input);
+  // The description renders twice: the folder card and the parsed-skill panel.
+  await screen.findAllByText("Handle refunds");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.canManageMembers = false;
+});
+
+describe("SkillUploadDialog — which tier an upload lands in", () => {
+  it("sends an admin's upload to the project library", async () => {
+    mocks.canManageMembers = true;
+    render(<SkillUploadDialog open onOpenChange={vi.fn()} source={CLOUD} />);
+
+    expect(
+      screen.getByText(/will be added to the project library/i),
+    ).toBeInTheDocument();
+    // No decision is offered — the checkbox is gone, not merely disabled.
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+
+    await pickSkillFolder();
+    fireEvent.click(screen.getByRole("button", { name: /add to library/i }));
+
+    await waitFor(() => expect(mocks.uploadSkillFolder).toHaveBeenCalled());
+    expect(mocks.uploadSkillFolder.mock.calls[0][3]).toBe("project");
+  });
+
+  it("lands a non-admin's upload as personal, and says an admin can publish it", async () => {
+    render(<SkillUploadDialog open onOpenChange={vi.fn()} source={CLOUD} />);
+
+    expect(
+      screen.getByText(/added as a personal skill/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/admin can publish it to the project library/i),
+    ).toBeInTheDocument();
+
+    await pickSkillFolder();
+    fireEvent.click(screen.getByRole("button", { name: /add to library/i }));
+
+    await waitFor(() => expect(mocks.uploadSkillFolder).toHaveBeenCalled());
+    expect(mocks.uploadSkillFolder.mock.calls[0][3]).toBe("user");
+  });
+
+  it("keeps local uploads out of the tier question entirely", async () => {
+    // A local skill is a file on this machine — it has no sharing tier to
+    // resolve and no library hint to show, whatever the member's role is.
+    mocks.canManageMembers = true;
+    render(<SkillUploadDialog open onOpenChange={vi.fn()} />);
+
+    expect(
+      screen.queryByText(/project library/i),
+    ).not.toBeInTheDocument();
+
+    await pickSkillFolder();
+    fireEvent.click(screen.getByRole("button", { name: /upload skill/i }));
+
+    await waitFor(() => expect(mocks.uploadSkillFolder).toHaveBeenCalled());
+    expect(mocks.uploadSkillFolder.mock.calls[0][3]).toBe("user");
+  });
+
+  it("holds the members query closed until the dialog is open on a project", () => {
+    // The dialog is mounted (closed) by every chat input, so an ungated query
+    // would hold a standing Convex subscription per composer on screen.
+    render(
+      <SkillUploadDialog open={false} onOpenChange={vi.fn()} source={CLOUD} />,
+    );
+
+    expect(useProjectMembers).toHaveBeenCalledWith(
+      expect.objectContaining({ isAuthenticated: false }),
+    );
+  });
+
+  it("asks nothing of Convex for a local upload", () => {
+    render(<SkillUploadDialog open onOpenChange={vi.fn()} />);
+
+    expect(useProjectMembers).toHaveBeenCalledWith({
+      isAuthenticated: false,
+      projectId: null,
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skill-upload-dialog.sharing.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skill-upload-dialog.sharing.test.tsx
@@ -302,6 +302,48 @@ describe("SkillUploadDialog — which tier an upload lands in", () => {
     ).toBeInTheDocument();
   });
 
+  it("stamps the created skill with the store it was written to", async () => {
+    // `SkillResultCard` falls back to the composer's ambient source for an
+    // unstamped result, and that source follows the ACTIVE project. Without
+    // this stamp, a skill uploaded into project A and expanded after switching
+    // to B would have its supporting files read out of B.
+    mocks.canManageMembers = true;
+    const onSkillCreated = vi.fn();
+    render(
+      <SkillUploadDialog
+        open
+        onOpenChange={vi.fn()}
+        source={CLOUD}
+        onSkillCreated={onSkillCreated}
+      />,
+    );
+
+    await pickSkillFolder();
+    fireEvent.click(screen.getByRole("button", { name: /add to library/i }));
+
+    await waitFor(() => expect(onSkillCreated).toHaveBeenCalled());
+    expect(onSkillCreated.mock.calls[0][0].source).toEqual(CLOUD);
+  });
+
+  it("leaves a local upload unstamped rather than inventing a source", async () => {
+    // There is no source to record for a filesystem write, and stamping a
+    // fabricated one would be worse than the existing fallback.
+    const onSkillCreated = vi.fn();
+    render(
+      <SkillUploadDialog
+        open
+        onOpenChange={vi.fn()}
+        onSkillCreated={onSkillCreated}
+      />,
+    );
+
+    await pickSkillFolder();
+    fireEvent.click(screen.getByRole("button", { name: /upload skill/i }));
+
+    await waitFor(() => expect(onSkillCreated).toHaveBeenCalled());
+    expect(onSkillCreated.mock.calls[0][0].source).toBeUndefined();
+  });
+
   it("asks nothing of Convex for a local upload", () => {
     render(<SkillUploadDialog open onOpenChange={vi.fn()} />);
 

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skill-upload-dialog.sharing.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skill-upload-dialog.sharing.test.tsx
@@ -357,9 +357,10 @@ describe("SkillUploadDialog — which tier an upload lands in", () => {
     expect(onSkillCreated.mock.calls[0][0].source).toEqual(CLOUD);
   });
 
-  it("leaves a local upload unstamped rather than inventing a source", async () => {
-    // There is no source to record for a filesystem write, and stamping a
-    // fabricated one would be worse than the existing fallback.
+  it("stamps a local upload as local rather than leaving it to the fallback", async () => {
+    // An absent `source` prop is not "no source" — it is the filesystem route,
+    // which is exactly what `{kind:'local'}` names. Leaving it unstamped would
+    // send the card to its ambient prop, which now follows the active project.
     const onSkillCreated = vi.fn();
     render(
       <SkillUploadDialog
@@ -373,7 +374,7 @@ describe("SkillUploadDialog — which tier an upload lands in", () => {
     fireEvent.click(screen.getByRole("button", { name: /upload skill/i }));
 
     await waitFor(() => expect(onSkillCreated).toHaveBeenCalled());
-    expect(onSkillCreated.mock.calls[0][0].source).toBeUndefined();
+    expect(onSkillCreated.mock.calls[0][0].source).toEqual({ kind: "local" });
   });
 
   it("asks nothing of Convex for a local upload", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skill-upload-dialog.sharing.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skill-upload-dialog.sharing.test.tsx
@@ -167,6 +167,54 @@ describe("SkillUploadDialog — which tier an upload lands in", () => {
     expect(mocks.uploadSkillFolder).not.toHaveBeenCalled();
   });
 
+  it("keeps a resolved role through a reconnect instead of re-asking", async () => {
+    // Convex throws its whole remote query set away on every websocket
+    // reconnect, so `useQuery` goes back to `undefined`. Without a latch, a
+    // reconnect while the dialog is open — role long since resolved, files
+    // already picked — would re-disable the button and flip the hint back to
+    // "Checking your role…", freezing a submit over an answered question.
+    mocks.canManageMembers = true;
+    const { rerender } = render(
+      <SkillUploadDialog open onOpenChange={vi.fn()} source={CLOUD} />,
+    );
+    await pickSkillFolder();
+    expect(
+      screen.getByText(/will be added to the project library/i),
+    ).toBeInTheDocument();
+
+    // The socket drops: the query replays "not decided yet".
+    mocks.roleLoading = true;
+    rerender(<SkillUploadDialog open onOpenChange={vi.fn()} source={CLOUD} />);
+
+    expect(
+      screen.getByRole("button", { name: /add to library/i }),
+    ).not.toBeDisabled();
+    expect(
+      screen.getByText(/will be added to the project library/i),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /add to library/i }));
+    await waitFor(() => expect(mocks.uploadSkillFolder).toHaveBeenCalled());
+    expect(mocks.uploadSkillFolder.mock.calls[0][3]).toBe("project");
+  });
+
+  it("refuses to reuse a 'decision' taken while the dialog was closed", async () => {
+    // The query is SKIPPED when the dialog is closed, so `canManageMembers`
+    // reads false and `isLoading` reads false — a non-answer that looks
+    // settled. Latching it would restore the very bug the guard closes.
+    mocks.canManageMembers = false;
+    const { rerender } = render(
+      <SkillUploadDialog open={false} onOpenChange={vi.fn()} source={CLOUD} />,
+    );
+
+    mocks.roleLoading = true;
+    rerender(<SkillUploadDialog open onOpenChange={vi.fn()} source={CLOUD} />);
+
+    expect(
+      screen.getByText(/Checking your role in this project/i),
+    ).toBeInTheDocument();
+  });
+
   it("holds the upload while Convex auth is still hydrating", async () => {
     // The trap one layer up: while auth hydrates, `isAuthenticated` reads
     // FALSE, so the members query is never enabled and `roleLoading` is false
@@ -197,6 +245,61 @@ describe("SkillUploadDialog — which tier an upload lands in", () => {
 
     await waitFor(() => expect(mocks.uploadSkillFolder).toHaveBeenCalled());
     expect(mocks.uploadSkillFolder.mock.calls[0][3]).toBe("user");
+  });
+
+  it("refuses a folder with no SKILL.md, and uploads nothing", async () => {
+    render(<SkillUploadDialog open onOpenChange={vi.fn()} source={CLOUD} />);
+
+    const input = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const stray = new File(["nope"], "README.md", { type: "text/markdown" });
+    Object.defineProperty(stray, "text", { value: async () => "nope" });
+    Object.defineProperty(input, "files", { value: [stray] });
+    fireEvent.change(input);
+
+    expect(
+      await screen.findByText(/No SKILL.md file found/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /add to library/i }),
+    ).toBeDisabled();
+    expect(mocks.uploadSkillFolder).not.toHaveBeenCalled();
+  });
+
+  it("refuses a SKILL.md whose name the backend would reject", async () => {
+    render(<SkillUploadDialog open onOpenChange={vi.fn()} source={CLOUD} />);
+
+    const body = "---\nname: Not A Valid Name\ndescription: d\n---\n";
+    const file = new File([body], "SKILL.md", { type: "text/markdown" });
+    Object.defineProperty(file, "text", { value: async () => body });
+    const input = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    Object.defineProperty(input, "files", { value: [file] });
+    fireEvent.change(input);
+
+    expect(await screen.findByText(/Invalid skill name/i)).toBeInTheDocument();
+    expect(mocks.uploadSkillFolder).not.toHaveBeenCalled();
+  });
+
+  it("shows the server's message when the upload itself is rejected", async () => {
+    mocks.canManageMembers = true;
+    mocks.uploadSkillFolder.mockRejectedValueOnce(
+      new Error("A skill named refunds already exists"),
+    );
+    render(<SkillUploadDialog open onOpenChange={vi.fn()} source={CLOUD} />);
+
+    await pickSkillFolder();
+    fireEvent.click(screen.getByRole("button", { name: /add to library/i }));
+
+    expect(
+      await screen.findByText(/A skill named refunds already exists/i),
+    ).toBeInTheDocument();
+    // The dialog stays open so the failure is reachable, not dismissed.
+    expect(
+      screen.getByRole("button", { name: /add to library/i }),
+    ).toBeInTheDocument();
   });
 
   it("asks nothing of Convex for a local upload", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skill-upload-dialog.sharing.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skill-upload-dialog.sharing.test.tsx
@@ -19,6 +19,7 @@ const { mocks } = vi.hoisted(() => ({
   mocks: {
     canManageMembers: false,
     roleLoading: false,
+    authLoading: false,
     uploadSkillFolder: vi.fn(async () => ({
       name: "refunds",
       description: "Handle refunds",
@@ -33,7 +34,10 @@ vi.mock("@/lib/apis/mcp-skills-api", () => ({
 }));
 
 vi.mock("convex/react", () => ({
-  useConvexAuth: () => ({ isAuthenticated: true }),
+  useConvexAuth: () => ({
+    isAuthenticated: !mocks.authLoading,
+    isLoading: mocks.authLoading,
+  }),
 }));
 
 const useProjectMembers = vi.fn(() => ({
@@ -79,6 +83,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.canManageMembers = false;
   mocks.roleLoading = false;
+  mocks.authLoading = false;
 });
 
 describe("SkillUploadDialog — which tier an upload lands in", () => {
@@ -150,6 +155,24 @@ describe("SkillUploadDialog — which tier an upload lands in", () => {
     // submits inside this window would silently land a PERSONAL skill, which
     // contradicts the rule the dialog itself states two lines above the button.
     mocks.roleLoading = true;
+    render(<SkillUploadDialog open onOpenChange={vi.fn()} source={CLOUD} />);
+
+    expect(screen.getByText(/Checking your role in this project/i))
+      .toBeInTheDocument();
+
+    await pickSkillFolder();
+    expect(
+      screen.getByRole("button", { name: /add to library/i }),
+    ).toBeDisabled();
+    expect(mocks.uploadSkillFolder).not.toHaveBeenCalled();
+  });
+
+  it("holds the upload while Convex auth is still hydrating", async () => {
+    // The trap one layer up: while auth hydrates, `isAuthenticated` reads
+    // FALSE, so the members query is never enabled and `roleLoading` is false
+    // too. The role then looks settled at "not an admin" though nothing was
+    // asked — exactly the bug the resolving guard exists to close.
+    mocks.authLoading = true;
     render(<SkillUploadDialog open onOpenChange={vi.fn()} source={CLOUD} />);
 
     expect(screen.getByText(/Checking your role in this project/i))

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skill-upload-dialog.sharing.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skill-upload-dialog.sharing.test.tsx
@@ -18,6 +18,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const { mocks } = vi.hoisted(() => ({
   mocks: {
     canManageMembers: false,
+    roleLoading: false,
     uploadSkillFolder: vi.fn(async () => ({
       name: "refunds",
       description: "Handle refunds",
@@ -37,7 +38,7 @@ vi.mock("convex/react", () => ({
 
 const useProjectMembers = vi.fn(() => ({
   canManageMembers: mocks.canManageMembers,
-  isLoading: false,
+  isLoading: mocks.roleLoading,
 }));
 vi.mock("@/hooks/useProjects", () => ({
   useProjectMembers: (...args: unknown[]) => useProjectMembers(...args),
@@ -77,6 +78,7 @@ async function pickSkillFolder() {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.canManageMembers = false;
+  mocks.roleLoading = false;
 });
 
 describe("SkillUploadDialog — which tier an upload lands in", () => {
@@ -141,6 +143,37 @@ describe("SkillUploadDialog — which tier an upload lands in", () => {
     expect(useProjectMembers).toHaveBeenCalledWith(
       expect.objectContaining({ isAuthenticated: false }),
     );
+  });
+
+  it("holds the upload while the role is still resolving", async () => {
+    // Failing closed is not good enough here. An admin who drops a folder and
+    // submits inside this window would silently land a PERSONAL skill, which
+    // contradicts the rule the dialog itself states two lines above the button.
+    mocks.roleLoading = true;
+    render(<SkillUploadDialog open onOpenChange={vi.fn()} source={CLOUD} />);
+
+    expect(screen.getByText(/Checking your role in this project/i))
+      .toBeInTheDocument();
+
+    await pickSkillFolder();
+    expect(
+      screen.getByRole("button", { name: /add to library/i }),
+    ).toBeDisabled();
+    expect(mocks.uploadSkillFolder).not.toHaveBeenCalled();
+  });
+
+  it("never holds a local upload on a question that was never asked", async () => {
+    // The members query is not enabled in local mode, so `isLoading` is false
+    // there — but a future hook that reported otherwise must not freeze a
+    // filesystem upload that has no tier to resolve.
+    mocks.roleLoading = true;
+    render(<SkillUploadDialog open onOpenChange={vi.fn()} />);
+
+    await pickSkillFolder();
+    fireEvent.click(screen.getByRole("button", { name: /upload skill/i }));
+
+    await waitFor(() => expect(mocks.uploadSkillFolder).toHaveBeenCalled());
+    expect(mocks.uploadSkillFolder.mock.calls[0][3]).toBe("user");
   });
 
   it("asks nothing of Convex for a local upload", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skills-popover-section.merged.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skills-popover-section.merged.test.tsx
@@ -269,6 +269,55 @@ describe("SkillsPopoverSection — local and library in one list", () => {
     expect(screen.getByText("refunds")).toBeInTheDocument();
   });
 
+  it("keeps the highlight on its row when a late local half shifts the list", async () => {
+    // Rendering each half as it lands means the list can grow at the FRONT.
+    // The parent holds only a numeric index, so a library row highlighted
+    // before the local half arrived would otherwise have the highlight — and
+    // the row Enter selects — slide onto a different skill.
+    let releaseLocal: (rows: unknown[]) => void = () => {};
+    mockListSkills.mockImplementation(async (source?: { kind: string }) => {
+      if (source?.kind === "cloud") return [libraryItem("refunds")];
+      return new Promise((resolve) => {
+        releaseLocal = resolve as (rows: unknown[]) => void;
+      });
+    });
+    const setHighlightedIndex = vi.fn();
+    const { rerender } = render(
+      <SkillsPopoverSection
+        onSkillSelected={vi.fn()}
+        highlightedIndex={0}
+        setHighlightedIndex={setHighlightedIndex}
+        startIndex={0}
+        isHovering={false}
+        actionTrigger={null}
+        skillsSource={LIBRARY}
+      />,
+    );
+
+    // Only the library row is on screen, highlighted at index 0.
+    await screen.findByText("refunds");
+    expect(setHighlightedIndex).not.toHaveBeenCalled();
+
+    // The local half lands and is prepended, pushing "refunds" to index 1.
+    releaseLocal([localItem("notes")]);
+    await screen.findByText("notes");
+
+    await waitFor(() => expect(setHighlightedIndex).toHaveBeenCalledWith(1));
+    // And the row itself is unchanged — the highlight followed the skill.
+    rerender(
+      <SkillsPopoverSection
+        onSkillSelected={vi.fn()}
+        highlightedIndex={1}
+        setHighlightedIndex={setHighlightedIndex}
+        startIndex={0}
+        isHovering={false}
+        actionTrigger={null}
+        skillsSource={LIBRARY}
+      />,
+    );
+    expect(screen.getByText("refunds")).toBeInTheDocument();
+  });
+
   it("counts both halves for the parent's arrow-key range", async () => {
     halves({
       local: [localItem("notes")],

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skills-popover-section.merged.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skills-popover-section.merged.test.tsx
@@ -237,6 +237,32 @@ describe("SkillsPopoverSection — local and library in one list", () => {
     expect(screen.queryByText(/No skills found/i)).not.toBeInTheDocument();
   });
 
+  it("says so plainly when both halves come back empty", async () => {
+    halves({});
+    renderPicker({ onOpenUploadDialog: vi.fn() });
+
+    expect(await screen.findByText(/No skills found/i)).toBeInTheDocument();
+  });
+
+  it("stops the row spinning when loading the chosen skill fails", async () => {
+    // Otherwise the row spins forever and the picker looks hung on a click
+    // that has already failed.
+    halves({ library: [libraryItem("refunds")] });
+    mockGetSkill.mockRejectedValueOnce(new Error("skill was deleted"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const onSkillSelected = vi.fn();
+    renderPicker({ onSkillSelected });
+
+    fireEvent.click(await screen.findByText("refunds"));
+
+    await waitFor(() =>
+      expect(screen.queryByLabelText("Loading")).not.toBeInTheDocument(),
+    );
+    expect(onSkillSelected).not.toHaveBeenCalled();
+    // The row is still there to try again.
+    expect(screen.getByText("refunds")).toBeInTheDocument();
+  });
+
   it("counts both halves for the parent's arrow-key range", async () => {
     halves({
       local: [localItem("notes")],

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skills-popover-section.merged.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skills-popover-section.merged.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * The `/` picker shows BOTH halves of the project catalog, badged.
+ *
+ * It used to show one or the other, decided by build mode: hosted read the
+ * project library, local read the filesystem. So a local user's own project
+ * skills — the durable, versioned ones the library exists for — were
+ * unreachable from the place skills are actually used, and a hosted user's
+ * picker silently omitted a half that simply doesn't exist there.
+ *
+ * Merging them raises the question the old design never had to answer: two
+ * skills may share a name. They are different artifacts, so both rows render,
+ * each badged, and each carries its OWN source — which is what `getSkill`
+ * reads through and what gets stamped onto the selection. A row that read
+ * through the ambient source would return the other half's content.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockListSkills, mockGetSkill, mockTrack } = vi.hoisted(() => ({
+  mockListSkills: vi.fn(),
+  mockGetSkill: vi.fn(),
+  mockTrack: vi.fn(),
+}));
+
+vi.mock("@/lib/apis/mcp-skills-api", () => ({
+  listSkills: (...args: unknown[]) => mockListSkills(...args),
+  getSkill: (...args: unknown[]) => mockGetSkill(...args),
+}));
+
+vi.mock("@/lib/apis/server-skills-api", () => ({
+  listServerSkills: vi.fn(async () => ({ skills: [] })),
+  getServerSkill: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
+}));
+
+import { SkillsPopoverSection } from "../skills-popover-section";
+
+const LIBRARY = { kind: "cloud" as const, projectId: "proj-1" };
+
+const localItem = (name: string) => ({
+  name,
+  description: `local ${name}`,
+  path: `~/.mcpjam/skills/${name}`,
+  origin: "local" as const,
+});
+const libraryItem = (name: string) => ({
+  name,
+  description: `library ${name}`,
+  path: "Library",
+  skillId: `skill-${name}`,
+  sharing: "project" as const,
+  isOwner: false,
+  origin: "cloud" as const,
+});
+
+/** Answer the two half-listings by the source each was called with. */
+function halves({
+  local = [] as unknown[],
+  library = [] as unknown[],
+  localFails = false,
+  libraryFails = false,
+} = {}) {
+  mockListSkills.mockImplementation(async (source?: { kind: string }) => {
+    if (source?.kind === "cloud") {
+      if (libraryFails) throw new Error("convex unreachable");
+      return library;
+    }
+    if (localFails) throw new Error("no filesystem here");
+    return local;
+  });
+}
+
+function renderPicker(props: Record<string, unknown> = {}) {
+  return render(
+    <SkillsPopoverSection
+      onSkillSelected={vi.fn()}
+      highlightedIndex={-1}
+      setHighlightedIndex={vi.fn()}
+      startIndex={0}
+      isHovering={false}
+      actionTrigger={null}
+      skillsSource={LIBRARY}
+      {...props}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetSkill.mockImplementation(async (name: string) => ({
+    name,
+    description: "d",
+    content: "# body",
+    path: "SKILL.md",
+  }));
+});
+
+describe("SkillsPopoverSection — local and library in one list", () => {
+  it("renders both halves, each badged with the store it came from", async () => {
+    halves({ local: [localItem("notes")], library: [libraryItem("refunds")] });
+    renderPicker();
+
+    expect(await screen.findByText("notes")).toBeInTheDocument();
+    expect(screen.getByText("refunds")).toBeInTheDocument();
+    expect(screen.getByText("Local")).toBeInTheDocument();
+    expect(screen.getByText("Library")).toBeInTheDocument();
+  });
+
+  it("shows a name held by both halves twice, not once", async () => {
+    // They are different artifacts with different contents. Collapsing them
+    // would choose for the user, silently and by fetch order.
+    halves({ local: [localItem("refunds")], library: [libraryItem("refunds")] });
+    renderPicker();
+
+    await waitFor(() =>
+      expect(screen.getAllByText("refunds")).toHaveLength(2),
+    );
+    expect(screen.getByText("Local")).toBeInTheDocument();
+    expect(screen.getByText("Library")).toBeInTheDocument();
+  });
+
+  it("reads each row through its own source and stamps it on the result", async () => {
+    halves({ local: [localItem("refunds")], library: [libraryItem("refunds")] });
+    const onSkillSelected = vi.fn();
+    renderPicker({ onSkillSelected });
+
+    await waitFor(() =>
+      expect(screen.getAllByText("refunds")).toHaveLength(2),
+    );
+    // Local rows come first, so the first match is the local one.
+    fireEvent.click(screen.getAllByText("refunds")[0]!);
+
+    await waitFor(() => expect(onSkillSelected).toHaveBeenCalled());
+    expect(mockGetSkill).toHaveBeenCalledWith("refunds", { kind: "local" });
+    // Stamped even for a local row: the card's fallback prop now names the
+    // library, so an unstamped local skill would expand against Convex.
+    expect(onSkillSelected.mock.calls[0][0].source).toEqual({ kind: "local" });
+  });
+
+  it("reads a library row through the library source", async () => {
+    halves({ local: [localItem("refunds")], library: [libraryItem("refunds")] });
+    const onSkillSelected = vi.fn();
+    renderPicker({ onSkillSelected });
+
+    await waitFor(() =>
+      expect(screen.getAllByText("refunds")).toHaveLength(2),
+    );
+    fireEvent.click(screen.getAllByText("refunds")[1]!);
+
+    await waitFor(() => expect(onSkillSelected).toHaveBeenCalled());
+    expect(mockGetSkill).toHaveBeenCalledWith("refunds", LIBRARY);
+    expect(onSkillSelected.mock.calls[0][0].source).toEqual(LIBRARY);
+  });
+
+  it("records which half a selection came from", async () => {
+    halves({ library: [libraryItem("refunds")] });
+    renderPicker();
+
+    fireEvent.click(await screen.findByText("refunds"));
+
+    await waitFor(() => expect(mockTrack).toHaveBeenCalled());
+    expect(mockTrack).toHaveBeenCalledWith(
+      "skill_injected",
+      expect.objectContaining({ skill_origin: "library" }),
+    );
+  });
+
+  it("asks for no library half when there is no library to read", async () => {
+    halves({ local: [localItem("notes")] });
+    renderPicker({ skillsSource: undefined });
+
+    expect(await screen.findByText("notes")).toBeInTheDocument();
+    expect(screen.queryByText("Library")).not.toBeInTheDocument();
+    for (const call of mockListSkills.mock.calls) {
+      expect(call[0]).toBeUndefined();
+    }
+  });
+
+  it("still renders one half when the other fails", async () => {
+    // An unreachable Convex must not take the user's local files off the menu.
+    halves({ local: [localItem("notes")], libraryFails: true });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    renderPicker();
+
+    expect(await screen.findByText("notes")).toBeInTheDocument();
+    expect(screen.queryByText("refunds")).not.toBeInTheDocument();
+  });
+
+  it("still renders the library when the local half fails", async () => {
+    halves({ library: [libraryItem("refunds")], localFails: true });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    renderPicker();
+
+    expect(await screen.findByText("refunds")).toBeInTheDocument();
+  });
+
+  it("counts both halves for the parent's arrow-key range", async () => {
+    halves({
+      local: [localItem("notes")],
+      library: [libraryItem("refunds"), libraryItem("returns")],
+    });
+    const onCountChange = vi.fn();
+    renderPicker({ onCountChange });
+
+    await waitFor(() => expect(onCountChange).toHaveBeenCalledWith(3));
+  });
+
+  it("indexes Enter into the library range, past the local rows", async () => {
+    halves({ local: [localItem("notes")], library: [libraryItem("refunds")] });
+    const onSkillSelected = vi.fn();
+    // Index 1 is the first LIBRARY row: local rows occupy the range below it.
+    renderPicker({
+      onSkillSelected,
+      highlightedIndex: 1,
+      actionTrigger: "Enter",
+    });
+
+    await waitFor(() => expect(onSkillSelected).toHaveBeenCalled());
+    expect(mockGetSkill).toHaveBeenCalledWith("refunds", LIBRARY);
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skills-popover-section.merged.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skills-popover-section.merged.test.tsx
@@ -14,7 +14,7 @@
  * through the ambient source would return the other half's content.
  */
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockListSkills, mockGetSkill, mockTrack } = vi.hoisted(() => ({
   mockListSkills: vi.fn(),
@@ -96,6 +96,12 @@ beforeEach(() => {
     content: "# body",
     path: "SKILL.md",
   }));
+});
+
+afterEach(() => {
+  // The failure cases silence `console.error`; leaving the spy installed would
+  // swallow diagnostics in every test that ran after them.
+  vi.restoreAllMocks();
 });
 
 describe("SkillsPopoverSection — local and library in one list", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skills-popover-section.merged.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skills-popover-section.merged.test.tsx
@@ -197,6 +197,46 @@ describe("SkillsPopoverSection — local and library in one list", () => {
     expect(await screen.findByText("refunds")).toBeInTheDocument();
   });
 
+  it("renders the local half while the library half is still hanging", async () => {
+    // `allSettled` on the PAIR bought independence from one half FAILING but
+    // none from one half being SLOW: a Convex request that hangs rather than
+    // rejects would hold ready local files behind a spinner for as long as it
+    // took.
+    mockListSkills.mockImplementation(async (source?: { kind: string }) => {
+      if (source?.kind === "cloud") return new Promise(() => {}); // never settles
+      return [localItem("notes")];
+    });
+    renderPicker();
+
+    expect(await screen.findByText("notes")).toBeInTheDocument();
+    expect(screen.queryByText(/Loading skills/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the library half while the local half is still hanging", async () => {
+    mockListSkills.mockImplementation(async (source?: { kind: string }) => {
+      if (source?.kind === "cloud") return [libraryItem("refunds")];
+      return new Promise(() => {});
+    });
+    renderPicker();
+
+    expect(await screen.findByText("refunds")).toBeInTheDocument();
+  });
+
+  it("withholds the empty state while a half is still outstanding", async () => {
+    // "No skills found" over a half that is still coming is a claim about a
+    // catalog nobody has read yet.
+    mockListSkills.mockImplementation(async (source?: { kind: string }) => {
+      if (source?.kind === "cloud") return new Promise(() => {});
+      return [];
+    });
+    renderPicker({ onOpenUploadDialog: vi.fn() });
+
+    await waitFor(() =>
+      expect(screen.queryByText(/Loading skills/i)).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/No skills found/i)).not.toBeInTheDocument();
+  });
+
   it("counts both halves for the parent's arrow-key range", async () => {
     halves({
       local: [localItem("notes")],

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skills-popover-section.merged.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/__tests__/skills-popover-section.merged.test.tsx
@@ -27,8 +27,9 @@ vi.mock("@/lib/apis/mcp-skills-api", () => ({
   getSkill: (...args: unknown[]) => mockGetSkill(...args),
 }));
 
+const mockListServerSkills = vi.fn(async () => ({ skills: [] as unknown[] }));
 vi.mock("@/lib/apis/server-skills-api", () => ({
-  listServerSkills: vi.fn(async () => ({ skills: [] })),
+  listServerSkills: (...args: unknown[]) => mockListServerSkills(...args),
   getServerSkill: vi.fn(),
 }));
 
@@ -90,6 +91,7 @@ function renderPicker(props: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockListServerSkills.mockResolvedValue({ skills: [] });
   mockGetSkill.mockImplementation(async (name: string) => ({
     name,
     description: "d",
@@ -316,6 +318,53 @@ describe("SkillsPopoverSection — local and library in one list", () => {
       />,
     );
     expect(screen.getByText("refunds")).toBeInTheDocument();
+  });
+
+  it("follows a highlighted SERVER row when the local half prepends", async () => {
+    // Server rows occupy the indices AFTER the project list, so a highlight on
+    // one starts out beyond the project range — the case a naive guard skips.
+    // A late local half still shifts them, and the row Enter selects with it.
+    let releaseLocal: (rows: unknown[]) => void = () => {};
+    mockListSkills.mockImplementation(async (source?: { kind: string }) => {
+      if (source?.kind === "cloud") return [libraryItem("refunds")];
+      return new Promise((resolve) => {
+        releaseLocal = resolve as (rows: unknown[]) => void;
+      });
+    });
+    mockListServerSkills.mockResolvedValue({
+      skills: [
+        {
+          name: "lookup",
+          description: "Server lookup",
+          serverId: "srv-1",
+          skillUri: "skill://lookup",
+        },
+      ],
+    });
+    const setHighlightedIndex = vi.fn();
+    render(
+      <SkillsPopoverSection
+        onSkillSelected={vi.fn()}
+        // Index 1 = the server row: one library row precedes it, local pending.
+        highlightedIndex={1}
+        setHighlightedIndex={setHighlightedIndex}
+        startIndex={0}
+        isHovering={false}
+        actionTrigger={null}
+        skillsSource={LIBRARY}
+        mcpServers={[{ serverId: "srv-1", label: "Support", connected: true }]}
+      />,
+    );
+
+    await screen.findByText("refunds");
+    await screen.findByText(/lookup/);
+    expect(setHighlightedIndex).not.toHaveBeenCalled();
+
+    // Local lands and is prepended: the server row moves from 1 to 2.
+    releaseLocal([localItem("notes")]);
+    await screen.findByText("notes");
+
+    await waitFor(() => expect(setHighlightedIndex).toHaveBeenCalledWith(2));
   });
 
   it("counts both halves for the parent's arrow-key range", async () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-result-card.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-result-card.tsx
@@ -22,9 +22,14 @@ export function SkillResultCard({
   onUpdate,
   skillsSource,
 }: SkillResultCardProps) {
-  // Prefer the source stamped on the skill at selection time; fall back to the
-  // current prop for legacy/local selections. This keeps file reads pinned to
-  // the project the skill was selected from, even if the active project changed.
+  // Prefer the source stamped on the skill at selection time; the prop is a
+  // fallback for results persisted BEFORE the stamp existed, and for nothing
+  // else. Every new selection stamps its own source (see
+  // `SkillsPopoverSection.handleSkillClick`), which matters now that the
+  // picker offers both halves: the prop names the library in both build modes,
+  // so an unstamped local skill would expand into file reads against Convex.
+  // Stamping also keeps reads pinned to the project the skill came from even
+  // if the active project has since changed.
   const effectiveSource = skillResult.source ?? skillsSource;
   const [isExpanded, setIsExpanded] = useState(false);
   const [files, setFiles] = useState<SkillFile[]>([]);

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
@@ -313,13 +313,20 @@ export function SkillUploadDialog({
         file_count: files.length,
         sharing,
       });
-      // Stamped with the source it was WRITTEN to, for the same reason picker
-      // selections are: `SkillResultCard` falls back to the composer's ambient
-      // source for an unstamped result, and that source now follows the active
-      // project. A skill uploaded locally (or into project A) and expanded
-      // after the project syncs (or switches to B) would otherwise have its
-      // supporting files read out of the wrong store.
-      onSkillCreated?.({ ...skill, ...(source ? { source } : {}) });
+      // Stamped with the source it was WRITTEN to — ALWAYS, local included.
+      //
+      // An absent `source` is not "no source": `uploadSkillFolder` reads it the
+      // way the rest of this API does, so undefined means the local filesystem
+      // route (`/api/mcp/skills/upload-folder`). Recording that as
+      // `{kind:'local'}` describes where the bytes went; it is what the picker
+      // already stamps on local rows, not an invention.
+      //
+      // It matters for the same reason it does there: `SkillResultCard` falls
+      // back to the composer's ambient source for an unstamped result, and
+      // that source now follows the active project. A skill uploaded before a
+      // project synced, and expanded after, would otherwise have its
+      // supporting files read out of Convex.
+      onSkillCreated?.({ ...skill, source: source ?? { kind: "local" } });
       handleOpenChange(false);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useMemo } from "react";
 import { Loader2, Upload, FolderOpen, File, X } from "lucide-react";
+import { useConvexAuth } from "convex/react";
 import { Button } from "@mcpjam/design-system/button";
 import {
   Dialog,
@@ -14,6 +15,7 @@ import {
 } from "@/lib/apis/mcp-skills-api";
 import type { SkillResult } from "./skill-types";
 import { isValidSkillName } from "../../../../../../shared/skill-types";
+import { useProjectMembers } from "@/hooks/useProjects";
 import { track } from "@/lib/analytics";
 
 interface SkillUploadDialogProps {
@@ -59,17 +61,39 @@ export function SkillUploadDialog({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
-  // Cloud-only: share the new skill with every project member (else personal).
-  const [shareWithProject, setShareWithProject] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const isCloud = source?.kind === "cloud";
+
+  /**
+   * Which tier this member can actually write to.
+   *
+   * "Add to library" is ONE button, not a choice: an admin's skill goes to the
+   * project library, everyone else's lands personal because the backend
+   * (`projectSkills:createSkill`) refuses `sharing: 'project'` from a
+   * non-admin. Asking the user to tick a box for a permission they may not
+   * hold turns a plumbing detail into a decision, and refuses it after they
+   * have committed the upload.
+   *
+   * `canManageMembers` is the SAME backend authority as the skill gate — both
+   * resolve to `canManageProjectMembers` — and it fails closed to `false`, so
+   * a still-loading query uploads a personal skill rather than one the server
+   * will reject.
+   *
+   * Gated on `open` as well as on the cloud source: this dialog is mounted
+   * (closed) by every chat input, and an ungated query would hold a standing
+   * Convex subscription per mounted composer.
+   */
+  const { isAuthenticated } = useConvexAuth();
+  const { canManageMembers: canManageShared } = useProjectMembers({
+    isAuthenticated: isAuthenticated && open && isCloud,
+    projectId: source?.kind === "cloud" ? source.projectId : null,
+  });
 
   const resetForm = () => {
     setFiles([]);
     setSkillInfo(null);
     setError(null);
     setIsDragOver(false);
-    setShareWithProject(false);
   };
 
   const handleOpenChange = (newOpen: boolean) => {
@@ -209,7 +233,8 @@ export function SkillUploadDialog({
     setIsLoading(true);
 
     try {
-      const sharing = isCloud && shareWithProject ? "project" : "user";
+      // Resolved from the member's role, never from a form control.
+      const sharing = isCloud && canManageShared ? "project" : "user";
       const skill = await uploadSkillFolder(
         files,
         skillInfo.name,
@@ -257,7 +282,7 @@ export function SkillUploadDialog({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Upload Skill</DialogTitle>
+          <DialogTitle>{isCloud ? "Add to library" : "Upload Skill"}</DialogTitle>
           <DialogDescription>
             {source?.kind === "cloud" ? (
               <>
@@ -401,24 +426,13 @@ export function SkillUploadDialog({
             </div>
           )}
 
-          {/* Cloud-only: share with the whole project (else personal). */}
+          {/* Where it lands — stated, not asked. See `canManageShared`. */}
           {isCloud && (
-            <label className="flex items-start gap-2 text-sm cursor-pointer select-none">
-              <input
-                type="checkbox"
-                checked={shareWithProject}
-                onChange={(e) => setShareWithProject(e.target.checked)}
-                disabled={isLoading}
-                className="mt-0.5"
-              />
-              <span>
-                Share with the project
-                <span className="block text-xs text-muted-foreground">
-                  Every member can see and use it. Otherwise it stays personal
-                  (only you). Publishing to a project requires admin.
-                </span>
-              </span>
-            </label>
+            <p className="text-xs text-muted-foreground">
+              {canManageShared
+                ? "This skill will be added to the project library. Every member can see and use it."
+                : "This will be added as a personal skill — only you can use it. A project admin can publish it to the project library."}
+            </p>
           )}
 
           {/* Error message */}
@@ -453,7 +467,7 @@ export function SkillUploadDialog({
               ) : (
                 <>
                   <Upload className="h-4 w-4 mr-2" />
-                  Upload Skill
+                  {isCloud ? "Add to library" : "Upload Skill"}
                 </>
               )}
             </Button>

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
@@ -304,7 +304,13 @@ export function SkillUploadDialog({
         file_count: files.length,
         sharing,
       });
-      onSkillCreated?.(skill);
+      // Stamped with the source it was WRITTEN to, for the same reason picker
+      // selections are: `SkillResultCard` falls back to the composer's ambient
+      // source for an unstamped result, and that source now follows the active
+      // project. A skill uploaded locally (or into project A) and expanded
+      // after the project syncs (or switches to B) would otherwise have its
+      // supporting files read out of the wrong store.
+      onSkillCreated?.({ ...skill, ...(source ? { source } : {}) });
       handleOpenChange(false);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
@@ -127,6 +127,13 @@ export function SkillUploadDialog({
    * skipped then — and reusing it on open would restore exactly the bug the
    * guard exists to close.
    *
+   * Scoped to ONE open session, and dropped on close. Carrying it further
+   * would answer the next session's question with the last session's answer:
+   * an admin who is demoted between opening the dialog twice would reopen to
+   * an enabled button that uploads `sharing: 'project'` before the new query
+   * lands, and the server would refuse it. A reconnect is a re-load of a
+   * question already asked; a reopen is a new question.
+   *
    * Keyed on the project, and every later resolution overwrites it, so a
    * revoked role takes effect as soon as the list says so.
    */
@@ -135,7 +142,9 @@ export function SkillUploadDialog({
   const decidedRoleRef = useRef<{ key: string; canManage: boolean } | null>(
     null,
   );
-  if (roleQueryActive && !rolePending) {
+  if (!open) {
+    decidedRoleRef.current = null;
+  } else if (roleQueryActive && !rolePending) {
     decidedRoleRef.current = { key: roleKey, canManage: canManageShared };
   }
   const decidedRole = decidedRoleRef.current;

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
@@ -109,7 +109,42 @@ export function SkillUploadDialog({
    * False whenever the question does not arise (local mode, dialog closed),
    * so nothing is ever held on something that was never asked.
    */
-  const roleResolving = isCloud && (authLoading || roleLoading);
+  const rolePending = isCloud && (authLoading || roleLoading);
+  /**
+   * The last DECIDED role for this project, so a reconnect doesn't re-ask.
+   *
+   * The members list does not load only once: the Convex client throws its
+   * whole remote query set away on every websocket reconnect, so `useQuery`
+   * goes back to `undefined` until the first transition lands. Without a latch
+   * a reconnect while the dialog is OPEN — role long since resolved, files
+   * already picked — would re-disable the button and flip the hint back to
+   * "Checking your role…", freezing a submit mid-flow over a question that was
+   * answered minutes ago. Same reasoning, and the same shape, as
+   * `useViewerProjectRole`.
+   *
+   * Written only while the query is genuinely ENABLED. A decision recorded
+   * while the dialog was closed would be `false` by default — the query is
+   * skipped then — and reusing it on open would restore exactly the bug the
+   * guard exists to close.
+   *
+   * Keyed on the project, and every later resolution overwrites it, so a
+   * revoked role takes effect as soon as the list says so.
+   */
+  const roleQueryActive = isAuthenticated && open && isCloud;
+  const roleKey = source?.kind === "cloud" ? source.projectId : "";
+  const decidedRoleRef = useRef<{ key: string; canManage: boolean } | null>(
+    null,
+  );
+  if (roleQueryActive && !rolePending) {
+    decidedRoleRef.current = { key: roleKey, canManage: canManageShared };
+  }
+  const decidedRole = decidedRoleRef.current;
+  const usingDecidedRole = rolePending && decidedRole?.key === roleKey;
+  const roleResolving = rolePending && !usingDecidedRole;
+  /** What the dialog acts on: the live answer, or the latched one mid-reconnect. */
+  const resolvedCanManage = usingDecidedRole
+    ? decidedRole!.canManage
+    : canManageShared;
 
   const resetForm = () => {
     setFiles([]);
@@ -256,7 +291,7 @@ export function SkillUploadDialog({
 
     try {
       // Resolved from the member's role, never from a form control.
-      const sharing = isCloud && canManageShared ? "project" : "user";
+      const sharing = isCloud && resolvedCanManage ? "project" : "user";
       const skill = await uploadSkillFolder(
         files,
         skillInfo.name,
@@ -455,7 +490,7 @@ export function SkillUploadDialog({
             <p className="text-xs text-muted-foreground">
               {roleResolving
                 ? "Checking your role in this project…"
-                : canManageShared
+                : resolvedCanManage
                   ? "This skill will be added to the project library. Every member can see and use it."
                   : "This will be added as a personal skill — only you can use it. A project admin can publish it to the project library."}
             </p>

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
@@ -282,7 +282,9 @@ export function SkillUploadDialog({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>{isCloud ? "Add to library" : "Upload Skill"}</DialogTitle>
+          <DialogTitle>
+            {isCloud ? "Add to library" : "Upload Skill"}
+          </DialogTitle>
           <DialogDescription>
             {source?.kind === "cloud" ? (
               <>

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
@@ -83,7 +83,7 @@ export function SkillUploadDialog({
    * (closed) by every chat input, and an ungated query would hold a standing
    * Convex subscription per mounted composer.
    */
-  const { isAuthenticated } = useConvexAuth();
+  const { isAuthenticated, isLoading: authLoading } = useConvexAuth();
   const { canManageMembers: canManageShared, isLoading: roleLoading } =
     useProjectMembers({
       isAuthenticated: isAuthenticated && open && isCloud,
@@ -99,10 +99,17 @@ export function SkillUploadDialog({
    * the hint says so rather than showing the non-admin copy as if it were
    * settled.
    *
-   * False whenever the query is not enabled (local mode, signed out, dialog
-   * closed), so nothing is ever held on a question that was never asked.
+   * `authLoading` is half of this, and the half that is easy to miss. While
+   * Convex auth hydrates, `isAuthenticated` reads FALSE — so the members query
+   * is not enabled, so `roleLoading` is false too, and the role looks settled
+   * at "not an admin" when nothing has been asked yet. Waiting on
+   * `roleLoading` alone would leave exactly the bug this guard exists to
+   * close, one layer up.
+   *
+   * False whenever the question does not arise (local mode, dialog closed),
+   * so nothing is ever held on something that was never asked.
    */
-  const roleResolving = isCloud && roleLoading;
+  const roleResolving = isCloud && (authLoading || roleLoading);
 
   const resetForm = () => {
     setFiles([]);

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
@@ -84,10 +84,25 @@ export function SkillUploadDialog({
    * Convex subscription per mounted composer.
    */
   const { isAuthenticated } = useConvexAuth();
-  const { canManageMembers: canManageShared } = useProjectMembers({
-    isAuthenticated: isAuthenticated && open && isCloud,
-    projectId: source?.kind === "cloud" ? source.projectId : null,
-  });
+  const { canManageMembers: canManageShared, isLoading: roleLoading } =
+    useProjectMembers({
+      isAuthenticated: isAuthenticated && open && isCloud,
+      projectId: source?.kind === "cloud" ? source.projectId : null,
+    });
+  /**
+   * The role hasn't come back yet, so the tier is not yet knowable.
+   *
+   * `canManageShared` is `false` in this window, and merely failing closed is
+   * not good enough HERE: an admin who drops a folder and submits fast enough
+   * would silently land a personal skill, contradicting the rule the dialog
+   * itself states. Uploading is held for the moment it takes to answer, and
+   * the hint says so rather than showing the non-admin copy as if it were
+   * settled.
+   *
+   * False whenever the query is not enabled (local mode, signed out, dialog
+   * closed), so nothing is ever held on a question that was never asked.
+   */
+  const roleResolving = isCloud && roleLoading;
 
   const resetForm = () => {
     setFiles([]);
@@ -267,8 +282,8 @@ export function SkillUploadDialog({
   };
 
   const isSubmitDisabled = useMemo(() => {
-    return files.length === 0 || !skillInfo || isLoading;
-  }, [files.length, skillInfo, isLoading]);
+    return files.length === 0 || !skillInfo || isLoading || roleResolving;
+  }, [files.length, skillInfo, isLoading, roleResolving]);
 
   // Get folder name from paths (for display)
   const folderName = useMemo(() => {
@@ -431,9 +446,11 @@ export function SkillUploadDialog({
           {/* Where it lands — stated, not asked. See `canManageShared`. */}
           {isCloud && (
             <p className="text-xs text-muted-foreground">
-              {canManageShared
-                ? "This skill will be added to the project library. Every member can see and use it."
-                : "This will be added as a personal skill — only you can use it. A project admin can publish it to the project library."}
+              {roleResolving
+                ? "Checking your role in this project…"
+                : canManageShared
+                  ? "This skill will be added to the project library. Every member can see and use it."
+                  : "This will be added as a personal skill — only you can use it. A project admin can publish it to the project library."}
             </p>
           )}
 

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skills-popover-section.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skills-popover-section.tsx
@@ -377,31 +377,47 @@ export function SkillsPopoverSection({
   );
 
   /**
+   * Every selectable row, in index order, identified rather than numbered.
+   *
+   * The parent navigates by a single number across BOTH lists, so following a
+   * shifted row means describing the whole range — project rows then server
+   * rows, exactly as they render. Prefixed so a project row can never collide
+   * with a server row that happens to share its text.
+   */
+  const rowKeys = useMemo(
+    () => [
+      ...skills.map((row) => `project:${rowKey(row)}`),
+      ...serverSkills.map((item) => `server:${item.serverId}:${item.skillUri}`),
+    ],
+    [skills, serverSkills]
+  );
+
+  /**
    * Keep the keyboard highlight on the ROW it was on when a late half lands.
    *
    * Rendering each half as it settles means the list can grow at the FRONT:
    * if the library answers first and the local half arrives after, local rows
-   * are prepended and every library row shifts down. The parent holds only a
-   * numeric `highlightedIndex`, so without this the highlight — and the row
-   * Enter would select — slides silently onto a different skill while someone
-   * is browsing.
+   * are prepended and everything below them shifts down — library rows and,
+   * because they occupy the indices after the project list, server rows too.
+   * The parent holds only a numeric `highlightedIndex`, so without this the
+   * highlight — and the row Enter would select — slides silently onto a
+   * different skill while someone is browsing.
    *
    * Looks up where the previously highlighted row went and follows it. Keyed
    * on the row list alone: reacting to `highlightedIndex` too would fight the
    * parent's own arrow-key updates.
    */
-  const prevSkillsRef = useRef<SkillRow[]>(skills);
+  const prevRowKeysRef = useRef<string[]>(rowKeys);
   useEffect(() => {
-    const prev = prevSkillsRef.current;
-    prevSkillsRef.current = skills;
-    if (prev === skills || prev.length === 0) return;
+    const prev = prevRowKeysRef.current;
+    prevRowKeysRef.current = rowKeys;
+    if (prev === rowKeys || prev.length === 0) return;
     const wasAt = highlightedIndex - startIndex;
     if (wasAt < 0 || wasAt >= prev.length) return;
-    const key = rowKey(prev[wasAt]!);
-    const nowAt = skills.findIndex((row) => rowKey(row) === key);
+    const nowAt = rowKeys.indexOf(prev[wasAt]!);
     if (nowAt !== -1 && nowAt !== wasAt) setHighlightedIndex(startIndex + nowAt);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [skills]);
+  }, [rowKeys]);
 
   // The parent's navigation range must cover BOTH lists — see `onCountChange`.
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skills-popover-section.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skills-popover-section.tsx
@@ -5,7 +5,7 @@ import {
 } from "@mcpjam/design-system/tooltip";
 import { cn } from "@/lib/chat-utils";
 import { SquareSlash, Loader2 } from "lucide-react";
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import {
   listSkills,
   getSkill,
@@ -103,26 +103,33 @@ export function SkillsPopoverSection({
   projectId,
   onCountChange,
 }: SkillsPopoverSectionProps) {
-  const [skills, setSkills] = useState<SkillRow[]>([]);
+  // One slice per half, `null` while that half is still outstanding. Kept
+  // apart rather than merged into one array so each can land on its own — see
+  // the fetch effect — and so row ORDER stays local-then-library whichever
+  // arrives first.
+  const [localRows, setLocalRows] = useState<SkillRow[] | null>(null);
+  const [libraryRows, setLibraryRows] = useState<SkillRow[] | null>(null);
   const [serverSkills, setServerSkills] = useState<ServerSkillPickerItem[]>([]);
   const [loadingSkillName, setLoadingSkillName] = useState<string | null>(null);
   // Why a rendered field and not just a console line: the person who clicked
   // the row is the one who needs to know it was refused, and they are not
   // looking at the devtools console.
   const [serverSkillError, setServerSkillError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
 
   /**
-   * Both halves of the project catalog, in one list.
+   * Both halves of the project catalog, each rendering the moment it lands.
    *
    * The local half is always requested: `listSkills(undefined)` self-empties
    * in hosted mode (`runByMode`), where there is no filesystem to read, so the
    * caller needs no build-mode branch of its own. The library half is
    * requested only when there is a library to read.
    *
-   * `allSettled`, not `all`: an unreachable Convex must not take the user's
-   * local files off the menu, and a broken local route must not hide the
-   * project's skills. Each half fails on its own and logs; the other renders.
+   * Each half owns its own state slice and settles alone. Awaiting the PAIR —
+   * even with `allSettled` — buys independence from one half FAILING but none
+   * from one half being SLOW: a Convex request that hangs rather than rejects
+   * would hold back local files that were ready, behind a spinner, for as
+   * long as it took. A rejection logs and yields an empty half so the other
+   * still renders.
    *
    * NOT deduped by name. A local `refunds` and a library `refunds` are
    * different artifacts with different contents, and the person typing `/` is
@@ -131,43 +138,68 @@ export function SkillsPopoverSection({
    */
   useEffect(() => {
     let active = true;
-    (async () => {
-      setIsLoading(true);
-      const [localResult, libraryResult] = await Promise.allSettled([
-        listSkills(undefined),
-        skillsSource ? listSkills(skillsSource) : Promise.resolve([]),
-      ]);
-      if (!active) return;
-      const rows: SkillRow[] = [];
-      if (localResult.status === "fulfilled") {
-        for (const item of localResult.value) {
-          rows.push({ item, source: { kind: "local" }, label: "Local" });
-        }
-      } else {
+    setLocalRows(null);
+    setLibraryRows(null);
+    listSkills(undefined).then(
+      (items) => {
+        if (!active) return;
+        setLocalRows(
+          items.map((item) => ({
+            item,
+            source: { kind: "local" } as SkillsSource,
+            label: "Local" as const,
+          }))
+        );
+      },
+      (err) => {
+        if (!active) return;
         console.error(
           "[SkillsPopoverSection] Failed to fetch local skills",
-          localResult.reason
+          err
         );
+        setLocalRows([]);
       }
-      if (libraryResult.status === "fulfilled") {
-        if (skillsSource) {
-          for (const item of libraryResult.value) {
-            rows.push({ item, source: skillsSource, label: "Library" });
-          }
+    );
+    if (skillsSource) {
+      listSkills(skillsSource).then(
+        (items) => {
+          if (!active) return;
+          setLibraryRows(
+            items.map((item) => ({
+              item,
+              source: skillsSource,
+              label: "Library" as const,
+            }))
+          );
+        },
+        (err) => {
+          if (!active) return;
+          console.error(
+            "[SkillsPopoverSection] Failed to fetch library skills",
+            err
+          );
+          setLibraryRows([]);
         }
-      } else {
-        console.error(
-          "[SkillsPopoverSection] Failed to fetch library skills",
-          libraryResult.reason
-        );
-      }
-      setSkills(rows);
-      setIsLoading(false);
-    })();
+      );
+    }
     return () => {
       active = false;
     };
   }, [skillsSource]);
+
+  // Local first, so the badge order on screen matches the index order the
+  // Enter handler and the parent's arrow keys walk.
+  const skills = useMemo(
+    () => [...(localRows ?? []), ...(libraryRows ?? [])],
+    [localRows, libraryRows]
+  );
+  /** A half that was asked for and hasn't answered. */
+  const stillFetching =
+    localRows === null || (Boolean(skillsSource) && libraryRows === null);
+  // The spinner stands only while NOTHING has arrived. Once either half is in,
+  // it renders — a hung half must not hide a settled one.
+  const isLoading =
+    localRows === null && (skillsSource ? libraryRows === null : true);
 
   // Server-served skills (SEP-2640). Fetched per connected server, and only
   // for connections where the extension is mutually declared — the API answers
@@ -523,6 +555,7 @@ export function SkillsPopoverSection({
         {/* Empty state with upload button */}
         {skills.length === 0 &&
           serverSkills.length === 0 &&
+          !stillFetching &&
           onOpenUploadDialog && (
             <div className="px-2 py-2 text-xs text-muted-foreground">
               No skills found. Create your first skill!

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skills-popover-section.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skills-popover-section.tsx
@@ -5,7 +5,7 @@ import {
 } from "@mcpjam/design-system/tooltip";
 import { cn } from "@/lib/chat-utils";
 import { SquareSlash, Loader2 } from "lucide-react";
-import { useEffect, useState, useCallback, useMemo } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import {
   listSkills,
   getSkill,
@@ -375,6 +375,33 @@ export function SkillsPopoverSection({
     },
     [onSkillSelected]
   );
+
+  /**
+   * Keep the keyboard highlight on the ROW it was on when a late half lands.
+   *
+   * Rendering each half as it settles means the list can grow at the FRONT:
+   * if the library answers first and the local half arrives after, local rows
+   * are prepended and every library row shifts down. The parent holds only a
+   * numeric `highlightedIndex`, so without this the highlight — and the row
+   * Enter would select — slides silently onto a different skill while someone
+   * is browsing.
+   *
+   * Looks up where the previously highlighted row went and follows it. Keyed
+   * on the row list alone: reacting to `highlightedIndex` too would fight the
+   * parent's own arrow-key updates.
+   */
+  const prevSkillsRef = useRef<SkillRow[]>(skills);
+  useEffect(() => {
+    const prev = prevSkillsRef.current;
+    prevSkillsRef.current = skills;
+    if (prev === skills || prev.length === 0) return;
+    const wasAt = highlightedIndex - startIndex;
+    if (wasAt < 0 || wasAt >= prev.length) return;
+    const key = rowKey(prev[wasAt]!);
+    const nowAt = skills.findIndex((row) => rowKey(row) === key);
+    if (nowAt !== -1 && nowAt !== wasAt) setHighlightedIndex(startIndex + nowAt);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [skills]);
 
   // The parent's navigation range must cover BOTH lists — see `onCountChange`.
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skills-popover-section.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skills-popover-section.tsx
@@ -30,7 +30,11 @@ interface SkillsPopoverSectionProps {
   isHovering: boolean;
   actionTrigger: string | null;
   onOpenUploadDialog?: () => void;
-  /** When set, list/load skills from the cloud (Convex/Computer) source. */
+  /**
+   * The project LIBRARY half, when there is one to read. Absent (no synced
+   * project, or the `skills-enabled` flag off) ⇒ the picker shows the local
+   * half and server skills only.
+   */
   skillsSource?: SkillsSource;
   /**
    * Connected MCP servers whose skills (SEP-2640) may be injected. Read live
@@ -41,7 +45,7 @@ interface SkillsPopoverSectionProps {
   /** Convex project id — required for the hosted server-skills route. */
   projectId?: string;
   /**
-   * Reports the TOTAL selectable-row count (project skills + server skills)
+   * Reports the TOTAL selectable-row count (local + library + server skills)
    * upward.
    *
    * The parent drives arrow navigation and its open/closed state from this, so
@@ -59,6 +63,33 @@ interface ServerSkillPickerItem extends ServerSkillSummary {
   ref: string;
 }
 
+/**
+ * One project-skill row, carrying the source it was listed FROM.
+ *
+ * The picker used to show one half or the other — local files XOR the project
+ * library, decided by build mode — so a single ambient `skillsSource` said
+ * where every row came from. It now shows both, and the two are genuinely
+ * different artifacts that may share a name, so the source travels with the
+ * row: it is what `getSkill` reads through, and what gets stamped onto the
+ * selection so later file reads resolve against the same store.
+ */
+interface SkillRow {
+  item: SkillListItem;
+  /** `{kind:'local'}` or the library source — never absent. */
+  source: SkillsSource;
+  label: "Local" | "Library";
+}
+
+/**
+ * Identity for one row's React key and its loading spinner.
+ *
+ * The name alone is not it: the two halves may each hold a `refunds`, and a
+ * name-keyed spinner would spin on both rows while one of them loads.
+ */
+function rowKey(row: SkillRow): string {
+  return `${row.source.kind}:${row.item.name}`;
+}
+
 export function SkillsPopoverSection({
   onSkillSelected,
   highlightedIndex,
@@ -72,7 +103,7 @@ export function SkillsPopoverSection({
   projectId,
   onCountChange,
 }: SkillsPopoverSectionProps) {
-  const [skills, setSkills] = useState<SkillListItem[]>([]);
+  const [skills, setSkills] = useState<SkillRow[]>([]);
   const [serverSkills, setServerSkills] = useState<ServerSkillPickerItem[]>([]);
   const [loadingSkillName, setLoadingSkillName] = useState<string | null>(null);
   // Why a rendered field and not just a console line: the person who clicked
@@ -81,23 +112,57 @@ export function SkillsPopoverSection({
   const [serverSkillError, setServerSkillError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  /**
+   * Both halves of the project catalog, in one list.
+   *
+   * The local half is always requested: `listSkills(undefined)` self-empties
+   * in hosted mode (`runByMode`), where there is no filesystem to read, so the
+   * caller needs no build-mode branch of its own. The library half is
+   * requested only when there is a library to read.
+   *
+   * `allSettled`, not `all`: an unreachable Convex must not take the user's
+   * local files off the menu, and a broken local route must not hide the
+   * project's skills. Each half fails on its own and logs; the other renders.
+   *
+   * NOT deduped by name. A local `refunds` and a library `refunds` are
+   * different artifacts with different contents, and the person typing `/` is
+   * choosing between them — collapsing them into one row would pick for them,
+   * silently and by fetch order. They render twice, badged.
+   */
   useEffect(() => {
-    // Fetch skills on mount
     let active = true;
     (async () => {
-      try {
-        setIsLoading(true);
-        const skillsList = await listSkills(skillsSource);
-        if (!active) return;
-        setSkills(skillsList);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error("[SkillsPopoverSection] Failed to fetch skills", message);
-      } finally {
-        if (active) {
-          setIsLoading(false);
+      setIsLoading(true);
+      const [localResult, libraryResult] = await Promise.allSettled([
+        listSkills(undefined),
+        skillsSource ? listSkills(skillsSource) : Promise.resolve([]),
+      ]);
+      if (!active) return;
+      const rows: SkillRow[] = [];
+      if (localResult.status === "fulfilled") {
+        for (const item of localResult.value) {
+          rows.push({ item, source: { kind: "local" }, label: "Local" });
         }
+      } else {
+        console.error(
+          "[SkillsPopoverSection] Failed to fetch local skills",
+          localResult.reason
+        );
       }
+      if (libraryResult.status === "fulfilled") {
+        if (skillsSource) {
+          for (const item of libraryResult.value) {
+            rows.push({ item, source: skillsSource, label: "Library" });
+          }
+        }
+      } else {
+        console.error(
+          "[SkillsPopoverSection] Failed to fetch library skills",
+          libraryResult.reason
+        );
+      }
+      setSkills(rows);
+      setIsLoading(false);
     })();
     return () => {
       active = false;
@@ -251,17 +316,24 @@ export function SkillsPopoverSection({
   );
 
   const handleSkillClick = useCallback(
-    async (skill: SkillListItem) => {
+    async (row: SkillRow) => {
       try {
-        setLoadingSkillName(skill.name);
-        const fullSkill = await getSkill(skill.name, skillsSource);
+        setLoadingSkillName(rowKey(row));
+        // The ROW's source, not the ambient one: with both halves on screen a
+        // local `refunds` and a library `refunds` are two different rows, and
+        // reading either through the wrong store returns the other's content.
+        const fullSkill = await getSkill(row.item.name, row.source);
         track("skill_injected", {
           location: "chat_input_skills_popover",
-          skill_name: skill.name,
+          skill_name: row.item.name,
+          skill_origin: row.label === "Library" ? "library" : "local",
         });
-        // Stamp the source onto the result so later file reads (expanding the
-        // card) stay pinned to the project it was selected from.
-        onSkillSelected({ ...fullSkill, source: skillsSource });
+        // Stamped ALWAYS, including for local rows. `SkillResultCard` falls
+        // back to its ambient source prop for an unstamped result, and that
+        // prop is now the library in both build modes — so an unstamped local
+        // selection would expand into file reads against Convex. The fallback
+        // remains only for results persisted before this stamp existed.
+        onSkillSelected({ ...fullSkill, source: row.source });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         console.error("[SkillsPopoverSection] Failed to get skill", message);
@@ -269,7 +341,7 @@ export function SkillsPopoverSection({
         setLoadingSkillName(null);
       }
     },
-    [onSkillSelected, skillsSource]
+    [onSkillSelected]
   );
 
   // The parent's navigation range must cover BOTH lists — see `onCountChange`.
@@ -284,7 +356,7 @@ export function SkillsPopoverSection({
     const localIndex = highlightedIndex - startIndex;
     if (localIndex < 0) return;
     if (localIndex < skills.length) {
-      handleSkillClick(skills[localIndex]);
+      handleSkillClick(skills[localIndex]!);
       return;
     }
     const serverIndex = localIndex - skills.length;
@@ -325,13 +397,14 @@ export function SkillsPopoverSection({
 
       {/* Skills list */}
       <div className="flex flex-col">
-        {skills.map((skill, index) => {
+        {skills.map((row, index) => {
           const globalIndex = startIndex + index;
           const isHighlighted = highlightedIndex === globalIndex;
-          const isLoadingThis = loadingSkillName === skill.name;
+          const key = rowKey(row);
+          const isLoadingThis = loadingSkillName === key;
 
           return (
-            <Tooltip key={skill.name} delayDuration={1000}>
+            <Tooltip key={key} delayDuration={1000}>
               <TooltipTrigger asChild>
                 <button
                   type="button"
@@ -339,7 +412,7 @@ export function SkillsPopoverSection({
                     "flex items-center gap-2 rounded-sm px-2 max-w-[300px] py-1.5 text-xs select-none hover:bg-accent hover:text-accent-foreground",
                     isHighlighted ? "bg-accent text-accent-foreground" : ""
                   )}
-                  onClick={() => handleSkillClick(skill)}
+                  onClick={() => handleSkillClick(row)}
                   onMouseEnter={() => {
                     if (isHovering) {
                       setHighlightedIndex(globalIndex);
@@ -348,7 +421,14 @@ export function SkillsPopoverSection({
                 >
                   <SquareSlash size={16} className="shrink-0 text-primary" />
                   <span className="flex-1 text-left truncate">
-                    {skill.name}
+                    {row.item.name}
+                  </span>
+                  {/* Which store this row is, carried on the row rather than
+                      in a group heading: the same name can legitimately appear
+                      in both halves, and the badge is what tells them apart at
+                      the moment of choosing. */}
+                  <span className="shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground/70">
+                    {row.label}
                   </span>
                   {isLoadingThis && (
                     <Loader2
@@ -359,7 +439,7 @@ export function SkillsPopoverSection({
                   )}
                 </button>
               </TooltipTrigger>
-              <TooltipContent>{skill.description}</TooltipContent>
+              <TooltipContent>{row.item.description}</TooltipContent>
             </Tooltip>
           );
         })}
@@ -453,33 +533,3 @@ export function SkillsPopoverSection({
   );
 }
 
-// Export the skill count getter for the parent popover to calculate navigation
-export function useSkillsCount(skillsSource?: SkillsSource): {
-  count: number;
-  isLoading: boolean;
-} {
-  const [count, setCount] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    let active = true;
-    (async () => {
-      try {
-        const skills = await listSkills(skillsSource);
-        if (!active) return;
-        setCount(skills.length);
-      } catch {
-        // Ignore errors, just set count to 0
-      } finally {
-        if (active) {
-          setIsLoading(false);
-        }
-      }
-    })();
-    return () => {
-      active = false;
-    };
-  }, [skillsSource]);
-
-  return { count, isLoading };
-}

--- a/mcpjam-inspector/client/src/components/environment-composer/skills-pill.tsx
+++ b/mcpjam-inspector/client/src/components/environment-composer/skills-pill.tsx
@@ -80,7 +80,7 @@ export function SkillsPill({
         portalled={!inModal}
       >
         <div className="px-1 pb-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-          Skills · shared pins
+          Skills · library pins
         </div>
         <ProjectEnvironmentSkillsPicker
           projectId={projectId}

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
@@ -31,6 +31,27 @@ export const MAX_ENVIRONMENT_SKILLS = 20;
  * identifier: this list grows on the backend, and a picker on an older client
  * should say something true rather than something internal.
  */
+/**
+ * Why this skill can't be pinned, or `null` if it can.
+ *
+ * `pinnability` is OPTIONAL on the wire — absent on a backend older than P0.3
+ * — so it cannot be the only thing consulted. That was harmless while personal
+ * skills were filtered out client-side and every remaining row was already
+ * eligible; now that they are listed, a row with no metadata would render as
+ * selectable, and the save would be the first the user heard of it.
+ *
+ * Shared-only is the one rule this picker can evaluate for itself, from a
+ * field that is not optional, so it is checked independently. The backend's
+ * own verdict still wins when it is present — it knows about restrictions
+ * (plugin components) this client cannot see.
+ */
+function pinRejection(skill: SkillListItem): string | null {
+  if (skill.pinnability && !skill.pinnability.ok)
+    return skill.pinnability.reason;
+  if (skill.sharing !== "project") return "not_shared";
+  return null;
+}
+
 function ineligibleReason(reason: string | undefined): string {
   switch (reason) {
     case "not_shared":
@@ -214,8 +235,8 @@ export function ProjectEnvironmentSkillsPicker({
         {skills.map((skill) => {
           const skillId = skill.skillId!;
           const checked = selectedIds.has(skillId);
-          const ineligible =
-            skill.pinnability !== undefined && skill.pinnability.ok === false;
+          const rejection = pinRejection(skill);
+          const ineligible = rejection !== null;
           const capBlocked = !checked && atCap;
           // Ineligibility (and the cap) block NEW selections only — a skill that
           // was pinned and later became ineligible must stay uncheckable so the
@@ -271,11 +292,7 @@ export function ProjectEnvironmentSkillsPicker({
               </TooltipTrigger>
               <TooltipContent side="right" className="max-w-[260px]">
                 <p className="text-xs leading-snug">
-                  {ineligibleReason(
-                    skill.pinnability && !skill.pinnability.ok
-                      ? skill.pinnability.reason
-                      : undefined,
-                  )}
+                  {ineligibleReason(rejection ?? undefined)}
                 </p>
               </TooltipContent>
             </Tooltip>

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
@@ -2,11 +2,6 @@ import { useEffect, useMemo, useState } from "react";
 import { Loader2, SquareSlash } from "lucide-react";
 import { Checkbox } from "@mcpjam/design-system/checkbox";
 import { Label } from "@mcpjam/design-system/label";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@mcpjam/design-system/tooltip";
 import { cn } from "@/lib/utils";
 import {
   listSkills,
@@ -261,7 +256,18 @@ export function ProjectEnvironmentSkillsPicker({
               <SquareSlash className="size-3.5 shrink-0 text-muted-foreground" />
               <span className="flex min-w-0 flex-col">
                 <span className="truncate font-normal">{skill.name}</span>
-                {skill.description ? (
+                {/* An ineligible row shows WHY, in place of its description.
+                    The reason used to live only in a tooltip, and a tooltip is
+                    not reachable here: the trigger wraps a row whose only
+                    focusable control is a DISABLED checkbox, so a keyboard or
+                    screen-reader user met a greyed-out row with no stated
+                    cause. It is also the more useful line — a reader scanning
+                    a disabled row wants the restriction, not the blurb. */}
+                {ineligible ? (
+                  <span className="text-[11px] leading-snug text-muted-foreground">
+                    {ineligibleReason(rejection ?? undefined)}
+                  </span>
+                ) : skill.description ? (
                   <span className="truncate text-[11px] text-muted-foreground">
                     {skill.description}
                   </span>
@@ -283,20 +289,7 @@ export function ProjectEnvironmentSkillsPicker({
               ) : null}
             </Label>
           );
-          if (!ineligible) return row;
-          return (
-            <Tooltip key={skillId}>
-              <TooltipTrigger asChild>
-                {/* span keeps the tooltip alive over the disabled row */}
-                <span>{row}</span>
-              </TooltipTrigger>
-              <TooltipContent side="right" className="max-w-[260px]">
-                <p className="text-xs leading-snug">
-                  {ineligibleReason(rejection ?? undefined)}
-                </p>
-              </TooltipContent>
-            </Tooltip>
-          );
+          return row;
         })}
         {orphanSelectedIds.map((skillId) => (
           <Label

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
@@ -156,8 +156,8 @@ export function ProjectEnvironmentSkillsPicker({
   if (skills.length === 0 && orphanSelectedIds.length === 0) {
     return (
       <p className="py-1 text-xs italic text-muted-foreground">
-        No shared skills in this project yet. Share a skill with the project to
-        pin it here.
+        No skills in the project library yet. Add a skill to the library to pin
+        it here.
       </p>
     );
   }
@@ -263,7 +263,7 @@ export function ProjectEnvironmentSkillsPicker({
                 </span>
               </span>
               <span className="truncate text-[11px] text-muted-foreground">
-                No longer shared with this project — remove it to save.
+                No longer in the project library — remove it to save.
               </span>
             </span>
           </Label>
@@ -274,7 +274,7 @@ export function ProjectEnvironmentSkillsPicker({
         {pinnedVersionBySkillId.size > 0
           ? ` (${pinnedVersionBySkillId.size} pinned to a version)`
           : ""}
-        {atCap ? " — cap reached" : ""}. Shared skills only.
+        {atCap ? " — cap reached" : ""}. Library skills only.
       </p>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
@@ -20,13 +20,46 @@ import type { ProjectEnvironmentSkillSelection } from "@/hooks/useProjectEnviron
 export const MAX_ENVIRONMENT_SKILLS = 20;
 
 /**
- * Shared-skill multi-select for a project environment's `skillSelection`.
+ * Why a listed skill can't be pinned, in the reader's words.
  *
- * Only SHARED (`sharing === 'project'`) skills are selectable — the backend
- * rejects personal skills. Rows the backend flags as non-pinnable (P0.3
- * `pinnability` metadata: plugin_component skills, supporting files, extra
- * frontmatter) render disabled with the backend-aligned reason, so users
- * never pick a skill only to discover the restriction at save time.
+ * The backend `reason` is an enum meant for callers (`not_shared`,
+ * `plugin_component`), and it used to be rendered raw. That was survivable
+ * while only exotic rows were ineligible; now that every personal skill is
+ * listed, the most common disabled row in the picker would read "not_shared".
+ *
+ * Unknown reasons fall through to the generic line rather than leaking an
+ * identifier: this list grows on the backend, and a picker on an older client
+ * should say something true rather than something internal.
+ */
+function ineligibleReason(reason: string | undefined): string {
+  switch (reason) {
+    case "not_shared":
+      return "Personal skill — only skills in the project library can run in environments. An admin can publish it.";
+    case "plugin_component":
+      return "Delivered by its plugin, not pinned on its own. Pin the plugin version instead.";
+    default:
+      return "This skill can't be pinned to an environment.";
+  }
+}
+
+/**
+ * Library-skill multi-select for a project environment's `skillSelection`.
+ *
+ * Only skills in the project LIBRARY (`sharing === 'project'`) can be pinned —
+ * the backend rejects personal ones, because an environment a teammate runs
+ * must resolve to the same skills for them as for you.
+ *
+ * Personal skills are nonetheless LISTED, disabled, with the reason on the row.
+ * Filtering them out client-side made the picker lie by omission: a user who
+ * had just uploaded a skill and came here to pin it found no trace of it and
+ * no way to tell whether it had failed to upload, been named something else,
+ * or simply wasn't eligible. The backend already says which of those it is —
+ * every listed row carries P0.3 `pinnability` metadata — so the picker shows
+ * the row and quotes the reason.
+ *
+ * The same machinery covers every other ineligible row (plugin_component
+ * skills), so users never pick a skill only to discover the restriction at
+ * save time.
  *
  * Each selected skill also gets a VERSION control, defaulting to "Latest" —
  * the skill's current revision, resolved when the run starts, which is what an
@@ -62,7 +95,16 @@ export function ProjectEnvironmentSkillsPicker({
       try {
         const list = await listSkills({ kind: "cloud", projectId });
         if (!active) return;
-        setSkills(list.filter((s) => s.sharing === "project" && s.skillId));
+        // `skillId` is the only hard requirement — it is what a pin addresses.
+        // Library skills sort first: they are the ones that can be picked, and
+        // a picker that opens on a wall of disabled rows reads as broken.
+        const pinnable = list.filter((s) => s.skillId);
+        pinnable.sort((a, b) => {
+          const aLib = a.sharing === "project" ? 0 : 1;
+          const bLib = b.sharing === "project" ? 0 : 1;
+          return aLib - bLib;
+        });
+        setSkills(pinnable);
       } catch (err) {
         if (!active) return;
         setLoadError(
@@ -229,9 +271,11 @@ export function ProjectEnvironmentSkillsPicker({
               </TooltipTrigger>
               <TooltipContent side="right" className="max-w-[260px]">
                 <p className="text-xs leading-snug">
-                  {skill.pinnability && !skill.pinnability.ok
-                    ? skill.pinnability.reason
-                    : "This skill can't be pinned to an environment."}
+                  {ineligibleReason(
+                    skill.pinnability && !skill.pinnability.ok
+                      ? skill.pinnability.reason
+                      : undefined,
+                  )}
                 </p>
               </TooltipContent>
             </Tooltip>

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/orphan-selections.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/orphan-selections.test.tsx
@@ -2,9 +2,11 @@
  * Orphaned-selection rows for both environment pickers.
  *
  * Both surfaces persist a list of ids and render rows from a LIVE query. An id
- * the query doesn't return — hard-deleted, unshared, or moved out of the
- * project — otherwise renders no row at all: invisible, unremovable, and still
- * shipped on every save. Each picker must surface those ids as detach-only
+ * the query doesn't return — hard-deleted, or moved out of the project —
+ * otherwise renders no row at all: invisible, unremovable, and still shipped
+ * on every save. (A skill that was merely UNSHARED is no longer one of these:
+ * the picker lists personal skills too, so it comes back as a checked,
+ * ineligible row that names its own reason.) Each picker must surface those ids as detach-only
  * rows. (The archived-but-present case was already handled; this covers the
  * genuinely-missing case.)
  */

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/orphan-selections.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/orphan-selections.test.tsx
@@ -95,7 +95,7 @@ describe("SuiteProjectEnvironmentsPicker — unresolvable attached ids", () => {
 });
 
 describe("ProjectEnvironmentSkillsPicker — unresolvable pinned ids", () => {
-  it("renders a removable row for a pinned skill missing from the shared list", async () => {
+  it("renders a removable row for a pinned skill missing from the library list", async () => {
     mockListSkills.mockResolvedValue([
       { skillId: "sk-live", name: "Live skill", description: "d" },
     ]);
@@ -119,7 +119,7 @@ describe("ProjectEnvironmentSkillsPicker — unresolvable pinned ids", () => {
     });
   });
 
-  it("still surfaces orphaned pins when the project has NO shared skills", async () => {
+  it("still surfaces orphaned pins when the project library is empty", async () => {
     // The empty-list early return would otherwise swallow the pins entirely,
     // leaving them invisible AND unremovable while still counted + saved.
     mockListSkills.mockResolvedValue([]);
@@ -137,7 +137,7 @@ describe("ProjectEnvironmentSkillsPicker — unresolvable pinned ids", () => {
       /Unavailable skill sk-gone \(remove\)/i
     );
     expect(
-      screen.queryByText(/No shared skills in this project yet/i)
+      screen.queryByText(/No skills in the project library yet/i)
     ).not.toBeInTheDocument();
 
     // Clearing the last pin emits null, never an empty array.

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/skills-picker-personal-rows.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/skills-picker-personal-rows.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Personal skills in the environment picker: shown, disabled, explained.
+ *
+ * The picker used to filter them out client-side (`sharing === 'project'`),
+ * which made it lie by omission. Someone who had just uploaded a skill and
+ * came here to pin it found no trace of it — no way to tell whether the upload
+ * had failed, whether they had mis-named it, or whether it was simply not
+ * eligible. The backend already answers that question on every listed row
+ * (`pinnability: { ok: false, reason: 'not_shared' }`), so the row is rendered
+ * and the reason is quoted.
+ *
+ * The eligibility rule itself is unchanged and still enforced server-side:
+ * only library skills can run in an environment, because an environment a
+ * teammate runs must resolve to the same skills for them as for you.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockListSkills, mockListSkillVersions } = vi.hoisted(() => ({
+  mockListSkills: vi.fn(),
+  mockListSkillVersions: vi.fn(),
+}));
+
+vi.mock("@/lib/apis/mcp-skills-api", () => ({
+  listSkills: (...args: unknown[]) => mockListSkills(...args),
+  listSkillVersions: (...args: unknown[]) => mockListSkillVersions(...args),
+}));
+
+import { ProjectEnvironmentSkillsPicker } from "../ProjectEnvironmentSkillsPicker";
+
+const LIBRARY_SKILL = {
+  name: "refunds",
+  description: "Handle refunds",
+  path: "Library",
+  skillId: "skill-refunds",
+  sharing: "project" as const,
+  isOwner: false,
+  origin: "cloud" as const,
+  pinnability: { ok: true as const },
+  currentVersionId: "ver-4",
+  currentVersionNumber: 4,
+};
+
+const PERSONAL_SKILL = {
+  name: "scratchpad",
+  description: "My notes",
+  path: "Library",
+  skillId: "skill-scratchpad",
+  sharing: "user" as const,
+  isOwner: true,
+  origin: "cloud" as const,
+  pinnability: { ok: false as const, reason: "not_shared" },
+  currentVersionId: "ver-1",
+  currentVersionNumber: 1,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockListSkillVersions.mockResolvedValue([]);
+  // Deliberately personal-first, so a passing sort assertion means the picker
+  // sorted rather than that the fixture happened to be ordered.
+  mockListSkills.mockResolvedValue([PERSONAL_SKILL, LIBRARY_SKILL]);
+});
+
+describe("ProjectEnvironmentSkillsPicker — personal skills", () => {
+  it("lists a personal skill instead of hiding it", async () => {
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={null}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByLabelText("scratchpad")).toBeInTheDocument();
+  });
+
+  it("disables it and says why, in words rather than in an enum", async () => {
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={null}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByLabelText("scratchpad")).toBeDisabled();
+    fireEvent.focus(screen.getByLabelText("scratchpad"));
+    // Radix mirrors tooltip content into an aria-live node, so this matches
+    // more than once.
+    expect(
+      (await screen.findAllByText(/only skills in the project library can run/i))
+        .length,
+    ).toBeGreaterThan(0);
+    // The backend's identifier must never reach the reader.
+    expect(screen.queryByText("not_shared")).not.toBeInTheDocument();
+  });
+
+  it("refuses to select it, so the save can't be built to fail", async () => {
+    const onChange = vi.fn();
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={null}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(await screen.findByLabelText("scratchpad"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("sorts library skills above the rows nobody can pick", async () => {
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={null}
+        onChange={vi.fn()}
+      />,
+    );
+
+    await screen.findByLabelText("refunds");
+    const boxes = screen.getAllByRole("checkbox");
+    expect(boxes[0]).toHaveAttribute("aria-label", "refunds");
+    expect(boxes[1]).toHaveAttribute("aria-label", "scratchpad");
+  });
+
+  it("leaves the footer count to the selection, not to the row count", async () => {
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={{ mode: "explicit", skillIds: ["skill-refunds"] }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText(/1\/20 skills selected/)).toBeInTheDocument();
+  });
+
+  it("brings a pinned-then-unshared skill back as a removable row", async () => {
+    // It used to vanish into the anonymous "Unavailable skill <id>" orphan row
+    // — technically removable, but with no name and no explanation. Now it is
+    // the skill itself, checked, ineligible, and uncheckable-to-repair.
+    const onChange = vi.fn();
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={{ mode: "explicit", skillIds: ["skill-scratchpad"] }}
+        onChange={onChange}
+      />,
+    );
+
+    const row = await screen.findByLabelText("scratchpad");
+    expect(row).toBeChecked();
+    // Ineligibility blocks NEW selections only, so this one can be undone.
+    expect(row).not.toBeDisabled();
+    expect(
+      screen.queryByLabelText(/Unavailable skill/i),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(row);
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(null));
+  });
+
+  it("shows the empty state only when the project has no skills at all", async () => {
+    mockListSkills.mockResolvedValue([]);
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={null}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/No skills in the project library yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the empty state for a project with only personal skills", async () => {
+    mockListSkills.mockResolvedValue([PERSONAL_SKILL]);
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={null}
+        onChange={vi.fn()}
+      />,
+    );
+
+    await screen.findByLabelText("scratchpad");
+    expect(
+      screen.queryByText(/No skills in the project library yet/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/skills-picker-personal-rows.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/skills-picker-personal-rows.test.tsx
@@ -162,6 +162,51 @@ describe("ProjectEnvironmentSkillsPicker — personal skills", () => {
     await waitFor(() => expect(onChange).toHaveBeenCalledWith(null));
   });
 
+  it("disables a personal skill on a backend that sends no pinnability", async () => {
+    // `pinnability` is optional on the wire. Consulting it alone was harmless
+    // while personal rows were filtered out; now they are listed, so a row
+    // with no metadata would render selectable and the SAVE would be the first
+    // the user heard of the restriction. Sharing is not optional.
+    const { pinnability: _dropped, ...noMetadata } = PERSONAL_SKILL;
+    mockListSkills.mockResolvedValue([noMetadata]);
+    const onChange = vi.fn();
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={null}
+        onChange={onChange}
+      />,
+    );
+
+    expect(await screen.findByLabelText("scratchpad")).toBeDisabled();
+    fireEvent.click(screen.getByLabelText("scratchpad"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("still trusts the backend's verdict over its own where both exist", async () => {
+    // The backend knows about restrictions this client cannot see (plugin
+    // components), so a library skill it rejects stays rejected here.
+    mockListSkills.mockResolvedValue([
+      {
+        ...LIBRARY_SKILL,
+        pinnability: { ok: false as const, reason: "plugin_component" },
+      },
+    ]);
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={null}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByLabelText("refunds")).toBeDisabled();
+    fireEvent.focus(screen.getByLabelText("refunds"));
+    expect(
+      (await screen.findAllByText(/Delivered by its plugin/i)).length,
+    ).toBeGreaterThan(0);
+  });
+
   it("shows the empty state only when the project has no skills at all", async () => {
     mockListSkills.mockResolvedValue([]);
     render(

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/skills-picker-personal-rows.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/skills-picker-personal-rows.test.tsx
@@ -75,7 +75,11 @@ describe("ProjectEnvironmentSkillsPicker — personal skills", () => {
     expect(await screen.findByLabelText("scratchpad")).toBeInTheDocument();
   });
 
-  it("disables it and says why, in words rather than in an enum", async () => {
+  it("disables it and says why on the row, in words rather than in an enum", async () => {
+    // The reason used to live only in a tooltip whose trigger wrapped a row
+    // with nothing focusable in it (the checkbox is disabled), so a keyboard
+    // or screen-reader user met a greyed-out row with no stated cause. It is
+    // rendered on the row now, so no hover is needed to read it.
     render(
       <ProjectEnvironmentSkillsPicker
         projectId="proj-1"
@@ -85,15 +89,51 @@ describe("ProjectEnvironmentSkillsPicker — personal skills", () => {
     );
 
     expect(await screen.findByLabelText("scratchpad")).toBeDisabled();
-    fireEvent.focus(screen.getByLabelText("scratchpad"));
-    // Radix mirrors tooltip content into an aria-live node, so this matches
-    // more than once.
     expect(
-      (await screen.findAllByText(/only skills in the project library can run/i))
-        .length,
-    ).toBeGreaterThan(0);
+      screen.getByText(/only skills in the project library can run/i),
+    ).toBeInTheDocument();
     // The backend's identifier must never reach the reader.
     expect(screen.queryByText("not_shared")).not.toBeInTheDocument();
+  });
+
+  it("shows the reason in place of the description, not beside it", async () => {
+    // A reader scanning a disabled row wants the restriction, not the blurb.
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={null}
+        onChange={vi.fn()}
+      />,
+    );
+
+    await screen.findByLabelText("scratchpad");
+    expect(screen.queryByText("My notes")).not.toBeInTheDocument();
+    // An eligible row still shows its description.
+    expect(screen.getByText("Handle refunds")).toBeInTheDocument();
+  });
+
+  it("falls back to a generic line for a reason it doesn't know", async () => {
+    // The backend's reason list grows; an older client must say something true
+    // rather than leak an identifier it has no copy for.
+    mockListSkills.mockResolvedValue([
+      {
+        ...LIBRARY_SKILL,
+        pinnability: { ok: false as const, reason: "some_future_reason" },
+      },
+    ]);
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={null}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByLabelText("refunds")).toBeDisabled();
+    expect(
+      screen.getByText(/can't be pinned to an environment/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("some_future_reason")).not.toBeInTheDocument();
   });
 
   it("refuses to select it, so the save can't be built to fail", async () => {
@@ -201,10 +241,7 @@ describe("ProjectEnvironmentSkillsPicker — personal skills", () => {
     );
 
     expect(await screen.findByLabelText("refunds")).toBeDisabled();
-    fireEvent.focus(screen.getByLabelText("refunds"));
-    expect(
-      (await screen.findAllByText(/Delivered by its plugin/i)).length,
-    ).toBeGreaterThan(0);
+    expect(screen.getByText(/Delivered by its plugin/i)).toBeInTheDocument();
   });
 
   it("shows the empty state only when the project has no skills at all", async () => {

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/skills-picker-version-pins.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/skills-picker-version-pins.test.tsx
@@ -25,7 +25,7 @@ import { ProjectEnvironmentSkillsPicker } from "../ProjectEnvironmentSkillsPicke
 const REFUNDS = {
   name: "refunds",
   description: "Handle refunds",
-  path: "Shared",
+  path: "Library",
   skillId: "skill-refunds",
   sharing: "project" as const,
   isOwner: false,
@@ -179,7 +179,7 @@ describe("ProjectEnvironmentSkillsPicker — version pins", () => {
     expect(screen.getByText("Latest (v4)")).toBeInTheDocument();
   });
 
-  it("renders the empty state when the project has no shared skills", async () => {
+  it("renders the empty state when the project library is empty", async () => {
     mockListSkills.mockResolvedValue([]);
     render(
       <ProjectEnvironmentSkillsPicker
@@ -189,7 +189,7 @@ describe("ProjectEnvironmentSkillsPicker — version pins", () => {
       />,
     );
     expect(
-      await screen.findByText(/No shared skills in this project yet/i),
+      await screen.findByText(/No skills in the project library yet/i),
     ).toBeInTheDocument();
   });
 

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-composer.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-composer.test.tsx
@@ -90,7 +90,7 @@ vi.mock(
   () => ({
     ProjectEnvironmentSkillsPicker: () => (
       <p className="italic">
-        No shared skills in this project yet. Share a skill with the project to
+        No skills in the project library yet. Add a skill to the library to
         pin it here.
       </p>
     ),
@@ -236,7 +236,7 @@ describe("SwarmTargetComposer", () => {
       screen.queryByTestId("new-swarm-skills-picker")
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/No shared skills in this project yet/i)
+      screen.queryByText(/No skills in the project library yet/i)
     ).not.toBeInTheDocument();
   });
 
@@ -247,12 +247,12 @@ describe("SwarmTargetComposer", () => {
     expect(trigger).toBeVisible();
     expect(trigger).toHaveTextContent(/No skills · pick some/i);
     expect(
-      screen.queryByText(/No shared skills in this project yet/i)
+      screen.queryByText(/No skills in the project library yet/i)
     ).not.toBeInTheDocument();
 
     fireEvent.click(trigger);
     expect(
-      screen.getByText(/No shared skills in this project yet/i)
+      screen.getByText(/No skills in the project library yet/i)
     ).toBeVisible();
   });
 

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-skills-api.cloud-mapping.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-skills-api.cloud-mapping.test.ts
@@ -1,0 +1,101 @@
+/**
+ * What the cloud wire becomes on the client.
+ *
+ * `path` is synthetic for a project skill — there is no filesystem path to
+ * report — so it carries a human label for the STORE. It used to repeat the
+ * sharing tier ("Shared"/"Personal"), which the UI already renders as its own
+ * badge, so a skill header said the same word twice. These pin the label and
+ * the fields that travel beside it.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const webPostMock = vi.fn();
+
+vi.mock("@/lib/config", () => ({ HOSTED_MODE: true }));
+vi.mock("@/lib/apis/web/base", () => ({
+  webPost: (...args: unknown[]) => webPostMock(...args),
+}));
+vi.mock("@/lib/session-token", () => ({ authFetch: vi.fn() }));
+
+import { listSkills, getSkill } from "../mcp-skills-api";
+
+const SOURCE = { kind: "cloud" as const, projectId: "proj-1" };
+
+const wire = (over: Record<string, unknown> = {}) => ({
+  skillId: "skill-1",
+  name: "refunds",
+  description: "Handle refunds",
+  sharing: "project",
+  isOwner: false,
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("cloud skill mapping — the synthetic `path`", () => {
+  it("labels a project skill with its store, not its tier", async () => {
+    webPostMock.mockResolvedValue({ skills: [wire({ sharing: "project" })] });
+
+    const [row] = await listSkills(SOURCE);
+
+    expect(row.path).toBe("Library");
+    expect(row.sharing).toBe("project");
+  });
+
+  it("labels a personal skill with the same store", async () => {
+    // Both live in the project's library; `sharing` is a separate question and
+    // the badge's job. Repeating it here is what produced the doubled word.
+    webPostMock.mockResolvedValue({ skills: [wire({ sharing: "user" })] });
+
+    const [row] = await listSkills(SOURCE);
+
+    expect(row.path).toBe("Library");
+    expect(row.sharing).toBe("user");
+  });
+
+  it("labels the detail view the same way, with empty content tolerated", async () => {
+    webPostMock.mockResolvedValue({ skill: wire({ content: undefined }) });
+
+    const skill = await getSkill("refunds", SOURCE);
+
+    expect(skill.path).toBe("Library");
+    expect(skill.content).toBe("");
+  });
+
+  it("omits optional fields rather than inventing them", async () => {
+    // A row predating versioning has no `currentVersionId`; consumers render
+    // nothing rather than guessing "v1".
+    webPostMock.mockResolvedValue({ skills: [wire()] });
+
+    const [row] = await listSkills(SOURCE);
+
+    expect(row).not.toHaveProperty("currentVersionId");
+    expect(row).not.toHaveProperty("currentVersionNumber");
+    expect(row).not.toHaveProperty("pinnability");
+    expect(row.provenance).toBe("authored");
+  });
+
+  it("carries pinnability through verbatim when the backend sends it", async () => {
+    webPostMock.mockResolvedValue({
+      skills: [wire({ pinnability: { ok: false, reason: "not_shared" } })],
+    });
+
+    const [row] = await listSkills(SOURCE);
+
+    expect(row.pinnability).toEqual({ ok: false, reason: "not_shared" });
+  });
+
+  it("yields an empty list when the response carries no skills", async () => {
+    webPostMock.mockResolvedValue(null);
+
+    expect(await listSkills(SOURCE)).toEqual([]);
+  });
+
+  it("lets a failed request throw rather than reporting an empty library", async () => {
+    webPostMock.mockRejectedValue(new Error("forbidden"));
+
+    await expect(listSkills(SOURCE)).rejects.toThrow("forbidden");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/mcp-skills-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-skills-api.ts
@@ -60,11 +60,15 @@ function normalizeProvenance(value: string | undefined): SkillProvenance {
   return value === "computer-adopted" ? "computer-adopted" : "authored";
 }
 
+// A project skill has no filesystem path, so `path` carries a human label for
+// the store it lives in. It used to repeat the sharing tier ("Shared"/
+// "Personal"), which the UI already renders as its own badge — the same word
+// twice in one header. The store is what the path slot is for.
 function cloudToListItem(s: CloudSkillWire): SkillListItem {
   return {
     name: s.name,
     description: s.description,
-    path: s.sharing === "project" ? "Shared" : "Personal",
+    path: "Library",
     skillId: s.skillId,
     sharing: s.sharing,
     isOwner: s.isOwner,
@@ -83,7 +87,7 @@ function cloudToSkill(s: CloudSkillWire): Skill {
     name: s.name,
     description: s.description,
     content: s.content ?? "",
-    path: s.sharing === "project" ? "Shared" : "Personal",
+    path: "Library",
   };
 }
 


### PR DESCRIPTION
The skills surfaces grew around storage distinctions — Local vs Cloud, personal vs shared, promote flows — and presented each one as a *decision*, though the user has a single intent: make this skill available to my runs.

North star: **one library, one button ("Add to library"), one rule (evals/envs only run what's in it).**

The first four commits are the four planned steps, reviewable in order. The remaining seven are review fixes, described at the bottom. UI/copy only — no backend or Convex change. `createSkill` has always accepted `sharing: 'project'` from an admin.

---

### 1. `58338e1` — Vocabulary: Cloud → Library

The durable, versioned store the project owns is the **Library**; local files are the working tree you promote *from*.

- Browse toggle reads **Local | Library**. The `local`/`cloud` VALUES are untouched — they feed `SkillsSource.kind`, chat-persisted `SkillResult.source` and the API types, so renaming them would rewrite serialized state for a label. `ariaLabel`/`indicatorId` unchanged too.
- Origin badge says **Project**/Personal, matching the secrets dialog and dropping "shared" as a noun.
- Fixes a duplicated word: the synthetic `path` for a project skill was set to `"Shared"`/`"Personal"` and rendered as a path chip *next to the badge saying the same thing*. It now names the store it lives in.
- Environment picker and its pill speak of the project library.

`LocalComputerView`'s "Switch the toggle to Cloud" is the Computer engine toggle, deliberately left alone.

### 2. `d52177f` — One "Add to library" button, tier resolved by role

The upload dialog asked a question whose answer the user often wasn't allowed to give: "Share with the project", unchecked, whose small print admitted that ticking it "requires admin". A member filled the whole form and was refused at submit; an admin — the one person for whom the library IS the destination — opted in every time. Meanwhile the Publish (globe) button was offered to everyone, though `promoteSkillToProject` is admin-only, so a member's click produced a rejected request whose only trace was a `console.error`: the button read as broken rather than forbidden.

Both are now resolved from the member's role. `canManageMembers` is the same backend authority (`canManageProjectMembers`) that gates both mutations, and it fails closed.

- The dialog **states** where the skill lands: the project library for an admin, a personal skill plus "a project admin can publish it" for everyone else. Checkbox deleted, not disabled.
- The members query is gated on `open` as well as on the cloud source — the dialog is mounted (closed) by every chat input, so an ungated query would hold a standing Convex subscription per composer on screen.
- Publish is offered only to someone who can publish, and its title names the library.
- A failed publish raises a toast carrying the server's own message.

`skill_uploaded` still records `sharing`, now the resolved value.

### 3. `21f4547` — Merge local + library into one `/` picker

The chat picker showed one half or the other, decided by build mode. A local user's own project skills — the durable, versioned ones the library exists for — were unreachable from the one place skills are actually used.

- Both halves render in one list, local first, each row badged with its store. Fetched concurrently and rendered independently: an unreachable *or slow* Convex must not take local files off the menu, and a broken local route must not hide the project's skills. The local half needs no build-mode branch — `listSkills(undefined)` self-empties in hosted via `runByMode`.
- **No dedupe.** Both halves may hold a `refunds`; they are different artifacts, so both rows render, badged. Collapsing them would choose for the user, silently and by fetch order.
- Each row carries its **own** source — what `getSkill` reads through and what is stamped on the selection. The stamp goes on local selections too: `SkillResultCard` falls back to its ambient prop for an unstamped result, and that prop names the library in both modes, so an unstamped local skill would expand into file reads against Convex. The fallback remains for results persisted before the stamp existed.
- Drops `useSkillsCount`, an exported duplicate listing with zero call sites.
- Adds `skill_origin` to `skill_injected`, mirroring the `"mcp-server"` value the server-skill path already sends.

One accepted consequence: in local mode the `/` composer's upload now writes to the library, since it follows the same source. That is the intended destination.

### 4. `6b4b839` — Personal skills visible-but-disabled in the env picker

The picker filtered personal skills out client-side, so someone who had just uploaded one and came here to pin it found no trace of it — no way to tell whether the upload had failed, whether they had mis-named it, or whether it was simply ineligible. The rule is real (only library skills can run in an environment, so a teammate's run resolves to the same skills as yours) and the backend already states it per row.

- Rows are shown, disabled, through the machinery that already handled every other ineligible row, with the reason stated **on the row, in words**. The enum was being rendered raw, which would have made `not_shared` the most common line in the picker. Unknown reasons fall through to a generic line rather than leaking an identifier a newer backend added.
- Library skills sort first; a picker that opens on a wall of disabled rows reads as broken.
- A skill that was pinned and later unshared used to fall into the anonymous "Unavailable skill &lt;id&gt;" orphan row. It now comes back as itself: checked, ineligible, uncheckable-to-repair. The orphan row goes back to meaning what it says — an id the project no longer has.

---

## Review fixes (`84459a5` … `2341532`)

Eleven findings from Codex, cubic and CodeRabbit across seven rounds. All were real; each fix has a test that fails without it.

Most were one theme — **something not yet known being read as an answer**:

- The upload gate waited on the members query but not on Convex auth. During hydration `isAuthenticated` is false, so the query is *disabled*, so its `isLoading` is false too — the role looked settled at "not an admin" when nothing had been asked. Now gated on `authLoading || roleLoading`.
- That gate then read `isLoading` raw, which flips back on every Convex websocket reconnect. The resolved role is latched, following `useViewerProjectRole`, which documents the same mechanism — scoped to one open dialog session and written only while the query is genuinely enabled, so neither a reopen nor a closed-dialog non-answer can be mistaken for a decision.
- The env picker derived eligibility from `pinnability` alone, which is optional on the wire. Harmless while personal rows were filtered out; a regression once they are listed. Shared-only is now checked independently, with the backend's verdict still winning where present.
- The `/` picker awaited `allSettled` on the *pair*, which buys independence from one half failing but not from one half hanging. Each half now renders on arrival.

Rendering each half on arrival then created its own problem, fixed over the last two rounds: the row list can grow at the **front**, and the parent navigates by a bare numeric index, so a keyboard highlight slid onto a different skill. The highlighted row is now followed by identity across the whole selectable range — project rows *and* the server rows that occupy the indices after them.

Two others:

- The ineligibility reason lived only in a tooltip whose trigger wrapped a row with nothing focusable in it, so keyboard and screen-reader users met a greyed-out row with no cause. It is on the row now, in place of the description.
- Uploads reached the composer unstamped — including local ones, which an earlier round wrongly left alone on the grounds that an absent `source` meant "no source". It means the filesystem route, so they now carry `{kind:'local'}` like every picker row.

Plus: the members query is skipped when the library is off the surface (matching the rule that already keeps `listSkills` from firing), a leaked `console.error` spy restored between tests, and the coverage gaps reviewers named — error paths, unknown-reason branch, empty catalog, invalid input, the cloud `path` mapping for both tiers.

One suggestion declined, with reasoning on the thread: a `SkillsPill` test asserting its heading string, which would pin a literal rather than a behaviour.

## Verification

- `npm test -- client/` on `2341532` — **1009 files / 11270 tests pass**, 0 failures (2 files skipped, pre-existing).
- `npm run typecheck:client` clean. CI green on the head: Build and Test, Inspector Tests 1–4, Run Tests, E2E Smoke, CodeQL.
- New suites: `skill-upload-dialog.sharing.test.tsx` (16), `skills-popover-section.merged.test.tsx` (17), `skills-picker-personal-rows.test.tsx` (12), `SkillsTab.promote-gate.test.tsx` (4), `mcp-skills-api.cloud-mapping.test.ts` (7).
- Updated: `SkillsTab.source-toggle` / `.cloud-gate` / `.list-summary`, `skills-picker-version-pins`, `orphan-selections`, `swarm-target-composer`.

Note for a clean checkout: 154 client test files fail to *collect* on `@mcpjam/sdk/platform` until `npm run build -w @mcpjam/sdk` has run. Pre-existing, unrelated to this branch.

**Manual checks still outstanding** — nothing automated substitutes for these: hosted admin upload lands with the PROJECT badge and no checkbox; a member's upload lands personal with the hint and sees no Publish button; a failed promote raises a toast; local + flag + synced project shows Local and Library rows in `/`, each expanding the correct file tree.

## One thing worth a maintainer's judgement

Three of the seven review rounds were the merged picker's keyboard-index bookkeeping. Patching it in `SkillsPopoverSection` works and is tested, but the root cause is that `PromptsPopover` navigates by a bare number across a list that can now change shape underneath it. Having the parent track row *identity* would close the class rather than the instances. That's outside this PR's scope and I haven't done it — flagging it as the obvious follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_011rFVWoU3khKDN4stSfZni3)_