### PR TITLE
Only ping the frame socket while the document is visible

### DIFF
--- a/mcpjam-inspector/client/src/lib/webmcp-inspector/frame-stream-connection.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp-inspector/frame-stream-connection.ts
@@ -36,7 +36,11 @@ export const FRAME_WS_CLOSE = {
   UNAVAILABLE: 4503,
 } as const;
 
-/** How often to ping, to keep an idle socket off any proxy's idle timer. */
+/**
+ * How often to ping. A ping keeps an idle socket off any proxy's idle timer
+ * AND refreshes the session's idle deadline server-side — which is why it is
+ * only sent while the document is visible (see the guard in `onopen`).
+ */
 export const FRAME_WS_PING_MS = 30_000;
 
 export interface FrameStreamConnection {
@@ -57,6 +61,11 @@ export interface OpenFrameStreamOptions {
   wsFactory?: (url: string, protocols: string[]) => WebSocket;
   setTimer?: (fn: () => void, ms: number) => unknown;
   clearTimer?: (handle: unknown) => void;
+  /**
+   * Whether anyone can currently SEE the pane; defaults to the document's
+   * visibility. Injected for tests, like the timers.
+   */
+  isVisible?: () => boolean;
 }
 
 /**
@@ -103,10 +112,26 @@ export function openWebMcpFrameStream(
   const ws = factory(url, token ? [token] : []);
   ws.binaryType = "arraybuffer";
 
+  const isVisible =
+    opts.isVisible ??
+    (() =>
+      typeof document === "undefined" ||
+      document.visibilityState === "visible");
+
   let ping: unknown;
 
   ws.onopen = () => {
     ping = setTimer(() => {
+      // A ping tells the server "someone is still watching", and the server
+      // refreshes the session's idle deadline on it. So it is only sent while
+      // that is actually TRUE: a hidden tab already stops the screencast on
+      // the same signal, and a ping from it would hold the session — a real
+      // Chromium, and one of the capacity slots — unreapable for as long as
+      // the tab existed anywhere in the browser. Skipping the tick (rather
+      // than tearing the socket down) means a person coming back is at most
+      // one interval away from claiming the session again, and if the reaper
+      // won the wait the 4404 close tells the ladder the honest story.
+      if (!isVisible()) return;
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ type: "ping" }));
       }

--- a/mcpjam-inspector/client/src/stores/__tests__/webmcp-inspector-store.test.ts
+++ b/mcpjam-inspector/client/src/stores/__tests__/webmcp-inspector-store.test.ts
@@ -1368,6 +1368,38 @@ describe("webmcp inspector store — frame transport", () => {
     expect(ws.sent).toHaveLength(1);
   });
 
+  it("does NOT ping while the document is hidden, and resumes when it shows", async () => {
+    vi.useFakeTimers();
+    // Shadows the prototype getter; the delete in `finally` restores it.
+    const setVisibility = (value: DocumentVisibilityState) =>
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => value,
+      });
+    try {
+      setVisibility("hidden");
+      const { ws } = await openFrameSession();
+      ws.open();
+
+      // The server refreshes the session's idle deadline on every ping, so a
+      // hidden tab that kept pinging would hold the session — a real Chromium,
+      // and one of the capacity slots — unreapable for as long as the tab
+      // existed anywhere in the browser. Hidden already means "not watching"
+      // to the rest of this feature: the pane stops the screencast on the very
+      // same signal.
+      vi.advanceTimersByTime(120_000);
+      expect(ws.sent).toHaveLength(0);
+
+      // The socket stayed open, so coming back needs no handshake and is at
+      // most one interval from telling the server someone is watching again.
+      setVisibility("visible");
+      vi.advanceTimersByTime(30_000);
+      expect(ws.sent).toEqual([JSON.stringify({ type: "ping" })]);
+    } finally {
+      delete (document as { visibilityState?: unknown }).visibilityState;
+    }
+  });
+
   it("clears the frame and its blob when the stream stops", async () => {
     const revokedUrls: string[] = [];
     setFramePresenterForTests(


### PR DESCRIPTION
Follow-up to #4573, closing the one finding from its review.

The 30s ping refreshes the session's idle deadline server-side, and the socket deliberately stays open across visibility flips — so a hidden or backgrounded tab kept its session (a real Chromium, and one of the two capacity slots) unreapable for as long as the tab existed anywhere in the browser, where the idle reaper used to reclaim it after 10 minutes. It was also inconsistent with the feature's own model: the pane stops the screencast on the hidden signal, while the ping went on claiming "still watching."

The tick is now skipped while `document.visibilityState !== "visible"`, rather than the socket being torn down: a person coming back needs no handshake and is at most one interval from telling the server someone is watching again — and if the reaper won the wait, the 4404 close tells the fallback ladder the honest story.

Injectable `isVisible` seam, matching the module's existing timer and factory seams. One new store test (hidden → no pings over 120s; visible again → ping within one interval), proven load-bearing: it fails with the guard stashed, and the other 60 store tests plus the 135 webmcp client suite tests stay green. Client typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted client keepalive behavior aligned with existing screencast visibility semantics; no auth or server protocol changes.
> 
> **Overview**
> **Frame socket keepalives no longer run in background tabs**, fixing a case where hidden inspector tabs could pin a Chromium session and capacity slot indefinitely because each 30s ping refreshed the server idle deadline.
> 
> `openWebMcpFrameStream` now skips sending `{type:"ping"}` when the document is not visible (default: `document.visibilityState`), while **leaving the WebSocket open** so returning to the tab avoids a new handshake and resumes pings within one interval—or a `4404` close if the idle reaper already won. An injectable **`isVisible`** hook mirrors existing timer/WebSocket test seams.
> 
> Adds a store integration test: hidden → no pings over 120s; visible again → ping within 30s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf7f39da04f2890a869799e95e8a7d3bd83629c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the frame WebSocket ping while the document is hidden so a backgrounded tab no longer keeps its session and capacity slot alive.

- The 30s ping refreshes the server-side idle deadline; skipping it while hidden lets the idle reaper reclaim the session after 10 minutes.
- The socket stays open, so returning to the tab resumes pinging within one interval without a new handshake.
- Adds an injectable `isVisible` guard and a store test covering hidden/visible transitions.

<sup>Written for commit cf7f39da04f2890a869799e95e8a7d3bd83629c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

