### PR TITLE
Cursor CLI: a harness that pays for its own model

### DIFF
--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -17490,7 +17490,7 @@
           },
           "harness": {
             "type": ["string", "null"],
-            "enum": ["claude-code", "codex", null],
+            "enum": ["claude-code", "codex", "cursor", null],
             "description": "Execution runtime selector. Send `null` to clear this field back to absent. Setting one requires the matching feature flag; clearing never does."
           },
           "computer": {

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1135,6 +1135,7 @@ function useTemplateVerifyDeepLink({
     requestedFocusTab,
     claudeCodeEnabled,
     codexEnabled,
+    cursorCliEnabled,
     flagWaitExpired,
     themeMode,
     createHost,

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -277,6 +277,7 @@ import {
 } from "@mcpjam/sdk/host-config/templates";
 import { useClaudeCodeHostEnabledState } from "./hooks/useClaudeCodeHostEnabled";
 import { useCodexHostEnabledState } from "./hooks/useCodexHostEnabled";
+import { useCursorHostEnabledState } from "./hooks/useCursorHostEnabled";
 import { hostFeatureFlagState } from "@/lib/host-compat/feature-visibility";
 import {
   HOST_VERIFY_TAB_PARAM,
@@ -1013,6 +1014,7 @@ function useTemplateVerifyDeepLink({
   const { createHost } = useHostMutations();
   const claudeCodeEnabled = useClaudeCodeHostEnabledState();
   const codexEnabled = useCodexHostEnabledState();
+  const cursorCliEnabled = useCursorHostEnabledState();
   const requestedTemplateId = useMemo<HostTemplateId | null>(() => {
     if (typeof window === "undefined") return null;
     const raw = new URLSearchParams(window.location.search).get(
@@ -1082,6 +1084,7 @@ function useTemplateVerifyDeepLink({
     const templateEnabled = hostFeatureFlagState(requestedTemplateId, {
       claudeCode: claudeCodeEnabled,
       codex: codexEnabled,
+      cursorCli: cursorCliEnabled,
     });
     // Gated templates remain visible on caniuse.dev as reference profiles, but
     // they are not available for new-host creation until their rollout flags

--- a/mcpjam-inspector/client/src/components/compat/HostCompatContent.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatContent.tsx
@@ -40,6 +40,7 @@ import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { cloneHostTemplateInput } from "@/lib/client-config-v2";
 import { useClaudeCodeHostEnabled } from "@/hooks/useClaudeCodeHostEnabled";
 import { useCodexHostEnabled } from "@/hooks/useCodexHostEnabled";
+import { useCursorHostEnabled } from "@/hooks/useCursorHostEnabled";
 import { filterReportsByFeatureFlags } from "@/lib/host-compat/feature-visibility";
 import type { ToolsDataStatus } from "@/lib/host-compat/use-host-compat";
 
@@ -122,19 +123,21 @@ export function HostCompatContent({
         toolsData,
         widgetUsage,
         { protocolVersion },
-        catalogState?.catalog
+        catalogState?.catalog,
       ),
-    [toolsData, widgetUsage, protocolVersion, catalogState]
+    [toolsData, widgetUsage, protocolVersion, catalogState],
   );
   const claudeCodeEnabled = useClaudeCodeHostEnabled();
   const codexEnabled = useCodexHostEnabled();
+  const cursorCliEnabled = useCursorHostEnabled();
   const visibleReports = useMemo(
     () =>
       filterReportsByFeatureFlags(reports, {
         claudeCode: claudeCodeEnabled,
         codex: codexEnabled,
+        cursorCli: cursorCliEnabled,
       }),
-    [reports, claudeCodeEnabled, codexEnabled]
+    [reports, claudeCodeEnabled, codexEnabled, cursorCliEnabled],
   );
 
   // Tier-2: render the server's widget live in each host's emulation.
@@ -146,7 +149,7 @@ export function HostCompatContent({
   const themeMode = usePreferencesStore((s) => s.themeMode);
   // Which host's CTA is mid-create (drives its spinner + disables the rest).
   const [creatingTemplateId, setCreatingTemplateId] = useState<string | null>(
-    null
+    null,
   );
   // Findings are collapsed by default — the row shows a terse summary; the
   // full list expands on demand so the tab reads as a scannable list.
@@ -227,7 +230,7 @@ export function HostCompatContent({
       navigate(routePaths.playground);
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : `Couldn't open in ${label}`
+        err instanceof Error ? err.message : `Couldn't open in ${label}`,
       );
     } finally {
       setCreatingTemplateId(null);
@@ -382,7 +385,7 @@ export function HostCompatContent({
                 <div className="mt-2 space-y-2.5 pl-6">
                   {LANE_ORDER.map((lane) => {
                     const laneFindings = report.findings.filter(
-                      (f) => f.lane === lane
+                      (f) => f.lane === lane,
                     );
                     if (laneFindings.length === 0) return null;
                     const laneStatus = getCompatDisplayStatus({

--- a/mcpjam-inspector/client/src/components/compat/HostCompatMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatMatrix.tsx
@@ -17,6 +17,7 @@ import {
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { useClaudeCodeHostEnabled } from "@/hooks/useClaudeCodeHostEnabled";
 import { useCodexHostEnabled } from "@/hooks/useCodexHostEnabled";
+import { useCursorHostEnabled } from "@/hooks/useCursorHostEnabled";
 import { filterProfilesByFeatureFlags } from "@/lib/host-compat/feature-visibility";
 
 type HostColumn = {
@@ -164,6 +165,7 @@ export function HostCompatMatrix({
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const claudeCodeEnabled = useClaudeCodeHostEnabled();
   const codexEnabled = useCodexHostEnabled();
+  const cursorCliEnabled = useCursorHostEnabled();
   // Live catalog so the column set matches the per-row verdicts (which also
   // recompute on catalogState via useHostCompatReports).
   const catalogState = useHostCatalog();
@@ -172,6 +174,7 @@ export function HostCompatMatrix({
       filterProfilesByFeatureFlags(getHostProfiles(catalogState?.catalog), {
         claudeCode: claudeCodeEnabled,
         codex: codexEnabled,
+        cursorCli: cursorCliEnabled,
       }).map((p) => ({
         id: p.id,
         label: p.label,

--- a/mcpjam-inspector/client/src/components/compat/HostCompatMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatMatrix.tsx
@@ -181,7 +181,7 @@ export function HostCompatMatrix({
         logoSrc: p.logoSrc,
         logoSrcByTheme: p.logoSrcByTheme,
       })),
-    [catalogState, claudeCodeEnabled, codexEnabled]
+    [catalogState, claudeCodeEnabled, codexEnabled, cursorCliEnabled]
   );
 
   const [byServer, setByServer] = useState<Record<string, HostCompatReport[]>>(

--- a/mcpjam-inspector/client/src/components/evals/__tests__/compare-playground-helpers.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/compare-playground-helpers.test.ts
@@ -933,6 +933,49 @@ describe("resolveTraceModel", () => {
     expect(model.id).toBe("not-a-provider/mystery");
   });
 
+  it('treats an EMPTY snapshot field as absent, not as a provider named ""', () => {
+    // `||`, not `??`, so `""` falls through. Worth pinning because the two
+    // fields fall back independently: an empty provider with a real model must
+    // not produce the id `/gpt-5`, and an empty model must not produce
+    // `openai/` — either would be a model id nothing can resolve.
+    expect(
+      resolveTraceModel(
+        iterationWith({ provider: "", model: "auto" }),
+        caseWith([{ provider: "cursor", model: "ignored" }]),
+      ).id,
+    ).toBe("cursor/auto");
+
+    expect(
+      resolveTraceModel(iterationWith({ provider: "", model: "auto" }), null),
+    ).toEqual({
+      id: "openai/auto",
+      name: "auto",
+      provider: "openai",
+    });
+
+    expect(
+      resolveTraceModel(iterationWith({ provider: "cursor", model: "" }), null),
+    ).toEqual({
+      id: "cursor/unknown-model",
+      name: "unknown-model",
+      provider: "cursor",
+    });
+  });
+
+  it("falls back past an EMPTY case model too", () => {
+    // Both layers empty: neither may contribute a half-formed id.
+    expect(
+      resolveTraceModel(
+        iterationWith(),
+        caseWith([{ provider: "", model: "" }]),
+      ),
+    ).toEqual({
+      id: "openai/unknown-model",
+      name: "unknown-model",
+      provider: "openai",
+    });
+  });
+
   it("falls all the way back when neither snapshot nor case names anything", () => {
     const model = resolveTraceModel(iterationWith(), null);
     expect(model).toEqual({

--- a/mcpjam-inspector/client/src/components/evals/__tests__/compare-playground-helpers.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/compare-playground-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   resolveIterationModelValue,
   resolveInitialCompareModelValues,
   resolveLatestCompareRunId,
+  resolveTraceModel,
 } from "../compare-playground-helpers";
 import type { CompareRunRecord } from "../types";
 
@@ -850,5 +851,105 @@ describe("compare-playground-helpers", () => {
     });
 
     expect(records["openai/gpt-5-nano"]?.iteration?._id).toBe("suite-only");
+  });
+});
+
+/**
+ * `resolveTraceModel` decides what a run's trace header SAYS was used. It is
+ * the single copy for both the compare playground and the iteration detail
+ * pane (which imports it from here), so these cases cover both surfaces.
+ *
+ * The failure mode worth guarding is quiet: an unrecognized provider name is
+ * cast down to `custom` rather than rejected, so a half-registered provider
+ * mislabels every run it serves and nothing errors.
+ */
+describe("resolveTraceModel", () => {
+  const iterationWith = (snapshot?: { provider?: string; model?: string }) =>
+    ({
+      testCaseSnapshot: snapshot
+        ? {
+            title: "t",
+            query: "q",
+            provider: snapshot.provider,
+            model: snapshot.model,
+            expectedToolCalls: [],
+          }
+        : undefined,
+    } as any);
+
+  const caseWith = (models: Array<{ provider: string; model: string }>) =>
+    ({ models } as any);
+
+  it("keeps cursor/auto on the cursor provider", () => {
+    // The Cursor CLI sentinel. Before `cursor` joined the list this normalized
+    // to `custom`, and an eval of a Cursor host reported a provider that never
+    // served the turn.
+    const model = resolveTraceModel(
+      iterationWith({ provider: "cursor", model: "auto" }),
+      null,
+    );
+    expect(model.provider).toBe("cursor");
+    expect(model.id).toBe("cursor/auto");
+    expect(model.name).toBe("auto");
+  });
+
+  it("keeps cursor when the snapshot model is already prefixed", () => {
+    // `model.startsWith(`${provider}/`)` — the id must not become
+    // `cursor/cursor/auto`.
+    const model = resolveTraceModel(
+      iterationWith({ provider: "cursor", model: "cursor/auto" }),
+      null,
+    );
+    expect(model.id).toBe("cursor/auto");
+    expect(model.provider).toBe("cursor");
+    expect(model.name).toBe("auto");
+  });
+
+  it("falls back to the case's first model when the snapshot has none", () => {
+    const model = resolveTraceModel(
+      iterationWith(),
+      caseWith([{ provider: "cursor", model: "auto" }]),
+    );
+    expect(model.provider).toBe("cursor");
+    expect(model.id).toBe("cursor/auto");
+  });
+
+  it("prefers the snapshot over the case, so an edited case cannot rewrite a past run", () => {
+    const model = resolveTraceModel(
+      iterationWith({ provider: "cursor", model: "auto" }),
+      caseWith([{ provider: "openai", model: "gpt-5" }]),
+    );
+    expect(model.provider).toBe("cursor");
+  });
+
+  it("normalizes a provider name that is not a provider at all", () => {
+    // The cast is guarded for a reason: whatever this string is, it must not
+    // end up typed as a `ModelProvider`.
+    const model = resolveTraceModel(
+      iterationWith({ provider: "not-a-provider", model: "mystery" }),
+      null,
+    );
+    expect(model.provider).toBe("custom");
+    expect(model.id).toBe("not-a-provider/mystery");
+  });
+
+  it("falls all the way back when neither snapshot nor case names anything", () => {
+    const model = resolveTraceModel(iterationWith(), null);
+    expect(model).toEqual({
+      id: "openai/unknown-model",
+      name: "unknown-model",
+      provider: "openai",
+    });
+  });
+
+  it("resolves a catalog model to its curated entry rather than the fallback", () => {
+    // The fallback shape is only for ids the catalog does not know; a catalog
+    // hit carries a display name and context length no string parsing recovers.
+    const model = resolveTraceModel(
+      iterationWith({ provider: "anthropic", model: "claude-sonnet-4-5" }),
+      null,
+    );
+    expect(model.provider).toBe("anthropic");
+    expect(model.name).not.toBe("claude-sonnet-4-5");
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/compare-playground-helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/compare-playground-helpers.ts
@@ -35,6 +35,9 @@ const KNOWN_MODEL_PROVIDERS: ModelProvider[] = [
   "minimax",
   "qwen",
   "custom",
+  // The Cursor CLI harness runs on the customer's own Cursor account; without
+  // this it normalizes to "custom" and the run reads as an unknown provider.
+  "cursor",
 ];
 
 function normalizeModelProvider(provider?: string): ModelProvider {

--- a/mcpjam-inspector/client/src/components/evals/compare-playground-helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/compare-playground-helpers.ts
@@ -18,7 +18,17 @@ import type {
 } from "./types";
 import type { TraceEnvelope } from "./trace-viewer-adapter";
 
-const KNOWN_MODEL_PROVIDERS: ModelProvider[] = [
+/**
+ * The provider names a trace's snapshot may legitimately carry.
+ *
+ * A hand-kept list guarding a cast, so an id that is not a provider at all
+ * cannot be laundered into `ModelProvider` by `normalizeModelProvider`. The
+ * cost is drift: a provider added to the union but not here normalizes to
+ * `custom`, and the run reads as an unknown provider forever after — how
+ * `cursor` nearly shipped. `KNOWN_MODEL_PROVIDERS_ARE_EXHAUSTIVE` below turns
+ * that silent mislabel into a typecheck failure.
+ */
+const KNOWN_MODEL_PROVIDERS = [
   "anthropic",
   "azure",
   "bedrock",
@@ -38,10 +48,27 @@ const KNOWN_MODEL_PROVIDERS: ModelProvider[] = [
   // The Cursor CLI harness runs on the customer's own Cursor account; without
   // this it normalizes to "custom" and the run reads as an unknown provider.
   "cursor",
-];
+] as const satisfies readonly ModelProvider[];
+
+/**
+ * Compile-time proof the list above covers the whole union. If a new
+ * `ModelProvider` member is added without being listed, `Exclude<...>` is no
+ * longer `never` and this assignment fails to typecheck — naming the missing
+ * member in the error.
+ */
+type UnlistedModelProvider = Exclude<
+  ModelProvider,
+  (typeof KNOWN_MODEL_PROVIDERS)[number]
+>;
+const KNOWN_MODEL_PROVIDERS_ARE_EXHAUSTIVE: UnlistedModelProvider extends never
+  ? true
+  : UnlistedModelProvider = true;
+void KNOWN_MODEL_PROVIDERS_ARE_EXHAUSTIVE;
 
 function normalizeModelProvider(provider?: string): ModelProvider {
-  return KNOWN_MODEL_PROVIDERS.includes(provider as ModelProvider)
+  return (KNOWN_MODEL_PROVIDERS as readonly ModelProvider[]).includes(
+    provider as ModelProvider,
+  )
     ? (provider as ModelProvider)
     : "custom";
 }

--- a/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
+++ b/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
@@ -104,6 +104,9 @@ const KNOWN_MODEL_PROVIDERS: ModelProvider[] = [
   "minimax",
   "qwen",
   "custom",
+  // The Cursor CLI harness runs on the customer's own Cursor account; without
+  // this it normalizes to "custom" and the run reads as an unknown provider.
+  "cursor",
 ];
 
 function tryParseStructuredArgumentString(value: string): unknown | null {

--- a/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
+++ b/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
@@ -8,6 +8,12 @@ import {
 } from "./goal-completion-presentation";
 import { evaluateToolCalls } from "@/shared/eval-matching";
 import { ToolCallDiff } from "./tool-call-diff";
+// One copy, deliberately. This module used to carry a byte-identical
+// `resolveTraceModel` (plus its own hand-copied `KNOWN_MODEL_PROVIDERS`), so a
+// provider added to the union had to be remembered in two places or the trace
+// header silently labelled the run `custom` — which is exactly how `cursor`
+// nearly shipped half-registered.
+import { resolveTraceModel } from "./compare-playground-helpers";
 import {
   PredicatesList,
   parseIterationPredicates,
@@ -49,11 +55,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@mcpjam/design-system/collapsible";
-import {
-  getModelById,
-  type ModelDefinition,
-  type ModelProvider,
-} from "@/shared/types";
 import { cn } from "@/lib/utils";
 import { formatConvexBlobLoadError } from "@/lib/convex-action-error";
 import { Alert, AlertDescription, AlertTitle } from "@mcpjam/design-system/alert";
@@ -87,27 +88,6 @@ function formatToolCallsSummary(
   if (s.length <= maxLen) return s;
   return `${s.slice(0, maxLen - 1)}…`;
 }
-const KNOWN_MODEL_PROVIDERS: ModelProvider[] = [
-  "anthropic",
-  "azure",
-  "bedrock",
-  "openai",
-  "ollama",
-  "deepseek",
-  "google",
-  "meta",
-  "xai",
-  "mistral",
-  "moonshotai",
-  "openrouter",
-  "z-ai",
-  "minimax",
-  "qwen",
-  "custom",
-  // The Cursor CLI harness runs on the customer's own Cursor account; without
-  // this it normalizes to "custom" and the run reads as an unknown provider.
-  "cursor",
-];
 
 function tryParseStructuredArgumentString(value: string): unknown | null {
   const trimmed = value.trim();
@@ -181,38 +161,6 @@ export function resolveFormattedArgumentValue(
       textValue.length > TOOL_ARGUMENT_BLOCK_THRESHOLD ||
       textValue.includes("\n"),
   };
-}
-
-function normalizeModelProvider(provider?: string): ModelProvider {
-  return KNOWN_MODEL_PROVIDERS.includes(provider as ModelProvider)
-    ? (provider as ModelProvider)
-    : "custom";
-}
-
-function resolveTraceModel(
-  iteration: EvalIteration,
-  testCase: EvalCase | null,
-): ModelDefinition {
-  const snapshotProvider = iteration.testCaseSnapshot?.provider;
-  const snapshotModel = iteration.testCaseSnapshot?.model;
-  const fallbackProvider = testCase?.models[0]?.provider;
-  const fallbackModel = testCase?.models[0]?.model;
-
-  const provider = snapshotProvider || fallbackProvider || "openai";
-  const model = snapshotModel || fallbackModel || "unknown-model";
-  const providerModelId =
-    model.startsWith(`${provider}/`) || !provider
-      ? model
-      : `${provider}/${model}`;
-
-  return (
-    getModelById(providerModelId) ??
-    getModelById(model) ?? {
-      id: providerModelId,
-      name: model.includes("/") ? model.split("/").slice(1).join("/") : model,
-      provider: normalizeModelProvider(provider),
-    }
-  );
 }
 
 function TraceBlobLoadErrorPanel({

--- a/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx
@@ -17,6 +17,7 @@ import { useHostMutations } from "@/hooks/useClients";
 import { useProjectServers } from "@/hooks/useViews";
 import { useClaudeCodeHostEnabled } from "@/hooks/useClaudeCodeHostEnabled";
 import { useCodexHostEnabled } from "@/hooks/useCodexHostEnabled";
+import { useCursorHostEnabled } from "@/hooks/useCursorHostEnabled";
 import { cloneHostTemplateInput } from "@/lib/client-config-v2";
 import { useHostCatalog } from "@/lib/host-compat/use-host-catalog";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
@@ -61,15 +62,17 @@ export function CreateHostDialog({
   const catalogState = useHostCatalog();
   const claudeCodeEnabled = useClaudeCodeHostEnabled();
   const codexEnabled = useCodexHostEnabled();
+  const cursorCliEnabled = useCursorHostEnabled();
   const visibleCatalogHosts = useMemo(
     () =>
       catalogState.status === "live"
         ? filterHostsByFeatureFlags(getCatalogHosts(catalogState.catalog), {
             claudeCode: claudeCodeEnabled,
             codex: codexEnabled,
+            cursorCli: cursorCliEnabled,
           }).sort((a, b) => a.label.localeCompare(b.label))
         : [],
-    [catalogState, claudeCodeEnabled, codexEnabled]
+    [catalogState, claudeCodeEnabled, codexEnabled, cursorCliEnabled]
   );
   const defaultHostId =
     visibleCatalogHosts.find((host) => host.id === DEFAULT_CATALOG_HOST_ID)

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -50,8 +50,12 @@ import { useSearchParams } from "react-router";
 import { useHost, useHostList } from "@/hooks/useClients";
 import { useClaudeCodeHostEnabled } from "@/hooks/useClaudeCodeHostEnabled";
 import { useCodexHostEnabled } from "@/hooks/useCodexHostEnabled";
+import { useCursorHostEnabled } from "@/hooks/useCursorHostEnabled";
 import { shouldQueryProjectId } from "@/hooks/useProjects";
-import { FLAG_GATED_HOST_IDS } from "@/lib/host-compat/feature-visibility";
+import {
+  excludedFlagGatedHostIds,
+  FLAG_GATED_HOST_IDS,
+} from "@/lib/host-compat/feature-visibility";
 import { useHostCatalog } from "@/lib/host-compat/use-host-catalog";
 import { bundledHostCompatCatalog } from "@mcpjam/sdk/host-compat";
 import type {
@@ -238,6 +242,7 @@ export function HostConfigCompareView({
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const claudeCodeEnabled = useClaudeCodeHostEnabled();
   const codexEnabled = useCodexHostEnabled();
+  const cursorCliEnabled = useCursorHostEnabled();
   // The flags gate the New Host template picker, not this matrix — so they
   // apply only to the signed-in surface, where a preset column sits next to
   // hosts you can actually create. In public (caniuse) mode the matrix is
@@ -245,13 +250,19 @@ export function HostConfigCompareView({
   // gating it there hid Claude Code and Codex from every anonymous visitor,
   // since the hooks read an unresolved flag as off and the flags are scoped
   // to @mcpjam.com users.
+  //
+  // DERIVED from the shared FLAG_GATED_HOSTS map, not typed out per host: the
+  // hand-written version gated each id with its own `if`, so a newly gated host
+  // was hidden on the five surfaces that share the map and silently offered
+  // here.
   const excludedPresetTemplateIds = useMemo(() => {
-    const excluded = new Set<string>();
-    if (presetOnly) return excluded;
-    if (!claudeCodeEnabled) excluded.add("claude-code");
-    if (!codexEnabled) excluded.add("codex");
-    return excluded;
-  }, [claudeCodeEnabled, codexEnabled, presetOnly]);
+    if (presetOnly) return new Set<string>();
+    return excludedFlagGatedHostIds({
+      claudeCode: claudeCodeEnabled,
+      codex: codexEnabled,
+      cursorCli: cursorCliEnabled,
+    });
+  }, [claudeCodeEnabled, codexEnabled, cursorCliEnabled, presetOnly]);
   // Public caniuse still displays flag-gated hosts as reference data, but must
   // not offer their verify links because those links auto-create a host, and
   // the app refuses to create one until the rollout flag is on. The flags

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/BehaviorTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/BehaviorTab.tsx
@@ -237,10 +237,15 @@ export function BehaviorTab({
 
   // A real harness (e.g. Claude Code) runs its own loop, so some knobs don't
   // cross into its runtime until the MCP proxy mediates them — and a few never
-  // can. Gray those out per-control (model + system prompt always apply, so
-  // they stay enabled) with an honest note, instead of letting the toggle look
+  // can. Gray those out per-control (the system prompt always applies, so it
+  // stays enabled) with an honest note, instead of letting the control look
   // live while doing nothing. Un-graying is a one-line change in
   // `harness-capabilities.ts` as each proxy phase lands.
+  //
+  // The MODEL is gated too, for one harness: Cursor authenticates with the
+  // customer's own Cursor account and that account picks the model, so a
+  // selection would persist onto the host and reach nothing.
+  const modelState = harnessControlState(draft.harness, "modelId");
   const tempState = harnessControlState(draft.harness, "temperature");
   const approvalState = harnessControlState(draft.harness, "requireToolApproval");
   const visibilityState = harnessControlState(
@@ -260,7 +265,11 @@ export function BehaviorTab({
       <FocusBlock title="Agent tooling">
         <FieldRow
           label={fModel.label}
-          description={fModel.description}
+          description={
+            modelState.enforced
+              ? fModel.description
+              : `${fModel.description} ${modelState.note}`
+          }
           control={
             <div
               className={
@@ -273,7 +282,7 @@ export function BehaviorTab({
                 currentModel={currentModel}
                 availableModels={availableModels}
                 onModelChange={(model) => update({ modelId: String(model.id) })}
-                disabled={readOnly}
+                disabled={readOnly || !modelState.enforced}
                 align="end"
                 analyticsLocation="client_builder"
               />

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ComputerTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ComputerTab.tsx
@@ -4,6 +4,7 @@ import { Input } from "@mcpjam/design-system/input";
 import type { HostConfigInputV2 } from "@/lib/client-config-v2";
 import { FieldRow, FocusBlock } from "./primitives";
 import { useBuiltInToolCatalog } from "@/hooks/useBuiltInToolCatalog";
+import { HARNESS_DISPLAY_NAME } from "@/lib/harness-capabilities";
 import {
   attachComputerPatch,
   detachComputerPatch,
@@ -42,11 +43,16 @@ export function ComputerTab({
   const update = (patch: Partial<HostConfigInputV2>) =>
     onDraftChange((prev) => ({ ...prev, ...patch }));
 
-  // The Claude Code harness runs inside this computer, so it can't be detached
-  // while a harness is selected (the backend enforces `harness ⇒ computer`).
-  // Remove the harness first (e.g. on the Behavior tab) to free the toggle.
+  // A harness runtime runs inside this computer, so it can't be detached while
+  // one is selected (the backend enforces `harness ⇒ computer`). Remove the
+  // harness first (e.g. on the Behavior tab) to free the toggle.
   const lockedByHarness =
     draft.harness !== undefined && draft.computer !== undefined;
+  // Named, not hardcoded: this copy said "Claude Code" for every harness, which
+  // was already wrong on a Codex host.
+  const harnessName = draft.harness
+    ? HARNESS_DISPLAY_NAME[draft.harness]
+    : undefined;
 
   // Working directory (COMP-16). Locally-buffered text so keystrokes don't
   // re-hash the whole host config; committed on blur. The stored value clears to
@@ -70,8 +76,8 @@ export function ComputerTab({
         <FieldRow
           label="Personal computer"
           description={
-            lockedByHarness
-              ? "Required by the Claude Code harness — remove the harness to detach. A per-member cloud workstation (a persistent Linux sandbox) the real Claude Code runtime runs inside."
+            lockedByHarness && harnessName
+              ? `Required by the ${harnessName} harness — remove the harness to detach. A per-member cloud workstation (a persistent Linux sandbox) the real ${harnessName} runtime runs inside.`
               : "Attach a per-member cloud workstation (a persistent Linux sandbox). Required by computer-backed tools like Bash, which you enable in the Tools tab."
           }
           control={

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/BehaviorTab.harness.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/BehaviorTab.harness.test.tsx
@@ -10,7 +10,14 @@ vi.mock("@/hooks/use-available-models", () => ({
   useAvailableModels: () => ({ availableModels: [] }),
 }));
 vi.mock("@/components/chat-v2/chat-input/model-selector", () => ({
-  ModelSelector: () => <div data-testid="model-selector" />,
+  // Carries `disabled` through: it is the prop the harness gating decides, and
+  // a stub that swallowed it would let the model selector silently un-gate.
+  ModelSelector: ({ disabled }: { disabled?: boolean }) => (
+    <div
+      data-testid="model-selector"
+      data-disabled={disabled ? "true" : undefined}
+    />
+  ),
 }));
 
 function renderBehaviorTab(partial?: Parameters<typeof emptyHostConfigInputV2>[0]) {
@@ -40,8 +47,11 @@ describe("BehaviorTab harness gray-out", () => {
     ).toBeInTheDocument();
 
     // Model + system prompt DO cross into the harness, so they stay editable
-    // (no blanket isHarnessHost disable).
-    expect(screen.getByTestId("model-selector")).toBeInTheDocument();
+    // (no blanket isHarnessHost disable). Claude Code's model credentials are
+    // brokered by MCPJam, so the selection is what the runtime launches with.
+    expect(screen.getByTestId("model-selector")).not.toHaveAttribute(
+      "data-disabled",
+    );
     expect(
       screen.getByPlaceholderText(/helpful assistant/i),
     ).not.toHaveAttribute("readonly");
@@ -120,9 +130,42 @@ describe("BehaviorTab harness gray-out", () => {
     ).toBeInTheDocument();
   });
 
+  it("disables the MODEL selector for a cursor harness host, and says who chooses", () => {
+    // The one harness whose model is not MCPJam's to choose: it authenticates
+    // with the customer's own Cursor account and that account picks the model.
+    // Left enabled, a selection persists onto the host and reaches nothing —
+    // the host then displays a model that never ran.
+    const { container } = renderBehaviorTab({ harness: "cursor" });
+
+    expect(screen.getByTestId("model-selector")).toHaveAttribute(
+      "data-disabled",
+      "true",
+    );
+    expect(
+      screen.getByText(/Cursor account, which chooses the model itself/i),
+    ).toBeInTheDocument();
+
+    // Temperature goes with it, for the same reason.
+    expect(sliderRoot(container)).toHaveAttribute("data-disabled");
+
+    // NOT a blanket harness disable: the ACP bridge really does pause on its
+    // native tools, so approval stays editable and carries no stale note.
+    expect(
+      screen.getByRole("switch", { name: /require tool approval/i }),
+    ).toBeEnabled();
+    expect(
+      screen.queryByText(/refused rather than run unapproved/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("leaves every control enabled for an emulated (no-harness) host", () => {
     const { container } = renderBehaviorTab();
 
+    // Includes the emulated `cursor` host style — the IDE chat panel carries no
+    // harness and picks its model normally. Only the CLI runtime is gated.
+    expect(screen.getByTestId("model-selector")).not.toHaveAttribute(
+      "data-disabled",
+    );
     expect(sliderRoot(container)).not.toHaveAttribute("data-disabled");
     expect(
       screen.getByRole("switch", { name: /require tool approval/i }),

--- a/mcpjam-inspector/client/src/hooks/useCursorHostEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useCursorHostEnabled.ts
@@ -1,0 +1,31 @@
+import { useFeatureFlagEnabled } from "posthog-js/react";
+
+/**
+ * PostHog rollout gate for the "Cursor CLI" host template running the REAL
+ * Cursor harness (the `@ai-sdk/harness-cursor` adapter over ACP) in the New
+ * Host template picker (CreateHostDialog). Flag off ⇒ the template is hidden
+ * from the grid, so the host profile can be iterated on before it is exposed —
+ * no deploy needed to flip it on. Mirrors `useCodexHostEnabled`.
+ *
+ * Note: the pre-existing EMULATED `cursor` template (the IDE chat-panel mirror)
+ * is a different host and is NOT gated by this — it stays visible exactly as
+ * before. This flag governs `cursor-cli` only.
+ *
+ * The backend enforces the same key server-side (`cursor-harness` in
+ * `lib/featureGates.ts`), so hiding the template and refusing the write are one
+ * lever rather than two that can drift.
+ *
+ * `useFeatureFlagEnabled` returns `undefined` while flags load — treated as off
+ * (`=== true`) so the template never flickers into the picker before PostHog
+ * resolves.
+ */
+export const CURSOR_HOST_FEATURE_FLAG = "cursor-host-enabled";
+
+/** Tri-state flag value for route guards that must wait for PostHog. */
+export function useCursorHostEnabledState(): boolean | undefined {
+  return useFeatureFlagEnabled(CURSOR_HOST_FEATURE_FLAG);
+}
+
+export function useCursorHostEnabled(): boolean {
+  return useCursorHostEnabledState() === true;
+}

--- a/mcpjam-inspector/client/src/hooks/useCursorHostEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useCursorHostEnabled.ts
@@ -11,9 +11,11 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
  * is a different host and is NOT gated by this — it stays visible exactly as
  * before. This flag governs `cursor-cli` only.
  *
- * The backend enforces the same key server-side (`cursor-harness` in
- * `lib/featureGates.ts`), so hiding the template and refusing the write are one
- * lever rather than two that can drift.
+ * The backend enforces the SAME PostHog key server-side: its `cursor-harness`
+ * gate (`lib/featureGates.ts`) is a code-facing gate NAME whose descriptor
+ * points at the flag key `cursor-host-enabled` — the string below. So hiding
+ * the template and refusing the write really are one lever; the two identifiers
+ * are a gate name and a flag key, not two flags.
  *
  * `useFeatureFlagEnabled` returns `undefined` while flags load — treated as off
  * (`=== true`) so the template never flickers into the picker before PostHog

--- a/mcpjam-inspector/client/src/lib/__tests__/harness-capabilities.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/harness-capabilities.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { HARNESS_MCP_DELIVERY } from "@/shared/harness-mcp-delivery";
 import type { HostConfigHarnessV2 } from "@/lib/client-config-v2";
 import {
+  HARNESS_DISPLAY_NAME,
   harnessControlState,
   type HarnessGatedControl,
 } from "@/lib/harness-capabilities";
@@ -86,6 +87,7 @@ describe("harnessControlState — loop-owned controls", () => {
 describe("harnessControlState — emulated engine", () => {
   it("enforces every control when there is no harness", () => {
     const controls: HarnessGatedControl[] = [
+      "modelId",
       "temperature",
       "requireToolApproval",
       "respectToolVisibility",
@@ -101,10 +103,81 @@ describe("harnessControlState — emulated engine", () => {
   it("fails OPEN for an unknown harness id rather than graying a control out", () => {
     const unknown = "pi" as HostConfigHarnessV2;
     expect(harnessControlState(unknown, "temperature").enforced).toBe(true);
+    // The model is the most consequential control to gray out by accident — a
+    // future harness id must not lose its model selector on a guess.
+    expect(harnessControlState(unknown, "modelId").enforced).toBe(true);
     // The derived arm needs its own fail-open: an id with no delivery
     // declaration must not silently read as `native` and disable the switch.
     expect(harnessControlState(unknown, "respectToolVisibility").enforced).toBe(
       true,
     );
+  });
+});
+
+describe("harnessControlState — who chooses the MODEL", () => {
+  /**
+   * The distinction this control exists for. Claude Code and Codex run on model
+   * credentials MCPJam brokers, so the host's selection IS what launches. The
+   * Cursor CLI authenticates with the customer's own Cursor account and that
+   * account picks the model, so a selection persists onto the host, shows in
+   * the editor, and reaches nothing — a saved setting that lies about what ran.
+   */
+  it("is enforced exactly for the harnesses whose models MCPJam brokers", () => {
+    expect(harnessControlState("claude-code", "modelId")).toEqual({
+      enforced: true,
+    });
+    expect(harnessControlState("codex", "modelId")).toEqual({ enforced: true });
+
+    const cursor = harnessControlState("cursor", "modelId");
+    expect(cursor.enforced).toBe(false);
+    // The note is what a user reads beside the disabled selector, so it has to
+    // name the account that actually decides — not read as an MCPJam limit.
+    expect(cursor.enforced === false && cursor.note).toMatch(
+      /Cursor account.*chooses the model/i,
+    );
+  });
+
+  it("leaves the emulated host's selector alone", () => {
+    // The emulated `cursor` host style (the IDE chat panel) carries no harness
+    // and picks its model normally. Only the CLI runtime is gated.
+    expect(harnessControlState(undefined, "modelId")).toEqual({
+      enforced: true,
+    });
+  });
+});
+
+describe("harnessControlState — the Cursor CLI runtime", () => {
+  it("enforces tool approval on its native surface", () => {
+    // Not a formality: the ACP bridge routes every native call through
+    // `session/request_permission`, so unlike Codex the turn genuinely pauses.
+    // Reading this as unenforced would tell users approval does nothing here.
+    expect(harnessControlState("cursor", "requireToolApproval")).toEqual({
+      enforced: true,
+    });
+  });
+
+  it("cannot filter tool visibility, because it connects to MCP servers itself", () => {
+    const state = harnessControlState("cursor", "respectToolVisibility");
+    expect(state.enforced).toBe(false);
+    expect(state.enforced === false && state.note).toMatch(
+      /connects to MCP servers itself/i,
+    );
+  });
+});
+
+describe("HARNESS_DISPLAY_NAME", () => {
+  it("names the CLI runtime, never the bare product", () => {
+    // "Cursor" alone is the emulated IDE chat-panel host style, which is a
+    // different thing a user can also attach. A label that did not distinguish
+    // them would make the two indistinguishable in every picker.
+    expect(HARNESS_DISPLAY_NAME.cursor).toBe("Cursor CLI");
+  });
+
+  it("names every harness that has a delivery declaration", () => {
+    // The two maps are keyed by the same union; a harness added to one and not
+    // the other renders as a blank or an id somewhere in the host UI.
+    for (const harness of HARNESSES) {
+      expect(HARNESS_DISPLAY_NAME[harness], harness).toBeTruthy();
+    }
   });
 });

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -110,7 +110,7 @@ export type HostConfigComputerV2 = {
 
 /** True when this attachment is platform-minted and therefore not editable. */
 export function isReadOnlyHostComputer(
-  computer: HostConfigComputerV2 | undefined
+  computer: HostConfigComputerV2 | undefined,
 ): boolean {
   return computer !== undefined && computer.kind !== "personal";
 }
@@ -118,13 +118,14 @@ export function isReadOnlyHostComputer(
 export type McpToolResultImageRendering = McpToolResultImageRenderingPolicy;
 
 /**
- * Real agent harness for this host. `"claude-code"` / `"codex"` run the real CLI
- * runtime (the `@ai-sdk/harness-claude-code` / `@ai-sdk/harness-codex` adapter)
- * inside the attached personal computer instead of MCPJam's emulated engine.
- * Absent ⇒ emulated. Mirrors the SDK's `Harness` type; the backend enforces
+ * Real agent harness for this host. `"claude-code"` / `"codex"` / `"cursor"` run
+ * the real CLI runtime (the `@ai-sdk/harness-claude-code` /
+ * `@ai-sdk/harness-codex` / `@ai-sdk/harness-cursor` adapter) inside the
+ * attached personal computer instead of MCPJam's emulated engine. Absent ⇒
+ * emulated. Mirrors the SDK's `Harness` type; the backend enforces
  * `harness ⇒ computer`.
  */
-export type HostConfigHarnessV2 = "claude-code" | "codex";
+export type HostConfigHarnessV2 = "claude-code" | "codex" | "cursor";
 
 /**
  * Mutable input shape. All fields are required at write time so the editor
@@ -330,7 +331,7 @@ export const DEFAULT_SEEDED_HOST_MODEL_ID = "anthropic/claude-haiku-4.5";
 // CLI. Cast to the strict client aggregate — the runtime object is
 // field-identical (guarded by host-template-seed-parity.test.ts).
 export const emptyHostConfigInputV2 = sdkEmptyHostConfigInputV2 as unknown as (
-  partial?: Partial<HostConfigInputV2>
+  partial?: Partial<HostConfigInputV2>,
 ) => HostConfigInputV2;
 
 /**
@@ -349,7 +350,7 @@ export const emptyHostConfigInputV2 = sdkEmptyHostConfigInputV2 as unknown as (
  * "attach one", instead of silently claiming a box the user never attached.
  */
 export function withoutReadOnlyComputer(
-  input: HostConfigInputV2
+  input: HostConfigInputV2,
 ): HostConfigInputV2 {
   if (!isReadOnlyHostComputer(input.computer)) return input;
   const { computer: _dropped, ...rest } = input;
@@ -358,7 +359,7 @@ export function withoutReadOnlyComputer(
 
 export function cloneHostTemplateInput(
   value: unknown,
-  options: { themeMode?: ThemeMode } = {}
+  options: { themeMode?: ThemeMode } = {},
 ): HostConfigInputV2 {
   const input = deepCloneJsonValue(value) as HostConfigInputV2;
   if (options.themeMode !== undefined) {
@@ -443,7 +444,7 @@ export function hostConfigDtoToInput(dto: HostConfigDtoV2): HostConfigInputV2 {
                 ? { mcpProtocolVersionOverride: v.mcpProtocolVersionOverride }
                 : {}),
             },
-          ])
+          ]),
         )
       : undefined,
   };
@@ -501,7 +502,7 @@ export function resolveEffectiveHostCapabilities(args: {
     return buildHostCapabilities(
       matrix,
       style?.hostCapabilitiesAugment,
-      style?.hostCapabilitiesReplacement
+      style?.hostCapabilitiesReplacement,
     );
   }
   // 2. Legacy override path — strip-then-return semantics preserved from
@@ -533,7 +534,7 @@ export function resolveEffectiveHostCapabilities(args: {
  * stays one-grep-able.
  */
 export function resolveClientInfo(
-  profile: HostConfigMcpProfileV1 | undefined
+  profile: HostConfigMcpProfileV1 | undefined,
 ): Record<string, unknown> | undefined {
   return profile?.initialize?.clientInfo;
 }
@@ -547,7 +548,7 @@ export function resolveClientInfo(
  * callers never see it here.
  */
 export function resolveSupportedProtocolVersions(
-  profile: HostConfigMcpProfileV1 | undefined
+  profile: HostConfigMcpProfileV1 | undefined,
 ): string[] | undefined {
   return profile?.initialize?.supportedProtocolVersions;
 }
@@ -562,7 +563,7 @@ export function resolveSupportedProtocolVersions(
  * layer (base-protocol `initialize` vs. MCP Apps `ui/initialize`).
  */
 export function resolveHostInfo(
-  profile: HostConfigMcpProfileV1 | undefined
+  profile: HostConfigMcpProfileV1 | undefined,
 ): Record<string, unknown> | undefined {
   return profile?.apps?.uiInitialize?.hostInfo;
 }
@@ -616,7 +617,7 @@ export function resolveEffectiveCompatRuntime(args: {
     injected: true,
     capabilities: mergeOpenAiAppsCapabilities(
       baseCapabilities,
-      override?.openaiAppsOverrides
+      override?.openaiAppsOverrides,
     ),
   };
 }
@@ -633,7 +634,7 @@ export function resolveEffectiveCompatRuntime(args: {
  */
 export function mergeOpenAiAppsCapabilities(
   base: ResolvedOpenAiAppsCapabilities,
-  override: OpenAiAppsCapabilities | undefined
+  override: OpenAiAppsCapabilities | undefined,
 ): ResolvedOpenAiAppsCapabilities {
   if (!override) return base;
   return {
@@ -669,7 +670,7 @@ export function mergeOpenAiAppsCapabilities(
  */
 export function mergeMcpAppsCapabilities(
   base: ResolvedMcpAppsCapabilities,
-  override: McpAppsCapabilities | undefined
+  override: McpAppsCapabilities | undefined,
 ): ResolvedMcpAppsCapabilities {
   if (!override) return base;
   const modesOverride = override.availableDisplayModes;
@@ -797,7 +798,7 @@ export function resolveEffectiveMcpAppsCapabilities(args: {
  * `resolveEffectiveHostCapabilities`.
  */
 export function hostCapabilitiesOverrideToMatrix(
-  legacy: Record<string, unknown> | undefined
+  legacy: Record<string, unknown> | undefined,
 ): McpAppsCapabilities | undefined {
   if (legacy === undefined) return undefined;
   return {
@@ -848,7 +849,7 @@ export function isMcpProfileEmpty(profile: HostConfigMcpProfileV1): boolean {
     // canonicalizer drops it), but any boolean leaf is a real setting.
     (profile.toolListChanged === undefined ||
       Object.values(profile.toolListChanged).every(
-        (value) => value === undefined
+        (value) => value === undefined,
       )) &&
     !profile.apps &&
     !profile.extensions
@@ -857,7 +858,7 @@ export function isMcpProfileEmpty(profile: HostConfigMcpProfileV1): boolean {
 
 export function setMcpAppsOverridesOnDraft(
   prev: HostConfigInputV2,
-  next: McpAppsCapabilities | undefined
+  next: McpAppsCapabilities | undefined,
 ): HostConfigInputV2 {
   const hasKeys = next !== undefined && Object.keys(next).length > 0;
   const prevProfile = prev.mcpProfile;
@@ -899,7 +900,7 @@ export function setMcpAppsOverridesOnDraft(
  * `HostConfigMcpProfileV1` type at the boundary.
  */
 function cloneMcpProfile(
-  profile: HostConfigMcpProfileV1
+  profile: HostConfigMcpProfileV1,
 ): HostConfigMcpProfileV1 {
   return deepCloneJsonValue(profile) as HostConfigMcpProfileV1;
 }
@@ -915,7 +916,7 @@ function cloneChatUiOverride(override: ChatUiOverride): ChatUiOverride {
 }
 
 function deepCloneJsonRecord(
-  value: Record<string, unknown>
+  value: Record<string, unknown>,
 ): Record<string, unknown> {
   return deepCloneJsonValue(value) as Record<string, unknown>;
 }
@@ -935,25 +936,25 @@ function deepCloneJsonValue(value: unknown): unknown {
 }
 
 export function cloneModelVisibleMcpToolResults(
-  value: ModelVisibleMcpToolResults
+  value: ModelVisibleMcpToolResults,
 ): ModelVisibleMcpToolResults {
   return deepCloneJsonValue(value) as ModelVisibleMcpToolResults;
 }
 
 export function cloneMcpToolResultImageRendering(
-  value: McpToolResultImageRenderingPolicy
+  value: McpToolResultImageRenderingPolicy,
 ): McpToolResultImageRenderingPolicy {
   return deepCloneJsonValue(value) as McpToolResultImageRenderingPolicy;
 }
 
 export function isMcpDirectContentImageVisible(
-  policy: ModelVisibleMcpToolResults | undefined
+  policy: ModelVisibleMcpToolResults | undefined,
 ): boolean {
   return policy?.directContent?.image ?? true;
 }
 
 export function isMcpEmbeddedResourceBlobImageVisible(
-  policy: ModelVisibleMcpToolResults | undefined
+  policy: ModelVisibleMcpToolResults | undefined,
 ): boolean {
   return (
     (policy?.embeddedResources?.blob?.enabled ?? true) &&
@@ -962,7 +963,7 @@ export function isMcpEmbeddedResourceBlobImageVisible(
 }
 
 export function isMcpLinkedResourceBlobImageVisible(
-  policy: ModelVisibleMcpToolResults | undefined
+  policy: ModelVisibleMcpToolResults | undefined,
 ): boolean {
   return (
     (policy?.linkedResources?.blob?.enabled ?? true) &&
@@ -972,7 +973,7 @@ export function isMcpLinkedResourceBlobImageVisible(
 
 export function setMcpDirectContentImageVisible(
   policy: ModelVisibleMcpToolResults | undefined,
-  visible: boolean
+  visible: boolean,
 ): ModelVisibleMcpToolResults {
   return {
     ...policy,
@@ -985,7 +986,7 @@ export function setMcpDirectContentImageVisible(
 
 export function setMcpEmbeddedResourceBlobImageVisible(
   policy: ModelVisibleMcpToolResults | undefined,
-  visible: boolean
+  visible: boolean,
 ): ModelVisibleMcpToolResults {
   return {
     ...policy,
@@ -1001,7 +1002,7 @@ export function setMcpEmbeddedResourceBlobImageVisible(
 
 export function setMcpLinkedResourceBlobImageVisible(
   policy: ModelVisibleMcpToolResults | undefined,
-  visible: boolean
+  visible: boolean,
 ): ModelVisibleMcpToolResults {
   return {
     ...policy,
@@ -1016,32 +1017,32 @@ export function setMcpLinkedResourceBlobImageVisible(
 }
 
 export function getMcpToolResultImageRenderPlacement(
-  policy: McpToolResultImageRenderingPolicy | undefined
+  policy: McpToolResultImageRenderingPolicy | undefined,
 ): McpToolResultImageRenderPlacement {
   return policy?.placement ?? "inline";
 }
 
 export function isMcpDirectContentImageRendered(
-  policy: McpToolResultImageRenderingPolicy | undefined
+  policy: McpToolResultImageRenderingPolicy | undefined,
 ): boolean {
   return policy?.directContent?.image ?? true;
 }
 
 export function isMcpEmbeddedResourceBlobImageRendered(
-  policy: McpToolResultImageRenderingPolicy | undefined
+  policy: McpToolResultImageRenderingPolicy | undefined,
 ): boolean {
   return policy?.embeddedResources?.blob?.image ?? true;
 }
 
 export function isMcpLinkedResourceBlobImageRendered(
-  policy: McpToolResultImageRenderingPolicy | undefined
+  policy: McpToolResultImageRenderingPolicy | undefined,
 ): boolean {
   return policy?.linkedResources?.blob?.image ?? true;
 }
 
 export function setMcpToolResultImageRenderPlacement(
   policy: McpToolResultImageRenderingPolicy | undefined,
-  placement: McpToolResultImageRenderPlacement
+  placement: McpToolResultImageRenderPlacement,
 ): McpToolResultImageRenderingPolicy {
   return {
     ...policy,
@@ -1051,7 +1052,7 @@ export function setMcpToolResultImageRenderPlacement(
 
 export function setMcpDirectContentImageRendered(
   policy: McpToolResultImageRenderingPolicy | undefined,
-  rendered: boolean
+  rendered: boolean,
 ): McpToolResultImageRenderingPolicy {
   return {
     ...policy,
@@ -1064,7 +1065,7 @@ export function setMcpDirectContentImageRendered(
 
 export function setMcpEmbeddedResourceBlobImageRendered(
   policy: McpToolResultImageRenderingPolicy | undefined,
-  rendered: boolean
+  rendered: boolean,
 ): McpToolResultImageRenderingPolicy {
   return {
     ...policy,
@@ -1080,7 +1081,7 @@ export function setMcpEmbeddedResourceBlobImageRendered(
 
 export function setMcpLinkedResourceBlobImageRendered(
   policy: McpToolResultImageRenderingPolicy | undefined,
-  rendered: boolean
+  rendered: boolean,
 ): McpToolResultImageRenderingPolicy {
   return {
     ...policy,
@@ -1096,7 +1097,7 @@ export function setMcpLinkedResourceBlobImageRendered(
 
 export function gateMcpToolResultImageRenderingByModelVisibility(
   renderingPolicy: McpToolResultImageRenderingPolicy | undefined,
-  modelVisiblePolicy: ModelVisibleMcpToolResults | undefined
+  modelVisiblePolicy: ModelVisibleMcpToolResults | undefined,
 ): McpToolResultImageRenderingPolicy | undefined {
   const directVisible = isMcpDirectContentImageVisible(modelVisiblePolicy);
   const embeddedVisible =
@@ -1131,7 +1132,7 @@ export function gateMcpToolResultImageRenderingByModelVisibility(
  */
 export function hostConfigInputsEqual(
   a: HostConfigInputV2,
-  b: HostConfigInputV2
+  b: HostConfigInputV2,
 ): boolean {
   if (a.hostStyle !== b.hostStyle) return false;
   if (a.modelId !== b.modelId) return false;
@@ -1146,14 +1147,14 @@ export function hostConfigInputsEqual(
   if (
     !optionalModelVisibleMcpToolResultsEq(
       a.modelVisibleMcpToolResults,
-      b.modelVisibleMcpToolResults
+      b.modelVisibleMcpToolResults,
     )
   )
     return false;
   if (
     !optionalMcpToolResultImageRenderingEq(
       a.mcpToolResultImageRendering,
-      b.mcpToolResultImageRendering
+      b.mcpToolResultImageRendering,
     )
   ) {
     return false;
@@ -1187,7 +1188,7 @@ export function hostConfigInputsEqual(
   if (
     !optionalJsonRecordEq(
       a.hostCapabilitiesOverride,
-      b.hostCapabilitiesOverride
+      b.hostCapabilitiesOverride,
     )
   )
     return false;
@@ -1197,7 +1198,7 @@ export function hostConfigInputsEqual(
   if (
     !serverConnectionOverridesEqual(
       a.serverConnectionOverrides,
-      b.serverConnectionOverrides
+      b.serverConnectionOverrides,
     )
   )
     return false;
@@ -1211,10 +1212,10 @@ export function hostConfigInputsEqual(
  */
 export function serverConnectionOverridesEqual(
   a: HostConfigInputV2["serverConnectionOverrides"],
-  b: HostConfigInputV2["serverConnectionOverrides"]
+  b: HostConfigInputV2["serverConnectionOverrides"],
 ): boolean {
   const normalize = (
-    overrides: HostConfigInputV2["serverConnectionOverrides"]
+    overrides: HostConfigInputV2["serverConnectionOverrides"],
   ): Record<
     string,
     {
@@ -1260,7 +1261,7 @@ export function serverConnectionOverridesEqual(
 
 function optionalMcpProfileEq(
   a: HostConfigMcpProfileV1 | undefined,
-  b: HostConfigMcpProfileV1 | undefined
+  b: HostConfigMcpProfileV1 | undefined,
 ): boolean {
   // Same undefined-vs-empty rule as optionalJsonRecordEq: backend hashes
   // `undefined` and `{ profileVersion: 1 }` distinctly, so flipping
@@ -1276,7 +1277,7 @@ function optionalMcpProfileEq(
 
 function optionalModelVisibleMcpToolResultsEq(
   a: ModelVisibleMcpToolResults | undefined,
-  b: ModelVisibleMcpToolResults | undefined
+  b: ModelVisibleMcpToolResults | undefined,
 ): boolean {
   if (a === undefined && b === undefined) return true;
   if (a === undefined || b === undefined) return false;
@@ -1285,7 +1286,7 @@ function optionalModelVisibleMcpToolResultsEq(
 
 function optionalMcpToolResultImageRenderingEq(
   a: McpToolResultImageRenderingPolicy | undefined,
-  b: McpToolResultImageRenderingPolicy | undefined
+  b: McpToolResultImageRenderingPolicy | undefined,
 ): boolean {
   if (a === undefined && b === undefined) return true;
   if (a === undefined || b === undefined) return false;
@@ -1294,7 +1295,7 @@ function optionalMcpToolResultImageRenderingEq(
 
 function optionalJsonRecordEq(
   a: Record<string, unknown> | undefined,
-  b: Record<string, unknown> | undefined
+  b: Record<string, unknown> | undefined,
 ): boolean {
   // Treat `undefined` (use profile preset) and `{}` (explicit empty override)
   // as distinct values — flipping between them changes the resolved blob and
@@ -1312,7 +1313,7 @@ function optionalJsonRecordEq(
  */
 function optionalChatUiOverrideEq(
   a: ChatUiOverride | undefined,
-  b: ChatUiOverride | undefined
+  b: ChatUiOverride | undefined,
 ): boolean {
   if (a === undefined && b === undefined) return true;
   if (a === undefined || b === undefined) return false;
@@ -1331,7 +1332,7 @@ function stringArrayEq(a: string[], b: string[]): boolean {
 
 function jsonRecordEq(
   a: Record<string, unknown>,
-  b: Record<string, unknown>
+  b: Record<string, unknown>,
 ): boolean {
   // Use the shared canonicalizer so nested object key order doesn't make
   // semantically equal records compare unequal — e.g.

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -53,6 +53,7 @@ import {
 } from "@mcpjam/sdk/host-config/internal";
 import type {
   CspDomainSet,
+  Harness,
   HostConfigConnectionDefaults,
   HostConfigMcpProfileV1,
   McpToolResultImageRenderPlacement,
@@ -122,10 +123,15 @@ export type McpToolResultImageRendering = McpToolResultImageRenderingPolicy;
  * the real CLI runtime (the `@ai-sdk/harness-claude-code` /
  * `@ai-sdk/harness-codex` / `@ai-sdk/harness-cursor` adapter) inside the
  * attached personal computer instead of MCPJam's emulated engine. Absent ⇒
- * emulated. Mirrors the SDK's `Harness` type; the backend enforces
- * `harness ⇒ computer`.
+ * emulated. The backend enforces `harness ⇒ computer`.
+ *
+ * ALIASED, not re-listed. This was a hand-copied union that had to be edited
+ * in lockstep with `HARNESS_IDS`, and the dangerous direction is narrow drift:
+ * the editor would reject a harness the API and the backend validator both
+ * accept, which reads as "that host cannot be built" rather than as a stale
+ * type. The name stays because 60+ files import it from here.
  */
-export type HostConfigHarnessV2 = "claude-code" | "codex" | "cursor";
+export type HostConfigHarnessV2 = Harness;
 
 /**
  * Mutable input shape. All fields are required at write time so the editor

--- a/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
@@ -492,6 +492,44 @@ export const CURSOR_HOST_STYLE: HostStyleDefinition = {
 };
 
 /**
+ * Cursor CLI host style.
+ *
+ * `cursor-agent` is a terminal agent with no chat chrome of its own, so it
+ * borrows Cursor's surface wholesale (platform, fonts, style variables,
+ * background) and differs only in identity: its own label and picker copy.
+ * Exactly the recipe CLAUDE_CODE_HOST_STYLE uses over Claude's, and
+ * CODEX_HOST_STYLE over ChatGPT's.
+ *
+ * What it does NOT borrow is the app-capability claim. `mcpAppsCapabilities`
+ * drops to the no-claims preset: the Cursor row above was captured from the IDE
+ * chat panel, which renders MCP Apps in a webview, and a CLI cannot. Reusing
+ * that matrix would advertise a widget surface that does not exist. (The
+ * template also sets `hostCapabilitiesOverride: {}`, so this preset is only the
+ * fallback if a host ever clears that override — which is exactly when getting
+ * it right matters.)
+ */
+export const CURSOR_CLI_HOST_STYLE: HostStyleDefinition = {
+  id: "cursor-cli",
+  mcp: {
+    protocolOverride: UIType.MCP_APPS,
+    platform: CURSOR_PLATFORM,
+    fontCss: CURSOR_FONT_CSS,
+    mcpAppsCapabilities: MCP_APPS_NO_CLAIMS_SURFACE,
+    resolveStyleVariables: getCursorStyleVariables,
+  },
+  chatUi: {
+    label: "Cursor CLI",
+    shortLabel: "Cursor CLI-style host",
+    pickerDescription: "Cursor coding CLI chrome",
+    logoSrc: cursorLogo,
+    // Same flat, dark, IDE-adjacent visual bucket as the Cursor panel.
+    family: "chatgpt",
+    resolveChatBackground: (theme) => CURSOR_CHAT_BACKGROUND[theme],
+    loadingIndicator: CursorShineIndicator,
+  },
+};
+
+/**
  * Microsoft 365 Copilot host style. Reuses ChatGPT's MCP profile and most
  * of its chat chrome — Copilot routes widgets through the OpenAI Apps SDK
  * under the hood and its chat UI sits in the same flat-neutral visual
@@ -842,6 +880,7 @@ export const BUILT_IN_HOST_STYLES: readonly HostStyleDefinition[] = [
   GOOSE_HOST_STYLE,
   SLACK_HOST_STYLE,
   CURSOR_HOST_STYLE,
+  CURSOR_CLI_HOST_STYLE,
   COPILOT_HOST_STYLE,
   CODEX_HOST_STYLE,
   CLAUDE_CODE_HOST_STYLE,

--- a/mcpjam-inspector/client/src/lib/harness-capabilities.ts
+++ b/mcpjam-inspector/client/src/lib/harness-capabilities.ts
@@ -47,6 +47,23 @@ import {
  * moves the runtime and the editor's claim about it in one edit.
  */
 
+/**
+ * Human-facing runtime name per harness — the client's copy of the server
+ * registry's `displayName`.
+ *
+ * Keyed by `HostConfigHarnessV2`, so adding a harness without naming it is a
+ * COMPILE error. That is the point: the copy this feeds used to hardcode
+ * "Claude Code", which was already wrong for a Codex host and would have been
+ * wrong for two harnesses out of three.
+ */
+export const HARNESS_DISPLAY_NAME: Record<HostConfigHarnessV2, string> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+  // "Cursor CLI", not "Cursor": the emulated `cursor` host style is the IDE's
+  // chat panel, and a user reading this needs to know which one they attached.
+  cursor: "Cursor CLI",
+};
+
 /** Behavior-tab controls whose value may not cross into a harness runtime. */
 export type HarnessGatedControl =
   | "temperature"
@@ -110,6 +127,33 @@ const HARNESS_LOOP_CONTROL_STATE: Record<
     progressiveToolDiscovery: {
       enforced: false,
       note: "Codex does its own tool discovery.",
+    },
+  },
+  cursor: {
+    // Permanent for a different reason than the other two: Cursor's CLI takes
+    // no temperature AND no model — it runs on the customer's Cursor account,
+    // which picks the model itself (Cursor Auto). There is nothing on this host
+    // for the value to reach.
+    temperature: {
+      enforced: false,
+      note: "The Cursor CLI runs on your Cursor account and ignores temperature.",
+    },
+    // The ACP bridge pauses on its own built-ins: every tool call goes through
+    // `session/request_permission`, and under the adapter's "allow-reads" mode
+    // anything outside read/search/think/fetch emits a `tool-approval-request`
+    // the turn waits on. Verified against a live cursor-agent.
+    //
+    // ENFORCED describes the NATIVE surface, which is what this control means
+    // here. Whether Cursor also pauses on MCP-server tools is not yet measured
+    // — the adapter's `supportsMcpToolApproval` is `false` pending that check,
+    // so a host that requires approval AND selects servers is refused outright
+    // rather than run with some calls unapproved. Refused, never silently
+    // un-enforced.
+    requireToolApproval: ENFORCED,
+    // The real Cursor CLI owns its own tool discovery, same as the other two.
+    progressiveToolDiscovery: {
+      enforced: false,
+      note: "The Cursor CLI does its own tool discovery.",
     },
   },
 };

--- a/mcpjam-inspector/client/src/lib/harness-capabilities.ts
+++ b/mcpjam-inspector/client/src/lib/harness-capabilities.ts
@@ -66,6 +66,7 @@ export const HARNESS_DISPLAY_NAME: Record<HostConfigHarnessV2, string> = {
 
 /** Behavior-tab controls whose value may not cross into a harness runtime. */
 export type HarnessGatedControl =
+  | "modelId"
   | "temperature"
   | "requireToolApproval"
   | "respectToolVisibility"
@@ -88,6 +89,9 @@ const HARNESS_LOOP_CONTROL_STATE: Record<
   Record<HarnessLoopControl, HarnessControlState>
 > = {
   "claude-code": {
+    // MCPJam brokers this harness's model credentials, so the selected model is
+    // the model the runtime is launched with.
+    modelId: ENFORCED,
     // Permanent: the Claude Code CLI exposes no temperature knob.
     temperature: {
       enforced: false,
@@ -110,6 +114,8 @@ const HARNESS_LOOP_CONTROL_STATE: Record<
     },
   },
   codex: {
+    // Brokered, same as Claude Code — the selection reaches the runtime.
+    modelId: ENFORCED,
     // Permanent: the Codex CLI exposes no temperature knob to the host.
     temperature: {
       enforced: false,
@@ -130,10 +136,17 @@ const HARNESS_LOOP_CONTROL_STATE: Record<
     },
   },
   cursor: {
-    // Permanent for a different reason than the other two: Cursor's CLI takes
-    // no temperature AND no model — it runs on the customer's Cursor account,
-    // which picks the model itself (Cursor Auto). There is nothing on this host
-    // for the value to reach.
+    // The one harness whose MODEL is not MCPJam's to choose. It authenticates
+    // with the customer's own Cursor account and that account picks the model
+    // (Cursor Auto), so a selection here would persist onto the host, show in
+    // the editor, and reach nothing — a saved setting that silently lies about
+    // what ran. The host carries the `cursor/auto` sentinel instead, which is
+    // what the runtime actually resolves to.
+    modelId: {
+      enforced: false,
+      note: "The Cursor CLI runs on your Cursor account, which chooses the model itself.",
+    },
+    // Permanent for the same reason: Cursor's CLI takes no temperature either.
     temperature: {
       enforced: false,
       note: "The Cursor CLI runs on your Cursor account and ignores temperature.",

--- a/mcpjam-inspector/client/src/lib/host-compat/__tests__/feature-visibility.test.ts
+++ b/mcpjam-inspector/client/src/lib/host-compat/__tests__/feature-visibility.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+  FLAG_GATED_HOST_IDS,
+  excludedFlagGatedHostIds,
+  filterHostsByFeatureFlags,
+  filterProfilesByFeatureFlags,
+  filterReportsByFeatureFlags,
+  hostFeatureFlagState,
+  isHostVisibleByFeatureFlags,
+  type HostFeatureVisibility,
+} from "../feature-visibility";
+
+/**
+ * This module is the ONLY thing standing between an unlaunched host and every
+ * user, on six surfaces at once. Two failure directions matter and they are not
+ * symmetric: showing a gated host to someone outside the launch audience is a
+ * leak, while hiding an ungated host makes a shipped product vanish.
+ */
+const ALL_ON: HostFeatureVisibility = {
+  claudeCode: true,
+  codex: true,
+  cursorCli: true,
+};
+const ALL_OFF: HostFeatureVisibility = {
+  claudeCode: false,
+  codex: false,
+  cursorCli: false,
+};
+
+describe("which hosts are gated at all", () => {
+  it("gates the Cursor CLI host and NOT the emulated cursor template", () => {
+    // The trap this file is worth the most for. `cursor` is the IDE chat-panel
+    // host style, ungated and shipped for months; `cursor-cli` is the new
+    // runtime. A gate keyed on the wrong id either leaks the new host or
+    // deletes the old one from every picker.
+    expect(FLAG_GATED_HOST_IDS.has("cursor-cli")).toBe(true);
+    expect(FLAG_GATED_HOST_IDS.has("cursor")).toBe(false);
+  });
+
+  it("leaves an ungated host visible no matter what the flags say", () => {
+    for (const hostId of ["cursor", "vscode", "windsurf", "anything-else"]) {
+      expect(isHostVisibleByFeatureFlags(hostId, ALL_OFF), hostId).toBe(true);
+      expect(
+        hostFeatureFlagState(hostId, {
+          claudeCode: undefined,
+          codex: undefined,
+          cursorCli: undefined,
+        }),
+        hostId,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("cursor-cli visibility", () => {
+  it("is hidden when the flag is off", () => {
+    expect(isHostVisibleByFeatureFlags("cursor-cli", ALL_OFF)).toBe(false);
+    expect(
+      isHostVisibleByFeatureFlags("cursor-cli", {
+        ...ALL_ON,
+        cursorCli: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("is shown only when its OWN flag is on", () => {
+    // Not "any harness flag": a user in the Claude Code audience is not
+    // thereby in the Cursor audience.
+    expect(
+      isHostVisibleByFeatureFlags("cursor-cli", {
+        ...ALL_OFF,
+        cursorCli: true,
+      }),
+    ).toBe(true);
+    expect(
+      isHostVisibleByFeatureFlags("cursor-cli", {
+        claudeCode: true,
+        codex: true,
+        cursorCli: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("reads UNRESOLVED as unresolved, never as visible", () => {
+    // The tri-state exists so a deep link can wait rather than guess. The
+    // boolean gate must treat "still loading" as not-yet-visible: guessing
+    // `true` for the few hundred milliseconds before PostHog answers would show
+    // the host to everyone.
+    const loading = {
+      claudeCode: undefined,
+      codex: undefined,
+      cursorCli: undefined,
+    };
+    expect(hostFeatureFlagState("cursor-cli", loading)).toBeUndefined();
+    expect(
+      isHostVisibleByFeatureFlags(
+        "cursor-cli",
+        loading as HostFeatureVisibility,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("every surface reads the same map", () => {
+  // The regression the module was extracted for: the exclusion set used to be
+  // hand-typed per host in one view, so a newly gated host was gated on five
+  // surfaces and offered on the sixth.
+  const hosts = [
+    { id: "cursor-cli" },
+    { id: "cursor" },
+    { id: "claude-code" },
+    { id: "codex" },
+  ];
+
+  it("hides cursor-cli from the host picker, the reports, and the profiles alike", () => {
+    const visibility = { ...ALL_ON, cursorCli: false };
+    expect(
+      filterHostsByFeatureFlags(hosts, visibility).map((h) => h.id),
+    ).toEqual(["cursor", "claude-code", "codex"]);
+    expect(
+      filterProfilesByFeatureFlags(hosts, visibility).map((h) => h.id),
+    ).toEqual(["cursor", "claude-code", "codex"]);
+    expect(
+      filterReportsByFeatureFlags(
+        hosts.map((h) => ({ hostId: h.id })),
+        visibility,
+      ).map((r) => r.hostId),
+    ).toEqual(["cursor", "claude-code", "codex"]);
+  });
+
+  it("derives the exclusion set from the same map, for every combination", () => {
+    expect(excludedFlagGatedHostIds(ALL_ON)).toEqual(new Set());
+    expect(excludedFlagGatedHostIds(ALL_OFF)).toEqual(
+      new Set(FLAG_GATED_HOST_IDS),
+    );
+    expect(excludedFlagGatedHostIds({ ...ALL_ON, cursorCli: false })).toEqual(
+      new Set(["cursor-cli"]),
+    );
+  });
+
+  it("keeps the exclusion set and the filters agreeing", () => {
+    // Two ways of asking the same question, on six surfaces between them. If
+    // they ever disagree, one surface shows what another hides.
+    for (const visibility of [
+      ALL_ON,
+      ALL_OFF,
+      { ...ALL_ON, cursorCli: false },
+      { ...ALL_OFF, cursorCli: true },
+    ]) {
+      const excluded = excludedFlagGatedHostIds(visibility);
+      const shown = new Set(
+        filterHostsByFeatureFlags(hosts, visibility).map((h) => h.id),
+      );
+      for (const id of FLAG_GATED_HOST_IDS) {
+        expect(excluded.has(id), `${id} in ${JSON.stringify(visibility)}`).toBe(
+          !shown.has(id),
+        );
+      }
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/lib/host-compat/feature-visibility.ts
+++ b/mcpjam-inspector/client/src/lib/host-compat/feature-visibility.ts
@@ -1,6 +1,7 @@
 export type HostFeatureVisibility = {
   claudeCode: boolean;
   codex: boolean;
+  cursorCli: boolean;
 };
 
 /** Same flags before PostHog answers, where `undefined` means "not resolved". */
@@ -19,6 +20,10 @@ const FLAG_GATED_HOSTS: Partial<
 > = {
   "claude-code": "claudeCode",
   codex: "codex",
+  // The Cursor CLI host ONLY. The emulated `cursor` template (the IDE chat
+  // panel) is deliberately absent: it is a different, ungated host that has
+  // shipped for months, and gating it here would hide it from everyone.
+  "cursor-cli": "cursorCli",
 };
 
 export const FLAG_GATED_HOST_IDS: ReadonlySet<string> = new Set(
@@ -43,6 +48,25 @@ export function isHostVisibleByFeatureFlags(
   visibility: HostFeatureVisibility
 ): boolean {
   return hostFeatureFlagState(hostId, visibility) === true;
+}
+
+/**
+ * The flag-gated host ids currently hidden, as a Set.
+ *
+ * DERIVED from {@link FLAG_GATED_HOSTS} rather than hand-listed, which is the
+ * whole point: the one caller that used to build this itself
+ * (`HostConfigCompareView`) had `if (!claudeCodeEnabled) excluded.add(…)` typed
+ * out per host, so a newly gated host was gated on five surfaces and silently
+ * offered on the sixth. Adding a host to the map above now covers all of them.
+ */
+export function excludedFlagGatedHostIds(
+  visibility: HostFeatureVisibility
+): Set<string> {
+  const excluded = new Set<string>();
+  for (const hostId of Object.keys(FLAG_GATED_HOSTS)) {
+    if (!isHostVisibleByFeatureFlags(hostId, visibility)) excluded.add(hostId);
+  }
+  return excluded;
 }
 
 export function filterReportsByFeatureFlags<T extends { hostId: string }>(

--- a/mcpjam-inspector/client/src/lib/host-compat/use-host-compat.ts
+++ b/mcpjam-inspector/client/src/lib/host-compat/use-host-compat.ts
@@ -135,5 +135,6 @@ export function useHostCompatReports(
     catalogState,
     claudeCodeEnabled,
     codexEnabled,
+    cursorCliEnabled,
   ]);
 }

--- a/mcpjam-inspector/client/src/lib/host-compat/use-host-compat.ts
+++ b/mcpjam-inspector/client/src/lib/host-compat/use-host-compat.ts
@@ -9,6 +9,7 @@ import { useHostCatalog } from "./use-host-catalog";
 import { useWidgetUsageState } from "./use-widget-usage";
 import { useClaudeCodeHostEnabled } from "@/hooks/useClaudeCodeHostEnabled";
 import { useCodexHostEnabled } from "@/hooks/useCodexHostEnabled";
+import { useCursorHostEnabled } from "@/hooks/useCursorHostEnabled";
 import { filterReportsByFeatureFlags } from "./feature-visibility";
 
 const TOOLS_FETCH_MAX_ATTEMPTS = 3;
@@ -30,7 +31,7 @@ export type ServerToolsDataState = {
  * an in-flight request from a terminal failure.
  */
 export function useServerToolsData(
-  server: ServerWithName | null
+  server: ServerWithName | null,
 ): ServerToolsDataState {
   const isConnected = server?.connectionStatus === "connected";
   const serverName = server?.name;
@@ -62,7 +63,7 @@ export function useServerToolsData(
             // after every attempt has failed.
             retryTimer = setTimeout(
               () => attempt(tries + 1),
-              1000 * (tries + 1)
+              1000 * (tries + 1),
             );
           } else {
             setState({ data: null, status: "failed" });
@@ -86,7 +87,7 @@ export function useServerToolsData(
  * (the detail modal) should call `evaluateAllHosts` directly instead.
  */
 export function useHostCompatReports(
-  server: ServerWithName
+  server: ServerWithName,
 ): HostCompatEvaluation {
   const toolsState = useServerToolsData(server);
   const widgetScan = useWidgetUsageState(server.name, toolsState.data);
@@ -96,6 +97,7 @@ export function useHostCompatReports(
   const catalogState = useHostCatalog();
   const claudeCodeEnabled = useClaudeCodeHostEnabled();
   const codexEnabled = useCodexHostEnabled();
+  const cursorCliEnabled = useCursorHostEnabled();
 
   const protocolVersion = server.initializationInfo?.protocolVersion;
   const connectionStatus = server.connectionStatus;
@@ -104,7 +106,7 @@ export function useHostCompatReports(
       toolsState.data,
       widgetUsage,
       { protocolVersion },
-      catalogState?.catalog
+      catalogState?.catalog,
     );
     return {
       ...evaluation,
@@ -121,6 +123,7 @@ export function useHostCompatReports(
       reports: filterReportsByFeatureFlags(evaluation.reports, {
         claudeCode: claudeCodeEnabled,
         codex: codexEnabled,
+        cursorCli: cursorCliEnabled,
       }),
     };
   }, [

--- a/mcpjam-inspector/client/src/lib/host-logo.ts
+++ b/mcpjam-inspector/client/src/lib/host-logo.ts
@@ -27,6 +27,12 @@ const LOGO_NAME_HINTS: Array<[RegExp, string]> = [
   [/claude/i, "claude"],
   [/chatgpt|openai/i, "chatgpt"],
   [/copilot/i, "copilot"],
+  // BEFORE the bare /cursor/i, same ordering trap as claude-code above: a host
+  // named "Cursor CLI" must resolve to the `cursor-cli` id, not to `cursor`.
+  // The two happen to share a logo file today, so this is about the resolved ID
+  // being right (theme-keyed lookups and anything else that keys off it), not
+  // about the pixels.
+  [/cursor[ -]?cli/i, "cursor-cli"],
   [/cursor/i, "cursor"],
   [/vs ?code/i, "vscode"],
   [/goose/i, "goose"],
@@ -39,7 +45,7 @@ const LOGO_NAME_HINTS: Array<[RegExp, string]> = [
 
 export function resolveHostLogoByName(
   name: string,
-  themeMode?: HostThemeMode | null
+  themeMode?: HostThemeMode | null,
 ): string {
   for (const [pattern, hostId] of LOGO_NAME_HINTS) {
     if (pattern.test(name)) return getHostLogoSrc(hostId, themeMode);

--- a/mcpjam-inspector/client/src/lib/host-ui-metadata.ts
+++ b/mcpjam-inspector/client/src/lib/host-ui-metadata.ts
@@ -31,6 +31,9 @@ const LOGO_BY_HOST_ID: Record<string, string> = {
   goose: gooseLogoLight,
   slack: slackLogo,
   cursor: cursorLogo,
+  // Same mark as the IDE: one Cursor brand, two products. Mapped explicitly
+  // because an id absent from this record falls back to the anonymous MCP mark.
+  "cursor-cli": cursorLogo,
   codex: codexLogo,
   copilot: copilotLogo,
   vscode: vscodeLogo,
@@ -57,7 +60,7 @@ const LOGO_BY_HOST_ID_AND_THEME: Record<
 
 export function getHostLogoSrc(
   hostId: string,
-  themeMode?: HostThemeMode | null
+  themeMode?: HostThemeMode | null,
 ): string {
   return (
     (themeMode ? LOGO_BY_HOST_ID_AND_THEME[hostId]?.[themeMode] : undefined) ??
@@ -71,5 +74,5 @@ export const HOST_LOGO_OPTIONS = Object.entries(LOGO_BY_HOST_ID).map(
     id,
     logoSrc,
     logoSrcByTheme: LOGO_BY_HOST_ID_AND_THEME[id],
-  })
+  }),
 );

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -112,6 +112,7 @@
     "@ai-sdk/harness": "^1.0.96",
     "@ai-sdk/harness-claude-code": "^1.0.100",
     "@ai-sdk/harness-codex": "^1.0.98",
+    "@ai-sdk/harness-cursor": "^1.0.9",
     "@ai-sdk/mistral": "^3.0.18",
     "@ai-sdk/openai": "^3.0.25",
     "@ai-sdk/react": "^3.0.156",

--- a/mcpjam-inspector/server/routes/v1/__tests__/openapi-harness-enum.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/openapi-harness-enum.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { HARNESS_IDS } from "@mcpjam/sdk/host-config/internal";
+
+/**
+ * The published `harness` enum must match what the route actually accepts.
+ *
+ * `PATCH /clients/{id}` validates with `z.enum(HARNESS_IDS)`, but
+ * `docs/reference/openapi.json` is HAND-AUTHORED, and neither existing guard
+ * covers this: `openapi-drift` compares paths and methods only, and
+ * `openapi-types-parity` compares enum values but only for schemas paired with
+ * an SDK interface — `ClientFieldSet` has none, so it is not looked at.
+ *
+ * That gap is how `cursor` shipped accepted-but-undocumented: the API took the
+ * value while the published contract said it was invalid. Whichever direction
+ * the two drift, someone is misled — a client that trusts the spec refuses a
+ * value the API accepts, and a generated client refuses to send it at all.
+ */
+const here = dirname(fileURLToPath(import.meta.url));
+const spec = JSON.parse(
+  readFileSync(
+    resolve(here, "../../../../../docs/reference/openapi.json"),
+    "utf8",
+  ),
+) as {
+  components: {
+    schemas: Record<
+      string,
+      { properties?: Record<string, { enum?: unknown[] }> }
+    >;
+  };
+};
+
+describe("openapi.json ClientFieldSet.harness ↔ HARNESS_IDS", () => {
+  const harness = spec.components.schemas.ClientFieldSet?.properties?.harness;
+
+  it("documents the field at all", () => {
+    // Guard the guard: a renamed schema or property would make every
+    // assertion below vacuous.
+    expect(
+      harness,
+      "ClientFieldSet.harness is missing from the spec",
+    ).toBeDefined();
+    expect(Array.isArray(harness?.enum)).toBe(true);
+  });
+
+  it("lists exactly the harness ids the route accepts, plus null", () => {
+    // `null` is the documented clear-this-field sentinel, so it belongs in the
+    // enum and nowhere in HARNESS_IDS.
+    const documented = (harness?.enum ?? []).filter((v) => v !== null);
+    expect(new Set(documented)).toEqual(new Set(HARNESS_IDS));
+    expect(harness?.enum).toContain(null);
+  });
+
+  it("keeps cursor in the contract", () => {
+    // Named explicitly rather than left to the set comparison: this is the
+    // value the gap was found on, and a future edit that drops it should say
+    // so in the failure.
+    expect(harness?.enum).toContain("cursor");
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/clients.ts
+++ b/mcpjam-inspector/server/routes/v1/clients.ts
@@ -50,6 +50,11 @@ import {
   getCatalogTemplate,
   type HostCompatCatalog,
 } from "@mcpjam/sdk/host-compat";
+// DERIVED, not re-listed: the wire enum is the SDK's own harness list, so a
+// harness added to HARNESS_IDS is accepted here without a second hand-edit
+// nobody would think to make (this route accepts no unknown-harness value, so
+// a stale copy is a silent "that host cannot be created through the API").
+import { HARNESS_IDS } from "@mcpjam/sdk/host-config/internal";
 import { parseWithSchema, ErrorCode, WebRouteError } from "../web/errors.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import { logger } from "../../utils/logger.js";
@@ -183,7 +188,7 @@ function markDeprecated(c: Context): void {
   c.header("Deprecation", "true");
   c.header(
     "Link",
-    '</api/v1/projects/{projectId}/clients>; rel="successor-version"'
+    '</api/v1/projects/{projectId}/clients>; rel="successor-version"',
   );
 }
 
@@ -227,7 +232,7 @@ async function fetchBackendHostCatalog(): Promise<HostCompatCatalog | null> {
 
 async function resolveHostTemplateInput(
   templateId: string,
-  theme: "light" | "dark" | undefined
+  theme: "light" | "dark" | undefined,
 ): Promise<Record<string, unknown>> {
   const liveCatalog = await fetchBackendHostCatalog();
   const template =
@@ -237,7 +242,7 @@ async function resolveHostTemplateInput(
     throw new WebRouteError(
       400,
       ErrorCode.VALIDATION_ERROR,
-      `Unknown client template: ${templateId}`
+      `Unknown client template: ${templateId}`,
     );
   }
 
@@ -251,7 +256,7 @@ async function resolveHostTemplateInput(
     throw new WebRouteError(
       400,
       ErrorCode.VALIDATION_ERROR,
-      `Client template "${templateId}" does not pin a model; pass an explicit \`config\` instead.`
+      `Client template "${templateId}" does not pin a model; pass an explicit \`config\` instead.`,
     );
   }
   if (theme !== undefined) {
@@ -272,7 +277,7 @@ function createConvexClient(convexAuthToken: string): ConvexHttpClient {
     throw new WebRouteError(
       500,
       ErrorCode.INTERNAL_ERROR,
-      "Server missing CONVEX_URL configuration"
+      "Server missing CONVEX_URL configuration",
     );
   }
   const client = new ConvexHttpClient(convexUrl);
@@ -297,13 +302,13 @@ function translateConvexWriteError(error: unknown): WebRouteError {
 
 async function listHostRows(
   convexAuthToken: string,
-  projectId: string
+  projectId: string,
 ): Promise<HostListRow[]> {
   const readClient = createConvexClient(convexAuthToken);
   try {
     return ((await readClient.query(
       "hosts:listHosts" as any,
-      { projectId } as any
+      { projectId } as any,
     )) ?? []) as HostListRow[];
   } catch (error) {
     throw translateConvexWriteError(error);
@@ -313,7 +318,7 @@ async function listHostRows(
 async function readHostDetail(
   convexAuthToken: string,
   projectId: string,
-  hostId: string
+  hostId: string,
 ): Promise<HostDetailRow> {
   const readClient = createConvexClient(convexAuthToken);
   let detail: HostDetailRow | null;
@@ -326,7 +331,7 @@ async function readHostDetail(
       {
         hostId,
         projectId,
-      } as any
+      } as any,
     )) as HostDetailRow | null;
   } catch (error) {
     throw translateConvexWriteError(error);
@@ -367,13 +372,13 @@ async function resolveClientId(
   convexAuthToken: string,
   projectId: string,
   selector: string,
-  includePrivateBacking: boolean
+  includePrivateBacking: boolean,
 ): Promise<string> {
   const readClient = createConvexClient(convexAuthToken);
   try {
     const resolved = (await readClient.query(
       "hosts:resolveHostByNameOrId" as any,
-      { projectId, selector, includePrivateBacking } as any
+      { projectId, selector, includePrivateBacking } as any,
     )) as { hostId: string } | null;
     if (resolved?.hostId) return resolved.hostId;
     throw new WebRouteError(404, ErrorCode.NOT_FOUND, "Client not found");
@@ -383,13 +388,13 @@ async function resolveClientId(
   }
 
   const rows = (await listHostRows(convexAuthToken, projectId)).filter(
-    (row) => includePrivateBacking || !isPrivateBacking(row)
+    (row) => includePrivateBacking || !isPrivateBacking(row),
   );
   const byId = rows.find((row) => row.hostId === selector);
   if (byId) return byId.hostId;
   const needle = selector.trim().toLocaleLowerCase();
   const matches = rows.filter(
-    (row) => row.name.trim().toLocaleLowerCase() === needle
+    (row) => row.name.trim().toLocaleLowerCase() === needle,
   );
   if (matches.length === 1) return matches[0]!.hostId;
   if (matches.length > 1) {
@@ -401,7 +406,7 @@ async function resolveClientId(
       } clients in this project. Use an ID instead: ${matches
         .map((row) => row.hostId)
         .join(", ")}`,
-      { candidateIds: matches.map((row) => row.hostId) }
+      { candidateIds: matches.map((row) => row.hostId) },
     );
   }
   throw new WebRouteError(404, ErrorCode.NOT_FOUND, "Client not found");
@@ -470,7 +475,7 @@ const READ_ONLY_CONFIG_KEYS = ["id", "schemaVersion"] as const;
  * Only ever a trim; the id itself is never rewritten.
  */
 function normalizeConfigForWrite(
-  config: Record<string, unknown>
+  config: Record<string, unknown>,
 ): Record<string, unknown> {
   const normalized: Record<string, unknown> = { ...config };
   for (const key of READ_ONLY_CONFIG_KEYS) delete normalized[key];
@@ -546,7 +551,7 @@ const clientSetSchema = z
       .optional(),
     respectToolVisibility: z.boolean().nullable().optional(),
     progressiveToolDiscovery: z.boolean().nullable().optional(),
-    harness: z.enum(["claude-code", "codex"]).nullable().optional(),
+    harness: z.enum(HARNESS_IDS).nullable().optional(),
     computer: z
       .strictObject({
         kind: z.literal("personal"),
@@ -696,7 +701,7 @@ async function listHandler(c: Context, { legacy }: Surface) {
   const projectId = pathParam(c, "projectId");
   const rows = await listHostRows(
     await getConvexBearerForRequest(c),
-    projectId
+    projectId,
   );
   if (legacy) {
     markDeprecated(c);
@@ -721,7 +726,7 @@ async function listHandler(c: Context, { legacy }: Surface) {
 async function resolveSelector(
   c: Context,
   token: string,
-  { legacy }: Surface
+  { legacy }: Surface,
 ): Promise<string> {
   const projectId = pathParam(c, "projectId");
   if (legacy) return pathParam(c, "hostId");
@@ -729,7 +734,7 @@ async function resolveSelector(
     token,
     projectId,
     pathParam(c, "client"),
-    includePrivateBackingParam(c)
+    includePrivateBackingParam(c),
   );
 }
 
@@ -772,7 +777,7 @@ async function createHandler(c: Context, surface: Surface) {
   const input = normalizeConfigForWrite(
     body.template
       ? await resolveHostTemplateInput(body.template, body.theme)
-      : body.config!
+      : body.config!,
   );
 
   let created: { hostId: string };
@@ -783,7 +788,7 @@ async function createHandler(c: Context, surface: Surface) {
         projectId,
         name: body.name,
         input,
-      } as any
+      } as any,
     )) as { hostId: string };
   } catch (error) {
     throw translateConvexWriteError(error);
@@ -807,7 +812,7 @@ async function createHandler(c: Context, surface: Surface) {
  */
 function assertConfigKeepsPinnedModel(
   current: HostDetailRow,
-  nextConfig: Record<string, unknown>
+  nextConfig: Record<string, unknown>,
 ): void {
   if (
     hostConfigPinsAModel(current.config) &&
@@ -817,7 +822,7 @@ function assertConfigKeepsPinnedModel(
       400,
       ErrorCode.VALIDATION_ERROR,
       "`config.modelId` is required and must be a non-empty model id: this client pins a model, and clearing it would leave it unable to back a headless environment.",
-      { modelId: current.config.modelId }
+      { modelId: current.config.modelId },
     );
   }
 }
@@ -830,7 +835,7 @@ async function updateClientHandler(c: Context) {
     token,
     projectId,
     pathParam(c, "client"),
-    includePrivateBackingParam(c)
+    includePrivateBackingParam(c),
   );
   const convexClient = createConvexClient(token);
 
@@ -852,7 +857,7 @@ async function updateClientHandler(c: Context) {
       // preflight read is only for the specific model-clearing 400.
       assertConfigKeepsPinnedModel(
         await readHostDetail(token, projectId, clientId),
-        body.config
+        body.config,
       );
       await convexClient.mutation(
         "hosts:updateHost" as any,
@@ -862,7 +867,7 @@ async function updateClientHandler(c: Context) {
           ...(body.name === undefined ? {} : { name: body.name }),
           input: normalizeConfigForWrite(body.config),
           ...tokens,
-        } as any
+        } as any,
       );
     } else {
       // Rename-only and partial edits both go through the partial mutation: it
@@ -876,7 +881,7 @@ async function updateClientHandler(c: Context) {
           ...(body.name === undefined ? {} : { name: body.name }),
           ...(body.set === undefined ? {} : { set: body.set }),
           ...tokens,
-        } as any
+        } as any,
       );
     }
   } catch (error) {
@@ -884,7 +889,7 @@ async function updateClientHandler(c: Context) {
   }
   return v1Resource(
     c,
-    toClientDetailDto(await readHostDetail(token, projectId, clientId))
+    toClientDetailDto(await readHostDetail(token, projectId, clientId)),
   );
 }
 
@@ -900,7 +905,7 @@ async function updateHostAliasHandler(c: Context) {
   if (body.config !== undefined) {
     assertConfigKeepsPinnedModel(
       await readHostDetail(token, projectId, hostId),
-      body.config
+      body.config,
     );
     updateArgs.input = normalizeConfigForWrite(body.config);
   }
@@ -913,7 +918,7 @@ async function updateHostAliasHandler(c: Context) {
   markDeprecated(c);
   return v1Resource(
     c,
-    toLegacyHostDetailDto(await readHostDetail(token, projectId, hostId))
+    toLegacyHostDetailDto(await readHostDetail(token, projectId, hostId)),
   );
 }
 
@@ -944,7 +949,7 @@ async function setServersHandler(c: Context, surface: Surface) {
   return detailResponse(
     c,
     await readHostDetail(token, projectId, clientId),
-    surface.legacy
+    surface.legacy,
   );
 }
 
@@ -954,7 +959,7 @@ async function duplicateHandler(c: Context, surface: Surface) {
   const clientId = await resolveSelector(c, token, surface);
   const body = parseWithSchema(
     duplicateClientSchema,
-    await readJsonObjectBody(c)
+    await readJsonObjectBody(c),
   );
   const convexClient = createConvexClient(token);
 
@@ -968,7 +973,7 @@ async function duplicateHandler(c: Context, surface: Surface) {
     throw new WebRouteError(
       400,
       ErrorCode.VALIDATION_ERROR,
-      `Client "${source.name}" does not pin a model, so duplicating it would create another client that cannot back a headless environment. Pin a model on it first.`
+      `Client "${source.name}" does not pin a model, so duplicating it would create another client that cannot back a headless environment. Pin a model on it first.`,
     );
   }
 
@@ -1021,20 +1026,20 @@ const LEGACY: Surface = { legacy: true };
 clients.get("/projects/:projectId/clients", (c) => listHandler(c, CANONICAL));
 // Canonical detail routes take a client NAME or ID.
 clients.get("/projects/:projectId/clients/:client", (c) =>
-  getHandler(c, CANONICAL)
+  getHandler(c, CANONICAL),
 );
 clients.post("/projects/:projectId/clients", (c) =>
-  createHandler(c, CANONICAL)
+  createHandler(c, CANONICAL),
 );
 clients.patch("/projects/:projectId/clients/:client", updateClientHandler);
 clients.post("/projects/:projectId/clients/:client/servers", (c) =>
-  setServersHandler(c, CANONICAL)
+  setServersHandler(c, CANONICAL),
 );
 clients.post("/projects/:projectId/clients/:client/duplicate", (c) =>
-  duplicateHandler(c, CANONICAL)
+  duplicateHandler(c, CANONICAL),
 );
 clients.delete("/projects/:projectId/clients/:client", (c) =>
-  deleteHandler(c, CANONICAL)
+  deleteHandler(c, CANONICAL),
 );
 
 // Deprecated aliases: the original `/hosts` paths, ID-only, old DTOs, old
@@ -1045,13 +1050,13 @@ clients.get("/projects/:projectId/hosts/:hostId", (c) => getHandler(c, LEGACY));
 clients.post("/projects/:projectId/hosts", (c) => createHandler(c, LEGACY));
 clients.patch("/projects/:projectId/hosts/:hostId", updateHostAliasHandler);
 clients.post("/projects/:projectId/hosts/:hostId/servers", (c) =>
-  setServersHandler(c, LEGACY)
+  setServersHandler(c, LEGACY),
 );
 clients.post("/projects/:projectId/hosts/:hostId/duplicate", (c) =>
-  duplicateHandler(c, LEGACY)
+  duplicateHandler(c, LEGACY),
 );
 clients.delete("/projects/:projectId/hosts/:hostId", (c) =>
-  deleteHandler(c, LEGACY)
+  deleteHandler(c, LEGACY),
 );
 
 export default clients;

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -26,7 +26,6 @@ import type {
 import type { MCPClientManager, Harness } from "@mcpjam/sdk";
 import type { ModelVisibleMcpToolResults } from "@mcpjam/sdk/host-config/internal";
 import type { ModelDefinition } from "@/shared/types";
-import { getCanonicalModelId } from "@/shared/types";
 import { isHostedCatalogModel } from "../services/hosted-model-catalog.js";
 import type { LiveChatTraceUsage } from "@/shared/live-chat-trace";
 import type {
@@ -40,6 +39,7 @@ import {
 import type { ChatOrigin, PersistedTurnTrace } from "./chat-ingestion.js";
 import { runHarnessTurn } from "./harness/run-harness-turn.js";
 import { getHarnessAdapter } from "./harness/registry.js";
+import { harnessModelEligibleForRuntime } from "./harness/harness-availability.js";
 import type { HarnessSessionCommitPayload } from "./harness/harness-session-state.js";
 import { logger } from "./logger.js";
 
@@ -335,7 +335,7 @@ export interface RunAssistantTurnResult {
 }
 
 function extractAssistantMessages(
-  messages: ModelMessage[]
+  messages: ModelMessage[],
 ): AssistantModelMessage[] {
   const out: AssistantModelMessage[] = [];
   for (const msg of messages) {
@@ -347,7 +347,7 @@ function extractAssistantMessages(
 }
 
 function extractToolCalls(
-  messages: ModelMessage[]
+  messages: ModelMessage[],
 ): RunAssistantTurnResult["toolCalls"] {
   const out: RunAssistantTurnResult["toolCalls"] = [];
   for (const msg of messages) {
@@ -368,7 +368,7 @@ function extractToolCalls(
 }
 
 function extractToolResults(
-  messages: ModelMessage[]
+  messages: ModelMessage[],
 ): RunAssistantTurnResult["toolResults"] {
   const out: RunAssistantTurnResult["toolResults"] = [];
   for (const msg of messages) {
@@ -392,7 +392,7 @@ function extractToolResults(
  * with the scenario synthetic surface.)
  */
 function buildExtraBodyFields(
-  opts: RunAssistantTurnOptions
+  opts: RunAssistantTurnOptions,
 ): Record<string, unknown> | undefined {
   const base = { ...(opts.extraBodyFields ?? {}) };
   return Object.keys(base).length > 0 ? base : undefined;
@@ -410,8 +410,8 @@ function buildHandlerOptions(
   captureTranscript: (
     messages: ModelMessage[],
     turnTrace: PersistedTurnTrace,
-    harnessSessionCommit?: HarnessSessionCommitPayload
-  ) => void
+    harnessSessionCommit?: HarnessSessionCommitPayload,
+  ) => void,
 ): MCPJamHandlerOptions {
   const wrappedOnConversationComplete: MCPJamHandlerOptions["onConversationComplete"] =
     async (fullHistory, turnTrace, harnessSessionCommit) => {
@@ -433,7 +433,7 @@ function buildHandlerOptions(
         return await opts.onConversationComplete(
           fullHistory,
           turnTrace,
-          harnessSessionCommit
+          harnessSessionCommit,
         );
       }
       return undefined;
@@ -470,9 +470,7 @@ function buildHandlerOptions(
     // (runHarnessTurn REQUIRES harnessMcpProxy when servers are selected) and
     // (b) claim the correct owner lane (`swarm-chat` for swarm).
     ...(opts.harnessMcpProxy ? { harnessMcpProxy: opts.harnessMcpProxy } : {}),
-    ...(opts.evalIterationId
-      ? { evalIterationId: opts.evalIterationId }
-      : {}),
+    ...(opts.evalIterationId ? { evalIterationId: opts.evalIterationId } : {}),
     ...(opts.onHarnessEvidenceDecision
       ? { onHarnessEvidenceDecision: opts.onHarnessEvidenceDecision }
       : {}),
@@ -584,7 +582,7 @@ function buildHandlerOptions(
  *   `messageHistory` from the engine (NOT a fallback to the input).
  */
 export async function runAssistantTurn(
-  opts: RunAssistantTurnOptions
+  opts: RunAssistantTurnOptions,
 ): Promise<RunAssistantTurnResult> {
   let capturedMessages: ModelMessage[] | undefined;
   let capturedTrace: PersistedTurnTrace | undefined;
@@ -596,7 +594,7 @@ export async function runAssistantTurn(
       capturedMessages = fullHistory;
       capturedTrace = turnTrace;
       capturedHarnessCommit = harnessSessionCommit;
-    }
+    },
   );
 
   // A host with a `harness` selected (claude-code | codex) runs the real runtime
@@ -625,19 +623,23 @@ export async function runAssistantTurn(
   const harnessAdapter = harnessRequested
     ? getHarnessAdapter(opts.harness as string)
     : undefined;
-  // supportsModel needs the CANONICAL id (bare hosted ids like `gpt-5-nano` →
-  // `openai/gpt-5-nano`); isHostedCatalogModel canonicalizes internally, so a
-  // bare id would otherwise pass eligibility but fail supportsModel and wrongly
-  // fall back to emulated.
-  const canonicalHarnessModelId = getCanonicalModelId(
-    harnessModelId,
-    opts.modelDefinition.provider
-  );
-  const modelEligible =
-    isHostedCatalogModel(harnessModelId, opts.modelDefinition.provider) &&
-    (harnessAdapter
-      ? harnessAdapter.supportsModel(canonicalHarnessModelId)
-      : true);
+  // Asked of the shared helper rather than spelled out here, because this
+  // decision has to match the pre-flight's exactly: a dispatch that says "not
+  // eligible" where the pre-flight said "available" does not error — it runs
+  // the EMULATED engine and reports the harness's name over it. That is a wrong
+  // answer attributed to the wrong runtime, which is worse than a failure.
+  //
+  // The helper also carries the external-account exemption: Cursor's host
+  // seeds a `cursor/auto` sentinel that is deliberately not an MCPJam-hosted
+  // model, so the hosted-model half would otherwise reject every Cursor turn
+  // here and silently fall back.
+  const modelEligible = harnessAdapter
+    ? harnessModelEligibleForRuntime({
+        adapter: harnessAdapter,
+        modelId: harnessModelId,
+        provider: opts.modelDefinition.provider,
+      })
+    : isHostedCatalogModel(harnessModelId, opts.modelDefinition.provider);
   const useHarness = harnessRequested && modelEligible;
   if (harnessRequested && !modelEligible) {
     logger.warn(
@@ -649,7 +651,7 @@ export async function runAssistantTurn(
         modelId: harnessModelId,
         provider: opts.modelDefinition.provider,
         sourceType: opts.sourceType,
-      }
+      },
     );
   }
   const engineResult = useHarness

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -281,7 +281,17 @@ export type ChatOrigin =
 interface PersistChatSessionOptions {
   chatSessionId: string;
   modelId: string;
-  modelSource: "mcpjam" | "byok" | "local_byok";
+  /**
+   * Who paid for the turn's model spend. Hand-mirrors the backend's
+   * `chatModelSourceValidator`.
+   *
+   * `"external-account"` — the customer's own account with the RUNTIME vendor
+   * (Cursor), where MCPJam holds no model credential at all. Distinct from
+   * `"byok"` on purpose: both mean "MCPJam is not charged", but byok also
+   * asserts a configured model PROVIDER and its key, which an external-account
+   * turn does not have.
+   */
+  modelSource: "mcpjam" | "byok" | "local_byok" | "external-account";
   authHeader?: string;
   projectId?: string;
   sourceType?: "scenario" | "direct" | "eval" | "swarm";
@@ -348,7 +358,7 @@ interface PersistChatSessionOptions {
     scenarioId?: string;
     leaseId: string;
     expectedStateVersion: number;
-    harnessId: "claude-code" | "codex";
+    harnessId: "claude-code" | "codex" | "cursor";
     harnessSessionId: string;
     resumeState: unknown;
     computerId: string;

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -1,6 +1,7 @@
 import type { Context } from "hono";
 import type { ChatRewind } from "@/shared/chat-v2";
 import type {
+  Harness,
   McpToolResultImageRenderingPolicy,
   ModelVisibleMcpToolResults,
 } from "@mcpjam/sdk/host-config/internal";
@@ -358,7 +359,9 @@ interface PersistChatSessionOptions {
     scenarioId?: string;
     leaseId: string;
     expectedStateVersion: number;
-    harnessId: "claude-code" | "codex" | "cursor";
+    // The SDK union itself, not a copy: a stale copy here silently drops the
+    // session commit for a harness the rest of the stack already runs.
+    harnessId: Harness;
     harnessSessionId: string;
     resumeState: unknown;
     computerId: string;

--- a/mcpjam-inspector/server/utils/harness/__tests__/cursor-acp-mcp.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/cursor-acp-mcp.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import {
+  attributeCursorToolCall,
+  buildHarnessProxyMcpJson,
+  harnessServerKeyToName,
+  toAcpMcpServers,
+} from "../mcp-config";
+
+/**
+ * The two Cursor-specific seams in `mcp-config`: the `.mcp.json` → ACP
+ * `session/new` shape conversion, and tool-call attribution from the call's
+ * INPUT (Cursor's stream name carries no identity at all).
+ */
+describe("toAcpMcpServers", () => {
+  it("ALWAYS emits headers as an array, even when there are none", () => {
+    // The load-bearing assertion. Omitting the key makes cursor-agent fail
+    // `session/new` with an opaque JSON-RPC -32603 that names neither the field
+    // nor the server, so "no headers" must be `[]` and never absent or an
+    // object. Verified against cursor-agent 2026.08.31.
+    const acp = toAcpMcpServers({
+      mcpServers: {
+        weather: { type: "http", url: "https://proxy.example/weather" },
+      },
+    });
+    expect(acp.weather).toEqual({
+      type: "http",
+      url: "https://proxy.example/weather",
+      headers: [],
+    });
+    expect(Array.isArray(acp.weather!.headers)).toBe(true);
+  });
+
+  it("converts the header OBJECT into name/value pairs", () => {
+    const acp = toAcpMcpServers({
+      mcpServers: {
+        weather: {
+          type: "http",
+          url: "https://proxy.example/weather",
+          headers: {
+            "X-MCPJam-Proxy-Token": "tok-1",
+            "X-MCPJam-Harness-Turn": "turn-1",
+          },
+        },
+      },
+    });
+    expect(acp.weather!.headers).toEqual([
+      { name: "X-MCPJam-Proxy-Token", value: "tok-1" },
+      { name: "X-MCPJam-Harness-Turn", value: "turn-1" },
+    ]);
+  });
+
+  it("carries the per-server proxy token built by the real generator", () => {
+    // End to end through `buildHarnessProxyMcpJson` rather than a hand-written
+    // entry: the token header is the credential the whole proxy design rests
+    // on, and a conversion that dropped it would produce a turn whose MCP calls
+    // are simply unauthenticated.
+    const json = buildHarnessProxyMcpJson([
+      {
+        name: "srv-weather",
+        proxyUrl: "https://inspector.example/api/mcp/adapter-http/srv-weather",
+        proxyToken: "mcpjpt-abc",
+        evidenceTurnId: "turn-9",
+      },
+    ]);
+    const acp = toAcpMcpServers(json);
+    const headers = acp["srv-weather"]!.headers;
+    expect(headers).toContainEqual({
+      name: "X-MCPJam-Proxy-Token",
+      value: "mcpjpt-abc",
+    });
+    expect(headers).toContainEqual({
+      name: "X-MCPJam-Harness-Turn",
+      value: "turn-9",
+    });
+  });
+
+  it("preserves the keys verbatim, so attribution still resolves", () => {
+    // Renaming a key here would orphan every tool call from that server:
+    // `harnessServerKeyToName` is built from the same assignment pass, and
+    // nothing reconciles the two afterwards.
+    const servers = [{ name: "srv a" }, { name: "srv a" }];
+    const json = buildHarnessProxyMcpJson(
+      servers.map((s) => ({ name: s.name, proxyUrl: "https://p.example/x" })),
+    );
+    const acp = toAcpMcpServers(json);
+    expect(Object.keys(acp)).toEqual(Object.keys(json.mcpServers));
+    expect(Object.keys(acp).sort()).toEqual(
+      Object.keys(harnessServerKeyToName(servers)).sort(),
+    );
+  });
+
+  it("refuses the name ACP reserves for its own tool channel", () => {
+    // `createACPV1` throws on this outright. Failing here instead names MCPJam
+    // and the server; re-keying would "work" and silently break attribution.
+    expect(() =>
+      toAcpMcpServers({
+        mcpServers: {
+          "ai-sdk-harness-tools": { type: "http", url: "https://p.example/x" },
+        },
+      }),
+    ).toThrow(/reserved/i);
+  });
+
+  it("passes an empty server set through as an empty map", () => {
+    expect(toAcpMcpServers({ mcpServers: {} })).toEqual({});
+  });
+});
+
+describe("attributeCursorToolCall", () => {
+  const keyToServerId = { weather: "srv-weather", "user-notes": "srv-notes" };
+
+  it("reads identity out of the INPUT, not the opaque stream name", () => {
+    expect(
+      attributeCursorToolCall({
+        rawToolName: "acp_tool_01H8XYZ",
+        input: {
+          providerIdentifier: "weather",
+          toolName: "get_forecast",
+          args: { city: "SF" },
+        },
+        keyToServerId,
+      }),
+    ).toEqual({ serverId: "srv-weather", toolName: "get_forecast" });
+  });
+
+  it("falls back to the user- prefixed form ONLY after the exact key misses", () => {
+    // Cursor prefixes user-configured providers with `user-`, but not
+    // universally.
+    expect(
+      attributeCursorToolCall({
+        rawToolName: "acp_tool_2",
+        input: {
+          providerIdentifier: "user-weather",
+          toolName: "get_forecast",
+          args: {},
+        },
+        keyToServerId,
+      }),
+    ).toEqual({ serverId: "srv-weather", toolName: "get_forecast" });
+  });
+
+  it("prefers the EXACT key when a server's own name starts with user-", () => {
+    // The reason the order is not "strip, then look up": `user-notes` is a real
+    // key here, and stripping blindly would attribute its calls to `notes` —
+    // a different server, or none.
+    expect(
+      attributeCursorToolCall({
+        rawToolName: "acp_tool_3",
+        input: {
+          providerIdentifier: "user-notes",
+          toolName: "search",
+          args: {},
+        },
+        keyToServerId,
+      }),
+    ).toEqual({ serverId: "srv-notes", toolName: "search" });
+  });
+
+  it("keeps a native tool under its raw name with no server attribution", () => {
+    // Cursor's own built-ins carry no provider identity in their input.
+    expect(
+      attributeCursorToolCall({
+        rawToolName: "bash",
+        input: { command: "ls" },
+        keyToServerId,
+      }),
+    ).toEqual({ toolName: "bash" });
+  });
+
+  it("returns the tool name but no serverId when the key is unresolvable", () => {
+    // The tool name is firsthand from the input; only the server mapping is
+    // unknown, so only that is withheld. Returning the opaque `acp_tool_…` id
+    // would discard a fact we actually have.
+    expect(
+      attributeCursorToolCall({
+        rawToolName: "acp_tool_4",
+        input: {
+          providerIdentifier: "ghost",
+          toolName: "do_thing",
+          args: {},
+        },
+        keyToServerId,
+      }),
+    ).toEqual({ toolName: "do_thing" });
+  });
+
+  it("never fabricates identity from a malformed input", () => {
+    for (const input of [
+      undefined,
+      null,
+      "not-an-object",
+      {},
+      { providerIdentifier: "weather" },
+      { toolName: "get_forecast" },
+      { providerIdentifier: 7, toolName: "get_forecast" },
+      { providerIdentifier: "weather", toolName: "" },
+    ]) {
+      expect(
+        attributeCursorToolCall({
+          rawToolName: "acp_tool_x",
+          input,
+          keyToServerId,
+        }),
+      ).toEqual({ toolName: "acp_tool_x" });
+    }
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/__tests__/external-account-plan-wall.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/external-account-plan-wall.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  EXTERNAL_ACCOUNT_PLAN_WALL_TEXTS,
+  externalAccountPlanWallError,
+  isExternalAccountPlanWallTurn,
+} from "../external-account-plan-wall";
+
+/**
+ * The detector is deliberately hard to trigger, and most of these cases exist
+ * to prove it STAYS that way: a false positive discards a real answer the
+ * customer paid for, which is strictly worse than recording a bad turn.
+ */
+const WALL = EXTERNAL_ACCOUNT_PLAN_WALL_TEXTS[0]!;
+
+const clean = {
+  finishReason: "stop",
+  successfulToolCalls: 0,
+};
+
+describe("isExternalAccountPlanWallTurn", () => {
+  it("fires on the exact observed wall text", () => {
+    expect(isExternalAccountPlanWallTurn({ ...clean, finalText: WALL })).toBe(
+      true,
+    );
+  });
+
+  it("tolerates surrounding and collapsed whitespace only", () => {
+    expect(
+      isExternalAccountPlanWallTurn({ ...clean, finalText: `\n  ${WALL}\t\n` }),
+    ).toBe(true);
+    expect(
+      isExternalAccountPlanWallTurn({
+        ...clean,
+        finalText: WALL.replace(/ /g, "  "),
+      }),
+    ).toBe(true);
+  });
+
+  it("does NOT fire on a turn that merely quotes the phrase", () => {
+    // The case the exact-match rule exists for. A substring test would classify
+    // every one of these as a wall and delete a real answer.
+    for (const text of [
+      `The CLI told me to "${WALL}", so you may need a different plan.`,
+      `${WALL} — that's what it said.`,
+      `Here's what happened: ${WALL}`,
+      `${WALL} ${WALL}`,
+    ]) {
+      expect(isExternalAccountPlanWallTurn({ ...clean, finalText: text })).toBe(
+        false,
+      );
+    }
+  });
+
+  it("does NOT fire when a tool call succeeded", () => {
+    // A turn that actually did work is a real turn whatever it then said.
+    expect(
+      isExternalAccountPlanWallTurn({
+        ...clean,
+        finalText: WALL,
+        successfulToolCalls: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("does NOT fire on anything but a plain stop", () => {
+    // A length cut-off, an error, or a tool-call pause are all their own
+    // failures with their own handling; misreading one as an entitlement wall
+    // would report the wrong cause.
+    for (const finishReason of [
+      "length",
+      "error",
+      "tool-calls",
+      "content-filter",
+      "unknown",
+    ]) {
+      expect(
+        isExternalAccountPlanWallTurn({
+          ...clean,
+          finalText: WALL,
+          finishReason,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("does NOT fire on empty, missing, or unrelated text", () => {
+    for (const finalText of [
+      undefined,
+      null,
+      "",
+      "   ",
+      "Here is the forecast for San Francisco.",
+      // Case and punctuation are NOT normalized away: widening the match is a
+      // step toward discarding real output, so a near-miss stays a miss.
+      WALL.toLowerCase(),
+      `${WALL}.`,
+    ]) {
+      expect(isExternalAccountPlanWallTurn({ ...clean, finalText })).toBe(
+        false,
+      );
+    }
+  });
+});
+
+describe("externalAccountPlanWallError", () => {
+  it("names the runtime and the account, not MCPJam", () => {
+    // Nothing about this is an MCPJam limit; copy that read like one would send
+    // the reader to the wrong place entirely.
+    const message = externalAccountPlanWallError("Cursor CLI").message;
+    expect(message).toContain("Cursor CLI");
+    expect(message).toContain("CURSOR_API_KEY");
+    expect(message).toMatch(/Cursor account/i);
+  });
+
+  it("says why the turn is recorded as a failure", () => {
+    // The turn LOOKS successful to the runtime, so the error has to explain why
+    // it is being failed — otherwise it reads as MCPJam losing an answer.
+    expect(externalAccountPlanWallError("Cursor CLI").message).toMatch(
+      /model never ran|failed turn/i,
+    );
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   checkHarnessRuntimeAvailable,
+  harnessModelEligibleForRuntime,
   harnessToolApprovalRefusalReason,
 } from "../harness-availability";
+import { registeredHarnessIds } from "../registry";
 import { getHarnessAdapter, type HarnessId } from "../registry";
 
 // The capability-driven preflight that lets the chat-v2 routes fail closed with a
@@ -40,7 +42,7 @@ function setFullyAvailable() {
 
 /** Default args: a fully-runnable harness host (no approval, no servers, eligible). */
 function args(
-  overrides: Partial<Parameters<typeof checkHarnessRuntimeAvailable>[0]> = {}
+  overrides: Partial<Parameters<typeof checkHarnessRuntimeAvailable>[0]> = {},
 ) {
   return {
     harnessId: "claude-code" as HarnessId,
@@ -64,10 +66,10 @@ describe("checkHarnessRuntimeAvailable", () => {
       setFullyAvailable();
       expect(
         checkHarnessRuntimeAvailable(
-          args({ harnessId, model: { id: modelId } })
-        )
+          args({ harnessId, model: { id: modelId } }),
+        ),
       ).toEqual({ ok: true });
-    }
+    },
   );
 
   // The harness reaches MCP servers through the signed-proxy route, whose
@@ -99,7 +101,7 @@ describe("checkHarnessRuntimeAvailable", () => {
     setFullyAvailable();
     // MCPJam-provided but not Codex-mappable ⇒ rejected, not silently defaulted.
     const r = checkHarnessRuntimeAvailable(
-      args({ harnessId: "codex", model: { id: "anthropic/claude-haiku-4.5" } })
+      args({ harnessId: "codex", model: { id: "anthropic/claude-haiku-4.5" } }),
     );
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toMatch(/can't run this host's model/);
@@ -135,7 +137,7 @@ describe("checkHarnessRuntimeAvailable", () => {
         harnessId: "claude-code",
         requireToolApproval: true,
         hasSelectedMcpServers: true,
-      })
+      }),
     );
     expect(r.ok).toBe(true);
   });
@@ -143,7 +145,7 @@ describe("checkHarnessRuntimeAvailable", () => {
   it("still blocks an approval host on Codex (no native approval)", () => {
     setFullyAvailable();
     const r = checkHarnessRuntimeAvailable(
-      args({ harnessId: "codex", requireToolApproval: true })
+      args({ harnessId: "codex", requireToolApproval: true }),
     );
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toMatch(/tool approval/);
@@ -169,8 +171,8 @@ describe("checkHarnessRuntimeAvailable", () => {
           harnessId: "codex",
           hasSelectedMcpServers: true,
           model: { id: "openai/gpt-5-nano", provider: "openai" },
-        })
-      )
+        }),
+      ),
     ).toEqual({ ok: true });
   });
 
@@ -185,7 +187,7 @@ describe("checkHarnessRuntimeAvailable", () => {
         hasSelectedMcpServers: true,
         requireToolApproval: true,
         model: { id: "openai/gpt-5-nano", provider: "openai" },
-      })
+      }),
     );
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.kind).toBe("tool-approval");
@@ -195,15 +197,15 @@ describe("checkHarnessRuntimeAvailable", () => {
     setFullyAvailable();
     expect(
       checkHarnessRuntimeAvailable(
-        args({ harnessId: "claude-code", hasSelectedMcpServers: true })
-      )
+        args({ harnessId: "claude-code", hasSelectedMcpServers: true }),
+      ),
     ).toEqual({ ok: true });
   });
 
   it("fails closed when the model isn't harness-eligible (no silent emulated)", () => {
     setFullyAvailable();
     const r = checkHarnessRuntimeAvailable(
-      args({ model: { id: "acme/private-llm", provider: "custom" } })
+      args({ model: { id: "acme/private-llm", provider: "custom" } }),
     );
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toMatch(/MCPJam-provided models/);
@@ -221,8 +223,8 @@ describe("checkHarnessRuntimeAvailable", () => {
         args({
           harnessId: "codex",
           model: { id: "gpt-5-nano", provider: "openai" },
-        })
-      )
+        }),
+      ),
     ).toEqual({ ok: true });
   });
 
@@ -244,7 +246,7 @@ describe("checkHarnessRuntimeAvailable", () => {
       if (mode === "unset") delete process.env.MCPJAM_HARNESS_BROKER_DELIVERY;
       else process.env.MCPJAM_HARNESS_BROKER_DELIVERY = "true";
       expect(checkHarnessRuntimeAvailable(args())).toEqual({ ok: true });
-    }
+    },
   );
 
   describe("external-account harnesses skip the model + broker gates", () => {
@@ -294,7 +296,7 @@ describe("checkHarnessRuntimeAvailable", () => {
           model: { id: "cursor/auto", provider: "cursor" },
           requireToolApproval: true,
           hasSelectedMcpServers: true,
-        })
+        }),
       );
       expect(approvalWithServers.ok).toBe(false);
       if (!approvalWithServers.ok)
@@ -308,8 +310,8 @@ describe("checkHarnessRuntimeAvailable", () => {
             model: { id: "cursor/auto", provider: "cursor" },
             requireToolApproval: true,
             hasSelectedMcpServers: false,
-          })
-        )
+          }),
+        ),
       ).toEqual({ ok: true });
     });
 
@@ -317,11 +319,94 @@ describe("checkHarnessRuntimeAvailable", () => {
       // The exemption is keyed on `modelAccess`, not on "harness runs a CLI".
       setFullyAvailable();
       const r = checkHarnessRuntimeAvailable(
-        args({ model: { id: "cursor/auto", provider: "cursor" } })
+        args({ model: { id: "cursor/auto", provider: "cursor" } }),
       );
       expect(r.ok).toBe(false);
       if (!r.ok) expect(r.kind).toBe("model-not-hosted");
     });
+  });
+});
+
+/**
+ * The DISPATCH gate, which decides whether a turn runs on the real runtime or
+ * silently falls back to the emulated engine.
+ *
+ * This must agree with the pre-flight above for every adapter. When they
+ * disagree the product does not error — it approves the turn, runs a different
+ * engine, and reports the harness's name over it. A wrong answer attributed to
+ * the wrong runtime is worse than a failure, which is why this is asserted
+ * against the pre-flight rather than on its own.
+ */
+describe("harnessModelEligibleForRuntime", () => {
+  it("agrees with the pre-flight for every registered adapter", () => {
+    setFullyAvailable();
+    const cases: Array<{ modelId: string; provider: string }> = [
+      { modelId: "anthropic/claude-haiku-4.5", provider: "anthropic" },
+      { modelId: "openai/gpt-5-nano", provider: "openai" },
+      // The external-account sentinel: deliberately NOT an MCPJam-hosted model.
+      { modelId: "cursor/auto", provider: "cursor" },
+      // Hosted, but not every runtime can run it.
+      { modelId: "anthropic/claude-sonnet-4.5", provider: "anthropic" },
+    ];
+    for (const id of registeredHarnessIds()) {
+      const adapter = getHarnessAdapter(id);
+      for (const model of cases) {
+        const eligible = harnessModelEligibleForRuntime({
+          adapter,
+          modelId: model.modelId,
+          provider: model.provider,
+        });
+        const preflight = checkHarnessRuntimeAvailable(
+          args({
+            harnessId: id,
+            model: { id: model.modelId, provider: model.provider },
+          }),
+        );
+        // The pre-flight can refuse for reasons this helper does not model
+        // (approval, data plane); restrict the comparison to the MODEL kinds.
+        const preflightModelRefusal =
+          !preflight.ok &&
+          (preflight.kind === "model-not-hosted" ||
+            preflight.kind === "model-unsupported");
+        expect(eligible, `${id} / ${model.modelId}`).toBe(
+          !preflightModelRefusal,
+        );
+      }
+    }
+  });
+
+  it("lets an external-account harness run its non-hosted sentinel model", () => {
+    // The regression that made the whole feature inert: `cursor/auto` fails the
+    // hosted-model check, so the dispatch ran the emulated engine and called it
+    // Cursor.
+    expect(
+      harnessModelEligibleForRuntime({
+        adapter: getHarnessAdapter("cursor"),
+        modelId: "cursor/auto",
+        provider: "cursor",
+      }),
+    ).toBe(true);
+  });
+
+  it("still refuses a non-hosted model for a BROKERED harness", () => {
+    // The exemption is keyed on `modelAccess`, not on "harness".
+    expect(
+      harnessModelEligibleForRuntime({
+        adapter: getHarnessAdapter("claude-code"),
+        modelId: "cursor/auto",
+        provider: "cursor",
+      }),
+    ).toBe(false);
+  });
+
+  it("still refuses a hosted model the runtime cannot run", () => {
+    expect(
+      harnessModelEligibleForRuntime({
+        adapter: getHarnessAdapter("codex"),
+        modelId: "anthropic/claude-haiku-4.5",
+        provider: "anthropic",
+      }),
+    ).toBe(false);
   });
 });
 
@@ -348,9 +433,9 @@ describe("harnessToolApprovalRefusalReason", () => {
           adapter: getHarnessAdapter(harnessId),
           requireToolApproval: false,
           hasSelectedMcpServers,
-        })
+        }),
       ).toBeUndefined();
-    }
+    },
   );
 
   // The gap this closes: Codex's NATIVE tools can't pause either, and its
@@ -363,7 +448,7 @@ describe("harnessToolApprovalRefusalReason", () => {
         adapter: codex,
         requireToolApproval: true,
         hasSelectedMcpServers: false,
-      })
+      }),
     ).toMatch(/doesn't support interactive tool approval/);
   });
 
@@ -373,7 +458,7 @@ describe("harnessToolApprovalRefusalReason", () => {
         adapter: codex,
         requireToolApproval: true,
         hasSelectedMcpServers: true,
-      })
+      }),
     ).toBeDefined();
   });
 
@@ -385,7 +470,7 @@ describe("harnessToolApprovalRefusalReason", () => {
         adapter: claudeCode,
         requireToolApproval: true,
         hasSelectedMcpServers: false,
-      })
+      }),
     ).toBeUndefined();
   });
 
@@ -400,7 +485,7 @@ describe("harnessToolApprovalRefusalReason", () => {
         adapter: claudeCode,
         requireToolApproval: true,
         hasSelectedMcpServers: true,
-      })
+      }),
     ).toBeUndefined();
   });
 
@@ -417,7 +502,7 @@ describe("harnessToolApprovalRefusalReason", () => {
         adapter: noMcpApproval,
         requireToolApproval: true,
         hasSelectedMcpServers: true,
-      })
+      }),
     ).toMatch(/MCP-server tools/);
     // …and only once a server is actually attached.
     expect(
@@ -425,7 +510,7 @@ describe("harnessToolApprovalRefusalReason", () => {
         adapter: noMcpApproval,
         requireToolApproval: true,
         hasSelectedMcpServers: false,
-      })
+      }),
     ).toBeUndefined();
   });
 
@@ -448,7 +533,7 @@ describe("harnessToolApprovalRefusalReason", () => {
         adapter: stillApproves,
         requireToolApproval: true,
         hasSelectedMcpServers: true,
-      })
+      }),
     ).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
@@ -246,6 +246,83 @@ describe("checkHarnessRuntimeAvailable", () => {
       expect(checkHarnessRuntimeAvailable(args())).toEqual({ ok: true });
     }
   );
+
+  describe("external-account harnesses skip the model + broker gates", () => {
+    // Three checks below are about a credential MCPJam supplies and a model
+    // MCPJam hosts. An external-account runtime has neither: Cursor
+    // authenticates on the customer's own Cursor account and its adapter
+    // passes NO model, so Cursor Auto picks one. Applying the brokered rules
+    // would refuse every Cursor host — its own seeded model is the
+    // deliberately-not-hosted `cursor/auto` sentinel.
+    const cursorArgs = () =>
+      args({
+        harnessId: "cursor" as HarnessId,
+        model: { id: "cursor/auto", provider: "cursor" },
+      });
+
+    it("is available on a model MCPJam does not host", () => {
+      setFullyAvailable();
+      expect(checkHarnessRuntimeAvailable(cursorArgs())).toEqual({ ok: true });
+    });
+
+    it("stays available with broker delivery killed (it has no broker)", () => {
+      setFullyAvailable();
+      process.env.MCPJAM_HARNESS_BROKER_DELIVERY = "false";
+      expect(checkHarnessRuntimeAvailable(cursorArgs())).toEqual({ ok: true });
+      // …while the brokered harness beside it is still refused, so this is a
+      // targeted exemption and not a hole in the kill switch.
+      const brokered = checkHarnessRuntimeAvailable(args());
+      expect(brokered.ok).toBe(false);
+    });
+
+    it("still enforces the gates that DO apply to it", () => {
+      setFullyAvailable();
+      // Data plane: the CLI runs inside a computer, so this one is real.
+      delete process.env.E2B_API_KEY;
+      const noDataPlane = checkHarnessRuntimeAvailable(cursorArgs());
+      expect(noDataPlane.ok).toBe(false);
+      if (!noDataPlane.ok)
+        expect(noDataPlane.kind).toBe("computers-unconfigured");
+
+      setFullyAvailable();
+      // Approval: `supportsMcpToolApproval` is false pending a live check, so
+      // an approval host WITH servers is refused rather than run with some MCP
+      // calls unapproved.
+      const approvalWithServers = checkHarnessRuntimeAvailable(
+        args({
+          harnessId: "cursor" as HarnessId,
+          model: { id: "cursor/auto", provider: "cursor" },
+          requireToolApproval: true,
+          hasSelectedMcpServers: true,
+        })
+      );
+      expect(approvalWithServers.ok).toBe(false);
+      if (!approvalWithServers.ok)
+        expect(approvalWithServers.kind).toBe("tool-approval");
+
+      // …but approval WITHOUT servers is fine: the native surface does pause.
+      expect(
+        checkHarnessRuntimeAvailable(
+          args({
+            harnessId: "cursor" as HarnessId,
+            model: { id: "cursor/auto", provider: "cursor" },
+            requireToolApproval: true,
+            hasSelectedMcpServers: false,
+          })
+        )
+      ).toEqual({ ok: true });
+    });
+
+    it("does not exempt a BROKERED harness from the model gate", () => {
+      // The exemption is keyed on `modelAccess`, not on "harness runs a CLI".
+      setFullyAvailable();
+      const r = checkHarnessRuntimeAvailable(
+        args({ model: { id: "cursor/auto", provider: "cursor" } })
+      );
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.kind).toBe("model-not-hosted");
+    });
+  });
 });
 
 /**

--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -825,22 +825,40 @@ describe("bootstrap recipes are auth-independent", () => {
       const ra = await a.getBootstrap!();
       const rb = await b.getBootstrap!();
 
+      // ORDER MATTERS, and it is the whole value of this block. Every value in
+      // `auth()` varies by suffix, so a leaked credential makes the two runs
+      // DIFFER — meaning the equality assertions below would throw first, on a
+      // multi-kilobyte tree diff, and a scan placed after them could never run.
+      // Scanned after the fact it is also unfalsifiable: if equality passed,
+      // the two runs are identical and no suffix-varying value can be present.
+      //
+      // So: scan first, each run against its OWN credentials, and name the
+      // VARIABLE rather than printing its value.
+      // `commands` is `{ command: string }[]`, not `string[]` — spreading it
+      // straight into the join stringifies each entry as "[object Object]" and
+      // makes the scan blind to command TEXT, which is exactly where a
+      // credential passed as an argument would sit.
+      const emitted = (r: typeof ra) =>
+        [
+          ...r.commands.map((c) => c.command),
+          ...r.files.map((f) => `${f.path}\n${f.content}`),
+        ].join("\n");
+      for (const [output, creds] of [
+        [emitted(ra), auth("one")],
+        [emitted(rb), auth("two")],
+      ] as const) {
+        for (const [name, value] of Object.entries(creds)) {
+          expect(output, `${id} bootstrap embeds ${name}`).not.toContain(value);
+        }
+      }
+
+      // The backstop: catches anything else that varies with auth, including a
+      // credential DERIVED into some form the literal scan above cannot see.
       // `hashBootstrap` is not exported, so compare exactly what it hashes.
       expect(rb.harnessId).toBe(ra.harnessId);
       expect(rb.bootstrapDir).toBe(ra.bootstrapDir);
       expect(rb.commands).toEqual(ra.commands);
       expect(rb.files).toEqual(ra.files);
-
-      // The equality above already implies this — a credential in the output
-      // would make the two runs differ — but state it directly so a failure
-      // says WHICH secret leaked instead of dumping two large file trees.
-      const emitted = [
-        ...ra.commands,
-        ...ra.files.map((f) => `${f.path}\n${f.content}`),
-      ].join("\n");
-      for (const value of Object.values(auth("one"))) {
-        expect(emitted, `${id} bootstrap embeds ${value}`).not.toContain(value);
-      }
     });
   }
 

--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -3,7 +3,9 @@ import { HARNESS_IDS } from "@mcpjam/sdk/host-config/internal";
 import { HARNESS_MCP_DELIVERY } from "@/shared/harness-mcp-delivery";
 import { createClaudeCode } from "@ai-sdk/harness-claude-code";
 import {
+  buildBrokerDummyAuth,
   getHarnessAdapter,
+  harnessUsesExternalAccount,
   isHarnessId,
   patchClaudeCodeHarnessBootstrap,
   registeredHarnessIds,
@@ -37,15 +39,35 @@ describe("harness registry", () => {
     // CI, for every registered adapter, before a turn is ever attempted.
     for (const id of registeredHarnessIds()) {
       const adapter = getHarnessAdapter(id);
-      // The two MCP delivery modes are mutually exclusive BY TYPE (the native
-      // arm requires `deliverMcpServers`, the host-executed arm forbids it), so
-      // this asserts the runtime shape matches the declared mode — the check
-      // the compiler makes for real adapters, made again for a hand-edited one.
+      // The MCP delivery arms are mutually exclusive BY TYPE (each native
+      // MECHANISM requires its own hook; the host-executed arm forbids them
+      // all), so this asserts the runtime shape matches the declared mode — the
+      // check the compiler makes for real adapters, made again for a
+      // hand-edited one.
       if (adapter.mcpDelivery === "native") {
-        expect(adapter.deliverMcpServers).toBeTypeOf("function");
+        if (adapter.mcpNativeDelivery === "sandbox-files") {
+          // Writes runtime config into the box before the process starts.
+          expect(adapter.deliverMcpServers).toBeTypeOf("function");
+        } else {
+          // The servers are a CONSTRUCTOR setting instead, so there must be
+          // nothing to write — a `session-config` adapter that also carried a
+          // sandbox write would deliver its servers twice.
+          expect(adapter.mcpNativeDelivery).toBe("session-config");
+          expect(adapter.deliverMcpServers).toBeUndefined();
+        }
       } else {
         expect(adapter.mcpDelivery).toBe("host-executed");
+        expect(adapter.mcpNativeDelivery).toBeUndefined();
         expect(adapter.deliverMcpServers).toBeUndefined();
+      }
+      // Model access is a required declaration, and an external-account adapter
+      // must NAME the credential it needs — otherwise the turn runner would
+      // start it with no auth and the failure would surface from inside the box.
+      expect(["broker", "external-account"]).toContain(adapter.modelAccess);
+      if (adapter.modelAccess === "external-account") {
+        expect(adapter.externalAccountCredentialEnv.length).toBeGreaterThan(0);
+      } else {
+        expect(adapter.externalAccountCredentialEnv).toBeUndefined();
       }
       if (adapter.supportsPluginBundles) {
         expect(adapter.deliverPluginBundles).toBeTypeOf("function");
@@ -71,32 +93,32 @@ describe("harness registry", () => {
     const { toNativeModel } = getHarnessAdapter("claude-code");
     expect(toNativeModel?.("anthropic/claude-haiku-4.5")).toBe("haiku");
     expect(toNativeModel?.("anthropic/claude-opus-4.7")).toBe(
-      "claude-opus-4-7"
+      "claude-opus-4-7",
     );
     expect(toNativeModel?.("anthropic/claude-opus-4-6")).toBe(
-      "claude-opus-4-6"
+      "claude-opus-4-6",
     );
     expect(toNativeModel?.("anthropic/claude-sonnet-4.6")).toBe(
-      "claude-sonnet-4-6"
+      "claude-sonnet-4-6",
     );
     expect(toNativeModel?.("anthropic/claude-sonnet-5")).toBe(
-      "claude-sonnet-5"
+      "claude-sonnet-5",
     );
     // Dated/pinned snapshot suffix (the exact shape Claude Code's own alias
     // resolution can produce on the wire — see the bridge's modelOverrides
     // keys) must still resolve to the haiku alias, not fall through to
     // undefined (which would silently drop the model pin).
     expect(toNativeModel?.("anthropic/claude-haiku-4-5-20251001")).toBe(
-      "haiku"
+      "haiku",
     );
     expect(toNativeModel?.("anthropic/claude-sonnet-4-5-20250929")).toBe(
-      "claude-sonnet-4-5"
+      "claude-sonnet-4-5",
     );
     // Major-only dated snapshot (no minor version between major and date):
     // the optional minor group's greedy digit match must not swallow the
     // date as if it were a minor version.
     expect(toNativeModel?.("anthropic/claude-opus-4-20250929")).toBe(
-      "claude-opus-4"
+      "claude-opus-4",
     );
     // A bare substring match must NOT route a non-Anthropic/malformed id to
     // Claude Code's haiku alias (the regex-gated shortcut, not a loose
@@ -213,7 +235,7 @@ const toUserMessage = (options) => ({
 
     const bootstrap = await harness.getBootstrap?.();
     const bridge = bootstrap?.files.find((file) =>
-      file.path.endsWith("/bridge.mjs")
+      file.path.endsWith("/bridge.mjs"),
     );
     // The adapter sets `parent_tool_use_id: null` on outbound user messages
     // ITSELF since the stable line; the patcher no longer injects it, it
@@ -228,7 +250,7 @@ const toUserMessage = (options) => ({
     // turn loop routes the terminal `result` message through it), gated on the
     // success subtype so an error result never masquerades as assistant text.
     expect(bridge?.content).toContain(
-      'type === "result" && msg.subtype === "success"'
+      'type === "result" && msg.subtype === "success"',
     );
     // Fallback text must open a step (mirroring the adapter's own
     // structured-output path) or the emitted parts are dropped, and its ids
@@ -243,7 +265,7 @@ const toUserMessage = (options) => ({
     // settings, spread last into the query options): injecting a bare
     // `settings` key earlier in the literal would be silently clobbered.
     expect(bridge?.content).toContain(
-      "settings: { ...(permissionOptions.settings ?? {})"
+      "settings: { ...(permissionOptions.settings ?? {})",
     );
     // Fallback dedup only suppresses an EXACT repeat of the immediately prior
     // fallback (e.g. msg.result echoing the last text block) — never a full
@@ -284,7 +306,7 @@ const toUserMessage = (options) => ({
     } as any);
 
     await expect(harness.getBootstrap?.()).rejects.toThrow(
-      "Unable to verify Claude Code bridge bootstrap: user-message shape changed"
+      "Unable to verify Claude Code bridge bootstrap: user-message shape changed",
     );
   });
 
@@ -297,25 +319,25 @@ const toUserMessage = (options) => ({
           AI_GATEWAY_API_KEY: "test",
           AI_GATEWAY_BASE_URL: "https://ai-gateway.vercel.sh/v1",
         },
-      }) as any
+      }) as any,
     );
 
     const bootstrap = await harness.getBootstrap?.();
     const bridge = bootstrap?.files.find((file) =>
-      file.path.endsWith("/bridge.mjs")
+      file.path.endsWith("/bridge.mjs"),
     );
     // The adapter's own user-message stamping (verified, no longer injected).
     expect(bridge?.content).toContain("parent_tool_use_id: null");
     expect(bridge?.content).toContain("emitAssistantTextFallback");
     expect(bridge?.content).toContain(
-      'type === "result" && msg.subtype === "success"'
+      'type === "result" && msg.subtype === "success"',
     );
     expect(bridge?.content).toContain("mcpjam-fallback-");
     expect(bridge?.content).toContain("gatewayModelOverrideSettingsFor");
     expect(bridge?.content).toContain("modelOverrides");
     expect(bridge?.content).toContain("claude-haiku-4-5-20251001");
     expect(bridge?.content).toContain(
-      "settings: { ...(permissionOptions.settings ?? {})"
+      "settings: { ...(permissionOptions.settings ?? {})",
     );
     // The effort-level compat knob is createClaudeCode `env` configuration
     // now, not a bridge-source rewrite (the installed bridge has no reference
@@ -331,15 +353,15 @@ const toUserMessage = (options) => ({
           AI_GATEWAY_API_KEY: "test",
           AI_GATEWAY_BASE_URL: "https://ai-gateway.vercel.sh/v1",
         },
-      }) as any
+      }) as any,
     );
 
     const bootstrap = await harness.getBootstrap?.();
     const npmrc = bootstrap?.files.find((file) =>
-      file.path.endsWith("/.npmrc")
+      file.path.endsWith("/.npmrc"),
     );
     const workspaces = bootstrap?.files.filter((file) =>
-      file.path.endsWith("/pnpm-workspace.yaml")
+      file.path.endsWith("/pnpm-workspace.yaml"),
     );
 
     // Without this, pnpm skips `@anthropic-ai/claude-code`'s postinstall and
@@ -359,11 +381,11 @@ const toUserMessage = (options) => ({
     // with conflicting content.
     expect(workspaces).toHaveLength(1);
     expect(workspaces?.[0]?.path).toBe(
-      `${bootstrap?.bootstrapDir}/pnpm-workspace.yaml`
+      `${bootstrap?.bootstrapDir}/pnpm-workspace.yaml`,
     );
     expect(workspaces?.[0]?.content).toContain("allowBuilds:");
     expect(workspaces?.[0]?.content).toMatch(
-      /'@anthropic-ai\/claude-code@[\d.]+': true/
+      /'@anthropic-ai\/claude-code@[\d.]+': true/,
     );
     expect(workspaces?.[0]?.content).not.toContain("dangerouslyAllowAllBuilds");
 
@@ -377,17 +399,17 @@ const toUserMessage = (options) => ({
     // rescue is present it must be guarded by the file check, so a missing
     // optional postinstall cannot make the bootstrap fail before `--version`.
     const installCommand = bootstrap?.commands.find((command) =>
-      command.command.includes("install.cjs")
+      command.command.includes("install.cjs"),
     );
     if (installCommand) {
       expect(installCommand.command).toContain(
-        "if [ -f node_modules/@anthropic-ai/claude-code/install.cjs ]; then"
+        "if [ -f node_modules/@anthropic-ai/claude-code/install.cjs ]; then",
       );
     }
     expect(
       bootstrap?.commands.some((command) =>
-        command.command.includes("claude --version")
-      )
+        command.command.includes("claude --version"),
+      ),
     ).toBe(true);
 
     // It has to sit BESIDE the adapter's manifest, not inside it: the install
@@ -395,15 +417,15 @@ const toUserMessage = (options) => ({
     // `onlyBuiltDependencies` would fail the lockfile check. Both halves of
     // that reasoning are pinned here so a future edit cannot quietly break one.
     const manifest = bootstrap?.files.find((file) =>
-      file.path.endsWith("/package.json")
+      file.path.endsWith("/package.json"),
     );
     if (manifest) {
       expect(JSON.parse(manifest.content).pnpm).toBeUndefined();
     }
     expect(
       bootstrap?.commands.some((command) =>
-        command.command.includes("--frozen-lockfile")
-      )
+        command.command.includes("--frozen-lockfile"),
+      ),
     ).toBe(true);
   });
 
@@ -412,8 +434,8 @@ const toUserMessage = (options) => ({
     expect(
       getHarnessAdapter("claude-code").parseToolName(
         "mcp__weather__forecast",
-        keyToServerId
-      )
+        keyToServerId,
+      ),
     ).toEqual({ serverId: "srv_123", toolName: "forecast" });
     // Codex used to pass these through verbatim (it had no MCP tools to name).
     // It now uses the SAME scheme — see the parity block below.
@@ -490,13 +512,13 @@ const toUserMessage = (options) => ({
       // here instead.
       for (const id of registeredHarnessIds()) {
         expect(getHarnessAdapter(id).mcpDelivery).toBe(
-          HARNESS_MCP_DELIVERY[id]
+          HARNESS_MCP_DELIVERY[id],
         );
       }
       // …and the shared map covers exactly the SDK's harness ids, so a new
       // harness cannot get an adapter without a delivery declaration.
       expect(Object.keys(HARNESS_MCP_DELIVERY).sort()).toEqual(
-        [...HARNESS_IDS].sort()
+        [...HARNESS_IDS].sort(),
       );
     });
   });
@@ -513,8 +535,8 @@ const toUserMessage = (options) => ({
         expect(
           getHarnessAdapter(id).parseToolName(
             "mcp__weather__get_forecast",
-            keyToServerId
-          )
+            keyToServerId,
+          ),
         ).toEqual({ serverId: "srv-weather", toolName: "get_forecast" });
       }
     });
@@ -522,7 +544,7 @@ const toUserMessage = (options) => ({
     it("a harness-native tool name keeps no server attribution", () => {
       for (const id of registeredHarnessIds()) {
         expect(
-          getHarnessAdapter(id).parseToolName("bash", keyToServerId)
+          getHarnessAdapter(id).parseToolName("bash", keyToServerId),
         ).toEqual({ toolName: "bash" });
       }
     });
@@ -530,7 +552,7 @@ const toUserMessage = (options) => ({
     it("an unknown server key is returned verbatim, never fabricated", () => {
       for (const id of registeredHarnessIds()) {
         expect(
-          getHarnessAdapter(id).parseToolName("mcp__ghost__do_thing", {})
+          getHarnessAdapter(id).parseToolName("mcp__ghost__do_thing", {}),
         ).toEqual({ toolName: "mcp__ghost__do_thing" });
       }
     });
@@ -578,6 +600,134 @@ const toUserMessage = (options) => ({
       const withSchema = list.filter((t) => t.inputSchema !== undefined);
       expect(withSchema.length).toBeGreaterThan(0);
     });
+  });
+});
+
+describe("cursor adapter (Cursor CLI / ACP)", () => {
+  const cursor = getHarnessAdapter("cursor");
+
+  it("constructs, and declares the external-account posture", () => {
+    expect(cursor.id).toBe("cursor");
+    // "Cursor CLI", not "Cursor": the emulated `cursor` host style is the IDE
+    // chat panel, and every preflight message a user reads comes from here.
+    expect(cursor.displayName).toBe("Cursor CLI");
+    expect(cursor.requiresComputer).toBe(true);
+    expect(cursor.modelAccess).toBe("external-account");
+    expect(harnessUsesExternalAccount("cursor")).toBe(true);
+    // The name the CLI itself reads (the adapter package declares the same one
+    // as its `credentialEnv`). A drift here is a turn started with no auth.
+    expect(cursor.externalAccountCredentialEnv).toEqual(["CURSOR_API_KEY"]);
+  });
+
+  it("delivers MCP natively, through the SESSION CONFIG rather than a file", () => {
+    // The MODE decides evidence capture (does the traffic cross MCPJam's
+    // proxy?) and must match the shared declaration the client reads; the
+    // MECHANISM decides how it is handed over. Both are asserted because they
+    // are separate facts that happen to travel together here.
+    expect(cursor.mcpDelivery).toBe("native");
+    expect(cursor.mcpDelivery).toBe(HARNESS_MCP_DELIVERY.cursor);
+    expect(cursor.mcpNativeDelivery).toBe("session-config");
+    expect(cursor.deliverMcpServers).toBeUndefined();
+  });
+
+  it("normalizes its builtin tool catalog without auth or a sandbox", () => {
+    const tools = cursor.listBuiltinTools();
+    // The ACP wrapper carries a static catalog, which is what lets the generic
+    // /v1/harness/:id/builtin-tools route work with no per-harness code.
+    expect(tools.length).toBeGreaterThan(20);
+    expect(tools.map((t) => t.key)).toContain("bash");
+    // Display-normalized: every entry has a name, and the list is sorted so the
+    // route's output is stable across processes.
+    expect(tools.every((t) => typeof t.name === "string" && t.name)).toBe(true);
+    expect(tools.map((t) => t.name)).toEqual(
+      [...tools.map((t) => t.name)].sort((a, b) => a.localeCompare(b)),
+    );
+  });
+
+  it("passes NO native model (Cursor Auto picks on the customer's account)", () => {
+    expect(
+      cursor.toNativeModel?.("anthropic/claude-sonnet-4.5"),
+    ).toBeUndefined();
+    expect(cursor.toNativeModel?.("cursor/auto")).toBeUndefined();
+  });
+
+  it("declares the approval posture it can actually keep", () => {
+    // Verified against a live cursor-agent: the ACP bridge pauses on its own
+    // built-ins under "allow-reads".
+    expect(cursor.supportsNativeToolApproval).toBe(true);
+    expect(cursor.approvalPermissionMode).toBe("allow-reads");
+    // NOT claimed, pending a live MCP-approval measurement. False means an
+    // approval host with servers attached is REFUSED at preflight rather than
+    // run with some MCP calls unapproved — the conservative direction, and the
+    // one this flag exists to protect.
+    expect(cursor.supportsMcpToolApproval).toBe(false);
+    expect(cursor.supportsHostExecutedToolApproval).toBe(false);
+  });
+
+  it("constructs a harness from the MCP json it is handed", () => {
+    // The `session-config` arm's signature REQUIRES mcpJson, so this is also
+    // the compile-time proof that the config cannot be dropped at construction.
+    const runtime = cursor.createHarness({
+      modelId: "cursor/auto",
+      auth: { CURSOR_API_KEY: "sk-test" },
+      mcpJson: {
+        mcpServers: {
+          weather: { type: "http", url: "https://proxy.example/weather" },
+        },
+      },
+    });
+    expect(runtime.harnessId).toBe("cursor");
+  });
+
+  it("names a runtime-version command (its CLI is NOT pinned by the package pin)", () => {
+    // The bootstrap installs via `curl https://cursor.com/install | bash`,
+    // which always fetches the current build — so what ran is only knowable by
+    // asking the box. The other two adapters bootstrap a pinned npm package and
+    // correctly declare nothing.
+    expect(cursor.runtimeVersionCommand?.("/home/user")).toContain("--version");
+    expect(
+      getHarnessAdapter("claude-code").runtimeVersionCommand,
+    ).toBeUndefined();
+    expect(getHarnessAdapter("codex").runtimeVersionCommand).toBeUndefined();
+  });
+});
+
+describe("buildBrokerDummyAuth", () => {
+  it("gives each brokered harness its own credential shape", () => {
+    const claude = buildBrokerDummyAuth("claude-code", "https://proxy.example");
+    expect(claude.ANTHROPIC_BASE_URL).toBe("https://proxy.example");
+    expect(claude.ANTHROPIC_AUTH_TOKEN).toBeTruthy();
+    // Deliberately absent, not empty: the adapter keys its credential-forwarding
+    // transforms off which variables are PRESENT.
+    expect(claude.ANTHROPIC_API_KEY).toBeUndefined();
+
+    const codex = buildBrokerDummyAuth("codex", "https://proxy.example");
+    expect(codex.OPENAI_BASE_URL).toBe("https://proxy.example");
+    expect(codex.CODEX_API_KEY).toBeTruthy();
+  });
+
+  it("THROWS for an external-account harness rather than defaulting", () => {
+    // This was a fallthrough `if (codex) … else Anthropic`, so a cursor id would
+    // have silently received Claude Code's ANTHROPIC_* environment — a dummy
+    // token and a base URL for a proxy it never talks to, failing later and
+    // opaquely from inside the box. Asking for broker auth here is a caller bug
+    // and now says so.
+    expect(() =>
+      buildBrokerDummyAuth("cursor", "https://proxy.example"),
+    ).toThrow(/external-account|does not|no broker|takes no/i);
+  });
+
+  it("covers every brokered harness in the registry", () => {
+    // Exhaustiveness at runtime as well as in the type: a brokered harness
+    // added without a credential shape would throw the `default` branch's
+    // error, which this would catch.
+    for (const id of registeredHarnessIds()) {
+      const adapter = getHarnessAdapter(id);
+      if (adapter.modelAccess === "external-account") continue;
+      expect(
+        Object.keys(buildBrokerDummyAuth(id, "https://proxy.example")).length,
+      ).toBeGreaterThan(0);
+    }
   });
 });
 

--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -784,6 +784,11 @@ describe("bootstrap recipes are auth-independent", () => {
     ANTHROPIC_BASE_URL: `https://${suffix}.invalid`,
     CODEX_API_KEY: `openai-key-${suffix}`,
     OPENAI_BASE_URL: `https://${suffix}.invalid`,
+    // Cursor's credential varies too, or the cursor arm of the loop below
+    // compares two runs handed the SAME value — which cannot detect a
+    // `CURSOR_API_KEY` written into a bootstrap file, the one leak the
+    // external-account harness makes possible.
+    CURSOR_API_KEY: `cursor-key-${suffix}`,
   });
 
   /**
@@ -825,6 +830,17 @@ describe("bootstrap recipes are auth-independent", () => {
       expect(rb.bootstrapDir).toBe(ra.bootstrapDir);
       expect(rb.commands).toEqual(ra.commands);
       expect(rb.files).toEqual(ra.files);
+
+      // The equality above already implies this — a credential in the output
+      // would make the two runs differ — but state it directly so a failure
+      // says WHICH secret leaked instead of dumping two large file trees.
+      const emitted = [
+        ...ra.commands,
+        ...ra.files.map((f) => `${f.path}\n${f.content}`),
+      ].join("\n");
+      for (const value of Object.values(auth("one"))) {
+        expect(emitted, `${id} bootstrap embeds ${value}`).not.toContain(value);
+      }
     });
   }
 

--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -679,6 +679,43 @@ describe("cursor adapter (Cursor CLI / ACP)", () => {
     expect(runtime.harnessId).toBe("cursor");
   });
 
+  it("shell-quotes the workdir so a metacharacter path cannot execute", () => {
+    // The workdir is host-configured. `resolveWorkingDirectory` confines it to
+    // /home/user but does NOT reject shell metacharacters, so this command is
+    // the injection surface: it is built as a string and handed to a shell in
+    // the box during session setup.
+    //
+    // These assert the EMITTED BYTES, not the intent. The first version of this
+    // used a template literal — where `\'` is just `'`, so the escape silently
+    // collapsed to three quotes, closing the quoted word and leaving the rest
+    // of the path unquoted. It read correctly and did nothing.
+    const cmd = (dir: string) =>
+      getHarnessAdapter("cursor").runtimeVersionCommand!(dir);
+
+    // A plain path is wrapped in single quotes and otherwise untouched.
+    expect(cmd("/home/user")).toBe(
+      "'/home/user/.harness-bootstrap/cursor/implementation/home/.local/bin/agent' --version",
+    );
+
+    // Command substitution stays INSIDE the quotes, so the shell never runs it.
+    for (const dangerous of [
+      "/home/user/$(id)",
+      "/home/user/`id`",
+      "/home/user/$IFS",
+    ]) {
+      const out = cmd(dangerous);
+      expect(out.startsWith("'" + dangerous + "/")).toBe(true);
+      // Balanced quoting, and nothing outside it but the flag.
+      expect(out.endsWith("agent' --version")).toBe(true);
+      expect((out.match(/'/g) ?? []).length % 2).toBe(0);
+    }
+
+    // An apostrophe is closed, escaped and reopened — never three bare quotes.
+    const withQuote = cmd("/home/user/it's");
+    expect(withQuote).toContain("it'\\''s");
+    expect(withQuote).not.toContain("it'''s");
+  });
+
   it("names a runtime-version command (its CLI is NOT pinned by the package pin)", () => {
     // The bootstrap installs via `curl https://cursor.com/install | bash`,
     // which always fetches the current build — so what ran is only knowable by
@@ -749,19 +786,36 @@ describe("bootstrap recipes are auth-independent", () => {
     OPENAI_BASE_URL: `https://${suffix}.invalid`,
   });
 
-  for (const id of ["claude-code", "codex"] as const) {
+  /**
+   * Construct any adapter, satisfying whichever arm it declares.
+   *
+   * Mirrors the narrowing `runHarnessTurn` does at its own construction site:
+   * a `session-config` adapter's `createHarness` REQUIRES `mcpJson`, so a test
+   * that called every adapter with the same argument shape would not typecheck
+   * — which is the invariant doing its job, not an obstacle to route around.
+   */
+  const makeHarness = (
+    adapter: ReturnType<typeof getHarnessAdapter>,
+    args: { modelId: string; auth: ReturnType<typeof auth> },
+  ) =>
+    adapter.mcpDelivery === "native" &&
+    adapter.mcpNativeDelivery === "session-config"
+      ? adapter.createHarness({ ...args, mcpJson: { mcpServers: {} } })
+      : adapter.createHarness(args);
+
+  // cursor included: its bootstrap fetches the CLI with `curl … | bash`, so an
+  // auth-dependent recipe there would re-run that install on every resume.
+  for (const id of ["claude-code", "codex", "cursor"] as const) {
     it(`${id}: two different credentials produce byte-identical files`, async () => {
       const adapter = getHarnessAdapter(id);
-      const a = adapter.createHarness({
-        modelId:
-          id === "codex" ? "openai/gpt-5-nano" : "anthropic/claude-haiku-4.5",
-        auth: auth("one"),
-      });
-      const b = adapter.createHarness({
-        modelId:
-          id === "codex" ? "openai/gpt-5-nano" : "anthropic/claude-haiku-4.5",
-        auth: auth("two"),
-      });
+      const modelId =
+        id === "codex"
+          ? "openai/gpt-5-nano"
+          : id === "cursor"
+          ? "cursor/auto"
+          : "anthropic/claude-haiku-4.5";
+      const a = makeHarness(adapter, { modelId, auth: auth("one") });
+      const b = makeHarness(adapter, { modelId, auth: auth("two") });
 
       const ra = await a.getBootstrap!();
       const rb = await b.getBootstrap!();
@@ -780,7 +834,7 @@ describe("bootstrap recipes are auth-independent", () => {
     // different hash than the turn does. This test is what makes that
     // divergence visible if anyone reaches for the bare constructor.
     // Dual-`ai` boundary cast, as everywhere else this constructor is used.
-    const patched = getHarnessAdapter("claude-code").createHarness({
+    const patched = makeHarness(getHarnessAdapter("claude-code"), {
       modelId: "anthropic/claude-haiku-4.5",
       auth: auth("patched"),
     });

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-external-account.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-external-account.test.ts
@@ -1,0 +1,324 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelMessage } from "@ai-sdk/provider-utils";
+
+/**
+ * The EXTERNAL-ACCOUNT turn path: a harness that authenticates on the
+ * customer's own account with the runtime vendor (Cursor), so MCPJam mints no
+ * lease and holds no model credential.
+ *
+ * Four things separate it from a brokered turn, and each is a way the turn can
+ * be silently wrong rather than loudly broken:
+ *   - the broker start is SKIPPED (a lease would install MCPJam's credential
+ *     into the egress transform for spend MCPJam is not billed for);
+ *   - the box reservation is HELD for the whole turn (nothing else takes over
+ *     the per-box fence, because there is no lease to do it);
+ *   - the credential comes OUT of the box's session env bag and goes to the
+ *     adapter directly;
+ *   - a missing credential is refused up front instead of defaulted.
+ */
+
+const harnessState = vi.hoisted(() => ({
+  finalText: "done",
+  session: {
+    sessionId: "session-1",
+    stop: vi.fn(async () => ({})),
+    destroy: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock("@ai-sdk/harness/agent", () => ({
+  HarnessAgent: class {
+    createSession = vi.fn(async () => harnessState.session);
+    stream = vi.fn(async () => ({
+      fullStream: (async function* () {
+        yield { type: "finish", finishReason: "stop" };
+      })(),
+      text: Promise.resolve(harnessState.finalText),
+    }));
+  },
+  collectHarnessAgentToolApprovalContinuations: vi.fn(() => []),
+}));
+
+const registryState = vi.hoisted(() => ({
+  createHarness: vi.fn(() => ({ harnessId: "cursor" })),
+}));
+
+vi.mock("../registry.js", () => ({
+  buildBrokerDummyAuth: vi.fn(() => {
+    throw new Error(
+      "buildBrokerDummyAuth must not be called for an external-account harness",
+    );
+  }),
+  getHarnessAdapter: vi.fn(() => ({
+    id: "cursor",
+    displayName: "Cursor CLI",
+    defaultPermissionMode: "allow-all",
+    approvalPermissionMode: "allow-reads",
+    supportsNativeToolApproval: true,
+    supportsMcpToolApproval: false,
+    supportsHostExecutedToolApproval: false,
+    supportsSkills: false,
+    supportsPluginBundles: false,
+    requiresComputer: true,
+    modelAccess: "external-account",
+    externalAccountCredentialEnv: ["CURSOR_API_KEY"],
+    mcpDelivery: "native",
+    mcpNativeDelivery: "session-config",
+    // Never consulted on this path — declared so a regression that starts
+    // consulting it is visible rather than silently permissive.
+    supportsModel: vi.fn(() => false),
+    createHarness: registryState.createHarness,
+    parseToolName: vi.fn((toolName: string) => ({ toolName })),
+  })),
+}));
+
+vi.mock("../resolve-sandbox.js", () => ({
+  resolveHarnessSandbox: vi.fn(async () => ({
+    computerId: "computer-1",
+    sandboxId: "sandbox-1",
+  })),
+}));
+
+const providerState = vi.hoisted(() => ({
+  lastArgs: undefined as Record<string, unknown> | undefined,
+}));
+
+vi.mock("../e2b-sandbox-provider.js", () => ({
+  createE2BHarnessSandboxProvider: vi.fn((args: Record<string, unknown>) => {
+    providerState.lastArgs = args;
+    return { sandboxId: "sandbox-1" };
+  }),
+}));
+
+vi.mock("../runtime-skills.js", () => ({
+  frontmatterSafeSkills: vi.fn((skills) => skills),
+  fetchRuntimeSkills: vi.fn(async () => ({ ok: true, skills: [] })),
+  skillsFingerprint: vi.fn(() => "empty-skills"),
+}));
+
+vi.mock("../reconcile-skill-dirs.js", () => ({
+  reconcileSkillDirs: vi.fn(async () => {}),
+}));
+
+vi.mock("../harness-session-state.js", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../harness-session-state.js")
+  >();
+  return {
+    ...actual,
+    claimHarnessSessionState: vi.fn(async () => ({
+      ok: true,
+      leaseId: "lease-1",
+      stateVersion: 1,
+      state: null,
+      fingerprintChanged: false,
+    })),
+    commitHarnessSessionState: vi.fn(async () => true),
+    heartbeatHarnessSessionState: vi.fn(async () => "ok"),
+    releaseHarnessSessionState: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../harness-model-broker.js", () => ({
+  reserveHarnessBox: vi.fn(async () => ({ ok: true })),
+  releaseHarnessBoxReservation: vi.fn(async () => ({ ok: true })),
+  renewHarnessBoxReservation: vi.fn(async () => ({ ok: true })),
+  revokeHarnessModelBroker: vi.fn(async () => {}),
+  startHarnessModelBroker: vi.fn(async () => ({
+    ok: true,
+    proxyBaseUrl: "https://broker.example",
+  })),
+}));
+
+vi.mock("../mcp-config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../mcp-config.js")>();
+  return {
+    ...actual,
+    buildHarnessMcpJson: vi.fn(() => ({ mcpServers: {} })),
+    harnessServerInputFromConfig: vi.fn(),
+    harnessServerKeyToName: vi.fn((key: string) => key),
+  };
+});
+
+import { runHarnessTurn } from "../run-harness-turn";
+import {
+  releaseHarnessBoxReservation,
+  reserveHarnessBox,
+  revokeHarnessModelBroker,
+  startHarnessModelBroker,
+} from "../harness-model-broker.js";
+import { EXTERNAL_ACCOUNT_PLAN_WALL_TEXTS } from "../external-account-plan-wall";
+
+const CURSOR_KEY = {
+  name: "CURSOR_API_KEY",
+  value: "key_live_abc",
+  updatedAt: 1,
+};
+const OTHER_SECRET = {
+  name: "STRIPE_API_KEY",
+  value: "sk_test_123",
+  updatedAt: 1,
+};
+
+function baseOptions(overrides: Record<string, unknown> = {}) {
+  const messages: ModelMessage[] = [
+    {
+      role: "user",
+      content: [{ type: "text", text: "hi" }],
+    } as unknown as ModelMessage,
+  ];
+  return {
+    messages,
+    modelId: "cursor/auto",
+    provider: "cursor",
+    systemPrompt: "You are a coding agent.",
+    authHeader: "Bearer test",
+    projectId: "project-1",
+    mcpClientManager: { getServerConfig: vi.fn() },
+    selectedServers: [],
+    requireToolApproval: false,
+    sourceType: "eval",
+    harness: "cursor",
+    runtimeSecrets: [CURSOR_KEY, OTHER_SECRET],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  harnessState.finalText = "done";
+  providerState.lastArgs = undefined;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response("{}", { status: 200 })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.mocked(startHarnessModelBroker).mockClear();
+  vi.mocked(reserveHarnessBox).mockClear();
+  vi.mocked(releaseHarnessBoxReservation).mockClear();
+  vi.mocked(revokeHarnessModelBroker).mockClear();
+  registryState.createHarness.mockClear();
+});
+
+describe("runHarnessTurn — external-account credential path", () => {
+  it("skips the broker entirely and hands the customer's key to the adapter", async () => {
+    const onEngineError = vi.fn();
+    await runHarnessTurn(baseOptions({ onEngineError }) as never, "none");
+
+    expect(onEngineError).not.toHaveBeenCalled();
+    // No lease minted, and therefore nothing to revoke at teardown.
+    expect(startHarnessModelBroker).not.toHaveBeenCalled();
+    expect(revokeHarnessModelBroker).not.toHaveBeenCalled();
+    // …but the box IS still claimed: the CLI runs inside it, so the same
+    // preparation race a brokered turn closes applies here too.
+    expect(reserveHarnessBox).toHaveBeenCalledTimes(1);
+
+    const args = registryState.createHarness.mock.calls[0]![0] as unknown as {
+      auth: Record<string, string>;
+      mcpJson: unknown;
+    };
+    expect(args.auth).toEqual({ CURSOR_API_KEY: CURSOR_KEY.value });
+    // The `session-config` arm's signature requires it; assert it actually
+    // arrives, since a turn constructed without it is silently tool-less.
+    expect(args.mcpJson).toBeDefined();
+  });
+
+  it("takes the credential OUT of the box's session env, keeping the others", async () => {
+    await runHarnessTurn(baseOptions() as never, "none");
+
+    const sessionEnv = providerState.lastArgs?.sessionEnv as
+      | Record<string, string>
+      | undefined;
+    // Reduces exposure to every OTHER command the agent shells out to in the
+    // box. The Cursor process itself still receives it — that is how the CLI
+    // authenticates — so this is a narrowing, not a removal.
+    expect(sessionEnv).toBeDefined();
+    expect(sessionEnv).not.toHaveProperty("CURSOR_API_KEY");
+    expect(sessionEnv).toHaveProperty("STRIPE_API_KEY", OTHER_SECRET.value);
+  });
+
+  it("stamps delivery even when the credential is the project's ONLY secret", async () => {
+    // The bag is empty in that case, so the provider's `onSessionEnvUsed` can
+    // never fire and nothing else would record the delivery — making a live
+    // credential read as dormant to whoever is deciding if it is safe to delete.
+    const onSecretEnvDelivered = vi.fn();
+    await runHarnessTurn(
+      baseOptions({
+        runtimeSecrets: [CURSOR_KEY],
+        onSecretEnvDelivered,
+      }) as never,
+      "none",
+    );
+    expect(onSecretEnvDelivered).toHaveBeenCalled();
+  });
+
+  it("refuses up front when the credential secret is missing", async () => {
+    const onEngineError = vi.fn();
+    await runHarnessTurn(
+      baseOptions({ runtimeSecrets: [OTHER_SECRET], onEngineError }) as never,
+      "none",
+    );
+
+    expect(onEngineError).toHaveBeenCalledTimes(1);
+    const err = onEngineError.mock.calls[0]![0] as { message: string };
+    // Preflight-shaped copy: names the variable AND where to set it.
+    expect(err.message).toContain("CURSOR_API_KEY");
+    expect(err.message).toMatch(/Project Settings/i);
+    expect(err.message).toContain("Cursor CLI");
+    // Never defaulted to an empty or absent credential.
+    expect(registryState.createHarness).not.toHaveBeenCalled();
+    expect(startHarnessModelBroker).not.toHaveBeenCalled();
+  });
+
+  it("refuses when NO secrets were wired at all (not just the wrong one)", async () => {
+    const onEngineError = vi.fn();
+    await runHarnessTurn(
+      baseOptions({ runtimeSecrets: undefined, onEngineError }) as never,
+      "none",
+    );
+    expect(onEngineError).toHaveBeenCalledTimes(1);
+    expect(
+      (onEngineError.mock.calls[0]![0] as { message: string }).message,
+    ).toContain("CURSOR_API_KEY");
+  });
+
+  it("hands the box back at teardown (the claim is held, not leaked)", async () => {
+    // Nothing consumes the reservation on this path — no lease is minted — so
+    // the turn's own teardown is the only thing that can release it. A leak
+    // here makes the next Cursor turn wait out the TTL for an idle box.
+    await runHarnessTurn(baseOptions() as never, "none");
+    expect(releaseHarnessBoxReservation).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs with broker delivery killed — it has no broker to disable", async () => {
+    vi.stubEnv("MCPJAM_HARNESS_BROKER_DELIVERY", "false");
+    const onEngineError = vi.fn();
+    await runHarnessTurn(baseOptions({ onEngineError }) as never, "none");
+    expect(onEngineError).not.toHaveBeenCalled();
+    expect(registryState.createHarness).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails the turn on an entitlement wall instead of persisting it as an answer", async () => {
+    // Cursor answers a plan-gated request with a normal, successful-looking
+    // turn. Left alone, chat persists that as the assistant's answer and an
+    // eval SCORES it — a verdict about a model that never ran.
+    harnessState.finalText = EXTERNAL_ACCOUNT_PLAN_WALL_TEXTS[0]!;
+    const onEngineError = vi.fn();
+    await runHarnessTurn(baseOptions({ onEngineError }) as never, "none");
+
+    expect(onEngineError).toHaveBeenCalledTimes(1);
+    const err = onEngineError.mock.calls[0]![0] as { message: string };
+    expect(err.message).toMatch(/entitlement/i);
+    expect(err.message).toContain("CURSOR_API_KEY");
+  });
+
+  it("does NOT fail a turn that merely quotes the wall text", async () => {
+    harnessState.finalText = `The CLI said "${EXTERNAL_ACCOUNT_PLAN_WALL_TEXTS[0]}" — you may need a different plan.`;
+    const onEngineError = vi.fn();
+    await runHarnessTurn(baseOptions({ onEngineError }) as never, "none");
+    expect(onEngineError).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-external-account.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-external-account.test.ts
@@ -23,12 +23,30 @@ const harnessState = vi.hoisted(() => ({
     sessionId: "session-1",
     stop: vi.fn(async () => ({})),
     destroy: vi.fn(async () => {}),
+    // The file-capable sandbox session the turn's `onSandboxSession` receives.
+    writeTextFile: vi.fn(async () => {}),
+    readTextFile: vi.fn(async () => null),
+    run: vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" })),
   },
 }));
 
 vi.mock("@ai-sdk/harness/agent", () => ({
   HarnessAgent: class {
-    createSession = vi.fn(async () => harnessState.session);
+    // The real agent invokes `onSandboxSession` when it opens the box, BEFORE
+    // the runtime process starts. The turn hangs real work off that hook (MCP
+    // delivery, the credential delivery stamp, the version canary), so a double
+    // that skipped it would silently not exercise any of it.
+    constructor(private readonly opts: Record<string, unknown>) {}
+    createSession = vi.fn(async () => {
+      const onSandboxSession = this.opts.onSandboxSession as
+        | ((a: { session: unknown; sessionWorkDir: string }) => Promise<void>)
+        | undefined;
+      await onSandboxSession?.({
+        session: harnessState.session,
+        sessionWorkDir: "/home/user",
+      });
+      return harnessState.session;
+    });
     stream = vi.fn(async () => ({
       fullStream: (async function* () {
         yield { type: "finish", finishReason: "stop" };
@@ -134,8 +152,9 @@ vi.mock("../mcp-config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../mcp-config.js")>();
   return {
     ...actual,
-    buildHarnessMcpJson: vi.fn(() => ({ mcpServers: {} })),
-    harnessServerInputFromConfig: vi.fn(),
+    // Only what the turn actually imports. `buildHarnessProxyMcpJson` is
+    // deliberately NOT stubbed — it comes through from the real module, so the
+    // mcpJson handed to `createHarness` below is the genuinely built object.
     harnessServerKeyToName: vi.fn((key: string) => key),
   };
 });

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-tool-policy.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-tool-policy.test.ts
@@ -50,7 +50,12 @@ vi.mock("../registry.js", () => ({
     displayName: "Claude Code",
     defaultPermissionMode: "allow-all",
     supportsSkills: false,
+    modelAccess: "broker",
     mcpDelivery: "native",
+    // The mechanism, not just the mode: `deliverMcpServers` is only reached on
+    // the `sandbox-files` arm, so a double without this would silently exercise
+    // a path the real Claude Code adapter never takes.
+    mcpNativeDelivery: "sandbox-files",
     deliverMcpServers: vi.fn(async () => {}),
     supportsModel: vi.fn(() => true),
     createHarness: vi.fn(() => ({ harnessId: "claude-code" })),
@@ -191,7 +196,7 @@ describe("runHarnessTurn tool-policy accounting", () => {
     // Policied hosted runs refuse without a usable seal secret.
     vi.stubEnv(
       "COMPUTERS_TERMINAL_TOKEN_SECRET",
-      "test-harness-proxy-secret-32-chars"
+      "test-harness-proxy-secret-32-chars",
     );
     harnessState.finalText = "I could not delete the repo.";
     harnessState.session.stop.mockClear();
@@ -205,7 +210,7 @@ describe("runHarnessTurn tool-policy accounting", () => {
   it("records a block from the adapter's flattened block text, and keeps it off the tool paths", async () => {
     harnessState.streamParts = toolCallParts(
       "mcp__srv-a__delete_repo",
-      "Call blocked by tool policy: denyList"
+      "Call blocked by tool policy: denyList",
     );
     const blocks: HarnessPolicyBlockRecord[] = [];
     const onToolResult = vi.fn(async () => {});
@@ -217,7 +222,7 @@ describe("runHarnessTurn tool-policy accounting", () => {
           blocks.push(...records);
         },
       }) as any,
-      "none"
+      "none",
     );
 
     expect(blocks).toHaveLength(1);
@@ -233,14 +238,14 @@ describe("runHarnessTurn tool-policy accounting", () => {
     // `blockedByPolicy`.
     expect(onToolResult).not.toHaveBeenCalled();
     expect(
-      (result.trace?.spans ?? []).some((span) => span.category === "tool")
+      (result.trace?.spans ?? []).some((span) => span.category === "tool"),
     ).toBe(false);
   });
 
   it("leaves an ordinary result alone", async () => {
     harnessState.streamParts = toolCallParts(
       "mcp__srv-a__read_file",
-      "file contents"
+      "file contents",
     );
     const blocks: HarnessPolicyBlockRecord[] = [];
     const onToolResult = vi.fn(async () => {});
@@ -252,7 +257,7 @@ describe("runHarnessTurn tool-policy accounting", () => {
           blocks.push(...records);
         },
       }) as any,
-      "none"
+      "none",
     );
 
     expect(blocks).toEqual([]);
@@ -264,7 +269,7 @@ describe("runHarnessTurn tool-policy accounting", () => {
     // matcher: the verdict comes from the sealed snapshot, never the payload.
     harnessState.streamParts = toolCallParts(
       "mcp__srv-a__read_file",
-      "Call blocked by tool policy: denyList"
+      "Call blocked by tool policy: denyList",
     );
     const blocks: HarnessPolicyBlockRecord[] = [];
     const onToolResult = vi.fn(async () => {});
@@ -276,7 +281,7 @@ describe("runHarnessTurn tool-policy accounting", () => {
           blocks.push(...records);
         },
       }) as any,
-      "none"
+      "none",
     );
 
     expect(blocks).toEqual([]);

--- a/mcpjam-inspector/server/utils/harness/__tests__/runtime-skills.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/runtime-skills.test.ts
@@ -21,6 +21,7 @@ import {
   frontmatterSafeSkills,
   prepareClaudeCodeSkills,
   prepareCodexSkills,
+  prepareNoSkills,
   toYamlDoubleQuoted,
   type RuntimeSkill,
 } from "../runtime-skills";
@@ -53,7 +54,7 @@ describe("fetchRuntimeSkills (tri-state)", () => {
 
   it("returns { ok: false } on failure — NEVER [] (so callers don't wipe/churn)", async () => {
     vi.mocked(convexListSkillsForRuntime).mockRejectedValue(
-      new Error("convex down")
+      new Error("convex down"),
     );
     const res = await fetchRuntimeSkills("Bearer x", "proj_1");
     expect(res).toEqual({ ok: false });
@@ -71,7 +72,7 @@ describe("fetchRuntimeSkills (tri-state)", () => {
     const res = await fetchRuntimeSkills("Bearer x", "proj_1");
     expect(convexListSkillsForRuntime).toHaveBeenCalledWith(
       "Bearer x",
-      "proj_1"
+      "proj_1",
     );
     expect(convexListSkillsForRuntimeExecution).not.toHaveBeenCalled();
     expect(res).toEqual({ ok: true, skills: [skill({ skillId: "s1" })] });
@@ -91,7 +92,7 @@ describe("fetchRuntimeSkills (tri-state)", () => {
     const res = await fetchRuntimeSkills("Bearer x", "proj_1", scope);
     expect(convexListSkillsForRuntimeExecution).toHaveBeenCalledWith(
       "Bearer x",
-      scope
+      scope,
     );
     expect(convexListSkillsForRuntime).not.toHaveBeenCalled();
     expect(res).toEqual({ ok: true, skills: [skill({ skillId: "s2" })] });
@@ -107,7 +108,7 @@ describe("fetchRuntimeSkillFiles (tri-state)", () => {
 
   it("returns { ok: false } on failure — NEVER [] (so the caller skips prune)", async () => {
     vi.mocked(convexListSkillFilesForRuntime).mockRejectedValue(
-      new Error("convex down")
+      new Error("convex down"),
     );
     const res = await fetchRuntimeSkillFiles("Bearer x", "proj_1");
     // Critically distinct from { ok: true, files: [] } — an empty set on a
@@ -138,13 +139,13 @@ describe("skillsFingerprint", () => {
     const one = [skill({ skillId: "s1", aggregateHash: "a", name: "pdf" })];
     const base = skillsFingerprint(one);
     expect(
-      skillsFingerprint([skill({ skillId: "s1", aggregateHash: "b" })])
+      skillsFingerprint([skill({ skillId: "s1", aggregateHash: "b" })]),
     ).not.toBe(base); // edit
     expect(
-      skillsFingerprint([...one, skill({ skillId: "s2", aggregateHash: "c" })])
+      skillsFingerprint([...one, skill({ skillId: "s2", aggregateHash: "c" })]),
     ).not.toBe(base); // add
     expect(
-      skillsFingerprint([skill({ skillId: "s1", name: "renamed" })])
+      skillsFingerprint([skill({ skillId: "s1", name: "renamed" })]),
     ).not.toBe(base); // rename
     expect(skillsFingerprint([])).not.toBe(base); // delete
   });
@@ -171,8 +172,8 @@ describe("toPinnableSkill", () => {
           content: "body",
           aggregateHash: "agg",
           provenance: "computer-adopted",
-        })
-      )
+        }),
+      ),
     ).toEqual({
       name: "pdf",
       description: "Process PDFs",
@@ -184,12 +185,12 @@ describe("toPinnableSkill", () => {
 
   it("defaults an absent/unknown provenance to 'authored'", () => {
     expect(toPinnableSkill(skill({ skillId: "s1" })).provenance).toBe(
-      "authored"
+      "authored",
     );
     expect(
       toPinnableSkill(
-        skill({ skillId: "s1", provenance: "future-value" as never })
-      ).provenance
+        skill({ skillId: "s1", provenance: "future-value" as never }),
+      ).provenance,
     ).toBe("authored");
   });
 });
@@ -262,5 +263,33 @@ describe("prepareSkills (per-adapter delivery shaping)", () => {
       { name: "..", reason: "invalid-skill-name" },
       { name: "Bad Name!", reason: "invalid-skill-name" },
     ]);
+  });
+});
+
+describe("prepareNoSkills", () => {
+  // The Cursor adapter ships `supportsSkills: false`, so `runHarnessTurn` never
+  // calls this. It is tested anyway because the guard is the only thing keeping
+  // it unreachable — if that guard ever moves, this must still be honest rather
+  // than silently claiming a delivery the runtime does not perform.
+  it("delivers nothing and reports every skill as skipped", () => {
+    const result = prepareNoSkills([
+      skill({ skillId: "sk-alpha", name: "alpha" }),
+      skill({ skillId: "sk-beta", name: "beta" }),
+    ]);
+    expect(result.payload).toEqual([]);
+    expect(result.delivered).toEqual([]);
+    expect(result.skipped).toEqual([
+      { name: "alpha", reason: "harness-does-not-deliver-skills" },
+      { name: "beta", reason: "harness-does-not-deliver-skills" },
+    ]);
+  });
+
+  it("is empty in all three fields for an empty input", () => {
+    // The "nothing to deliver" case must not read as "something was skipped".
+    expect(prepareNoSkills([])).toEqual({
+      payload: [],
+      delivered: [],
+      skipped: [],
+    });
   });
 });

--- a/mcpjam-inspector/server/utils/harness/external-account-plan-wall.ts
+++ b/mcpjam-inspector/server/utils/harness/external-account-plan-wall.ts
@@ -1,0 +1,96 @@
+/**
+ * Detect the ENTITLEMENT WALL an external-account harness answers with instead
+ * of failing.
+ *
+ * THE PROBLEM. A brokered harness that cannot run a model errors: the lease is
+ * refused, the proxy rejects the request, something throws, and the turn is
+ * visibly unsuccessful. An external-account harness has no such seam. Cursor
+ * routes every request through the customer's own account, and when that
+ * account's plan does not cover what was asked for, the CLI does not error —
+ * it completes a perfectly normal turn whose entire assistant answer is
+ * "Upgrade your plan to continue", with `end_turn` and no tools called
+ * (observed verbatim during the harness spike).
+ *
+ * Left alone that is the worst possible shape: chat persists it as the
+ * assistant's answer, and an eval SCORES it — a judge reading "Upgrade your
+ * plan to continue" against a rubric produces a real-looking failure (or, for a
+ * lenient rubric, a pass) for a turn where the model never ran at all. The
+ * run's own result becomes evidence about a model that was never asked.
+ *
+ * THE RULE. Deliberately conservative, because a false positive is worse than a
+ * miss: a miss records a bad turn, a false positive DELETES a real answer the
+ * customer paid for. All three conditions must hold:
+ *
+ *   1. the turn's normalized assistant text EQUALS a known wall string — never
+ *      `includes`, so an assistant discussing the phrase ("the CLI told me to
+ *      upgrade my plan to continue") cannot be misread as hitting one;
+ *   2. no tool call SUCCEEDED — a turn that actually did work is a real turn
+ *      whatever it then said;
+ *   3. the finish reason is a plain stop — not a length cut-off, not an error,
+ *      not a tool-call pause.
+ *
+ * Normalization is whitespace only (trim + collapse runs). NOT case folding and
+ * NOT punctuation stripping: those widen the match, and every widening is a
+ * step toward discarding real output.
+ */
+
+/**
+ * Wall strings observed VERBATIM from a real runtime.
+ *
+ * Only add a string that has actually been seen on the wire, quoted exactly.
+ * A guessed variant is a rule that discards genuine assistant answers matching
+ * a phrase nothing ever emitted — the exact-match discipline above is worth
+ * nothing if the list it matches against is speculative.
+ */
+export const EXTERNAL_ACCOUNT_PLAN_WALL_TEXTS: readonly string[] = [
+  // cursor-agent 2026.08.31, plan-gated model, harness spike.
+  "Upgrade your plan to continue",
+];
+
+/** Whitespace-only normalization — see the module note on why nothing more. */
+function normalizeAssistantText(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+/**
+ * Did this turn hit an external-account entitlement wall?
+ *
+ * Callers must only ask this for a harness whose `modelAccess` is
+ * `"external-account"`. A brokered harness cannot produce this shape (its
+ * refusals are errors), so running the check there would be pure false-positive
+ * surface.
+ */
+export function isExternalAccountPlanWallTurn(args: {
+  /** The authoritative final assistant text (`res.text`), not the live deltas. */
+  finalText: string | undefined | null;
+  /** The turn's settled finish reason. */
+  finishReason: string;
+  /** How many tool calls returned a NON-error result this turn. */
+  successfulToolCalls: number;
+}): boolean {
+  if (args.successfulToolCalls > 0) return false;
+  if (args.finishReason !== "stop") return false;
+  if (typeof args.finalText !== "string") return false;
+  const normalized = normalizeAssistantText(args.finalText);
+  return EXTERNAL_ACCOUNT_PLAN_WALL_TEXTS.some(
+    (wall) => normalized === normalizeAssistantText(wall),
+  );
+}
+
+/**
+ * The turn error a detected wall becomes.
+ *
+ * Phrased for the person who has to fix it, and it names the account rather
+ * than MCPJam: nothing about this is an MCPJam limit, and a message that read
+ * like one would send the reader to the wrong place entirely.
+ */
+export function externalAccountPlanWallError(displayName: string): Error {
+  return new Error(
+    `The ${displayName} harness answered with an account entitlement notice ` +
+      "instead of running the model — the Cursor account behind this " +
+      "environment's CURSOR_API_KEY does not cover the requested model. " +
+      "Upgrade or change the plan on that Cursor account, then retry. " +
+      "(Recorded as a failed turn on purpose: the model never ran, so there " +
+      "is no answer here to persist or score.)",
+  );
+}

--- a/mcpjam-inspector/server/utils/harness/harness-availability.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-availability.ts
@@ -27,6 +27,47 @@ import {
 } from "./registry.js";
 
 /**
+ * Is this harness+model combination eligible to run on the REAL runtime?
+ *
+ * The one answer the DISPATCH sites must share — `assistant-turn`'s `useHarness`
+ * and `web-chat-turn`'s MCPJam-free branch. They had it hand-written, and the
+ * copies stopped being equivalent the moment a harness ran a model MCPJam does
+ * not host: the preflight would approve a Cursor turn while the dispatch beside
+ * it silently ran the EMULATED engine, so the product would report "Cursor CLI"
+ * over a turn Cursor never touched. That is the worst failure this feature can
+ * have — not an error, a wrong answer attributed to the wrong runtime — so the
+ * decision lives here once.
+ *
+ * `checkHarnessRuntimeAvailable` below still spells the same two conditions out
+ * separately, because it has to report WHICH one failed as a typed refusal
+ * kind. A test asserts the two agree for every registered adapter.
+ *
+ * Two independent conditions, and an external-account harness is exempt from
+ * BOTH because neither is about it:
+ *
+ *  - "MCPJam provides this model" — for a brokered harness the credential is
+ *    MCPJam's, so a model MCPJam does not host cannot be paid for. An
+ *    external-account harness pays on the customer's own account, and its host
+ *    carries a sentinel (`cursor/auto`) that is deliberately NOT hosted.
+ *  - "the runtime can run this model" — guards the silent substitution where a
+ *    runtime falls back to its own default. An external-account adapter passes
+ *    NO model at all, so there is nothing to substitute and nothing to check.
+ */
+export function harnessModelEligibleForRuntime(args: {
+  adapter: HarnessRuntimeAdapter;
+  /** The host's model id as configured (bare or provider-prefixed). */
+  modelId: string;
+  /** REQUIRED for a bare id to canonicalize; see the note on the preflight. */
+  provider?: string;
+}): boolean {
+  if (args.adapter.modelAccess === "external-account") return true;
+  if (!isHostedCatalogModel(args.modelId, args.provider)) return false;
+  return args.adapter.supportsModel(
+    getCanonicalModelId(args.modelId, args.provider),
+  );
+}
+
+/**
  * The approval half of this pre-flight, as a value both gate sites share.
  *
  * `runHarnessTurn` has to re-assert exactly these rules, because the eval,

--- a/mcpjam-inspector/server/utils/harness/harness-availability.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-availability.ts
@@ -138,10 +138,19 @@ export function checkHarnessRuntimeAvailable(args: {
   const adapter = getHarnessAdapter(args.harnessId);
   const name = adapter.displayName;
 
-  // Broker delivery is the ONLY credential path (COMP-23) — with the kill
-  // switch off, no harness turn can obtain model access, so fail here with one
-  // clear pre-stream error instead of a raw mid-turn throw.
-  if (!harnessBrokerDeliveryEnabled()) {
+  // Does MCPJam supply this runtime's model credential, or does the runtime
+  // authenticate on the CUSTOMER's own provider account? Three checks below
+  // apply only to the former, and each would be actively wrong for the latter
+  // (see `HarnessModelAccess`): the broker kill switch, "MCPJam-provided models
+  // only", and per-runtime model support.
+  const brokered = adapter.modelAccess !== "external-account";
+
+  // Broker delivery is the ONLY credential path for a BROKERED harness
+  // (COMP-23) — with the kill switch off, no such turn can obtain model access,
+  // so fail here with one clear pre-stream error instead of a raw mid-turn
+  // throw. An external-account harness has no broker to disable: refusing it
+  // for this would be switching off a path it never uses.
+  if (brokered && !harnessBrokerDeliveryEnabled()) {
     return {
       ok: false,
       kind: "broker-disabled",
@@ -202,11 +211,19 @@ export function checkHarnessRuntimeAvailable(args: {
   // Derived, not passed: `isHostedCatalogModel` canonicalizes internally but
   // needs the PROVIDER to do it, and `supportsModel` needs the canonical form.
   // One resolution, used for both.
+  //
+  // BOTH are skipped for an external-account harness, and not as a leniency:
+  // the model MCPJam knows about is not the model that runs. Cursor's adapter
+  // passes no model at all and Cursor Auto picks one on the customer's own
+  // account, so "is this an MCPJam-hosted model?" and "can the runtime run it?"
+  // are questions about a value nothing consumes. Answering them would refuse
+  // every Cursor host — its own catalog model is the `cursor/auto` sentinel,
+  // which is deliberately not an MCPJam-hosted model.
   const canonicalModelId = getCanonicalModelId(
     args.model.id,
-    args.model.provider
+    args.model.provider,
   );
-  if (!isHostedCatalogModel(args.model.id, args.model.provider)) {
+  if (brokered && !isHostedCatalogModel(args.model.id, args.model.provider)) {
     return {
       ok: false,
       kind: "model-not-hosted",
@@ -219,7 +236,7 @@ export function checkHarnessRuntimeAvailable(args: {
   // Runtime model support: even an MCPJam-provided model may not be one this
   // runtime can run (e.g. a non-gpt-5 model on Codex). Reject it rather than let
   // the runtime silently substitute its own default model.
-  if (!adapter.supportsModel(canonicalModelId)) {
+  if (brokered && !adapter.supportsModel(canonicalModelId)) {
     return {
       ok: false,
       kind: "model-unsupported",

--- a/mcpjam-inspector/server/utils/harness/harness-model-broker.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-model-broker.ts
@@ -13,6 +13,20 @@
  */
 import type { ExecutionScope } from "../execution-scope.js";
 import { logger } from "../logger.js";
+import type { HarnessId } from "./registry.js";
+/**
+ * Every registered harness id — reserve/renew/release are taken by EVERY
+ * harness, brokered or not: an external-account harness still runs its CLI in
+ * the customer's box, so it claims that box for the span of a turn's
+ * preparation exactly like a brokered one does.
+ *
+ * `startHarnessModelBroker` is typed the same but must never be REACHED for an
+ * external-account harness. Three things stop it, and none of them is this
+ * type: `runHarnessTurn` branches on the adapter's `modelAccess` and skips the
+ * start entirely, `buildBrokerDummyAuth` throws if anything asks it for
+ * credentials that do not exist, and the backend's `/model-broker/start`
+ * refuses the request outright.
+ */
 
 export type HarnessBrokerStartResult =
   | {
@@ -88,7 +102,7 @@ function boxRequestFields(box: HarnessBrokerBox): Record<string, unknown> {
 
 export async function startHarnessModelBroker(args: {
   box: HarnessBrokerBox;
-  harnessId: "claude-code" | "codex";
+  harnessId: HarnessId;
   modelId: string;
   runId?: string;
   maxOutputTokens?: number;
@@ -254,7 +268,7 @@ export type HarnessBoxReservationResult =
  */
 export async function reserveHarnessBox(args: {
   box: HarnessBrokerBox;
-  harnessId: "claude-code" | "codex";
+  harnessId: HarnessId;
   modelId: string;
   runId: string;
   bearer: string;
@@ -325,7 +339,7 @@ export async function reserveHarnessBox(args: {
 /** Renew the preparation claim before its crash-recovery TTL elapses. */
 export async function renewHarnessBoxReservation(args: {
   box: HarnessBrokerBox;
-  harnessId: "claude-code" | "codex";
+  harnessId: HarnessId;
   modelId: string;
   runId: string;
   bearer: string;
@@ -384,7 +398,7 @@ export async function renewHarnessBoxReservation(args: {
  */
 export async function releaseHarnessBoxReservation(args: {
   box: HarnessBrokerBox;
-  harnessId: "claude-code" | "codex";
+  harnessId: HarnessId;
   modelId: string;
   runId: string;
   bearer: string;

--- a/mcpjam-inspector/server/utils/harness/local/__tests__/compatibility.test.ts
+++ b/mcpjam-inspector/server/utils/harness/local/__tests__/compatibility.test.ts
@@ -271,6 +271,11 @@ describe("claude-code native resolution", () => {
   });
 
   it("refuses a harness with no manifest entry", () => {
+    // `cursor` is a REAL harness id now (it runs hosted), which is exactly why
+    // it belongs here: shipping a local adapter is a security-sensitive act, so
+    // a harness earns the local lane only with a reviewed manifest and
+    // conformance evidence — never by being added to the SDK's HARNESS_IDS.
+    // `SupportedLocalHarnessId` stays deliberately narrower for the same reason.
     expect(
       resolveLocalCompatibility(
         {

--- a/mcpjam-inspector/server/utils/harness/mcp-config.ts
+++ b/mcpjam-inspector/server/utils/harness/mcp-config.ts
@@ -210,3 +210,124 @@ export function parseHarnessToolName(
 export function serializeHarnessMcpJson(json: HarnessMcpJson): string {
   return JSON.stringify(json, null, 2);
 }
+
+/* ── ACP (Cursor CLI) shape ────────────────────────────────────────────────
+ *
+ * The Cursor harness takes its MCP servers as a CONSTRUCTOR setting
+ * (`createCursor({ mcpServers })`) which the adapter forwards into the ACP
+ * `session/new` request, rather than as a file MCPJam writes into the box. Same
+ * DELIVERY MODE as Claude Code (the runtime's own MCP client dials MCPJam's
+ * signed proxy, so every `tools/call` is observable there); different
+ * mechanism, and a different wire shape for the headers.
+ */
+
+/** One ACP MCP HTTP header. ACP spells headers as an ARRAY of name/value pairs,
+ *  not the object `.mcp.json` uses. */
+export interface AcpMcpHeader {
+  name: string;
+  value: string;
+}
+
+/** One ACP `session/new` MCP server entry (http transport). */
+export interface AcpMcpHttpServer {
+  type: "http";
+  url: string;
+  /**
+   * REQUIRED, and an empty array when there is nothing to send.
+   *
+   * Not optional-with-a-default: omitting the key entirely makes cursor-agent
+   * fail `session/new` with an opaque JSON-RPC `-32603` internal error that
+   * names neither the field nor the server. Verified against cursor-agent
+   * 2026.08.31 during the harness spike — always emit the key.
+   */
+  headers: AcpMcpHeader[];
+}
+
+/**
+ * The MCP server name ACP reserves for `HarnessAgent`'s own host-executed tool
+ * channel. `createACPV1` throws outright if a supplied server uses it.
+ */
+const ACP_RESERVED_MCP_SERVER_NAME = "ai-sdk-harness-tools";
+
+/**
+ * Convert the shared `.mcp.json` object into ACP's `mcpServers` map.
+ *
+ * The KEYS are preserved exactly, which is what keeps tool attribution working:
+ * `harnessServerKeyToName` is built from the same `assignServerKeys` pass, so a
+ * rename here would silently orphan every tool call from that server. That is
+ * also why a collision with ACP's reserved name throws instead of being
+ * re-keyed — losing attribution is worse than failing the turn, and the turn
+ * would fail in the adapter anyway, just with a message that names neither
+ * MCPJam nor the server.
+ */
+export function toAcpMcpServers(
+  json: HarnessMcpJson,
+): Record<string, AcpMcpHttpServer> {
+  const out: Record<string, AcpMcpHttpServer> = {};
+  for (const [key, entry] of Object.entries(json.mcpServers)) {
+    if (key === ACP_RESERVED_MCP_SERVER_NAME) {
+      throw new Error(
+        `MCP server key "${key}" is reserved by the ACP harness runtime for its own tool channel; ` +
+          "rename the server so it does not sanitize to that key.",
+      );
+    }
+    out[key] = {
+      type: "http",
+      url: entry.url,
+      // Always an array — see AcpMcpHttpServer.headers.
+      headers: Object.entries(entry.headers ?? {}).map(([name, value]) => ({
+        name,
+        value,
+      })),
+    };
+  }
+  return out;
+}
+
+/**
+ * Attribute a Cursor/ACP tool call to MCPJam tool identity.
+ *
+ * Cursor does NOT namespace MCP tools the way Claude Code does. Every MCP call
+ * arrives under an opaque, per-session `acp_tool_<id>` stream name, and the
+ * real identity rides in the call's INPUT:
+ *
+ *   { providerIdentifier: "<mcp server key>", toolName: "<tool>", args: {…} }
+ *
+ * So the raw name is useless here and the input is the only source. When the
+ * input carries no provider identity the call is one of Cursor's own built-ins
+ * (bash, read, edit, …) and passes through under the raw name — the same
+ * "don't fabricate an attribution" rule `parseHarnessToolName` follows.
+ *
+ * When the input DOES name a tool but its provider key is unresolvable, the
+ * tool name still comes back (it is firsthand from the input) with no
+ * `serverId`. That is the same rule, not an exception to it: the unknown part
+ * is the server mapping, and only that part is withheld. Returning the opaque
+ * `acp_tool_…` id instead would discard a fact we actually have.
+ *
+ * THE `user-` PREFIX. Cursor prefixes user-configured MCP providers with
+ * `user-` in `providerIdentifier` (`user-<key>`), but not universally — it
+ * depends on how the server was registered. So the exact key is tried FIRST and
+ * the stripped form only as a fallback; stripping unconditionally would
+ * mis-attribute a server whose own key legitimately begins with `user-`.
+ */
+export function attributeCursorToolCall(args: {
+  rawToolName: string;
+  input: unknown;
+  keyToServerId: Record<string, string>;
+}): { serverId?: string; toolName: string } {
+  const { rawToolName, input, keyToServerId } = args;
+  const record =
+    input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+  const provider = record.providerIdentifier;
+  const inner = record.toolName;
+  if (typeof provider !== "string" || typeof inner !== "string" || !inner) {
+    return { toolName: rawToolName };
+  }
+  // Exact key first, THEN the `user-`-stripped form. Never the other way round.
+  const serverId =
+    keyToServerId[provider] ??
+    (provider.startsWith("user-")
+      ? keyToServerId[provider.slice("user-".length)]
+      : undefined);
+  return serverId ? { serverId, toolName: inner } : { toolName: inner };
+}

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -69,10 +69,18 @@ export type HarnessId = Harness;
 export type HarnessAuth = HarnessV1AuthenticationEnvironment;
 
 /** Escape a value for safe interpolation INSIDE a single-quoted shell word.
+ *
  *  A single quote is the only character with meaning there, and the standard
- *  `'\''` dance is how it is closed, escaped and reopened. */
+ *  close-escape-reopen dance is the replacement: `'` becomes `'\''` — end the
+ *  quoted word, an escaped literal quote, start a new quoted word.
+ *
+ *  A REGULAR string, not a template literal. In a template literal `\'` is just
+ *  `'` (JS drops the backslash), so the obvious-looking `` `'\''` `` silently
+ *  produces three quotes — which CLOSES the quoted word and leaves the rest of
+ *  the path unquoted, restoring the very `$(…)` execution this exists to
+ *  prevent. `__tests__/registry.test.ts` pins the emitted bytes. */
 function shellSingleQuote(value: string): string {
-  return value.replaceAll("'", `'\''`);
+  return value.replaceAll("'", "'\\''");
 }
 
 /** Placeholder credential value handed to the in-sandbox CLI on the broker path.

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -13,6 +13,7 @@
  */
 import { createClaudeCode } from "@ai-sdk/harness-claude-code";
 import { createCodex } from "@ai-sdk/harness-codex";
+import { createCursor } from "@ai-sdk/harness-cursor";
 import type { HarnessAgentAdapter } from "@ai-sdk/harness/agent";
 import type {
   HarnessV1AuthenticationEnvironment,
@@ -25,17 +26,24 @@ import {
   type HarnessMcpDelivery,
 } from "@/shared/harness-mcp-delivery";
 import {
+  attributeCursorToolCall,
   parseHarnessToolName,
   serializeHarnessMcpJson,
+  toAcpMcpServers,
   type HarnessMcpJson,
 } from "./mcp-config.js";
 import {
   prepareClaudeCodeSkills,
   prepareCodexSkills,
+  prepareNoSkills,
   type PreparedHarnessSkills,
   type RuntimeSkill,
 } from "./runtime-skills.js";
-import { CLAUDE_CODE_SKILLS_BASE, CODEX_SKILLS_BASE } from "./skill-roots.js";
+import {
+  CLAUDE_CODE_SKILLS_BASE,
+  CODEX_SKILLS_BASE,
+  CURSOR_SKILLS_BASE,
+} from "./skill-roots.js";
 
 /** A harness id this inspector has a runtime adapter for. Derived from the SDK's
  *  portable `Harness` union (the persistence-contract source of truth), so the
@@ -73,21 +81,45 @@ const BROKER_DUMMY_CREDENTIAL = "mcpjam-broker-dummy";
  *  `ANTHROPIC_API_KEY` is deliberately ABSENT rather than empty: the adapter
  *  keys its credential-forwarding transformations off which variables are
  *  present, and an empty string would register an `x-api-key` rewrite for a
- *  header the CLI never sends on the auth-token path. */
+ *  header the CLI never sends on the auth-token path.
+ *
+ *  EXHAUSTIVE, and it THROWS for an external-account harness. This used to be a
+ *  fallthrough `if (codex) … else Anthropic`, which meant any harness id that
+ *  was not codex silently received Claude Code's `ANTHROPIC_*` environment —
+ *  so a cursor turn would have been handed an Anthropic base URL and a dummy
+ *  token for a proxy it never talks to, and the failure would have surfaced as
+ *  a confusing runtime error inside the box rather than here. An
+ *  external-account harness has NO broker lease by construction
+ *  (`modelAccess`), so asking for its broker auth is a caller bug; the caller's
+ *  own `modelAccess` branch is what must skip this. */
 export function buildBrokerDummyAuth(
   harnessId: HarnessId,
-  proxyBaseUrl: string
+  proxyBaseUrl: string,
 ): HarnessAuth {
-  if (harnessId === "codex") {
-    return {
-      CODEX_API_KEY: BROKER_DUMMY_CREDENTIAL,
-      OPENAI_BASE_URL: proxyBaseUrl,
-    };
+  switch (harnessId) {
+    case "claude-code":
+      return {
+        ANTHROPIC_AUTH_TOKEN: BROKER_DUMMY_CREDENTIAL,
+        ANTHROPIC_BASE_URL: proxyBaseUrl,
+      };
+    case "codex":
+      return {
+        CODEX_API_KEY: BROKER_DUMMY_CREDENTIAL,
+        OPENAI_BASE_URL: proxyBaseUrl,
+      };
+    case "cursor":
+      throw new Error(
+        "The Cursor harness authenticates with the customer's own Cursor " +
+          "account (modelAccess: 'external-account') and takes no broker " +
+          "lease — buildBrokerDummyAuth must not be called for it.",
+      );
+    default: {
+      const unhandled: never = harnessId;
+      throw new Error(
+        `No broker auth strategy for harness: ${String(unhandled)}`,
+      );
+    }
   }
-  return {
-    ANTHROPIC_AUTH_TOKEN: BROKER_DUMMY_CREDENTIAL,
-    ANTHROPIC_BASE_URL: proxyBaseUrl,
-  };
 }
 
 /** `{ serverId?, toolName }` — the MCPJam tool identity a harness tool name maps
@@ -196,6 +228,41 @@ export type HarnessBuiltinToolInfo = {
  */
 export type { HarnessMcpDelivery };
 
+/**
+ * WHERE a harness's model spend lands — and therefore whether MCPJam brokers a
+ * credential for it at all.
+ *
+ *  - `broker`           — MCPJam mints a short-lived lease, E2B injects it into
+ *    the box's egress outside the VM, the model proxy meters every request and
+ *    MCPJam is billed. Claude Code, Codex. The CLI itself runs with
+ *    `buildBrokerDummyAuth` placeholders.
+ *
+ *  - `external-account` — the runtime reaches its model provider on the
+ *    CUSTOMER's own account, and MCPJam has no seam to broker at. Cursor's CLI
+ *    has no provider/gateway routing whatsoever: it authenticates with a
+ *    `CURSOR_API_KEY`, every request transits Cursor's servers, and the spend
+ *    is billed to that Cursor account. Verified three ways plus Cursor's own
+ *    docs before this arm existed.
+ *
+ * Not a cosmetic label. Everything below keys off it, and each is actively
+ * wrong for the other arm:
+ *   - the broker start is SKIPPED, and `buildBrokerDummyAuth` THROWS;
+ *   - the box reservation is HELD for the turn instead of being consumed by a
+ *     lease that never exists;
+ *   - the credential comes out of the project's materialized secrets and is
+ *     removed from the box's session env;
+ *   - the model gates — the preflight's model-hosted / model-supported checks
+ *     and the turn's `supportsModel` backstop — are skipped, because the model
+ *     MCPJam knows about is not the model that runs;
+ *   - the broker kill switch does not apply (there is no broker to kill);
+ *   - the turn is tagged `modelSource: 'external-account'` rather than
+ *     `'mcpjam'`, so it does not consume the org's MCPJam spend limit;
+ *   - the entitlement-wall check runs (see `external-account-plan-wall.ts`) —
+ *     an external-account runtime can answer "upgrade your plan" as a normal
+ *     successful turn, which a brokered one cannot.
+ */
+export type HarnessModelAccess = "broker" | "external-account";
+
 type HarnessRuntimeAdapterBase = {
   id: HarnessId;
   /** Human-facing runtime name for preflight/availability messages + UI. */
@@ -264,15 +331,6 @@ type HarnessRuntimeAdapterBase = {
   /** Native-tool name used to surface this runtime's `file-change` stream parts
    *  as a synthetic tool call. Undefined ⇒ the runtime doesn't emit file-change. */
   fileChangeToolName?: string;
-  /** Construct the harness adapter (already cast to the server's HarnessAgent
-   *  boundary type) for the given host model + broker dummy auth. (The
-   *  per-adapter `resolveAuth` credential fetch was removed in COMP-23 —
-   *  credentials are broker-delivered outside the VM; see
-   *  `buildBrokerDummyAuth`.) */
-  createHarness(args: {
-    modelId: string;
-    auth: HarnessAuth;
-  }): HarnessAgentAdapter;
   /** The harness's native built-in tools as a normalized, display-only catalog.
    *  No auth/sandbox needed — read straight from the constructed adapter's
    *  static `builtinTools` ToolSet. */
@@ -290,37 +348,142 @@ type HarnessRuntimeAdapterBase = {
    *  per-adapter rather than pinned to Claude's scheme. */
   parseToolName(
     rawToolName: string,
-    keyToServerId: Record<string, string>
+    keyToServerId: Record<string, string>,
   ): HarnessToolAttribution;
+  /** Map a tool CALL — name *and* input — back to MCPJam tool identity.
+   *
+   *  A superset of `parseToolName`, and the hook the turn runner actually calls.
+   *  It exists because not every runtime puts the identity in the NAME: Cursor
+   *  streams every MCP call under an opaque per-session `acp_tool_<id>` and
+   *  carries `{ providerIdentifier, toolName, args }` in the input instead, so a
+   *  name-only signature cannot attribute one at all.
+   *
+   *  Optional: an adapter that omits it falls back to its own `parseToolName`
+   *  at the call site. Both stay because they answer different questions —
+   *  `parseToolName` is also called where only a name exists (a result part
+   *  that omits the input). */
+  attributeToolCall?(args: {
+    rawToolName: string;
+    input: unknown;
+    keyToServerId: Record<string, string>;
+  }): HarnessToolAttribution;
   /** Install verified plugin bundles into a fresh sandbox session, before the
    *  runtime process starts. REQUIRED when `supportsPluginBundles`. */
   deliverPluginBundles?(args: HarnessPluginDeliveryArgs): Promise<void>;
+  /**
+   * Shell command that prints the INSTALLED runtime's version, given the
+   * session workdir — for adapters whose CLI version is NOT pinned by the
+   * package pin.
+   *
+   * Claude Code and Codex bootstrap a version-pinned npm package, so the
+   * installed CLI is knowable from the lockfile and this is absent. Cursor's
+   * bootstrap runs `curl https://cursor.com/install | bash`, which always
+   * fetches the CURRENT build: two builds observed four months apart behaved
+   * differently, so what actually ran is only knowable by asking the box.
+   *
+   * Read at turn end and recorded as telemetry, FAIL-SOFT throughout: a command
+   * that errors, times out, or stops matching the adapter's bootstrap layout
+   * records no version and never affects the turn. A canary is not worth a
+   * failed run.
+   */
+  runtimeVersionCommand?(sessionWorkDir: string): string;
+};
+
+/** Base args every adapter's `createHarness` receives. (The per-adapter
+ *  `resolveAuth` credential fetch was removed in COMP-23 — brokered credentials
+ *  are delivered outside the VM, see `buildBrokerDummyAuth`; an
+ *  external-account harness gets its customer credential in `auth` instead.) */
+export type HarnessCreateArgs = {
+  modelId: string;
+  auth: HarnessAuth;
+};
+
+/** Brokered model access: MCPJam supplies the credential, so the adapter needs
+ *  nothing from the customer's own secrets. */
+type BrokeredModelAccessArm = {
+  modelAccess: "broker";
+  externalAccountCredentialEnv?: never;
+};
+
+/** External-account model access: the runtime authenticates with the
+ *  CUSTOMER's credential, so it must SAY which one. */
+type ExternalAccountModelAccessArm = {
+  modelAccess: "external-account";
+  /**
+   * The environment variable names this runtime needs from the project's
+   * MATERIALIZED secrets, e.g. `["CURSOR_API_KEY"]` (which is exactly what
+   * `@ai-sdk/harness-cursor` declares as its own `credentialEnv`).
+   *
+   * REQUIRED on this arm, and that is the point: an external-account harness
+   * that did not name its credential would have the turn runner silently start
+   * it with no auth at all, and the failure would surface as an opaque error
+   * from inside the box. A missing secret is refused up front instead, with
+   * copy that names the variable and where to set it.
+   *
+   * The turn runner treats every name here as required, pulls them OUT of the
+   * box's session env (so they are not also handed to every other command that
+   * runs there) and passes them to the adapter as its auth environment.
+   */
+  externalAccountCredentialEnv: readonly [string, ...string[]];
+};
+
+/** NATIVE delivery, `sandbox-files` mechanism: MCPJam writes runtime config
+ *  into the box before the process starts (Claude Code's `.mcp.json`). */
+type NativeSandboxFilesArm = {
+  mcpDelivery: "native";
+  mcpNativeDelivery: "sandbox-files";
+  /** Write the host's MCP servers into a fresh sandbox session, before the
+   *  runtime process starts. */
+  deliverMcpServers(args: HarnessMcpDeliveryArgs): Promise<void>;
+  createHarness(args: HarnessCreateArgs): HarnessAgentAdapter;
+};
+
+/** NATIVE delivery, `session-config` mechanism: there is no file to write —
+ *  the servers are a CONSTRUCTOR setting the adapter forwards into its session
+ *  handshake (Cursor's ACP `session/new`). */
+type NativeSessionConfigArm = {
+  mcpDelivery: "native";
+  mcpNativeDelivery: "session-config";
+  /** Never present: nothing is written into the box for this mechanism. */
+  deliverMcpServers?: never;
+  /** `mcpJson` is REQUIRED here, and that is the whole point of the arm: an
+   *  adapter whose only channel for MCP config is construction cannot be
+   *  constructed without it, so the config can never be silently dropped. */
+  createHarness(
+    args: HarnessCreateArgs & { mcpJson: HarnessMcpJson },
+  ): HarnessAgentAdapter;
+};
+
+/** HOST-EXECUTED delivery: the servers reach the model as host-executed tools
+ *  MCPJam runs in-process, never as runtime config in the sandbox. */
+type HostExecutedArm = {
+  mcpDelivery: "host-executed";
+  mcpNativeDelivery?: never;
+  deliverMcpServers?: never;
+  createHarness(args: HarnessCreateArgs): HarnessAgentAdapter;
 };
 
 /**
- * The two MCP-delivery arms, as a discriminated union rather than a boolean +
- * an optional hook. This is what makes "the model never sees a tool twice" a
- * TYPE invariant:
- *   - `native` REQUIRES `deliverMcpServers` (advertise = implement, checked by
- *     the compiler instead of by a runtime throw in `runHarnessTurn`);
- *   - `host-executed` FORBIDS it (`?: never`), so an adapter cannot half-adopt
- *     the relay while still writing runtime MCP config.
+ * The MCP-delivery arms, as a discriminated union rather than a boolean + an
+ * optional hook. This is what makes "the model never sees a tool twice" a TYPE
+ * invariant:
+ *   - `native` REQUIRES a delivery mechanism, and each mechanism requires the
+ *     hook that implements it (advertise = implement, checked by the compiler
+ *     instead of by a runtime throw in `runHarnessTurn`);
+ *   - `host-executed` FORBIDS both (`?: never`), so an adapter cannot
+ *     half-adopt the relay while still writing runtime MCP config.
+ *
+ * `native` is NESTED rather than flat because the two native mechanisms need
+ * different hooks — one writes a file into the session, the other takes the
+ * config at construction — and a flat arm would have had to make both optional,
+ * which is exactly the "advertises MCP, delivers nothing" state this union
+ * exists to make unrepresentable. The MODE (does the traffic cross MCPJam's
+ * proxy? — what evidence capture keys off) stays `mcpDelivery`; the MECHANISM
+ * is `mcpNativeDelivery` and is invisible to everything but construction.
  */
 export type HarnessRuntimeAdapter = HarnessRuntimeAdapterBase &
-  (
-    | {
-        mcpDelivery: "native";
-        /** Write the host's MCP servers into a fresh sandbox session, before the
-         *  runtime process starts. */
-        deliverMcpServers(args: HarnessMcpDeliveryArgs): Promise<void>;
-      }
-    | {
-        mcpDelivery: "host-executed";
-        /** Never present: this arm's servers reach the model as host-executed
-         *  tools, not as runtime config in the sandbox. */
-        deliverMcpServers?: never;
-      }
-  );
+  (BrokeredModelAccessArm | ExternalAccountModelAccessArm) &
+  (NativeSandboxFilesArm | NativeSessionConfigArm | HostExecutedArm);
 
 /* ── Claude Code bridge patches ────────────────────────────────────────────
  *
@@ -561,7 +724,7 @@ function patchModernClaudeCodeBridgeContent(content: string): string {
   for (const [needle, replacement] of replacements) {
     if (!patched.includes(needle)) {
       throw new Error(
-        "Unable to patch Claude Code bridge bootstrap: modern bridge shape changed"
+        "Unable to patch Claude Code bridge bootstrap: modern bridge shape changed",
       );
     }
     patched = patched.replace(needle, replacement);
@@ -610,7 +773,7 @@ function patchClaudeCodeBridgeContent(content: string): string {
     ] as const) {
       if (!patched.includes(needle)) {
         throw new Error(
-          "Unable to patch Claude Code bridge bootstrap: assistant text shape changed"
+          "Unable to patch Claude Code bridge bootstrap: assistant text shape changed",
         );
       }
       patched = patched.replace(needle, replacement);
@@ -630,7 +793,7 @@ function patchClaudeCodeBridgeContent(content: string): string {
     ] as const) {
       if (!patched.includes(needle)) {
         throw new Error(
-          "Unable to patch Claude Code bridge bootstrap: model override shape changed"
+          "Unable to patch Claude Code bridge bootstrap: model override shape changed",
         );
       }
       patched = patched.replace(needle, replacement);
@@ -642,7 +805,7 @@ function patchClaudeCodeBridgeContent(content: string): string {
    * rather than let a subagent's stream merge into the parent transcript. */
   if (!patched.includes("parent_tool_use_id")) {
     throw new Error(
-      "Unable to verify Claude Code bridge bootstrap: user-message shape changed"
+      "Unable to verify Claude Code bridge bootstrap: user-message shape changed",
     );
   }
 
@@ -712,7 +875,7 @@ const CLAUDE_CODE_BOOTSTRAP_PNPM_WORKSPACE =
 function pnpmWorkspaceForClaudeCodeBootstrap(
   files: Awaited<
     ReturnType<NonNullable<HarnessAgentAdapter["getBootstrap"]>>
-  >["files"]
+  >["files"],
 ): string {
   const packageFile = files.find((file) => file.path.endsWith("/package.json"));
   if (packageFile) {
@@ -735,7 +898,7 @@ function pnpmWorkspaceForClaudeCodeBootstrap(
 }
 
 export function patchClaudeCodeHarnessBootstrap(
-  harness: HarnessAgentAdapter
+  harness: HarnessAgentAdapter,
 ): HarnessAgentAdapter {
   const originalGetBootstrap = harness.getBootstrap?.bind(harness);
   if (!originalGetBootstrap) return harness;
@@ -755,7 +918,7 @@ export function patchClaudeCodeHarnessBootstrap(
       // added only if the adapter stops shipping one. `.npmrc` is always ours —
       // the adapter ships none, and pnpm 10 reads nothing else.
       const shipsPnpmWorkspace = bootstrap.files.some((file) =>
-        file.path.endsWith("/pnpm-workspace.yaml")
+        file.path.endsWith("/pnpm-workspace.yaml"),
       );
       cachedPatchedBootstrap = {
         ...bootstrap,
@@ -763,7 +926,7 @@ export function patchClaudeCodeHarnessBootstrap(
           ...bootstrap.files.map((file) =>
             file.path.endsWith("/bridge.mjs")
               ? { ...file, content: patchClaudeCodeBridgeContent(file.content) }
-              : file
+              : file,
           ),
           {
             path: `${bootstrap.bootstrapDir}/.npmrc`,
@@ -806,7 +969,7 @@ function toClaudeCodeModel(modelId: string): string | undefined {
   // minor version (e.g. "claude-opus-4-20250929" -> minor="20250929"),
   // producing an invalid native model string instead of "claude-opus-4".
   const match = withoutProvider.match(
-    /^claude-(haiku|sonnet|opus)-(\d+)(?:-\d{8}|[.-](\d+)(?:-\d{8})?)?$/
+    /^claude-(haiku|sonnet|opus)-(\d+)(?:-\d{8}|[.-](\d+)(?:-\d{8})?)?$/,
   );
   if (match) {
     const [, family, major, minor] = match;
@@ -842,7 +1005,7 @@ function toCodexModel(modelId: string): string | undefined {
  *  inspector's own `zod@4` `z.toJSONSchema` can't read — so use `ai`'s
  *  `asSchema`, which handles both Zod versions and yields a JSON Schema. */
 function builtinInputJsonSchema(
-  schema: unknown
+  schema: unknown,
 ): Record<string, unknown> | undefined {
   if (!schema || typeof schema !== "object") return undefined;
   try {
@@ -858,7 +1021,7 @@ function builtinInputJsonSchema(
 /** Normalize a harness's static `builtinTools` ToolSet into the display catalog.
  *  Shared by every adapter so a new harness reuses the exact same shaping. */
 function normalizeHarnessBuiltinTools(
-  builtinTools: Record<string, unknown>
+  builtinTools: Record<string, unknown>,
 ): HarnessBuiltinToolInfo[] {
   const str = (v: unknown): string | undefined =>
     typeof v === "string" && v.length > 0 ? v : undefined;
@@ -888,13 +1051,13 @@ function normalizeHarnessBuiltinTools(
  *  process, and constructing the adapter (no auth, no sandbox) just to read its
  *  static `builtinTools` once is enough. */
 function memoizedBuiltinTools(
-  build: () => { builtinTools: unknown }
+  build: () => { builtinTools: unknown },
 ): () => HarnessBuiltinToolInfo[] {
   let cache: HarnessBuiltinToolInfo[] | undefined;
   return () => {
     if (!cache) {
       cache = normalizeHarnessBuiltinTools(
-        build().builtinTools as Record<string, unknown>
+        build().builtinTools as Record<string, unknown>,
       );
     }
     return cache;
@@ -913,6 +1076,9 @@ const claudeCodeAdapter: HarnessRuntimeAdapter = {
   id: "claude-code",
   displayName: "Claude Code",
   requiresComputer: true,
+  // MCPJam brokers the model credential: Convex mints a lease, E2B injects it
+  // outside the VM, and the model proxy meters the spend.
+  modelAccess: "broker",
   defaultPermissionMode: "allow-all",
   // WS3: the CLI pauses on a tool-approval-request for side-effecting tools;
   // the turn suspends and resumes with the user's decision (see
@@ -954,6 +1120,8 @@ const claudeCodeAdapter: HarnessRuntimeAdapter = {
   // the shared declaration so the host editor's promises about which knobs bite
   // move with this, instead of being re-asserted by hand on the client.
   mcpDelivery: HARNESS_MCP_DELIVERY["claude-code"],
+  // …by writing `.mcp.json` into the session workdir (see deliverMcpServers).
+  mcpNativeDelivery: "sandbox-files",
   supportsSkills: true,
   skillsBaseDir: CLAUDE_CODE_SKILLS_BASE,
   // Mirrors `writeClaudeCodeSkills` in `@ai-sdk/harness-claude-code`.
@@ -1006,7 +1174,7 @@ const claudeCodeAdapter: HarnessRuntimeAdapter = {
         // deliberate: the sandbox env is ours, and the adapter's own `effort`
         // option is the supported way to ask for a value.
         env: { CLAUDE_CODE_EFFORT_LEVEL: "unset" },
-      }) as unknown as HarnessAgentAdapter
+      }) as unknown as HarnessAgentAdapter,
     );
   },
 };
@@ -1015,6 +1183,9 @@ const codexAdapter: HarnessRuntimeAdapter = {
   id: "codex",
   displayName: "Codex",
   requiresComputer: true,
+  // Brokered, same as Claude Code — an OpenAI-protocol lease instead of an
+  // Anthropic one.
+  modelAccess: "broker",
   // Codex doesn't support built-in tool approval requests — use allow-all.
   defaultPermissionMode: "allow-all",
   // Unlike Claude Code (see `claudeCodeAdapter`, where the pause was available
@@ -1093,9 +1264,140 @@ const codexAdapter: HarnessRuntimeAdapter = {
   },
 };
 
+const cursorAdapter: HarnessRuntimeAdapter = {
+  id: "cursor",
+  // "Cursor CLI", not "Cursor" — the emulated `cursor` host style (the IDE's
+  // chat panel) keeps that name, and the two are different products with
+  // different surfaces. Every preflight/refusal message a user reads comes from
+  // here, so the distinction has to be in the name itself.
+  displayName: "Cursor CLI",
+  requiresComputer: true,
+  // NO BROKER. cursor-agent has no provider or gateway routing at all: it
+  // authenticates with a `CURSOR_API_KEY` (the adapter's own `credentialEnv`
+  // says so), every model request transits Cursor's servers, and the spend
+  // lands on that Cursor account. There is no seam for MCPJam to mint a lease
+  // at, so the turn skips the broker start entirely and `buildBrokerDummyAuth`
+  // throws if anything asks it for one.
+  modelAccess: "external-account",
+  // The name the CLI itself reads — `@ai-sdk/harness-cursor` declares exactly
+  // this as its `credentialEnv`. Delivered as a MATERIALIZED PROJECT SECRET:
+  // one key per environment, set once by an admin under Project Settings →
+  // Secrets. Missing ⇒ the turn is refused up front with copy that says so,
+  // never defaulted.
+  externalAccountCredentialEnv: ["CURSOR_API_KEY"],
+  defaultPermissionMode: "allow-all",
+  // The ACP bridge routes every tool call through `session/request_permission`
+  // and emits `tool-approval-request` for anything it does not auto-approve,
+  // then resumes on the host's decision — the same pause/resume contract Claude
+  // Code offers. Verified on a live cursor-agent during the harness spike.
+  supportsNativeToolApproval: true,
+  // "allow-reads" for the same reason as Claude Code, though by a different
+  // mechanism. The bridge's `shouldAutoApprove(permissionMode, kind)` lets a
+  // call through when the mode is "allow-all", when the ACP tool KIND is one of
+  // read/search/think/fetch, or — under "allow-edits" only — edit/delete/move.
+  // So "allow-reads" is the narrowest mode that still pauses on execute-class
+  // work while leaving reads free: the faithful mapping to the emulated engine,
+  // which gates tool CALLS and never reads.
+  approvalPermissionMode: "allow-reads",
+  // FALSE pending a live measurement, and deliberately not inferred.
+  //
+  // The mechanism is clearly there — an MCP call reaches the same
+  // `requestPermission` path as a native one, and the bridge's
+  // `claimHostToolPermission` short-circuit covers only HarnessAgent's OWN tool
+  // channel, not the host's servers. What is NOT established is the one fact
+  // that decides the answer: which ACP `toolCall.kind` cursor-agent reports for
+  // an MCP tool. `other`/`execute` would pause under "allow-reads"; a kind of
+  // read/search/fetch/think would be auto-approved and the call would run with
+  // no prompt at all.
+  //
+  // Claiming `true` on the strength of the mechanism would mean a host that
+  // explicitly asked for approval could silently execute MCP tools unapproved —
+  // the one failure this flag exists to prevent. At `false`, such a host is
+  // refused at preflight with a message that says why
+  // (`harnessToolApprovalRefusalReason`), and approval-free Cursor hosts are
+  // unaffected. Flip this to `true` — a one-line change — once a live run with
+  // `requireToolApproval` and a selected MCP server is observed pausing on the
+  // MCP call.
+  supportsMcpToolApproval: false,
+  // Not wired or tested for this adapter; same posture as Codex.
+  supportsHostExecutedToolApproval: false,
+  // NATIVE: the CLI's own MCP client dials MCPJam's signed per-server proxy, so
+  // every `tools/call` crosses the seam where firsthand evidence is captured.
+  // Read from the shared declaration, which the client's Behavior tab derives
+  // its promises from too.
+  mcpDelivery: HARNESS_MCP_DELIVERY.cursor,
+  // …but via the ACP `session/new` config rather than a file in the box: the
+  // servers are a CONSTRUCTOR setting (see createHarness). Same mode, different
+  // mechanism — which is exactly the distinction this field carries.
+  mcpNativeDelivery: "session-config",
+  // OFF for v1. ACP supports skills (`DEFAULT_ACP_SKILLS_DIRECTORY`), so this
+  // is a scope decision rather than a capability wall: shipping skills means
+  // owning the same delivery/reconcile/adopt passes the other two adapters
+  // have, plus a parity test against the real adapter. Tracked as a follow-up.
+  supportsSkills: false,
+  // Dormant while the flag above is false; see CURSOR_SKILLS_BASE.
+  skillsBaseDir: CURSOR_SKILLS_BASE,
+  skillsWriteOptions: { trailingNewline: false },
+  // Never called (`runHarnessTurn` guards on supportsSkills), and honest if the
+  // guard ever moves: nothing delivered, every skill reported skipped.
+  prepareSkills: prepareNoSkills,
+  supportsPluginBundles: false,
+  // Cursor does not emit file-change stream parts.
+  fileChangeToolName: undefined,
+  // The ACP wrapper carries a static builtin catalog (31 tools), so the generic
+  // `/v1/harness/:id/builtin-tools` route works with no per-harness edits.
+  listBuiltinTools: memoizedBuiltinTools(() => createCursor()),
+  // AUTO. The adapter passes no model, so Cursor picks — which is the only
+  // honest thing to do while MCPJam has no view of the account's entitlements
+  // (a plan-gated model does not error; it answers "Upgrade your plan to
+  // continue" in a normal end_turn, which the turn runner detects separately).
+  toNativeModel: () => undefined,
+  // Never consulted: `runHarnessTurn` and the preflight skip every model gate
+  // for an external-account harness, because the model MCPJam knows about is
+  // not the model that runs. Declared `true` so the shape is satisfied without
+  // implying a check happened.
+  supportsModel: () => true,
+  // Name-only attribution, for the result parts that arrive without an input.
+  // Cursor's stream name is an opaque `acp_tool_<id>`, so this can only ever
+  // return it verbatim with no serverId — which is the correct answer for a
+  // name that carries no identity. The real work is in attributeToolCall.
+  parseToolName: parseHarnessToolName,
+  // The identity lives in the INPUT (`{ providerIdentifier, toolName, args }`
+  // — the adapter's own `isMcpToolCall` predicate keys off exactly those three
+  // fields), so this hook is what makes Cursor MCP calls attributable at all.
+  attributeToolCall: attributeCursorToolCall,
+  // The installed CLI is whatever `curl https://cursor.com/install | bash`
+  // fetched at bootstrap — the adapter pins its own version but NOT the CLI's,
+  // and two observed builds are four months of behaviour apart. Recording the
+  // version per session is what makes a silent upstream change attributable
+  // instead of a mystery regression.
+  runtimeVersionCommand: (sessionWorkDir) =>
+    // Layout taken from the adapter's own bootstrap: `bootstrapDir` is
+    // `.harness-bootstrap/<harnessId>` under the session workdir, and
+    // `implementation.json` puts the executable at
+    // `implementation/home/.local/bin/agent` (privateHome: true).
+    `"${sessionWorkDir}/.harness-bootstrap/cursor/implementation/home/.local/bin/agent" --version`,
+  createHarness({ auth, mcpJson }) {
+    // Dual-`ai` boundary cast, same as the other two adapters.
+    return createCursor({
+      // The customer's own CURSOR_API_KEY, as the environment arm of
+      // HarnessV1Authentication. Passing an explicit env map (rather than
+      // 'auto' / 'ai-gateway' / 'direct') is what stops the adapter reading the
+      // SERVER's process env for a credential — and the routing modes would
+      // only produce a warning here anyway, since Cursor cannot be re-routed.
+      auth,
+      // REQUIRED by this arm's signature: `session-config` delivery has no
+      // other channel, so a construction that forgot the servers would be a
+      // silently tool-less turn. The type makes that unwritable.
+      mcpServers: toAcpMcpServers(mcpJson),
+    }) as unknown as HarnessAgentAdapter;
+  },
+};
+
 const HARNESS_ADAPTERS: Record<HarnessId, HarnessRuntimeAdapter> = {
   "claude-code": claudeCodeAdapter,
   codex: codexAdapter,
+  cursor: cursorAdapter,
 };
 
 /** Membership test against the installed adapters (own-property, prototype-safe).
@@ -1133,4 +1435,20 @@ export function registeredHarnessIds(): HarnessId[] {
  */
 export function harnessSupportsSkills(id: string): boolean {
   return isHarnessId(id) ? HARNESS_ADAPTERS[id].supportsSkills : false;
+}
+
+/**
+ * Does this harness pay for its own model spend on the CUSTOMER's account with
+ * the runtime vendor (`modelAccess: 'external-account'`)?
+ *
+ * Same non-throwing shape as `harnessSupportsSkills`, and the default matters:
+ * an unrecognized id answers `false` — "we cannot say this is customer-billed".
+ * The read decides how a turn is BILLED, so the safe direction is MCPJam's own
+ * ledger, where an over-recorded turn is reconciled rather than written off as
+ * someone else's spend.
+ */
+export function harnessUsesExternalAccount(id: string): boolean {
+  return isHarnessId(id)
+    ? HARNESS_ADAPTERS[id].modelAccess === "external-account"
+    : false;
 }

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -68,6 +68,13 @@ export type HarnessId = Harness;
  *  `createCodex`. */
 export type HarnessAuth = HarnessV1AuthenticationEnvironment;
 
+/** Escape a value for safe interpolation INSIDE a single-quoted shell word.
+ *  A single quote is the only character with meaning there, and the standard
+ *  `'\''` dance is how it is closed, escaped and reopened. */
+function shellSingleQuote(value: string): string {
+  return value.replaceAll("'", `'\''`);
+}
+
 /** Placeholder credential value handed to the in-sandbox CLI on the broker path.
  *  It is never used for auth (the proxy ignores VM-supplied Authorization/
  *  x-api-key and trusts only E2B's injected `x-mcpjam-harness-lease`); it just
@@ -1376,7 +1383,15 @@ const cursorAdapter: HarnessRuntimeAdapter = {
     // `.harness-bootstrap/<harnessId>` under the session workdir, and
     // `implementation.json` puts the executable at
     // `implementation/home/.local/bin/agent` (privateHome: true).
-    `"${sessionWorkDir}/.harness-bootstrap/cursor/implementation/home/.local/bin/agent" --version`,
+    //
+    // SINGLE-quoted with embedded quotes escaped, not double-quoted: the
+    // workdir is host-configured, and `$(…)`/backticks inside double quotes
+    // are still expanded by the shell. `resolveWorkingDirectory` confines the
+    // value to /home/user but does not reject shell metacharacters, so a path
+    // like `/home/user/$(id)` would otherwise run `id` during session setup.
+    `'${shellSingleQuote(
+      sessionWorkDir,
+    )}/.harness-bootstrap/cursor/implementation/home/.local/bin/agent' --version`,
   createHarness({ auth, mcpJson }) {
     // Dual-`ai` boundary cast, same as the other two adapters.
     return createCursor({

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -41,7 +41,11 @@ import {
   setToolSpanMessageRangesFromResults,
 } from "../live-chat-trace-stream.js";
 import { StreamTurnDriver } from "../stream-turn-driver.js";
-import { getHarnessAdapter, buildBrokerDummyAuth } from "./registry.js";
+import {
+  getHarnessAdapter,
+  buildBrokerDummyAuth,
+  type HarnessAuth,
+} from "./registry.js";
 import type { HarnessV1PermissionMode } from "@ai-sdk/harness";
 import {
   startHarnessModelBroker,
@@ -106,6 +110,10 @@ import {
   skillsFingerprint,
 } from "./runtime-skills.js";
 import { deliveredSecretsFingerprint, toSecretEnv } from "./runtime-secrets.js";
+import {
+  externalAccountPlanWallError,
+  isExternalAccountPlanWallTurn,
+} from "./external-account-plan-wall.js";
 import { materializeSkillFiles } from "./materialize-skill-files.js";
 import { materializePinnedSkillFiles } from "./pinned-harness-skills.js";
 import { selectHarnessSkillSource } from "./skill-delivery.js";
@@ -485,6 +493,15 @@ export function harnessRuntimeFingerprint(parts: {
    * which would read as "the secrets were removed".
    */
   secretsHash?: string;
+  /**
+   * EXTERNAL-ACCOUNT harnesses need no field of their own here, and this note
+   * is why rather than an oversight. Their credential is a materialized project
+   * secret, so a rotation already forks through `secretsHash`; and the harness
+   * id is a literal PREFIX of the returned fingerprint, so a cursor session can
+   * never resume into a brokered lane whatever else matches. The one dimension
+   * that looks missing — the model — is genuinely absent from the turn: the
+   * adapter passes none, so there is nothing to fork on.
+   */
 }): string {
   const pluginDimension = pluginVersionsFingerprint(parts.pluginVersions ?? []);
   const s = [
@@ -662,6 +679,14 @@ export async function runHarnessTurn(
     | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
     | undefined;
   let turnFinishReason: FinishReason = "stop";
+  // Tool calls that returned a NON-error result this turn. Read only by the
+  // external-account entitlement-wall check, which must never fire on a turn
+  // that actually did work — see `external-account-plan-wall.ts`.
+  let successfulToolCalls = 0;
+  // The runtime version this box actually installed, for adapters whose CLI is
+  // not version-pinned by the package pin. Telemetry only — see the capture in
+  // `onSandboxSession` and `runtimeVersionCommand` in the registry.
+  let installedRuntimeVersion: string | undefined;
   let capturedTurnTrace: PersistedTurnTrace | undefined;
   // §3 atomic commit: built in executeEngine's finally (after session.detach()),
   // consumed by onFinishEngine's onConversationComplete so the resume state
@@ -984,7 +1009,16 @@ export async function runHarnessTurn(
       // limit the Gateway credential or wake the box.
       //   (a) the runtime must be able to run this model — else createX() would
       //       silently substitute its own default model.
-      if (!harnessAdapter.supportsModel(modelId)) {
+      //       SKIPPED for an external-account harness: the model MCPJam knows
+      //       about is not the model that runs. Cursor's adapter passes no
+      //       model at all and Cursor Auto picks one on the customer's own
+      //       account, so there is no substitution to catch here — asking
+      //       `supportsModel` would only be asking the adapter to rubber-stamp
+      //       a value nothing consumes.
+      if (
+        harnessAdapter.modelAccess !== "external-account" &&
+        !harnessAdapter.supportsModel(modelId)
+      ) {
         throw new Error(
           `The ${harnessAdapter.displayName} harness can't run model "${modelId}".`,
         );
@@ -1029,7 +1063,15 @@ export async function runHarnessTurn(
       // EVERY scope fails closed here (guests were already broker-only —
       // this now covers members too); the chat-v2 routes surface the same
       // condition pre-stream via checkHarnessRuntimeAvailable.
-      if (!harnessBrokerDeliveryEnabled()) {
+      //
+      // An EXTERNAL-ACCOUNT harness is exempt, and not as a favour: it has no
+      // broker to disable. Its credential is the customer's own materialized
+      // project secret and its model traffic never touches MCPJam's proxy, so
+      // refusing it here would be switching off a path it never uses.
+      if (
+        harnessAdapter.modelAccess !== "external-account" &&
+        !harnessBrokerDeliveryEnabled()
+      ) {
         throw new Error(
           "Harness runs require broker credential delivery, but it is " +
             "disabled on this server (MCPJAM_HARNESS_BROKER_DELIVERY=false). " +
@@ -1220,6 +1262,64 @@ export async function runHarnessTurn(
       const secretEnv = runtimeSecrets
         ? toSecretEnv(runtimeSecrets)
         : undefined;
+
+      // EXTERNAL-ACCOUNT CREDENTIAL. A harness that authenticates on the
+      // customer's own provider account takes its credential from the SAME
+      // materialized project secrets above — there is no broker lease to mint,
+      // so this is the only place the value can come from.
+      //
+      // Resolved HERE, before the sandbox provider is built, for two reasons:
+      // a missing secret must fail the turn before anything is provisioned,
+      // and the credential has to be REMOVED from the box's session env bag
+      // that the provider is about to be constructed with.
+      //
+      // What that removal does and does not buy: the key no longer rides on
+      // every `run`/`spawn` in the box, so an unrelated command the agent
+      // shells out to cannot read it out of its own environment. The Cursor
+      // process itself still receives it — it has to, that is how the CLI
+      // authenticates. Fully keeping it out of the VM needs the adapter's
+      // credential-brokering hook wired to E2B's egress transform, which is
+      // tracked separately.
+      const externalAccountCredentialNames =
+        harnessAdapter.modelAccess === "external-account"
+          ? harnessAdapter.externalAccountCredentialEnv
+          : undefined;
+      let externalAccountAuth: HarnessAuth | undefined;
+      if (externalAccountCredentialNames) {
+        const missing = externalAccountCredentialNames.filter(
+          (name) => !secretEnv?.[name],
+        );
+        if (missing.length > 0) {
+          // Preflight-shaped copy: names the variable and where to set it, so
+          // the reader can act on it without opening a runbook. NEVER defaulted
+          // or silently skipped — starting the CLI with no credential produces
+          // an opaque failure from inside the box instead.
+          const one = missing.length === 1;
+          throw new Error(
+            `The ${harnessAdapter.displayName} harness requires ` +
+              `${one ? "a " : ""}${missing.join(", ")} project ` +
+              `${one ? "secret" : "secrets"} in this environment — add ` +
+              `${one ? "it" : "them"} under Project Settings → Secrets.`,
+          );
+        }
+        externalAccountAuth = Object.fromEntries(
+          externalAccountCredentialNames.map((name) => [
+            name,
+            secretEnv![name] as string,
+          ]),
+        );
+      }
+      // What the BOX's session env carries: everything the project materialized
+      // MINUS the credentials handed to the adapter directly (see above). An
+      // empty result is treated exactly like "no secrets" by the provider
+      // construction below.
+      const sessionSecretEnv = externalAccountCredentialNames
+        ? Object.fromEntries(
+            Object.entries(secretEnv ?? {}).filter(
+              ([name]) => !externalAccountCredentialNames.includes(name),
+            ),
+          )
+        : secretEnv;
       // What the ADAPTER will actually write, per its own rules (Codex rejects
       // a name outright — mid-`doStart`, i.e. it would fail the whole turn — so
       // it filters rather than throws). Every MCPJam-side skill pass below is
@@ -1590,9 +1690,9 @@ export async function runHarnessTurn(
         // In `envs`, never in the command line — the rule `plugin-box.ts`
         // already states: argv is readable by every process in the box through
         // `/proc`, and it lands in shell history.
-        ...(secretEnv && Object.keys(secretEnv).length > 0
+        ...(sessionSecretEnv && Object.keys(sessionSecretEnv).length > 0
           ? {
-              sessionEnv: secretEnv,
+              sessionEnv: sessionSecretEnv,
               // Stamped when the env is MERGED INTO A COMMAND, not here.
               //
               // Constructing this provider only puts the values in a local
@@ -1618,31 +1718,56 @@ export async function runHarnessTurn(
       // RECORD the run id before the POST: if the backend installs the E2B rule
       // but the response is lost or aborted, teardown can still revoke by this
       // id (the backend keys revoke on runId). From here on a lease may exist.
-      brokerRunId = turnRunId;
-      const broker = await startHarnessModelBroker({
-        // The project and the execution scope are fields of `box`'s COMPUTER
-        // arm (set where `box` is built, above), so the ephemeral path has no
-        // way to send either: the backend derives project + billing org from
-        // the sandbox row's run.
-        box,
-        harnessId: harnessAdapter.id,
-        modelId,
-        runId: brokerRunId,
-        bearer: authHeader,
-        ...(abortSignal ? { signal: abortSignal } : {}),
-      });
-      if (!broker.ok) {
-        // Throws propagate to the turn's outer catch; onFinishEngine frees the
-        // claimed lane (sessionEstablished still false) and revokes the broker
-        // lease (brokerRunId set) if the backend installed before a lost response.
-        throw new Error(broker.error);
+      let auth: HarnessAuth;
+      if (externalAccountAuth) {
+        // EXTERNAL-ACCOUNT: no lease exists to mint, so this whole step is
+        // skipped rather than made conditional inside it. `brokerRunId` stays
+        // unset, which is what keeps teardown from issuing a revoke for a lease
+        // that never existed.
+        //
+        // The RESERVATION is deliberately NOT released here. On the brokered
+        // path the lease consumes the claim and takes over the per-box fence;
+        // with no lease there is nothing to take over, so the claim has to be
+        // held by heartbeat for the whole turn — otherwise a second Cursor turn
+        // could start bootstrapping the same box mid-run. `reservationHeld`
+        // stays true and the turn's own teardown releases it.
+        auth = externalAccountAuth;
+        // Stamp delivery HERE, because this path took the credential out of the
+        // session env bag and the provider's `onSessionEnvUsed` can therefore
+        // never fire for it — for a project whose only secret is this one, the
+        // bag is empty and nothing would ever stamp. The value is about to be
+        // handed to the runtime that authenticates with it, which is exactly
+        // the "reached an execution surface" the stamp means. Getting this
+        // wrong makes a live credential read as dormant to whoever is deciding
+        // whether it is safe to delete.
+        onSecretEnvDelivered?.();
+      } else {
+        brokerRunId = turnRunId;
+        const broker = await startHarnessModelBroker({
+          // The project and the execution scope are fields of `box`'s COMPUTER
+          // arm (set where `box` is built, above), so the ephemeral path has no
+          // way to send either: the backend derives project + billing org from
+          // the sandbox row's run.
+          box,
+          harnessId: harnessAdapter.id,
+          modelId,
+          runId: brokerRunId,
+          bearer: authHeader,
+          ...(abortSignal ? { signal: abortSignal } : {}),
+        });
+        if (!broker.ok) {
+          // Throws propagate to the turn's outer catch; onFinishEngine frees the
+          // claimed lane (sessionEstablished still false) and revokes the broker
+          // lease (brokerRunId set) if the backend installed before a lost response.
+          throw new Error(broker.error);
+        }
+        // The lease is recorded, which consumed this turn's claim on the box; the
+        // lease's own per-box fence covers the rest of the turn. Releasing now
+        // would free a box that is very much still in use.
+        clearReservationHeartbeat();
+        reservationHeld = false;
+        auth = buildBrokerDummyAuth(harnessAdapter.id, broker.proxyBaseUrl);
       }
-      // The lease is recorded, which consumed this turn's claim on the box; the
-      // lease's own per-box fence covers the rest of the turn. Releasing now
-      // would free a box that is very much still in use.
-      clearReservationHeartbeat();
-      reservationHeld = false;
-      const auth = buildBrokerDummyAuth(harnessAdapter.id, broker.proxyBaseUrl);
       tBroker = Date.now();
 
       // 4. Assemble the harness over the host's E2B computer (the provider and
@@ -1654,7 +1779,18 @@ export async function runHarnessTurn(
       // constructs it (for Claude Code: the gateway `creator/model` id becomes a
       // CLI-native alias `sonnet|opus|haiku`; the raw gateway id makes the CLI
       // do zero inference). Returns the HarnessAgent boundary type directly.
-      const harnessRuntime = harnessAdapter.createHarness({ modelId, auth });
+      //
+      // Narrowed on the delivery MECHANISM rather than called through the
+      // union: a `session-config` adapter's `createHarness` REQUIRES `mcpJson`
+      // (its only channel for MCP config), and a `sandbox-files` one does not
+      // take it at all. Writing the branch here is what makes "the servers
+      // cannot be silently dropped at construction" a compile-time fact instead
+      // of a convention.
+      const harnessRuntime =
+        harnessAdapter.mcpDelivery === "native" &&
+        harnessAdapter.mcpNativeDelivery === "session-config"
+          ? harnessAdapter.createHarness({ modelId, auth, mcpJson })
+          : harnessAdapter.createHarness({ modelId, auth });
       // MCPJam's server-executed tools. The harness forwards each as a tool spec
       // to the runtime; when the runtime calls one it pauses, the agent runs the
       // tool's `execute()` HERE on MCPJam's server, and submits the result back.
@@ -1724,12 +1860,19 @@ export async function runHarnessTurn(
           // Code writes a `.mcp.json`). A host-executed adapter has nothing to
           // write — its servers already went out as `tools` above — and the
           // adapter union forbids it from carrying `deliverMcpServers` at all.
-          if (harnessAdapter.mcpDelivery === "native") {
+          if (
+            harnessAdapter.mcpDelivery === "native" &&
+            harnessAdapter.mcpNativeDelivery === "sandbox-files"
+          ) {
             // The "advertises MCP but has no delivery strategy" throw that used
-            // to guard this call is GONE, not relaxed: the native arm of
-            // `HarnessRuntimeAdapter` now REQUIRES `deliverMcpServers`, so the
+            // to guard this call is GONE, not relaxed: each native MECHANISM of
+            // `HarnessRuntimeAdapter` REQUIRES its own hook, so the
             // misconfiguration it caught is a compile error instead of a
             // turn-time one (tsc reports the old check's body as `never`).
+            //
+            // The other native mechanism (`session-config`) has nothing to do
+            // here by construction: its servers were passed to `createHarness`
+            // above, before this session existed.
             await harnessAdapter.deliverMcpServers({
               // Bind to the live session here (it lives behind the dual-`ai`
               // boundary) so the adapter stays free of the harness session type.
@@ -1739,6 +1882,35 @@ export async function runHarnessTurn(
               sessionWorkDir,
               mcpJson,
             });
+          }
+          // VERSION CANARY. For an adapter whose CLI version is not pinned by
+          // the package pin (Cursor bootstraps `curl … | bash`, which always
+          // fetches the current build), ask the box what it actually installed
+          // and record it. Two known cursor-agent builds are four months of
+          // behaviour apart, so without this a silent upstream change presents
+          // as an unattributable regression.
+          //
+          // FAIL-SOFT in every direction: bounded by the turn's own signal plus
+          // a deadline, every error swallowed, and nothing downstream reads the
+          // result. A canary must never be able to fail a run.
+          if (harnessAdapter.runtimeVersionCommand) {
+            try {
+              const probe = await session.run({
+                command: harnessAdapter.runtimeVersionCommand(sessionWorkDir),
+                abortSignal: abortSignal
+                  ? AbortSignal.any([
+                      abortSignal,
+                      AbortSignal.timeout(HARNESS_TEARDOWN_TIMEOUT_MS),
+                    ])
+                  : AbortSignal.timeout(HARNESS_TEARDOWN_TIMEOUT_MS),
+              });
+              const version = probe.stdout.trim().split("\n")[0]?.trim();
+              if (probe.exitCode === 0 && version) {
+                installedRuntimeVersion = version;
+              }
+            } catch {
+              // Deliberately silent: see above.
+            }
           }
           // The adapter writes skill CONTENT (via the `skills` param above); this
           // pass only removes managed dirs deleted/renamed in Convex (the adapter
@@ -2336,20 +2508,33 @@ export async function runHarnessTurn(
             const rawToolName = String(
               (part as { toolName?: unknown }).toolName ?? "tool",
             );
-            // Claude Code namespaces MCP tools as mcp__<server>__<tool>; map back
-            // to { serverId, un-namespaced toolName } so the UI chunks, engine
-            // callbacks, and persisted transcript carry MCPJam tool identity
-            // (eval matching + MCP App rendering key off it). Native harness
-            // tools (Bash, Read, …) have no prefix → serverId stays undefined.
-            const { serverId, toolName } = harnessAdapter.parseToolName(
-              rawToolName,
-              harnessKeyToServerId,
-            );
             const input = coerceToolInput(
               (part as { input?: unknown }).input ??
                 (part as { args?: unknown }).args ??
                 {},
             );
+            // Map back to { serverId, un-namespaced toolName } so the UI chunks,
+            // engine callbacks, and persisted transcript carry MCPJam tool
+            // identity (eval matching + MCP App rendering key off it).
+            //
+            // Name AND input, because not every runtime puts the identity in the
+            // name: Claude Code namespaces MCP tools as `mcp__<server>__<tool>`
+            // (native tools have no prefix → serverId stays undefined), while
+            // Cursor streams every MCP call as an opaque `acp_tool_<id>` and
+            // carries `{ providerIdentifier, toolName }` in the input instead.
+            // The adapter decides; this call site only has to hand over both.
+            // (Which is why `input` is now resolved FIRST — it is an argument to
+            // the attribution, not just something recorded after it.)
+            const { serverId, toolName } = harnessAdapter.attributeToolCall
+              ? harnessAdapter.attributeToolCall({
+                  rawToolName,
+                  input,
+                  keyToServerId: harnessKeyToServerId,
+                })
+              : harnessAdapter.parseToolName(
+                  rawToolName,
+                  harnessKeyToServerId,
+                );
             toolMeta.set(toolCallId, {
               ...(serverId ? { serverId } : {}),
               toolName,
@@ -2424,6 +2609,10 @@ export async function runHarnessTurn(
               (part as { error?: unknown }).error != null;
             // Reuse the identity resolved at tool-call time (the result part may
             // omit the name); fall back to parsing the result's own toolName.
+            // Name-only on purpose: a RESULT part carries no call input, so
+            // `attributeToolCall` would have nothing extra to work with. The
+            // identity resolved at call time (above) is the real answer and this
+            // is only its fallback.
             const meta =
               toolMeta.get(toolCallId) ??
               harnessAdapter.parseToolName(
@@ -2532,6 +2721,7 @@ export async function runHarnessTurn(
                 ...(meta.serverId ? { serverId: meta.serverId } : {}),
               });
             }
+            if (!isError) successfulToolCalls += 1;
             pendingResults.push({
               toolCallId,
               toolName: meta.toolName,
@@ -2727,6 +2917,25 @@ export async function runHarnessTurn(
         const finalText = await res.text;
         closeReasoning();
 
+        // ENTITLEMENT WALL (external-account harnesses only). Cursor answers a
+        // plan-gated request with a normal, successful-looking turn whose whole
+        // text is an upgrade notice — so without this check chat would persist
+        // it as the assistant's answer and an eval would SCORE it, producing a
+        // verdict about a model that never ran. Fail the turn instead. The rule
+        // is deliberately narrow (exact text, no successful tool call, plain
+        // stop); see `external-account-plan-wall.ts` for why each condition is
+        // there and why a substring match would be wrong.
+        if (
+          externalAccountAuth &&
+          isExternalAccountPlanWallTurn({
+            finalText,
+            finishReason: turnFinishReason,
+            successfulToolCalls,
+          })
+        ) {
+          throw externalAccountPlanWallError(harnessAdapter.displayName);
+        }
+
         // Settle cumulative usage + finish reason on the driver NOW — usage is
         // known from the finish part. Set before the completeness fallback below
         // so the synthesized tool step's finishStep() (and every step settling
@@ -2794,6 +3003,14 @@ export async function runHarnessTurn(
             tStream - tStart
           }ms resumed=${resumedSession}`,
         );
+        if (installedRuntimeVersion) {
+          // Its own line, and greppable: the canary alert watches for this
+          // value CHANGING between sessions of the same harness, which is not a
+          // question the timing line above could answer.
+          logger.info(
+            `[harness][runtime-version] harness=${harnessAdapter.id} version=${installedRuntimeVersion}`,
+          );
+        }
       } finally {
         if (heartbeatTimer) clearInterval(heartbeatTimer);
         try {

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -1294,6 +1294,22 @@ export async function runHarnessTurn(
           // the reader can act on it without opening a runbook. NEVER defaulted
           // or silently skipped — starting the CLI with no credential produces
           // an opaque failure from inside the box instead.
+          //
+          // KNOWN LIMITATION, and this is where it surfaces: callers that do
+          // NOT wire secrets deliver none (see the note on `runtimeSecrets`
+          // above — that is the documented contract, not an oversight). The
+          // SYNTHETIC path (`sessionSimulation/runner.ts`, which drives
+          // scenario/swarm/eval turns through `runUnifiedAssistantTurn`) is one
+          // of them, so an external-account harness is refused there today even
+          // when the environment does hold the secret.
+          //
+          // Deliberately not fixed here. Wiring it means fetching the secrets
+          // AND building the scrubber in that runner — the pair is what keeps
+          // delivered values out of the persisted transcript — and doing so
+          // would also start delivering project secrets to the EXISTING
+          // harnesses' synthetic turns, which today receive none. That is a
+          // security-relevant behaviour change well outside this change's
+          // scope. The refusal above is the fail-closed, legible alternative.
           const one = missing.length === 1;
           throw new Error(
             `The ${harnessAdapter.displayName} harness requires ` +
@@ -1732,15 +1748,6 @@ export async function runHarnessTurn(
         // could start bootstrapping the same box mid-run. `reservationHeld`
         // stays true and the turn's own teardown releases it.
         auth = externalAccountAuth;
-        // Stamp delivery HERE, because this path took the credential out of the
-        // session env bag and the provider's `onSessionEnvUsed` can therefore
-        // never fire for it — for a project whose only secret is this one, the
-        // bag is empty and nothing would ever stamp. The value is about to be
-        // handed to the runtime that authenticates with it, which is exactly
-        // the "reached an execution surface" the stamp means. Getting this
-        // wrong makes a live credential read as dormant to whoever is deciding
-        // whether it is safe to delete.
-        onSecretEnvDelivered?.();
       } else {
         brokerRunId = turnRunId;
         const broker = await startHarnessModelBroker({
@@ -1883,6 +1890,22 @@ export async function runHarnessTurn(
               mcpJson,
             });
           }
+          // DELIVERY STAMP for the external-account credential.
+          //
+          // Here rather than where `auth` was resolved, for the same reason the
+          // provider stamps on first USE and not at construction: resolving the
+          // value only put it in a local object, and setup can still throw
+          // before anything receives it. By this point a sandbox session
+          // exists and the runtime is about to be started holding the
+          // credential — the "reached an execution surface" the stamp means.
+          //
+          // It has to be stamped explicitly at all because this path took the
+          // credential OUT of the session env bag, so the provider's own
+          // `onSessionEnvUsed` can never fire for it: for a project whose only
+          // secret is this one the bag is empty and nothing would ever stamp,
+          // making a live credential read as dormant to whoever is deciding
+          // whether it is safe to delete.
+          if (externalAccountAuth) onSecretEnvDelivered?.();
           // VERSION CANARY. For an adapter whose CLI version is not pinned by
           // the package pin (Cursor bootstraps `curl … | bash`, which always
           // fetches the current build), ask the box what it actually installed
@@ -2721,7 +2744,14 @@ export async function runHarnessTurn(
                 ...(meta.serverId ? { serverId: meta.serverId } : {}),
               });
             }
-            if (!isError) successfulToolCalls += 1;
+            // `!policyBlock` for the SAME reason the result and span above
+            // exclude it: a policy block never reached the server, so no tool
+            // ran. Counting it here would let a turn whose every call MCPJam
+            // refused look like a turn that did work — and the entitlement-wall
+            // check reads this counter to decide whether an "upgrade your plan"
+            // answer is a real answer. A blocked call plus that text is exactly
+            // the case where the wall must still be caught.
+            if (!policyBlock && !isError) successfulToolCalls += 1;
             pendingResults.push({
               toolCallId,
               toolName: meta.toolName,

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -1890,22 +1890,6 @@ export async function runHarnessTurn(
               mcpJson,
             });
           }
-          // DELIVERY STAMP for the external-account credential.
-          //
-          // Here rather than where `auth` was resolved, for the same reason the
-          // provider stamps on first USE and not at construction: resolving the
-          // value only put it in a local object, and setup can still throw
-          // before anything receives it. By this point a sandbox session
-          // exists and the runtime is about to be started holding the
-          // credential — the "reached an execution surface" the stamp means.
-          //
-          // It has to be stamped explicitly at all because this path took the
-          // credential OUT of the session env bag, so the provider's own
-          // `onSessionEnvUsed` can never fire for it: for a project whose only
-          // secret is this one the bag is empty and nothing would ever stamp,
-          // making a live credential read as dormant to whoever is deciding
-          // whether it is safe to delete.
-          if (externalAccountAuth) onSecretEnvDelivered?.();
           // VERSION CANARY. For an adapter whose CLI version is not pinned by
           // the package pin (Cursor bootstraps `curl … | bash`, which always
           // fetches the current build), ask the box what it actually installed
@@ -2186,6 +2170,23 @@ export async function runHarnessTurn(
       // Session is up: the finalizer + heartbeat now own the continuity lane, so
       // the pre-session cleanup in onFinishEngine no longer needs to free it.
       sessionEstablished = true;
+
+      // DELIVERY STAMP for the external-account credential — HERE, because this
+      // is the first point at which the runtime has actually taken it: the
+      // adapter starts the CLI and completes its handshake inside
+      // `createSession`, so a session that resolved is a process that accepted
+      // the credential. Earlier points looked plausible and were not: resolving
+      // `auth` only puts the value in a local object, and `onSandboxSession`
+      // fires before the process exists at all — both would report a delivery
+      // that setup could still have thrown before making.
+      //
+      // It has to be stamped explicitly at all because this path took the
+      // credential OUT of the box's session env bag, so the provider's own
+      // `onSessionEnvUsed` can never fire for it: for a project whose only
+      // secret is this one the bag is empty and nothing would ever stamp,
+      // making a live credential read as dormant to whoever is deciding whether
+      // it is safe to delete.
+      if (externalAccountAuth) onSecretEnvDelivered?.();
 
       // Re-write SKILL.md WITH preserved extra frontmatter (allowed-tools /
       // license / …) for skills that carry it. The adapter's `skills` param
@@ -2554,10 +2555,7 @@ export async function runHarnessTurn(
                   input,
                   keyToServerId: harnessKeyToServerId,
                 })
-              : harnessAdapter.parseToolName(
-                  rawToolName,
-                  harnessKeyToServerId,
-                );
+              : harnessAdapter.parseToolName(rawToolName, harnessKeyToServerId);
             toolMeta.set(toolCallId, {
               ...(serverId ? { serverId } : {}),
               toolName,

--- a/mcpjam-inspector/server/utils/harness/runtime-skills.ts
+++ b/mcpjam-inspector/server/utils/harness/runtime-skills.ts
@@ -66,7 +66,7 @@ export type FetchRuntimeSkillsResult =
 export async function fetchRuntimeSkills(
   bearer: string,
   projectId: string,
-  executionScope?: ExecutionScope
+  executionScope?: ExecutionScope,
 ): Promise<FetchRuntimeSkillsResult> {
   try {
     const skills = executionScope
@@ -99,7 +99,7 @@ export type FetchRuntimeSkillFilesResult =
 export async function fetchRuntimeSkillFiles(
   bearer: string,
   projectId: string,
-  executionScope?: ExecutionScope
+  executionScope?: ExecutionScope,
 ): Promise<FetchRuntimeSkillFilesResult> {
   try {
     const files = executionScope
@@ -111,7 +111,7 @@ export async function fetchRuntimeSkillFiles(
       "[runtime-skills] file fetch failed; skipping materialization",
       {
         error: error instanceof Error ? error.message : String(error),
-      }
+      },
     );
     return { ok: false };
   }
@@ -191,7 +191,7 @@ export function toYamlDoubleQuoted(value: string): string {
  * adapter that composes frontmatter structurally must NOT use this.
  */
 export function frontmatterSafeSkills(
-  skills: RuntimeSkill[]
+  skills: RuntimeSkill[],
 ): HarnessSkillPayload[] {
   return skills.map((s) => ({
     name: s.name,
@@ -214,7 +214,7 @@ export interface PreparedHarnessSkills {
 
 /** Claude Code: every runtime skill is delivered, descriptions YAML-encoded. */
 export function prepareClaudeCodeSkills(
-  skills: RuntimeSkill[]
+  skills: RuntimeSkill[],
 ): PreparedHarnessSkills {
   return {
     payload: frontmatterSafeSkills(skills),
@@ -237,7 +237,7 @@ export function prepareClaudeCodeSkills(
  * (every other pass validates it the same way), so it is dropped with a reason.
  */
 export function prepareCodexSkills(
-  skills: RuntimeSkill[]
+  skills: RuntimeSkill[],
 ): PreparedHarnessSkills {
   const delivered: RuntimeSkill[] = [];
   const skipped: Array<{ name: string; reason: string }> = [];
@@ -254,4 +254,25 @@ export function prepareCodexSkills(
     });
   }
   return { payload: frontmatterSafeSkills(delivered), delivered, skipped };
+}
+
+/**
+ * A harness that delivers no skills at all (`supportsSkills: false`).
+ *
+ * `runHarnessTurn` never calls `prepareSkills` for such an adapter, so this is
+ * reached only if that guard is ever removed. It reports the honest answer —
+ * nothing delivered, nothing skipped — rather than a payload that would claim a
+ * delivery the runtime does not perform. Every skill is listed as skipped so a
+ * caller inspecting the result can say WHY the skills it fetched are missing
+ * from the box instead of finding an empty structure with no explanation.
+ */
+export function prepareNoSkills(skills: RuntimeSkill[]): PreparedHarnessSkills {
+  return {
+    payload: [],
+    delivered: [],
+    skipped: skills.map((skill) => ({
+      name: skill.name,
+      reason: "harness-does-not-deliver-skills",
+    })),
+  };
 }

--- a/mcpjam-inspector/server/utils/harness/skill-roots.ts
+++ b/mcpjam-inspector/server/utils/harness/skill-roots.ts
@@ -19,3 +19,16 @@ export const CLAUDE_CODE_SKILLS_BASE = "/home/user/.claude/skills";
 
 /** Codex's skills root (`~/.agents/skills`, the Agent-Skills-spec location). */
 export const CODEX_SKILLS_BASE = "/home/user/.agents/skills";
+
+/**
+ * The ACP runtimes' skills root (`~/.agents/skills`, the Agent-Skills-spec
+ * location — `DEFAULT_ACP_SKILLS_DIRECTORY` in `@ai-sdk/harness-acp`), which is
+ * where the Cursor CLI adapter would write.
+ *
+ * Declared but DORMANT: the cursor adapter ships with `supportsSkills: false`,
+ * so nothing writes here and no MCPJam pass targets it. It exists so the
+ * adapter's `skillsBaseDir` states a real path rather than a placeholder, and
+ * so turning skills on later is a one-line flip rather than a hunt for the
+ * runtime's root.
+ */
+export const CURSOR_SKILLS_BASE = "/home/user/.agents/skills";

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -934,6 +934,23 @@ export async function streamWebChatTurn(
       String(prepare.modelDefinition.id),
       prepare.modelDefinition.provider,
     );
+  // …OR an EXTERNAL-ACCOUNT harness, whose host carries a sentinel model
+  // (`cursor/auto`) that is deliberately not MCPJam-hosted.
+  //
+  // Without this the branch below sends a Cursor turn down the org-BYOK path,
+  // which never reaches `runHarnessTurn` at all: the harness pre-flight would
+  // approve the turn and the turn would then run on a completely different
+  // engine, reported as Cursor. `deriveOrgProviderKeyResult` would also reject
+  // `cursor/auto` outright, so the visible symptom is a 400 on a host the
+  // product just told the user was ready.
+  //
+  // Not folded into `isMCPJam` itself: that name means "MCPJam pays for this
+  // model", and an external-account turn is exactly the case where it does not.
+  // The two reasons to take the non-BYOK branch are different facts, so they
+  // stay separate values.
+  const isExternalAccountHarnessTurn =
+    !!persist.harness && harnessUsesExternalAccount(persist.harness);
+  const usesMcpjamFreePath = isMCPJam || isExternalAccountHarnessTurn;
 
   // Resolve the host config now that `resolvedTemperature` is known.
   // Legacy chat-v2 fed `resolvedTemperature` into `buildDirectHostConfig`;
@@ -1061,7 +1078,7 @@ export async function streamWebChatTurn(
     };
   };
 
-  if (!isMCPJam) {
+  if (!usesMcpjamFreePath) {
     const providerKeyResult = deriveOrgProviderKeyResult(
       prepare.modelDefinition,
     );
@@ -1202,9 +1219,7 @@ export async function streamWebChatTurn(
   // backend for the two surfaces that read it that way.
   const onConversationComplete = buildOnConversationComplete(
     mcpjamModelId,
-    persist.harness && harnessUsesExternalAccount(persist.harness)
-      ? "external-account"
-      : "mcpjam",
+    isExternalAccountHarnessTurn ? "external-account" : "mcpjam",
   );
   warnIfChatAbortSignalMissing(runtime.abortSignal, "web/chat-v2");
 

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -81,6 +81,7 @@ import {
 import { createSecretScrubber } from "./secrets/secret-scrubber.js";
 import type { HarnessSessionCommitPayload } from "./harness/harness-session-state.js";
 import { type RuntimeSkill } from "./harness/runtime-skills.js";
+import { harnessUsesExternalAccount } from "./harness/registry.js";
 import type { EffectiveCapabilitySet } from "../services/environments/effective-capabilities.js";
 import type { TurnSkillProvenance } from "../services/environments/runtime.js";
 import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
@@ -947,7 +948,7 @@ export async function streamWebChatTurn(
   // + modelSource.
   const buildOnConversationComplete = (
     modelId: string,
-    modelSource: "mcpjam" | "byok" | "local_byok",
+    modelSource: "mcpjam" | "byok" | "local_byok" | "external-account",
   ) => {
     if (!hostedChatSessionId) return undefined;
     return async (
@@ -1189,9 +1190,21 @@ export async function streamWebChatTurn(
 
   // MCPJam-free path.
   const mcpjamModelId = String(prepare.modelDefinition.id);
+  // …except when the HARNESS pays for its own model. An external-account
+  // runtime (Cursor) reaches its provider on the customer's account with the
+  // runtime vendor, so MCPJam is not charged for the turn and must not record
+  // it as though it were — `'mcpjam'` is what makes a turn consume the org's
+  // MCPJam spend limit.
+  //
+  // `'external-account'` rather than `'byok'`, though both mean "not charged to
+  // MCPJam": byok additionally asserts a configured model PROVIDER and its key,
+  // which this turn does not have. See `chatModelSourceValidator` in the
+  // backend for the two surfaces that read it that way.
   const onConversationComplete = buildOnConversationComplete(
     mcpjamModelId,
-    "mcpjam",
+    persist.harness && harnessUsesExternalAccount(persist.harness)
+      ? "external-account"
+      : "mcpjam",
   );
   warnIfChatAbortSignalMissing(runtime.abortSignal, "web/chat-v2");
 

--- a/mcpjam-inspector/shared/__tests__/model-provider-fixtures.ts
+++ b/mcpjam-inspector/shared/__tests__/model-provider-fixtures.ts
@@ -40,6 +40,10 @@ export const MODEL_PROVIDER_FIXTURES: ProviderFixture[] = [
   { id: "openai/gpt-5", provider: "openai" },
   { id: "ollama/llama3.1", provider: "ollama" },
   { id: "openrouter/auto", provider: "openrouter" },
+  // The Cursor CLI harness sentinel. Before `cursor` was a known prefix this
+  // fell through to the bare-id rule and classified as `ollama`, which stamped
+  // eval projections and disclosure with a provider the run never touched.
+  { id: "cursor/auto", provider: "cursor" },
   { id: "qwen/qwen3-max", provider: "qwen" },
   { id: "mistral/mistral-large", provider: "mistral" },
   { id: "z-ai/glm-4.6", provider: "z-ai" },

--- a/mcpjam-inspector/shared/harness-mcp-delivery.ts
+++ b/mcpjam-inspector/shared/harness-mcp-delivery.ts
@@ -52,6 +52,7 @@ export type HarnessMcpDelivery = "native" | "host-executed";
 export const HARNESS_MCP_DELIVERY = {
   "claude-code": "native",
   codex: "host-executed",
+  cursor: "native",
 } as const satisfies Record<Harness, HarnessMcpDelivery>;
 
 /** Delivery mode for `harness`. Callers holding a narrower union (the client's

--- a/mcpjam-inspector/shared/model-provider.ts
+++ b/mcpjam-inspector/shared/model-provider.ts
@@ -59,6 +59,9 @@ const MODEL_ID_PREFIX_IDENTITY = [
   "qwen",
   "mistral",
   "z-ai",
+  // `cursor/auto` — the Cursor CLI harness's sentinel. Without this prefix the
+  // bare-id fallback classifies it as `ollama`.
+  "cursor",
 ] as const satisfies readonly ModelProvider[];
 
 /**
@@ -69,7 +72,7 @@ export const MODEL_ID_PREFIX_TO_PROVIDER: Record<string, ModelProvider> =
   Object.assign(
     Object.create(null) as Record<string, ModelProvider>,
     Object.fromEntries(MODEL_ID_PREFIX_IDENTITY.map((p) => [p, p])),
-    MODEL_ID_PREFIX_ALIASES
+    MODEL_ID_PREFIX_ALIASES,
   );
 
 export type ModelProviderClassification = {
@@ -103,7 +106,7 @@ export type ModelProviderClassification = {
  * case that returns `null`.
  */
 export function classifyModelIdProvider(
-  modelId: string
+  modelId: string,
 ): ModelProviderClassification | null {
   const id = modelId.trim();
   if (id.length === 0) return null;

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -118,6 +118,13 @@ export type ModelProvider =
   | "z-ai"
   | "minimax"
   | "qwen"
+  // Not a model provider a customer configures a BYOK key for (that is
+  // `OrgModelProvider`) — it is who SERVES the model for a Cursor CLI harness
+  // turn: the request runs on the customer's own Cursor account. Registered so
+  // the `cursor/auto` sentinel classifies honestly instead of falling through
+  // the bare-id rule to `ollama` and stamping eval metadata with a provider
+  // nothing ran on.
+  | "cursor"
   | "custom";
 
 // The MCPJam-hosted ("free") model ids — the billing seed. Sourced from the
@@ -173,7 +180,7 @@ export const getCanonicalModelId = (
    * list here so catalog-only ids canonicalize correctly; defaults to `[]`, so
    * every server/shared caller keeps the exact prior static behavior.
    */
-  extraModels: readonly CanonicalModelCandidate[] = []
+  extraModels: readonly CanonicalModelCandidate[] = [],
 ): string => {
   const normalizedModelId = modelId.trim();
   if (!normalizedModelId) {
@@ -194,14 +201,14 @@ export const getCanonicalModelId = (
   // counterparts (e.g. "openai/gpt-4o-mini" — MCPJam-provided).
   if (normalizedProvider) {
     const providerModels = knownModels.filter(
-      (model) => model.provider.toLowerCase() === normalizedProvider
+      (model) => model.provider.toLowerCase() === normalizedProvider,
     );
 
     // If the caller didn't already pass a prefixed id, look for a prefixed
     // (hosted) match first within this provider — bare ids must not win here.
     const prefixedMatch = !normalizedModelId.includes("/")
       ? providerModels.find((model) =>
-          String(model.id).endsWith(`/${normalizedModelId}`)
+          String(model.id).endsWith(`/${normalizedModelId}`),
         )
       : undefined;
 
@@ -215,7 +222,7 @@ export const getCanonicalModelId = (
   }
 
   const exactMatch = knownModels.find(
-    (model) => String(model.id) === normalizedModelId
+    (model) => String(model.id) === normalizedModelId,
   );
   if (exactMatch) {
     return String(exactMatch.id);
@@ -226,19 +233,19 @@ export const getCanonicalModelId = (
 
 export const isMCPJamProvidedModel = (
   modelId: string,
-  provider?: string
+  provider?: string,
 ): boolean => {
   return MCPJAM_PROVIDED_MODEL_IDS.includes(
-    getCanonicalModelId(modelId, provider)
+    getCanonicalModelId(modelId, provider),
   );
 };
 
 export const isMCPJamGuestAllowedModel = (
   modelId: string,
-  provider?: string
+  provider?: string,
 ): boolean => {
   return MCPJAM_GUEST_ALLOWED_MODEL_IDS.includes(
-    getCanonicalModelId(modelId, provider)
+    getCanonicalModelId(modelId, provider),
   );
 };
 
@@ -286,7 +293,7 @@ export const modelSupportsTemperature = (modelId: string | Model): boolean => {
  * on a stale cache.
  */
 export const modelDefinitionSupportsTemperature = (
-  model: ModelDefinition
+  model: ModelDefinition,
 ): boolean => {
   if (!modelSupportsTemperature(model.id)) {
     return false;
@@ -787,15 +794,15 @@ export const DEFAULT_OAUTH_PROTOCOL_CONCRETE_MODE: ServerFormOAuthProtocolConcre
   "2025-11-25";
 
 export function isConcreteOauthProtocolMode(
-  value: string
+  value: string,
 ): value is ServerFormOAuthProtocolConcreteMode {
   return (SERVER_FORM_OAUTH_PROTOCOL_MODES as readonly string[]).includes(
-    value
+    value,
   );
 }
 
 export function isServerFormOAuthProtocolMode(
-  value: unknown
+  value: unknown,
 ): value is ServerFormOAuthProtocolMode {
   return (
     value === "auto" ||
@@ -816,7 +823,7 @@ export function isServerFormOAuthProtocolMode(
  * silently degrading a stored 2026-07-28 pin down to 2025-11-25.
  */
 export function normalizeOauthProtocolMode(
-  value?: string
+  value?: string,
 ): ServerFormOAuthProtocolMode {
   if (value === "auto") {
     return "auto";
@@ -840,7 +847,7 @@ export function normalizeOauthProtocolMode(
 export function resolveEffectiveOauthProtocolMode(
   mode: ServerFormOAuthProtocolMode,
   wireProtocolVersion?: string,
-  negotiatedProtocolVersion?: string
+  negotiatedProtocolVersion?: string,
 ): ServerFormOAuthProtocolConcreteMode {
   if (mode !== "auto") {
     return mode;
@@ -887,7 +894,7 @@ export function resolveOAuthProtocolSelection(input: {
     protocolVersion: resolveEffectiveOauthProtocolMode(
       mode,
       input.wireProtocolVersion,
-      input.negotiatedProtocolVersion
+      input.negotiatedProtocolVersion,
     ),
     source:
       mode !== "auto"

--- a/package-lock.json
+++ b/package-lock.json
@@ -411,6 +411,7 @@
         "@ai-sdk/harness": "^1.0.96",
         "@ai-sdk/harness-claude-code": "^1.0.100",
         "@ai-sdk/harness-codex": "^1.0.98",
+        "@ai-sdk/harness-cursor": "^1.0.9",
         "@ai-sdk/mistral": "^3.0.18",
         "@ai-sdk/openai": "^3.0.25",
         "@ai-sdk/react": "^3.0.156",
@@ -1284,6 +1285,141 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@ai-sdk/harness-acp": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/harness-acp/-/harness-acp-1.0.34.tgz",
+      "integrity": "sha512-/Wan1hQleg3KenU4OPQ8HXJz82yjDXSIm5sMj7FyeTkdNLOsu4K1oIW0loCrBiFSZPYb5WglgmS5BxDGb3JCfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/harness": "1.0.96",
+        "@ai-sdk/provider-utils": "5.0.34",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/harness-acp/node_modules/@ai-sdk/gateway": {
+      "version": "4.0.70",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.70.tgz",
+      "integrity": "sha512-0tzAH2vwXOs/kVktAZRS04dATEQJk1hf1QR+VuVfvo9QmW3UPgcjhhJD9QFgP8HZLxkrEGDImwLIQ7sUfQTIsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.9",
+        "@ai-sdk/provider-utils": "5.0.34",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/harness-acp/node_modules/@ai-sdk/harness": {
+      "version": "1.0.96",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/harness/-/harness-1.0.96.tgz",
+      "integrity": "sha512-ytJmwvtnYRXO0rdXmE7gXGxUZbwqB4iopz/iPIS2EY7yT3n2vGJRYgg5qBDR4k4Jzx47u7CbjAkSn0elfmUZWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.9",
+        "@ai-sdk/provider-utils": "5.0.34",
+        "ai": "7.0.87"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "ws": "^8.21.0",
+        "zod": "^3.25.76 || ^4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/harness-acp/node_modules/@ai-sdk/provider": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.9.tgz",
+      "integrity": "sha512-XnGXPWiBIfqjsVEud5pOaVneRByJQOu2sYNwlSVJTPCvakdCDkVuYKKfNuStkIpMUYl7JIkBZGBx+B5YfNeVjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/harness-acp/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.34",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.34.tgz",
+      "integrity": "sha512-tRBdgRcys/4d8wyQdOdyYScq1AxfMdMd0hIlwolxJKVIbBwXUgClZuQT0VIsz4e7pylY8FE6utYCCZ494UAMJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.9",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/harness-acp/node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@ai-sdk/harness-acp/node_modules/ai": {
+      "version": "7.0.87",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.87.tgz",
+      "integrity": "sha512-/hrT7toRx8vLIyr/lTKOOPDxCGdxk2tVs5viHDwIPlUsge5FBaLe9h3BhPAr7cOmEAXkN/Cf2+2N8HYGCjJbHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.70",
+        "@ai-sdk/provider": "4.0.9",
+        "@ai-sdk/provider-utils": "5.0.34"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/harness-acp/node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ai-sdk/harness-claude-code": {
       "version": "1.0.100",
       "resolved": "https://registry.npmjs.org/@ai-sdk/harness-claude-code/-/harness-claude-code-1.0.100.tgz",
@@ -1538,6 +1674,143 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
       "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/harness-cursor": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/harness-cursor/-/harness-cursor-1.0.9.tgz",
+      "integrity": "sha512-W5Q4+UdWXjoogD8moEXfjdQIaGfzml/lC892TTBwN20YPKtbIrhhBJ09+6Qk8ZpGlY/6blfffLrWej4RdcvRXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/harness": "1.0.96",
+        "@ai-sdk/harness-acp": "1.0.34",
+        "@ai-sdk/provider-utils": "5.0.34"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/harness-cursor/node_modules/@ai-sdk/gateway": {
+      "version": "4.0.70",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.70.tgz",
+      "integrity": "sha512-0tzAH2vwXOs/kVktAZRS04dATEQJk1hf1QR+VuVfvo9QmW3UPgcjhhJD9QFgP8HZLxkrEGDImwLIQ7sUfQTIsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.9",
+        "@ai-sdk/provider-utils": "5.0.34",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/harness-cursor/node_modules/@ai-sdk/harness": {
+      "version": "1.0.96",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/harness/-/harness-1.0.96.tgz",
+      "integrity": "sha512-ytJmwvtnYRXO0rdXmE7gXGxUZbwqB4iopz/iPIS2EY7yT3n2vGJRYgg5qBDR4k4Jzx47u7CbjAkSn0elfmUZWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.9",
+        "@ai-sdk/provider-utils": "5.0.34",
+        "ai": "7.0.87"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "ws": "^8.21.0",
+        "zod": "^3.25.76 || ^4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/harness-cursor/node_modules/@ai-sdk/provider": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.9.tgz",
+      "integrity": "sha512-XnGXPWiBIfqjsVEud5pOaVneRByJQOu2sYNwlSVJTPCvakdCDkVuYKKfNuStkIpMUYl7JIkBZGBx+B5YfNeVjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/harness-cursor/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.34",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.34.tgz",
+      "integrity": "sha512-tRBdgRcys/4d8wyQdOdyYScq1AxfMdMd0hIlwolxJKVIbBwXUgClZuQT0VIsz4e7pylY8FE6utYCCZ494UAMJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.9",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/harness-cursor/node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@ai-sdk/harness-cursor/node_modules/ai": {
+      "version": "7.0.87",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.87.tgz",
+      "integrity": "sha512-/hrT7toRx8vLIyr/lTKOOPDxCGdxk2tVs5viHDwIPlUsge5FBaLe9h3BhPAr7cOmEAXkN/Cf2+2N8HYGCjJbHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.70",
+        "@ai-sdk/provider": "4.0.9",
+        "@ai-sdk/provider-utils": "5.0.34"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/harness-cursor/node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2544,9 +2817,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2564,9 +2834,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2584,9 +2851,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2604,9 +2868,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -14062,9 +14323,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14082,9 +14340,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14102,9 +14357,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14122,9 +14374,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -26903,6 +27152,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -26923,6 +27173,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -26943,6 +27194,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -26963,6 +27215,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -26983,6 +27236,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -27003,6 +27257,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -27023,6 +27278,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -27043,6 +27299,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -27063,6 +27320,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -27083,6 +27341,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -27103,6 +27362,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -29117,9 +29377,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -29137,9 +29394,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -29157,9 +29411,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -29177,9 +29428,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -29197,9 +29445,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -29217,9 +29462,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -29237,9 +29479,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -29257,9 +29496,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -29277,9 +29513,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -29303,9 +29536,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -29329,9 +29559,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -29355,9 +29582,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -29381,9 +29605,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -29407,9 +29628,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -29433,9 +29651,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -29459,9 +29674,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -36057,6 +36269,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36073,6 +36286,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36089,6 +36303,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36105,6 +36320,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36121,6 +36337,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36137,6 +36354,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36153,6 +36371,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36169,6 +36388,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36185,6 +36405,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36201,6 +36422,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36217,6 +36439,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36233,6 +36456,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36249,6 +36473,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36265,6 +36490,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36281,6 +36507,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36297,6 +36524,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36313,6 +36541,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36329,6 +36558,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36345,6 +36575,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36361,6 +36592,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36377,6 +36609,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36393,6 +36626,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36409,6 +36643,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36425,6 +36660,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36441,6 +36677,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36457,6 +36694,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/sdk/scripts/gen-host-config-parity-fixture.mjs
+++ b/sdk/scripts/gen-host-config-parity-fixture.mjs
@@ -312,6 +312,17 @@ const inputs = [
     input: { ...base(), harness: "claude-code" },
   },
   {
+    // A harness id the BACKEND's pinned @mcpjam/sdk release does not know.
+    // The backend masks it to "claude-code" past that release's HARNESS_IDS
+    // guard and overwrites the key on the way out (`withSdkSafeHarness`), so
+    // this vector is the proof that the mask/restore round-trip is
+    // byte-identical to what a cursor-aware canonicalizer emits — key position
+    // included. Without it, the shim could silently reorder the canonical JSON
+    // and every shim-era row would need a rehash at the next dep bump.
+    label: "harness-cursor",
+    input: { ...base(), harness: "cursor" },
+  },
+  {
     // Empty builtInToolIds collapses to absent → canonical JSON has no key,
     // byte-identical to base-minimal for that dimension (hash-neutral default).
     label: "builtin-tool-ids-empty-omitted",

--- a/sdk/src/host-compat/catalog-schema.ts
+++ b/sdk/src/host-compat/catalog-schema.ts
@@ -226,7 +226,7 @@ const hostConfigTemplateSchema = z.object({
       workdir: z.string().optional(),
     })
     .optional(),
-  harness: z.enum(["claude-code", "codex"]).optional(),
+  harness: z.enum(["claude-code", "codex", "cursor"]).optional(),
   connectionDefaults: z.object({
     headers: z.record(z.string(), z.string()),
     requestTimeout: z.number(),

--- a/sdk/src/host-compat/catalog.generated.ts
+++ b/sdk/src/host-compat/catalog.generated.ts
@@ -2401,6 +2401,8 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
           clientInfo: {
             name: "cursor-agent",
             title: "Cursor CLI",
+            version: "2026.08.31-4057e58",
+            description: "Cursor's agentic coding CLI",
             websiteUrl: "https://cursor.com/cli",
           },
         },

--- a/sdk/src/host-compat/catalog.generated.ts
+++ b/sdk/src/host-compat/catalog.generated.ts
@@ -2331,6 +2331,104 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
         },
       },
     },
+    "cursor-cli": {
+      id: "cursor-cli",
+      label: "Cursor CLI",
+      provenance: "assumed",
+      rendersMcpApps: false,
+      supportedProtocolVersions: ["2025-11-25"],
+      verifiedAt: 1788220800000,
+      modelVisibleMcpToolResults: {
+        directContent: {
+          image: false,
+        },
+        embeddedResources: {
+          blob: {
+            image: false,
+          },
+        },
+        linkedResources: {
+          blob: {
+            image: false,
+          },
+        },
+      },
+      mcpToolResultImageRendering: {
+        placement: "none",
+        directContent: {
+          image: false,
+        },
+        embeddedResources: {
+          blob: {
+            image: false,
+          },
+        },
+        linkedResources: {
+          blob: {
+            image: false,
+          },
+        },
+      },
+      hostStyle: "cursor-cli",
+      modelId: "cursor/auto",
+      systemPrompt: "",
+      temperature: 1,
+      requireToolApproval: false,
+      respectToolVisibility: true,
+      progressiveToolDiscovery: false,
+      serverIds: [],
+      optionalServerIds: [],
+      builtInToolIds: [],
+      computer: {
+        kind: "personal",
+      },
+      harness: "cursor",
+      connectionDefaults: {
+        headers: {},
+        requestTimeout: 10000,
+      },
+      clientCapabilities: {
+        roots: {
+          listChanged: true,
+        },
+        elicitation: {},
+      },
+      hostContext: {},
+      mcpProfile: {
+        profileVersion: 1,
+        initialize: {
+          supportedProtocolVersions: ["2025-11-25"],
+          clientInfo: {
+            name: "cursor-agent",
+            title: "Cursor CLI",
+            websiteUrl: "https://cursor.com/cli",
+          },
+        },
+        apps: {
+          mcpAppsOverrides: {
+            availableDisplayModes: ["inline"],
+            toolInputPartial: false,
+            toolCancelled: false,
+            hostContextChanged: false,
+            resourceTeardown: false,
+            toolInfo: false,
+            openLinks: false,
+            serverTools: false,
+            serverResources: false,
+            logging: false,
+            updateModelContext: false,
+            message: false,
+            sandboxPermissions: false,
+            cspFrameDomains: false,
+            cspBaseUriDomains: false,
+            resourcePrefersBorder: false,
+            downloadFile: false,
+            requestTeardown: false,
+            widgetDisplayModeRequests: "accept",
+          },
+        },
+      },
+    },
     codex: {
       id: "codex",
       label: "Codex",

--- a/sdk/src/host-config/templates/empty-input.ts
+++ b/sdk/src/host-config/templates/empty-input.ts
@@ -57,11 +57,11 @@ export type SeededHostConfigInput = {
   modelVisibleMcpToolResults?: ModelVisibleMcpToolResults;
   mcpToolResultImageRendering?: McpToolResultImageRenderingPolicy;
   computer?: { kind: "personal"; workdir?: string };
-  // Real agent harness for this host. `"claude-code"` / `"codex"` run a real CLI
-  // runtime (requires an attached computer); absent ⇒ MCPJam's emulated engine.
-  // Kept as a local literal (mirrors the `Harness` union / HARNESS_IDS in
-  // ../types.ts) so this module stays free of cross-imports.
-  harness?: "claude-code" | "codex";
+  // Real agent harness for this host. `"claude-code"` / `"codex"` / `"cursor"`
+  // run a real CLI runtime (requires an attached computer); absent ⇒ MCPJam's
+  // emulated engine. Kept as a local literal (mirrors the `Harness` union /
+  // HARNESS_IDS in ../types.ts) so this module stays free of cross-imports.
+  harness?: "claude-code" | "codex" | "cursor";
   connectionDefaults: {
     headers: Record<string, string>;
     requestTimeout: number;

--- a/sdk/src/host-config/templates/empty-input.ts
+++ b/sdk/src/host-config/templates/empty-input.ts
@@ -17,6 +17,7 @@
 import { DEFAULT_TEMPERATURE_V2 } from "../defaults.js";
 import { getDefaultClientCapabilities } from "../../mcp-client-manager/capabilities.js";
 import type {
+  Harness,
   McpToolResultImageRenderingPolicy,
   ModelVisibleMcpToolResults,
 } from "../types.js";
@@ -59,9 +60,14 @@ export type SeededHostConfigInput = {
   computer?: { kind: "personal"; workdir?: string };
   // Real agent harness for this host. `"claude-code"` / `"codex"` / `"cursor"`
   // run a real CLI runtime (requires an attached computer); absent ⇒ MCPJam's
-  // emulated engine. Kept as a local literal (mirrors the `Harness` union /
-  // HARNESS_IDS in ../types.ts) so this module stays free of cross-imports.
-  harness?: "claude-code" | "codex" | "cursor";
+  // emulated engine.
+  //
+  // The canonical union, not a copy. This was a local literal justified as
+  // keeping the module cross-import-free, which it never was — `../types.js`
+  // is a sibling in this same package and already supplies two type imports
+  // above. What the literal did buy was a third place to forget: a harness in
+  // `HARNESS_IDS` but missing here is one a seeded template cannot express.
+  harness?: Harness;
   connectionDefaults: {
     headers: Record<string, string>;
     requestTimeout: number;

--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -1840,15 +1840,21 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
           // than measured — kept in lockstep with the backend catalog row.
           supportedProtocolVersions: ["2025-11-25"],
           // TODO(cursor-cli probe): capture the real clientInfo the cursor-agent
-          // MCP client sends and replace these. `version` is deliberately
-          // ABSENT rather than guessed: the harness bootstrap installs via
+          // MCP client sends and replace these.
+          //
+          // `version` is REQUIRED by the canonicalizer (non-empty string), so
+          // it cannot be omitted to signal "unknown". It carries the build
+          // actually OBSERVED during the harness spike — real, not a guess —
+          // but it is NOT a pin: the bootstrap installs via
           // `curl https://cursor.com/install | bash`, which always fetches the
-          // CURRENT build, so any pinned version here would be wrong for most
-          // sessions. (The turn records the installed version per session; see
-          // `runtimeVersionCommand` in the server registry.)
+          // current build, so most sessions run something newer. That gap is
+          // why the turn records the installed `agent --version` per session
+          // (see `runtimeVersionCommand` in the server registry); do not read
+          // this field as what ran. Kept in lockstep with the backend catalog.
           clientInfo: {
             name: "cursor-agent",
             title: "Cursor CLI",
+            version: "2026.08.31-4057e58",
             description: "Cursor's agentic coding CLI",
             websiteUrl: "https://cursor.com/cli",
           },

--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -241,6 +241,7 @@ export const HOST_TEMPLATE_IDS = [
   "goose",
   "slack",
   "cursor",
+  "cursor-cli",
   "codex",
   "copilot",
   "vscode",
@@ -1772,6 +1773,84 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
               setOpenInAppUrl: false,
               notifyIntrinsicHeight: false,
             },
+          },
+        },
+      };
+      return base;
+    },
+  },
+  {
+    id: "cursor-cli",
+    label: "Cursor CLI",
+    description:
+      "Cursor's coding CLI (cursor-agent, over ACP). Runs on your own Cursor account; no widget rendering.",
+    seed: () => {
+      const base = emptyHostConfigInputV2({
+        // Its own skin, NOT the emulated `cursor` style: that one mirrors the
+        // Cursor IDE's chat panel, which renders MCP Apps in a webview. This is
+        // a terminal CLI. See CURSOR_CLI_HOST_STYLE in
+        // client-styles/built-ins.ts.
+        hostStyle: "cursor-cli",
+        // A NEUTRAL SENTINEL, not a real provider model. The adapter passes no
+        // model at all: cursor-agent runs on the customer's Cursor account and
+        // Cursor Auto picks. Seeding `anthropic/...` here would put a model id
+        // into traces and eval metadata that nothing ever ran — the one thing
+        // a host template must not fabricate. Matches the backend catalog seed.
+        modelId: "cursor/auto",
+        temperature: 1.0,
+        requireToolApproval: false,
+        // Run the REAL Cursor CLI (the @ai-sdk/harness-cursor adapter) instead
+        // of MCPJam's emulated engine. It executes inside an attached personal
+        // computer, so seed one too — the backend enforces `harness ⇒ computer`
+        // on write.
+        harness: "cursor",
+        computer: { kind: "personal" },
+      });
+      // REPLACED, not spread. A spread would leak the SDK default's
+      // `extensions["io.modelcontextprotocol/ui"]` back in and advertise a
+      // widget-rendering surface a terminal CLI cannot have — the same move the
+      // Claude Code and Codex templates make, and for the same reason.
+      //
+      // Conservative rather than probed: unlike Claude Code's, these are NOT
+      // from a live `start-host-probe` capture. `roots` + `elicitation` is the
+      // floor an ACP client is expected to support; widen it only from a real
+      // capture (the backend catalog row is `provenance: 'assumed'` to match).
+      base.clientCapabilities = {
+        roots: {},
+        elicitation: {},
+      };
+      // The real Cursor CLI owns native tool discovery from the MCP servers
+      // MCPJam feeds its ACP session, so MCPJam's progressive meta-tools stay
+      // off — `search_mcp_tools` must never look like a Cursor built-in.
+      base.progressiveToolDiscovery = false;
+      // CLI client: no widget rendering, so `hostContext` stays empty and the
+      // host-side app advertise is explicitly zeroed. `{}` is "advertise
+      // nothing" (resolveEffectiveHostCapabilities treats it distinctly from
+      // `undefined`/preset-inherit), so the Apps tab shows an honest empty
+      // hostCapabilities instead of inheriting a style preset's claims.
+      base.hostCapabilitiesOverride = {};
+      //
+      // The CLI's native toolset (bash/read/edit/…) is NOT seeded into
+      // `builtInToolIds`: under `harness: "cursor"` those come from the real
+      // runtime inside the sandbox, not MCPJam's built-in tool registry.
+      base.mcpProfile = {
+        profileVersion: 1,
+        initialize: {
+          // ASSUMED, inherited from the same-vendor `cursor` template rather
+          // than measured — kept in lockstep with the backend catalog row.
+          supportedProtocolVersions: ["2025-11-25"],
+          // TODO(cursor-cli probe): capture the real clientInfo the cursor-agent
+          // MCP client sends and replace these. `version` is deliberately
+          // ABSENT rather than guessed: the harness bootstrap installs via
+          // `curl https://cursor.com/install | bash`, which always fetches the
+          // CURRENT build, so any pinned version here would be wrong for most
+          // sessions. (The turn records the installed version per session; see
+          // `runtimeVersionCommand` in the server registry.)
+          clientInfo: {
+            name: "cursor-agent",
+            title: "Cursor CLI",
+            description: "Cursor's agentic coding CLI",
+            websiteUrl: "https://cursor.com/cli",
           },
         },
       };

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -61,15 +61,16 @@ export const HOST_CONFIG_SCHEMA_VERSION_V2 = 2;
  * Adding a runtime is a one-line addition here + a registry adapter + tests —
  * never a schema migration (absent ⇒ emulated still hashes byte-identically).
  */
-export const HARNESS_IDS = ["claude-code", "codex"] as const;
+export const HARNESS_IDS = ["claude-code", "codex", "cursor"] as const;
 
 /**
  * Which real agent **harness** runs a host's turn. Absent ⇒ the MCPJam
  * **emulated** loop — the only historical behavior, so pre-feature rows hash
  * byte-identically (the key is simply never written). `"claude-code"` runs the
  * turn inside a real Claude Code runtime via the AI SDK harness; `"codex"` runs
- * OpenAI Codex. Extensible to additional runtimes (e.g. `"pi"`) later without a
- * schema migration.
+ * OpenAI Codex; `"cursor"` runs the Cursor CLI (`cursor-agent`) over ACP.
+ * Extensible to additional runtimes (e.g. `"pi"`) later without a schema
+ * migration.
  */
 export type Harness = (typeof HARNESS_IDS)[number];
 

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -7908,7 +7908,7 @@ const clientFieldSet = z
       .optional()
       .describe("null clears the host-level opt-in."),
     harness: z
-      .enum(["claude-code", "codex"])
+      .enum(["claude-code", "codex", "cursor"])
       .nullable()
       .optional()
       .describe(

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -1952,6 +1952,7 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "description": "Cursor's agentic coding CLI",
           "name": "cursor-agent",
           "title": "Cursor CLI",
+          "version": "2026.08.31-4057e58",
           "websiteUrl": "https://cursor.com/cli",
         },
         "supportedProtocolVersions": [
@@ -1994,6 +1995,7 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "description": "Cursor's agentic coding CLI",
           "name": "cursor-agent",
           "title": "Cursor CLI",
+          "version": "2026.08.31-4057e58",
           "websiteUrl": "https://cursor.com/cli",
         },
         "supportedProtocolVersions": [

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -1928,6 +1928,90 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     "systemPrompt": "",
     "temperature": 0.7,
   },
+  "cursor-cli/dark": {
+    "builtInToolIds": [],
+    "chatUiOverride": undefined,
+    "clientCapabilities": {
+      "elicitation": {},
+      "roots": {},
+    },
+    "computer": {
+      "kind": "personal",
+    },
+    "connectionDefaults": {
+      "headers": {},
+      "requestTimeout": 10000,
+    },
+    "harness": "cursor",
+    "hostCapabilitiesOverride": {},
+    "hostContext": {},
+    "hostStyle": "cursor-cli",
+    "mcpProfile": {
+      "initialize": {
+        "clientInfo": {
+          "description": "Cursor's agentic coding CLI",
+          "name": "cursor-agent",
+          "title": "Cursor CLI",
+          "websiteUrl": "https://cursor.com/cli",
+        },
+        "supportedProtocolVersions": [
+          "2025-11-25",
+        ],
+      },
+      "profileVersion": 1,
+    },
+    "modelId": "cursor/auto",
+    "optionalServerIds": [],
+    "progressiveToolDiscovery": false,
+    "requireToolApproval": false,
+    "respectToolVisibility": true,
+    "serverConnectionOverrides": undefined,
+    "serverIds": [],
+    "systemPrompt": "",
+    "temperature": 1,
+  },
+  "cursor-cli/light": {
+    "builtInToolIds": [],
+    "chatUiOverride": undefined,
+    "clientCapabilities": {
+      "elicitation": {},
+      "roots": {},
+    },
+    "computer": {
+      "kind": "personal",
+    },
+    "connectionDefaults": {
+      "headers": {},
+      "requestTimeout": 10000,
+    },
+    "harness": "cursor",
+    "hostCapabilitiesOverride": {},
+    "hostContext": {},
+    "hostStyle": "cursor-cli",
+    "mcpProfile": {
+      "initialize": {
+        "clientInfo": {
+          "description": "Cursor's agentic coding CLI",
+          "name": "cursor-agent",
+          "title": "Cursor CLI",
+          "websiteUrl": "https://cursor.com/cli",
+        },
+        "supportedProtocolVersions": [
+          "2025-11-25",
+        ],
+      },
+      "profileVersion": 1,
+    },
+    "modelId": "cursor/auto",
+    "optionalServerIds": [],
+    "progressiveToolDiscovery": false,
+    "requireToolApproval": false,
+    "respectToolVisibility": true,
+    "serverConnectionOverrides": undefined,
+    "serverIds": [],
+    "systemPrompt": "",
+    "temperature": 1,
+  },
   "cursor/dark": {
     "builtInToolIds": [],
     "chatUiOverride": undefined,

--- a/sdk/tests/fixtures/host-config-parity-fixtures.json
+++ b/sdk/tests/fixtures/host-config-parity-fixtures.json
@@ -1,5 +1,5 @@
 {
-  "__inputHash": "95e6e26dbc3585a95048a6c14d03bb590c6e72e1cb42b722d884c71a50b56f54",
+  "__inputHash": "a047a2dfb76819614b0787d079fe85a85048a61ad487ef2c5e0b1577b2eb354a",
   "rows": [
     {
       "label": "base-minimal",
@@ -618,6 +618,25 @@
       },
       "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"harness\":\"claude-code\",\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{}}",
       "sha256": "c444a57c5e3d89c4b78a8c877aa221eb14e1645355674acf0eed077aafc7b110"
+    },
+    {
+      "label": "harness-cursor",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "harness": "cursor"
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"harness\":\"cursor\",\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{}}",
+      "sha256": "b17118c15628178208197bbda40fa13ae54b9df110433e57c02086fe78a7c130"
     },
     {
       "label": "builtin-tool-ids-empty-omitted",

--- a/sdk/tests/host-config-parity.test.ts
+++ b/sdk/tests/host-config-parity.test.ts
@@ -24,7 +24,7 @@ import type { HostConfigInputV2 } from "../src/host-config/internal";
  * directly, so the SDK-side constant is the single source of truth.
  */
 const EXPECTED_INPUT_HASH =
-  "95e6e26dbc3585a95048a6c14d03bb590c6e72e1cb42b722d884c71a50b56f54";
+  "a047a2dfb76819614b0787d079fe85a85048a61ad487ef2c5e0b1577b2eb354a";
 
 type FixtureRow = {
   label: string;

--- a/sdk/tests/host-config-seed-host-template.test.ts
+++ b/sdk/tests/host-config-seed-host-template.test.ts
@@ -18,6 +18,7 @@ const ALL_IDS: HostTemplateId[] = [
   "goose",
   "slack",
   "cursor",
+  "cursor-cli",
   "codex",
   "copilot",
   "vscode",


### PR DESCRIPTION
Runs the real `cursor-agent` CLI (over ACP, via `@ai-sdk/harness-cursor`) as a third harness beside Claude Code and Codex, behind the `cursor-host-enabled` flag.

**Depends on [MCPJam/mcpjam-backend#1224](https://github.com/MCPJam/mcpjam-backend/pull/1224)** — merge and deploy that first. The control plane has to accept `harness: "cursor"` before a producer exists.

Two commits: the runtime (registry adapter + turn plumbing) and the user-facing template + flag.

---

## The thing that made this more than a third adapter

Cursor breaks an assumption every existing harness shared: **that MCPJam supplies the model credential.**

`cursor-agent` has no provider or gateway routing at all. It authenticates with a `CURSOR_API_KEY`, every request transits Cursor's servers, and the spend lands on that Cursor account. So the adapter declares `modelAccess: 'external-account'`, and that one capability is what the turn branches on:

| | brokered (Claude Code, Codex) | external-account (Cursor) |
|---|---|---|
| model credential | MCPJam lease, injected outside the VM | customer's project secret, handed to the adapter |
| broker start | yes | **skipped** |
| box reservation | consumed by the lease | **held by heartbeat for the turn** |
| model gates | enforced | **skipped** — the model MCPJam knows isn't the model that runs |
| broker kill switch | applies | **doesn't** — there is no broker to kill |
| billing tag | `mcpjam` | `external-account` |

The dangerous one was `buildBrokerDummyAuth`: a fallthrough `if (codex) … else Anthropic`, so a cursor id would have **silently** received Claude Code's `ANTHROPIC_*` environment — a dummy token pointed at a proxy it never talks to, failing later and opaquely from inside the box. It's now an exhaustive `switch` that throws.

The reservation is held rather than released because on the brokered path the *lease* consumes the claim and takes over the per-box fence. With no lease there is nothing to take over, and a released claim would let a second Cursor turn bootstrap the same box mid-run.

## Credential handling

The key is pulled from the project's materialized secrets and **removed from the box's session env** before the provider is built, so it no longer rides on every command the agent shells out to. The Cursor process still receives it — that is how the CLI authenticates. Fully keeping it out of the VM needs the adapter's credential-brokering hook wired to E2B's egress transform; tracked as a follow-up.

Because the value leaves the env bag, delivery is stamped explicitly. For a project whose only secret is this one the bag is empty, the provider's `onSessionEnvUsed` can never fire, and a live credential would read as **dormant** to whoever is deciding whether it's safe to delete.

A missing secret is refused up front, with copy naming the variable and where to set it. Never defaulted.

## MCP delivery: same mode, different mechanism

Cursor is `native` — its own MCP client dials MCPJam's signed proxy, so evidence capture works — but it takes its servers as a **constructor setting**, not a file in the box. The native arm became a nested union:

- `sandbox-files` → requires `deliverMcpServers` (Claude Code writes `.mcp.json`)
- `session-config` → `createHarness` **requires** `mcpJson`

So MCP config cannot be silently dropped at construction: the type won't let you build the adapter without it. The MODE (does traffic cross the proxy?) is what capture keys off and is unchanged; the mechanism is invisible to everything but construction.

ACP spells headers as an **array** of `{name, value}` — and `headers` is required. Omitting the key makes `session/new` fail with an opaque `-32603` that names neither the field nor the server, so the converter always emits it, `[]` included.

## Tool attribution

Cursor streams every MCP call under an opaque per-session `acp_tool_<id>` and carries `{providerIdentifier, toolName, args}` in the **input** — a name-only signature cannot attribute one at all. Adapters gained an optional `attributeToolCall({rawToolName, input, keyToServerId})`.

The `user-` prefix Cursor sometimes adds is tried as a **fallback**, never stripped blindly: a server whose own key starts with `user-` would otherwise be attributed to a different server, or none.

## The failure mode with no brokered analogue

A plan-gated model doesn't error. Cursor answers with a normal, successful-looking turn whose entire text is `Upgrade your plan to continue`. Left alone, chat persists that as the assistant's answer and an eval **scores** it — producing a verdict about a model that never ran.

The detector is deliberately hard to trigger, because a false positive discards a real answer the customer paid for: exact normalized text (never `includes`), no successful tool call, plain stop. A turn that merely *quotes* the phrase has a negative test.

## `supportsMcpToolApproval` ships `false`

Not because the mechanism is missing — an MCP call reaches the same `requestPermission` path as a native one, and the bridge's host-tool short-circuit doesn't cover the host's servers. What isn't measured is which ACP `toolCall.kind` cursor-agent reports for an MCP call: `other`/`execute` would pause under `allow-reads`, but a `read`/`search`/`fetch` kind would be auto-approved with **no prompt at all**.

At `false`, an approval host with servers is refused at preflight with a message saying why. At `true` on the strength of the mechanism, it would silently execute MCP tools unapproved on a host that explicitly asked for approval. One-line flip once a live run is observed — the check I could not run here.

Native approval **is** verified: `supportsNativeToolApproval: true`, `approvalPermissionMode: 'allow-reads'`.

## Template and rollout

`cursor-cli` seeds `modelId: "cursor/auto"` — a neutral sentinel, not a real provider model. The adapter passes no model and Cursor Auto picks, so seeding `anthropic/…` would put a model id into traces and eval metadata that nothing ever ran.

The existing emulated `cursor` template (the IDE chat-panel mirror) is untouched and stays ungated. `clientCapabilities` is **replaced**, not spread — a spread would leak the UI extension back in and advertise a widget surface a terminal CLI cannot have. Unlike Claude Code's template, none of this is probe data: it's a conservative floor matching the backend catalog's `provenance: 'assumed'`, and `clientInfo` omits `version` deliberately rather than guessing (the bootstrap always installs the current build).

The CLI version isn't pinned by the package pin — `curl https://cursor.com/install | bash` always fetches current, and two known builds are four months of behaviour apart — so the turn asks the box what it installed and logs `[harness][runtime-version]`, fail-soft, for a canary alert.

## Drift fixes that fell out

- `HostConfigCompareView` built its exclusion set with a hand-written `if` per gated host, so a newly gated host was hidden on the five surfaces sharing `FLAG_GATED_HOSTS` and silently **offered** on the sixth. Now derived from the same map.
- `ComputerTab` hardcoded "Claude Code" in copy shown for any harness — already wrong on a Codex host. Now `HARNESS_DISPLAY_NAME`, keyed by the harness union so the next harness can't be added without naming it.

## Deliberately not done

`cursor-cli` is absent from `PLAYGROUND_SEED_TEMPLATE_IDS` (flag-free ids only) and from the local-execution lane — `SupportedLocalHarnessId` stays narrower than the SDK union on purpose, and the compatibility resolver already answers `harness-not-supported`. Skills are off for v1 (`supportsSkills: false`); ACP supports them, so it's scope, not a capability wall.

`HostCapabilityMatrix` needs no `cursor-cli` branch: both ids resolve to the same logo file, so an extra branch returning the identical constant would be noise. Add it if the marks ever diverge.

## Verification

- **Typecheck**: SDK, client, and server clean (server has pre-existing unrelated noise under its stricter tsconfig; no new errors in touched files).
- **SDK suite**: 314 files / 6939 tests green. The seed golden snapshot was re-blessed — the diff is **84 additions, 0 deletions**, i.e. it only gained the new template.
- **Harness suite**: 41 files / 523 tests green.
- **Mirrors**: `harness-mcp-delivery-modes` agrees across both repos in diff mode (4 unrelated pairs were already drifting before this branch).
- Full inspector suite was running green at time of writing; I'll report the final count on this PR.

New tests: cursor adapter shape; `buildBrokerDummyAuth` throws for external-account and stays exhaustive; ACP conversion (headers-always-an-array, reserved-name refusal, key preservation vs. attribution); attribution (exact-key-first, `user-` fallback, the `user-`-named-server trap, malformed inputs); plan-wall detector including the quoted-phrase negative; external-account preflight skips **and** the gates that still apply; and the turn path — broker skipped, credential out of session env, delivery stamped, missing secret refused, reservation returned, wall failed.

## What I could not verify

The plan called for a live MCP-approval check to settle `supportsMcpToolApproval` and a live adapter-level rerun of the spike phases. The spike scripts are untracked and absent from this checkout, and I have no `CURSOR_API_KEY`, so neither ran. Everything asserted here is from the installed package's own source, the type system, or tests. The staging e2e in the plan is still outstanding.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjLfgzhqRyGCXWMqk6eJnP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces external-account credential handling, harness dispatch/eligibility, and billing attribution paths alongside a broad feature-flag rollout; misalignment would run the wrong engine or mislabel eval traces.
> 
> **Overview**
> Adds **`harness: "cursor"`** as a third real CLI runtime (via `@ai-sdk/harness-cursor`), with a gated **`cursor-cli`** host template behind PostHog **`cursor-host-enabled`**. The existing emulated **`cursor`** IDE template stays visible and ungated.
> 
> **Rollout and API surface:** Host pickers, compat matrices, verify deep links, and compare presets all thread the new flag through the shared **`FLAG_GATED_HOSTS`** map (plus **`excludedFlagGatedHostIds`** so compare view can't drift). OpenAPI and **`PATCH` client validation** derive the harness enum from **`HARNESS_IDS`**, with a test locking **`ClientFieldSet.harness`** to the SDK list.
> 
> **Host editor behavior:** **`HARNESS_DISPLAY_NAME`** and **`harnessControlState`** now gate **`modelId`** — Cursor CLI disables the model picker because the customer's Cursor account chooses the model; **`HostConfigHarnessV2`** aliases the SDK **`Harness`** union to avoid type drift.
> 
> **Evals and traces:** **`cursor`** is a first-class model provider in **`resolveTraceModel`** (single shared implementation from compare helpers), so **`cursor/auto`** runs don't normalize to **`custom`**.
> 
> **Turn routing:** **`runAssistantTurn`** uses **`harnessModelEligibleForRuntime`** so external-account harnesses (non–MCPJam-hosted **`cursor/auto`**) don't silently fall back to the emulated engine; ingest types add **`external-account`** **`modelSource`** and widen session-commit **`harnessId`** to the SDK union. Server tests cover ACP MCP header shape, Cursor tool attribution, plan-wall detection, and external-account preflight exemptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80c5227b48c76c9748b7bcfd4e5ce722cff60979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the real Cursor CLI (`cursor-agent`, over ACP, via `@ai-sdk/harness-cursor`) as a third harness beside Claude Code and Codex, behind the `cursor-host-enabled` flag. Cursor is the first harness where MCPJam doesn't supply the model credential — it authenticates on the customer's own Cursor account, so the turn branches on a new `external-account` model-access mode.

Depends on [MCPJam/mcpjam-backend#1224](https://github.com/MCPJam/mcpjam-backend/pull/1224) — merge and deploy that first, since the control plane must accept `harness: "cursor"` before a producer exists.

**External-account turn path**

- No broker lease is minted; the box reservation is held for the whole turn.
- Model gates and the broker kill switch are skipped.
- The `CURSOR_API_KEY` comes from materialized project secrets and is removed from the box's session env; a missing secret is refused up front, and delivery is stamped only once the harness session is established so a failed startup can't mark a live credential as delivered.
- `buildBrokerDummyAuth` is now an exhaustive switch — the old fallthrough would have silently handed Cursor Claude Code's `ANTHROPIC_*` env.
- A plan-gated Cursor account answers "Upgrade your plan to continue" as a successful-looking turn; a deliberately strict detector discards it so chat and evals never score it.
- Preflight and both dispatch sites now share one eligibility helper; before, the preflight approved Cursor turns but dispatch ran MCPJam's emulated engine, reporting "Cursor CLI" for a turn Cursor never touched.
- Policy-blocked tool calls no longer count as successful, so a turn whose calls MCPJam refused still reaches the plan-wall check.
- Eval/synthetic turns refuse external-account harnesses because they wire no project secrets; fail-closed and documented.

**Delivery, attribution, and rollout**

- MCP servers are passed as a constructor setting (`session-config`), not written into the box; the native arm is a nested union, so config can't be silently dropped.
- Tool calls are attributed from the call input, not the stream name; the `user-` prefix is only a fallback.
- `supportsMcpToolApproval` ships `false` until a live run measures the ACP tool kind.
- The CLI version isn't pinned by the package pin; the turn logs what the box installed for a canary alert, and the workdir is now quoted with a byte-asserted escape — the earlier fix emitted three bare quotes, so `$(…)` still ran.
- `cursor` is a registered model-id prefix, so the `cursor/auto` sentinel classifies as its own provider instead of `ollama`.
- The eval trace-model resolver is now one import shared by both eval surfaces, with its provider list held exhaustive by typecheck — the old duplicated copy was how `cursor` nearly shipped labeled `custom`; tests also pin the `||` empty-string fallback.
- New `cursor-cli` template seeds `modelId: "cursor/auto"` (a sentinel; the adapter passes no model); the emulated `cursor` template is unchanged and ungated.
- The model selector is disabled on `cursor-cli` hosts: `modelId` is now a harness-gated control (enforced for Claude Code and Codex), since the Cursor account picks the model and an edited selection would reach nothing.
- The template's `clientInfo.version` carries the observed cursor-agent build because the canonicalizer requires a non-empty string — it's not a pin, and the per-session installed-version log is authoritative.
- The published `harness` enum in the OpenAPI spec was missing `cursor` (the route already accepted it); a test now ratchets the documented enum to `HARNESS_IDS`.
- `HostConfigHarnessV2`, the session-commit `harnessId`, and the seed template's `harness` literal now all alias the SDK's `Harness` union, so the editor and the API can't drift on the next harness.
- Drift fixes: `HostConfigCompareView`'s exclusion set derives from the shared flag map, and `ComputerTab` copy uses `HARNESS_DISPLAY_NAME` keyed by the harness union.
- The bootstrap auth-independence test now varies `CURSOR_API_KEY`; its secret scan runs before the identity assertions and inspects bootstrap command text, so it can actually catch a credential leaking into a recipe.

<sup>Written for commit 80c5227b48c76c9748b7bcfd4e5ce722cff60979. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

