### PR TITLE
Check the packaged app exists before electron:install deletes the installed one

### DIFF
--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -92,7 +92,7 @@
     "icons:win": "node scripts/generate-windows-icon.mjs",
     "icons:mac": "node scripts/generate-mac-icon.mjs",
     "electron:make": "npm run icons:win && npm run icons:mac && electron-forge make",
-    "electron:install": "killall 'MCPJam Inspector' 2>/dev/null || true && rm -rf '/Applications/MCPJam Inspector.app' && cp -r 'out/MCPJam Inspector-darwin-arm64/MCPJam Inspector.app' /Applications/ && open '/Applications/MCPJam Inspector.app'",
+    "electron:install": "APP='out/MCPJam Inspector-darwin-arm64/MCPJam Inspector.app'; test -d \"$APP\" || { echo \"electron:install: $APP not found; run 'npm run electron:package' first (this script only copies a packaged app, and it removes the installed one before copying)\" >&2; exit 1; }; killall 'MCPJam Inspector' 2>/dev/null || true; rm -rf '/Applications/MCPJam Inspector.app' && cp -r \"$APP\" /Applications/ && open '/Applications/MCPJam Inspector.app'",
     "electron:publish": "electron-forge publish",
     "electron:dev": "electron-forge start",
     "pretest": "node scripts/bundle-sandbox-proxy-html.js && node scripts/bundle-browser-harness.mjs && node scripts/bundle-plugin-shim.mjs",


### PR DESCRIPTION
## The bug

`npm run electron:install -w @mcpjam/inspector` is only a copy step — it expects `electron:package` to have already produced `out/MCPJam Inspector-darwin-arm64/MCPJam Inspector.app`. The old script:

```sh
killall 'MCPJam Inspector' 2>/dev/null || true && rm -rf '/Applications/MCPJam Inspector.app' && cp -r 'out/…/MCPJam Inspector.app' /Applications/ && open '…'
```

The `rm -rf` runs **before** the `cp`. Run it without packaging first and it deletes your installed app, then fails on the missing source:

```
cp: out/MCPJam Inspector-darwin-arm64/MCPJam Inspector.app: No such file or directory
```

You end up with no app in `/Applications` and nothing to fall back to. Hit for real today.

## The fix

Guard the source path up front; exit non-zero with the command to run. Nothing is removed unless there is something to install. The happy path is unchanged (the repeated literal is now a shell var).

## Verified both ways

No `out/` present — fails clean, installed app survives:

```
electron:install: out/MCPJam Inspector-darwin-arm64/MCPJam Inspector.app not found; run 'npm run electron:package' first (this script only copies a packaged app, and it removes the installed one before copying)
npm error code 1
```

With a packaged app present — installs and launches as before.

## Two adjacent gotchas found while debugging (not fixed here)

Both are worth their own change if others hit them:

1. **`electron-forge package` silently no-ops on Node 26.** Under `node v26.3.0` it exits **0**, prints no error, and produces no `out/`. Debug output shows it dying mid-`Extracting …electron-v43.4.0-darwin-arm64.zip`, immediately followed by `electron-forge:plugin:vite handling process exit` — the event loop just drains. The same command on Node 22.22.3 packages fine. `engines` already says `>=22`, which Node 26 satisfies, so nothing catches this.
2. **The renderer build OOMs under forge.** `build:client` sets `NODE_OPTIONS=--max-old-space-size=6144`, but forge's own vite renderer build doesn't inherit it, so `electron:package` dies with `FATAL ERROR: Ineffective mark-compacts near heap limit`. Worked around with `NODE_OPTIONS=--max-old-space-size=8192`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReW2ncbkFbZBCgcvJmAEh9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only macOS install script change with no runtime, auth, or production deploy impact.
> 
> **Overview**
> **`electron:install` no longer removes `/Applications/MCPJam Inspector.app` when the packaged build output is missing.**
> 
> The npm script now verifies `out/MCPJam Inspector-darwin-arm64/MCPJam Inspector.app` exists before `killall`, `rm`, or `cp`. If packaging was skipped, it exits with a clear message to run `npm run electron:package` first. The successful install path is unchanged aside from storing the source path in a shell variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 101b5e908a79553a1f327a681a5656b5addf92af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `electron:install` in `@mcpjam/inspector` so it no longer deletes the installed app before checking that a packaged build exists. The script now verifies the source path up front and exits with an error if it's missing; the old behavior removed the installed app and then failed on the copy, leaving nothing in `/Applications`. The happy path is unchanged.

<sup>Written for commit 101b5e908a79553a1f327a681a5656b5addf92af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

