### PR TITLE
fix(connect): gate only the claim on AuthKit hydration, not the callback

### DIFF
--- a/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
@@ -313,13 +313,21 @@ export function ServerConnectionHandoff() {
   // stripped after a claim succeeds), the page cold-mounts, hydration races the
   // claim again, and the same screen comes back. Every cold load of a handoff
   // link is exactly the case that loses this race.
+  //
+  // ONLY THE CLAIM WAITS. The other two paths through this effect authenticate
+  // with the continuation cookie and want nothing from AuthKit, so holding
+  // them on it is strictly harmful: a slow hydration delays the `/state` read,
+  // and a hydration that never settles strands `/authorize/complete` — the
+  // code exchange — AFTER the user has already consented at the authorization
+  // server, spending an authorization that can never be redeemed. Route first,
+  // gate second.
   useEffect(() => {
-    if (isAuthLoading) return;
+    const route = matchHandoffRoute(window.location.pathname);
+    if (route?.kind === "claim" && isAuthLoading) return;
     if (claimed.current) return;
     claimed.current = true;
 
     void (async () => {
-      const route = matchHandoffRoute(window.location.pathname);
       const callback = readCallbackParams(window.location.search);
       const pending = readPendingAuthorization();
 

--- a/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
@@ -114,6 +114,9 @@ function goTo(path: string, search = "") {
 // fetch. Nothing below triggers a navigation, so the real object is fine.
 
 afterEach(() => {
+  // Reset here, not in each test: a leaked `isLoading: true` makes every
+  // later test claim nothing and fail somewhere unrelated.
+  authkit.isLoading = false;
   clearPendingAuthorization();
   // The claimed-handoff record is deliberately localStorage, so it outlives a
   // tab — and would outlive a test too.
@@ -467,6 +470,31 @@ describe("polling", () => {
 });
 
 describe("returning from the authorization server", () => {
+  it("completes even while AuthKit is still hydrating", async () => {
+    // The callback authenticates with the continuation cookie and wants
+    // nothing from AuthKit, so gating it on hydration is strictly harmful: a
+    // client that never settles would strand the code exchange AFTER the user
+    // has consented, spending an authorization that can never be redeemed.
+    authkit.isLoading = true;
+    const calls = mockApi({
+      "/authorize/complete": () => ({
+        requestId: "scr_1",
+        status: "validating",
+      }),
+      "/state": () => stateBody({ status: "validating" }),
+    });
+    rememberPendingAuthorization("scr_1", AUTH_URL);
+    goTo("/oauth/callback", "?code=auth-code&state=st&iss=https://as.example");
+
+    render(<ServerConnectionHandoff />);
+
+    await waitFor(() =>
+      expect(
+        calls.find((call) => call.path === "/authorize/complete"),
+      ).toBeDefined(),
+    );
+  });
+
   it("posts the callback and clears the marker", async () => {
     const calls = mockApi({
       "/authorize/complete": () => ({


### PR DESCRIPTION
Follow-up to #4335, and the only surviving piece of #4043 (now closed as superseded).

#4335 made the handoff page wait for AuthKit before claiming — correct, and it fixed the sign-in loop. But the wait sits *above* route resolution, so it also holds back the two paths that authenticate with the continuation cookie and want nothing from AuthKit:

- the initial `/state` read, and
- `/authorize/complete` — the OAuth code exchange.

The second is the one that matters. A slow hydration merely delays the exchange; a hydration that **never settles** strands it *after* the user has already consented at the authorization server — spending an authorization that can never be redeemed and leaving the request in `authorizing` until it expires.

**Change:** resolve the route first, gate second. Only `kind === "claim"` waits.

**Tests:** a new case drives the callback with `isLoading` stuck true and asserts `/authorize/complete` still posts. I verified it fails against the current gate and passes with this one. `afterEach` now resets `authkit.isLoading` too — a leaked `true` makes an unrelated *later* test fail instead of the one that set it, which is exactly what happened while writing this.

Client typecheck clean; 26 handoff tests green. Prettier reports four pre-existing formatting diffs elsewhere in these two files; left untouched.

Credit: originally flagged by cubic and coderabbit on #4043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth handoff timing on a security-sensitive flow; behavior change is narrow (claim still waits) but incorrect routing could still strand or mishandle authorizations.
> 
> **Overview**
> **Narrows the AuthKit hydration wait** on the server connection handoff page so it applies only to the token **claim**, not to every first-load path through the mount effect.
> 
> The effect now **resolves the route first** (`matchHandoffRoute`), then returns early on `isAuthLoading` **only when** `route?.kind === "claim"`. **OAuth return** (`/authorize/complete` via the continuation cookie) and the initial **`/state`** read no longer block on AuthKit—avoiding delayed state refresh and, critically, a stuck hydration that would never post the authorization code after the user has already consented.
> 
> **Tests:** adds a case with `authkit.isLoading` stuck true on `/oauth/callback` and expects `/authorize/complete` anyway; **`afterEach`** resets `authkit.isLoading` so later tests do not flake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff11031edeca0b31c29547cf9cede4d5f74634b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the AuthKit hydration wait on the claim path only, so the `/state` read and the `/authorize/complete` callback no longer wait for hydration. Previously a hydration that never settles would strand the OAuth code exchange after the user already consented, spending an authorization that can never be redeemed and leaving the request stuck in `authorizing` until it expires.

**Bug Fixes**
- Added a test asserting the callback posts even with `isLoading` stuck true, and `afterEach` now resets `authkit.isLoading` so leaked state doesn't fail unrelated tests.

<sup>Written for commit ff11031edeca0b31c29547cf9cede4d5f74634b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

