### PR TITLE
Every trial gets a chain: the per-trace user-value report card

### DIFF
--- a/.changeset/uvc-iteration-chain-read.md
+++ b/.changeset/uvc-iteration-chain-read.md
@@ -1,0 +1,20 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/inspector": patch
+---
+
+A passing trial can have its chain read too
+
+D9's decision summary carries a per-trial user-value chain, and the browser already fetches it — for **non-passing trials only**. That filter lives in the contract assembler and is deliberate: diagnostics are evidence beneath a verdict, and a trial that passed is not evidence of anything going wrong. The consequence is that a reader who opens a trial that succeeded has nothing to read, and "how far did value travel here" is exactly as good a question about a passing trial as a failing one.
+
+The iterations resource projects the same stage columns over every row of a run, passing included — verified against production, where all ten trials of a run came back carrying six rows each. This adds the client read for it.
+
+**One chain type, one validator.** The rows go through the contract's own chain assembler, now exported as `assembleEvalRunDecisionChain`, which is the same function D9's summary is built from. So the result is `EvalRunDecisionChain` — the type the decision card and the trial cards already render, with no adapter and no second shape — and the **whole derivation** is validated rather than the rows one at a time. Row-level validation accepts five rows, or six in the wrong order, and a renderer that numbers cards `01`–`06` by position would then publish a different claim about which stages were blocked, because `notReached` is derived from position. A test feeds it both shapes and pins that they come back `unverified`.
+
+**Three absences stay three facts.** A bare 404 from a router that never had the path is a deployment that does not serve iterations; an enveloped `NOT_FOUND` is a run that is not there; a row with no derivation is `absent`. Reading the first as the third would report every trial on an undeployed build as having no chain.
+
+**Keyed on the run's revision, not just terminal status.** A terminal run is not frozen — a judge landing minutes later rewrites `judgePending` into `judgeObserved`, which is a different chain for the same trial. The read keys its cache on the same revision marker the decision-summary store uses, so the two refresh together and one trial can never show two chains at once.
+
+**Silent unless asked.** Off without the caller's switch, a project id, and a finished run; with any missing it issues no request at all.
+
+The route needed an entry in `authFetch`'s bearer allowlist, and the existing eval-chain test already pinned it in the negative list — so this is a **move**, not an addition, and the test now pins that the trace and per-iteration paths beneath it are still *not* granted. Without the entry the read ships no `Authorization` and the 401 surfaces as "could not be loaded", which reads as a backend outage while the API is fine. That has happened three times before on this surface.

--- a/.changeset/uvc-per-trial-stage-cards.md
+++ b/.changeset/uvc-per-trial-stage-cards.md
@@ -1,0 +1,17 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Every failing trial now shows its own user-value chain, as cards
+
+The run-level funnel answers "how much of this run was measured, and where did it stop". The question a reader actually arrives with is narrower: **this** trial did not deliver value — how far did it get, and why. That answer already existed and was rendered as six lines of flat text inside a collapsed diagnostic row: `Connection: passed`, `Response: failed — the server reported a tool error`.
+
+It is now the same six numbered cards the suite page uses, reading left to right, with a "what happened" card underneath the one a reader selects. The chain opens on the stage the contract named as the first failure, so a reader lands on the break rather than hunting for it.
+
+**A trial is not a population, and the card row says so.** The aggregate chip counts (`failed in 2 of 3 measured`); a trial's chip states (`failed`). There are no rates on a trial's card — "100% (1/1)" over a single observation is a statistic manufactured from one trial — and no latency, which is deliberately not a field on a stage row. What a trial's card carries instead is what a trial actually has: one state, one reason, and that row's own evidence.
+
+**The reason stays off the chip and on the detail card.** Some reason labels are whole sentences, six cards at their minimum width would wrap into unreadable columns, and — the part that matters — keeping the chip to the state word keeps the "never says passed when nothing was decided" invariant total over the five states rather than dependent on the twenty-nine-member reason vocabulary. Two reason labels contain the word "made", which that invariant's own regex matches.
+
+**Which card opens is a UI choice; where the chain stopped is the contract's.** The default selection is `firstFailedStage`, read from the chain and never re-derived by scanning rows — the day a second derivation disagreed, the UI would be the one that was wrong while looking authoritative. When the contract established no failed stage at all, the card that opens is the first non-passing row carrying a reason: that is the setup-abort and policy-block shape, where every stage reads `not measured` and the single sentence explaining the trial would otherwise sit behind a click nobody knows to make.
+
+A withheld (`unverified`) or absent chain renders its existing notice and no cards. An empty six-card row would read as measured, which is exactly what those two states exist to prevent.

--- a/.changeset/uvc-trial-chain-on-trace-pane.md
+++ b/.changeset/uvc-trial-chain-on-trace-pane.md
@@ -1,0 +1,17 @@
+---
+"@mcpjam/inspector": patch
+---
+
+The trace pane opens with the chain, not just the transcript
+
+"View trace" lands a reader on one trial's transcript — the place they arrive when they want to know why that trial did not deliver value. The answer was not on that screen. It was back on the run page, inside a diagnostic row they had already navigated away from, and for a trial that PASSED it did not exist anywhere.
+
+The chain now sits above the transcript: six cards, opened on the break, with the "what happened" card under whichever one the reader selects. A passing trial reads as the delivery story end to end — Session connected → Tools and resources discovered → … → Request satisfied — which is the first time that story has been visible for a trial that worked.
+
+**`IterationDetails` does not fetch it.** It has five hosts and knows only its iteration: not the run, not the project, not whether the Evaluate opt-in is on — and the chain read needs all three. So it takes a slot, and the one host that can answer those questions builds the node. The other four pass nothing and issue no request, which keeps a shared component free of a read four of its callers never asked for.
+
+**The hooks sit above the early return, and that placement is load-bearing.** The editor returns a loading state before its test case resolves, so a hook called below it runs on some renders and not others — React reports that as "rendered more hooks than during the previous render". A test caught exactly that, on the first draft.
+
+Selection uses the same `undefined`-is-not-`null` rule as the run page: `undefined` means "not chosen yet" and derives the default at render time, `null` means the reader closed the card. The distinction is what makes the trace pane work at all — the chain arrives *after* mount there, so a state initialized once from an empty chain would compute `null` and never auto-open the break.
+
+An absent map key means "not loaded", never "no chain": a trial the page walk has not reached renders nothing rather than a false absence.

--- a/.changeset/uvc-trial-chain-table-chip.md
+++ b/.changeset/uvc-trial-chain-table-chip.md
@@ -1,0 +1,17 @@
+---
+"@mcpjam/inspector": patch
+---
+
+A run's case table says where each trial stopped
+
+The run-scoped case view lists every trial of one case and told you, per row, whether it passed. "Failed" is the least useful true thing you can say about a trial: the reader's next question is always *where*, and answering it meant opening rows one at a time.
+
+Each row now carries a one-line summary of its chain — `broke at Tool response`, `Request satisfied`, `chain withheld` — from the same read the trace pane uses, so the whole table costs one request rather than one per row.
+
+**The table takes a lookup, not a run.** The chain is scoped by run, and only the run-scoped host of this table knows which run its rows belong to; the cross-run case view passes nothing and issues no read, because filling that column there would mean one request per run.
+
+Three shades of nothing stay distinct, which is the whole reason this is a function of the chain rather than of the row's result:
+
+- a row whose chain has not loaded renders **no chip** — an absent map key means "not loaded", never "no chain";
+- a chain the server withheld says `chain withheld`, not silence, because the rows exist and did not validate;
+- a trial with no failed stage says `Request satisfied` **only when user value actually passed**. A policy-blocked trial has no failed stage either, and calling that satisfied would claim an outcome from an absence of evidence; it reads `not measured` instead.

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-decision-summary-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-decision-summary-card.test.tsx
@@ -36,7 +36,11 @@ import {
 } from "@/test/eval-decision-summary-fixtures";
 import { EvalRunDecisionSummaryError } from "@/lib/apis/eval-run-decision-summary-api";
 import { isDiagnosticTraceable } from "../run-decision-summary-presentation";
-import type { EvalRunDecisionSummary } from "@mcpjam/sdk/contract";
+import {
+  USER_VALUE_STAGE_LABELS,
+  USER_VALUE_STAGE_OUTCOMES,
+  type EvalRunDecisionSummary,
+} from "@mcpjam/sdk/contract";
 
 afterEach(cleanup);
 
@@ -256,7 +260,27 @@ describe("stage and category copy", () => {
     );
   });
 
-  it("renders every stage row's state once a trial is expanded", () => {
+  /**
+   * The first diagnostic's expandable body.
+   *
+   * `hidden={!expanded}` leaves every trial's body in the DOM, so a query over
+   * the whole card sees six cards per trial and picks whichever came first in
+   * document order. Scoping to one body is what makes an assertion about "this
+   * trial's chain" mean that.
+   */
+  function diagnosticBodies(card: HTMLElement): HTMLElement[] {
+    return Array.from(
+      card.querySelectorAll<HTMLElement>('[id^="run-decision-diagnostic-"]'),
+    );
+  }
+
+  function firstDiagnostic(card: HTMLElement): HTMLElement {
+    const body = diagnosticBodies(card)[0];
+    if (!body) throw new Error("no diagnostic body rendered");
+    return body;
+  }
+
+  it("renders every stage row as a card once a trial is expanded", () => {
     const summary = readDecisionSummaryFixture(
       "measured-failure-at-every-stage",
     );
@@ -272,7 +296,78 @@ describe("stage and category copy", () => {
     // The three non-verdicts stay three different sentences: "we did not
     // check", "it does not apply" and "it never ran" are different facts.
     expect(card).toHaveTextContent("never ran (an earlier stage failed)");
-    expect(card).toHaveTextContent("Connection: passed");
+    // The rows are cards now, not "Connection: passed" text. Scoped to ONE
+    // diagnostic each time: the expandable body stays in the DOM behind
+    // `hidden`, so a document-wide query would span every trial in the run.
+    //
+    // This fixture walks the break across all six stages, so the first trial
+    // broke AT connection and the last one got all the way to user value.
+    const bodies = diagnosticBodies(card);
+    const brokeAtConnection = within(bodies[0]!).getByTestId(
+      "stage-chain-card-connection",
+    );
+    expect(brokeAtConnection).toHaveTextContent(
+      USER_VALUE_STAGE_LABELS.connection,
+    );
+    expect(brokeAtConnection).toHaveAttribute("data-chip", "failed");
+
+    // …and where connection held, it wears its OUTCOME phrase rather than the
+    // word "passed", so the row reads as the delivery story.
+    const connectionHeld = within(bodies[bodies.length - 1]!).getByTestId(
+      "stage-chain-card-connection",
+    );
+    expect(connectionHeld).toHaveTextContent(
+      USER_VALUE_STAGE_OUTCOMES.connection,
+    );
+    expect(connectionHeld).toHaveAttribute("data-chip", "passed");
+  });
+
+  it("opens on the first failed stage, and lets a reader close it", () => {
+    const summary = readDecisionSummaryFixture(
+      "measured-failure-at-every-stage",
+    );
+    renderSummary(summary);
+    const card = screen.getByTestId("run-decision-summary");
+    fireEvent.click(
+      within(card).getAllByRole("button", { expanded: false })[0]!,
+    );
+    const body = firstDiagnostic(card);
+
+    // The contract named the stage; the card row opened on it rather than on
+    // a stage this component picked for itself.
+    const opened = within(body)
+      .getByTestId("trial-stage-detail-card")
+      .getAttribute("data-stage");
+    expect(opened).toBeTruthy();
+    const openedCard = within(body).getByTestId(`stage-chain-card-${opened}`);
+    expect(openedCard).toHaveAttribute("aria-pressed", "true");
+
+    // A second click on the open card closes it — the `null` path, distinct
+    // from "not chosen yet".
+    fireEvent.click(openedCard);
+    expect(within(body).queryByTestId("trial-stage-detail-card")).toBeNull();
+  });
+
+  it("shows no card row for a chain that was withheld", () => {
+    // `unverified` withheld its rows deliberately. It must not render as an
+    // empty six-card chain that reads as measured.
+    const summary = readDecisionSummaryFixture("unverified-and-version-ahead");
+    renderSummary(summary);
+    const card = screen.getByTestId("run-decision-summary");
+    for (const trigger of within(card).getAllByRole("button", {
+      expanded: false,
+    })) {
+      fireEvent.click(trigger);
+    }
+
+    // This fixture pairs a withheld chain with a verified one, which is the
+    // point: the withheld trial shows no cards while its neighbour still does,
+    // so "no cards" is a statement about THAT trial rather than about the run.
+    expect(
+      within(firstDiagnostic(card)).queryByTestId("stage-chain-cards"),
+    ).toBeNull();
+    expect(card).toHaveTextContent("did not validate");
+    expect(within(card).getAllByTestId("stage-chain-cards")).toHaveLength(1);
   });
 });
 

--- a/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
+++ b/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
@@ -222,6 +222,7 @@ export function IterationDetails({
   layoutMode = "compact",
   caseInsightSlot,
   judgeCase = null,
+  trialChainSlot,
 }: {
   iteration: EvalIteration;
   testCase: EvalCase | null;
@@ -231,6 +232,17 @@ export function IterationDetails({
   caseInsightSlot?: ReactNode;
   /** Advisory judge verdict for this case+run; surfaced on the Results tab. */
   judgeCase?: JudgeCase | null;
+  /**
+   * This trial's user-value chain — where value stopped travelling, and why.
+   *
+   * A SLOT, not a read this component performs. It has five hosts and knows
+   * only its iteration: not the run it belongs to, not the project, not
+   * whether the Evaluate opt-in is on — and the chain read needs all three.
+   * The one host that holds them builds the node; the other four pass nothing
+   * and issue no request, which is what keeps this shared component free of a
+   * fetch four of its callers never asked for.
+   */
+  trialChainSlot?: ReactNode;
 }) {
   const getBlob = useAction(
     "testSuites:getTestIterationBlob" as any,
@@ -1020,6 +1032,16 @@ export function IterationDetails({
       )}
     >
       {previewTraceToolbar}
+      {/* WHERE VALUE STOPPED, above the transcript.
+          A reader who opened this trial is asking why it did not deliver, and
+          the answer is six cards wide — putting it under the trace would make
+          them scroll a transcript to reach the summary of it. Absent for the
+          hosts that pass no slot, which is most of them. */}
+      {trialChainSlot ? (
+        <div className="shrink-0 px-3" data-testid="iteration-trial-chain">
+          {trialChainSlot}
+        </div>
+      ) : null}
       {/* Advisory judge verdict — pinned under the tab row so it's visible on
           every tab (Steps/Chat/Results/Trace/App/Raw), not buried in one. */}
       {layoutMode === "full" && judgeCase ? (

--- a/mcpjam-inspector/client/src/components/evals/run-decision-summary-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-decision-summary-card.tsx
@@ -46,10 +46,17 @@ import {
   formatDecisionCounts,
   truncateUntrusted,
 } from "./run-decision-summary-presentation";
+import { StageChainCards } from "@/components/evaluate/stage-chain-cards";
+import { TrialStageDetailCard } from "@/components/evaluate/trial-stage-detail-card";
+import {
+  defaultSelectedTrialStage,
+  toTrialCardViews,
+} from "@/components/evaluate/stage-trial-model";
 import type { EvalRunDecisionSummaryError } from "@/lib/apis/eval-run-decision-summary-api";
 import type {
   EvalRunDecisionDiagnostic,
   EvalRunDecisionSummary,
+  UserValueStage,
 } from "@mcpjam/sdk/contract";
 
 export interface RunDecisionSummaryCardProps {
@@ -361,6 +368,19 @@ function DiagnosticRow({
   }) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
+  /**
+   * Which stage's detail is open, with `undefined` kept apart from `null`.
+   *
+   * `undefined` means the reader has not chosen yet, so the default is derived
+   * AT RENDER TIME; `null` means they closed the card and it must stay closed.
+   * A plain initializer would work here — the chain is present at mount — but
+   * the same pair of components mounts on the trace pane, where the chain
+   * arrives after mount and an initializer would compute `null` once and never
+   * auto-open. One pattern in both places.
+   */
+  const [chosenStage, setChosenStage] = useState<
+    UserValueStage | null | undefined
+  >(undefined);
   const chain = describeDiagnosticChain(diagnostic);
   const evidence = describeDiagnosticEvidence(diagnostic);
   const title = truncateUntrusted(diagnostic.title) ?? "Untitled case";
@@ -369,6 +389,18 @@ function DiagnosticRow({
   // findings offering the same control get the same answer rather than a
   // second, drifting copy of the rule.
   const traceable = isDiagnosticTraceable(diagnostic, runId, onViewTrace);
+
+  // Only a `verified` chain carries rows. `unverified` withheld them because
+  // they did not validate and `absent` never had any — two different facts,
+  // and neither is an empty card row.
+  const rows =
+    diagnostic.chain.status === "verified" ? diagnostic.chain.stages : [];
+  const cards = toTrialCardViews(rows);
+  const selectedStage =
+    chosenStage === undefined
+      ? defaultSelectedTrialStage(diagnostic.chain)
+      : chosenStage;
+  const selectedRow = rows.find((row) => row.stage === selectedStage) ?? null;
 
   const detailId = `run-decision-diagnostic-${diagnostic.iterationId}`;
 
@@ -405,12 +437,26 @@ function DiagnosticRow({
       ) : null}
 
       <div id={detailId} hidden={!expanded}>
-        {chain.stageLines.length > 0 ? (
-          <ul className="mt-1 space-y-0.5 text-[11px] text-muted-foreground">
-            {chain.stageLines.map((line) => (
-              <li key={line}>{line}</li>
-            ))}
-          </ul>
+        {cards.length > 0 ? (
+          <div className="mt-2">
+            <StageChainCards
+              cards={cards}
+              selected={selectedStage}
+              onSelect={(stage) =>
+                // A second click on the open card closes it, which is what
+                // `null` is for — see the state's docblock.
+                setChosenStage(selectedStage === stage ? null : stage)
+              }
+            />
+            {selectedRow ? (
+              // No `nextAction` here: the row below already prints it once,
+              // for the whole trial, and it prints it even when there are no
+              // cards to show (a withheld or absent chain). One home beats a
+              // duplicate that appears only sometimes. The card's prop exists
+              // for the trace pane, which has no such line of its own.
+              <TrialStageDetailCard row={selectedRow} />
+            ) : null}
+          </div>
         ) : null}
         {observedFailure ? (
           <p className="mt-1 text-[11px] text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/evals/run-decision-summary-presentation.ts
+++ b/mcpjam-inspector/client/src/components/evals/run-decision-summary-presentation.ts
@@ -35,7 +35,6 @@ import {
   EVAL_VERDICT_DECISION_REASON_LABELS,
   FAILURE_CATEGORY_LABELS,
   STAGE_REASON_LABELS,
-  STAGE_STATE_LABELS,
   USER_VALUE_STAGE_LABELS,
   decisionDiagnosticFailureCategory,
   decisionDiagnosticFirstFailedStage,
@@ -44,6 +43,7 @@ import {
   type EvalRunDecisionDiagnostic,
   type EvalRunDecisionSummary,
   type EvalRunDecisionVerdict,
+  type StageResultRow,
 } from "@mcpjam/sdk/contract";
 
 /** Verdict badge copy. Title case for a badge; the contract's word otherwise. */
@@ -166,8 +166,6 @@ export interface DiagnosticChainSummary {
    * Flagged, never silently dropped.
    */
   trustNote: string | null;
-  /** The six stage rows, when a verified chain carried them. */
-  stageLines: string[];
 }
 
 /**
@@ -213,17 +211,11 @@ export function describeDiagnosticChain(
         ? `Recorded by stage analyzer v${versionAhead.reported}, newer than the v${versionAhead.known} this build knows. Shown as reported.`
         : null;
 
-  const stageLines =
-    chain.status === "verified"
-      ? chain.stages.map(
-          (row) =>
-            `${USER_VALUE_STAGE_LABELS[row.stage]}: ${
-              STAGE_STATE_LABELS[row.state]
-            }${row.reason ? ` — ${STAGE_REASON_LABELS[row.reason]}` : ""}`,
-        )
-      : [];
-
-  return { firstFailedStageLine, failureCategoryLine, trustNote, stageLines };
+  // The six stage rows used to be flattened into text lines here. They are now
+  // rendered as cards from the chain itself (`stage-trial-model.ts`), so the
+  // flattening is gone rather than left behind: a second, unrendered rendering
+  // of the same rows is what drifts out of step with the one on screen.
+  return { firstFailedStageLine, failureCategoryLine, trustNote };
 }
 
 function firstFailedStageReason(
@@ -260,6 +252,34 @@ export function describeDiagnosticEvidence(
   // Span ids and predicate reasons are authored elsewhere. React escapes them
   // on render; the bound is so one pathological reason cannot swamp the row.
   return `Evidence${at}: ${truncateUntrusted(parts.join("; "), 320) ?? ""}`;
+}
+
+/**
+ * The evidence locator for ONE stage row, in words.
+ *
+ * The row-level sibling of {@link describeDiagnosticEvidence}, which reads the
+ * diagnostic's own locator — already narrowed by the contract to the first
+ * failed stage. This one is for a surface that lets a reader select ANY stage
+ * and therefore has to answer "what was this stage decided from" for a row the
+ * diagnostic's locator says nothing about.
+ *
+ * Same bound and same wording as its sibling, and the same rule underneath:
+ * only ever THIS row's own evidence. Widening to a union across stages would
+ * hand a reader the spans that worked, labelled as evidence for the one that
+ * did not.
+ */
+export function describeStageRowEvidence(row: StageResultRow): string | null {
+  const evidence = row.evidence;
+  if (!evidence) return null;
+  const parts: string[] = [];
+  if (evidence.spanIds) parts.push(`span ids ${evidence.spanIds.join(", ")}`);
+  if (evidence.promptIndexes) {
+    parts.push(`prompt indexes ${evidence.promptIndexes.join(", ")}`);
+  }
+  if (parts.length === 0) return null;
+  // Span ids are authored elsewhere. React escapes them on render; the bound is
+  // so one pathological id cannot swamp the card.
+  return `Evidence: ${truncateUntrusted(parts.join("; "), 320) ?? ""}`;
 }
 
 /**

--- a/mcpjam-inspector/client/src/components/evals/run-test-case-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-test-case-detail-view.tsx
@@ -9,6 +9,7 @@ import {
 } from "./run-case-groups";
 import { RunCaseIterationBar } from "./run-case-list-shared";
 import type { EvalCase, EvalIteration, EvalSuiteRun } from "./types";
+import type { EvalRunDecisionChain } from "@mcpjam/sdk/contract";
 
 interface RunTestCaseDetailViewProps {
   run: EvalSuiteRun;
@@ -16,6 +17,14 @@ interface RunTestCaseDetailViewProps {
   iterations: EvalIteration[];
   onBack: () => void;
   serverNames?: string[];
+  /**
+   * Where each trial's chain stopped, by iteration id.
+   *
+   * Threaded from the caller because this view is RUN-SCOPED — every row here
+   * belongs to `run`, which is what makes one chain read enough. The cross-run
+   * case view has no such run and passes nothing.
+   */
+  chainFor?: (iterationId: string) => EvalRunDecisionChain | undefined;
 }
 
 function RunCaseSummaryStrip({
@@ -76,6 +85,7 @@ export function RunTestCaseDetailView({
   iterations,
   onBack,
   serverNames = [],
+  chainFor,
 }: RunTestCaseDetailViewProps) {
   const title =
     testCase?.title ?? iterations[0]?.testCaseSnapshot?.title ?? "Test case";
@@ -120,6 +130,7 @@ export function RunTestCaseDetailView({
           serverNames={serverNames}
           label={`All iterations (${iterations.length})`}
           sortMode="failing-first"
+          {...(chainFor ? { chainFor } : {})}
         />
       </div>
     </div>

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -33,6 +33,7 @@ import { RunTestCaseDetailView } from "./run-test-case-detail-view";
 import type { RunCaseGroup } from "./run-case-groups";
 import { RunDiffView } from "./run-diff-view";
 import { TestTemplateEditor } from "./test-template-editor";
+import { useEvalRunIterationChains } from "@/hooks/use-eval-run-iteration-chains";
 import { PassCriteriaSelector } from "./pass-criteria-selector";
 import { ValidatorsSection } from "./validators-section";
 import { JudgesSection } from "./judges-section";
@@ -561,6 +562,20 @@ export function SuiteIterationsView({
     const run = runs.find((r) => r._id === selectedRunId);
     return run ?? null;
   }, [selectedRunId, runs]);
+
+  /**
+   * Every trial's chain for the run currently open, keyed by iteration.
+   *
+   * ONE read for the whole run, shared by the rows beneath it — which is what
+   * the run-scoped case table needs and what a cross-run table could not have
+   * without a read per run. Gated on the same Evaluate opt-in and project id
+   * as the decision card, so with either missing it issues no request.
+   */
+  const runTrialChains = useEvalRunIterationChains({
+    projectId,
+    run: selectedRunDetails,
+    enabled: Boolean(evaluateDecisionSummary && projectId),
+  });
 
   const selectedCompareBaseRunId =
     route.type === "run-detail" ? route.compareToRunId ?? null : null;
@@ -1515,6 +1530,9 @@ export function SuiteIterationsView({
                     iterations={iterationsForSelectedRunTestCase}
                     onBack={handleBackToRunOverview}
                     serverNames={suite.environment?.servers || []}
+                    chainFor={(iterationId) =>
+                      runTrialChains.chains.get(iterationId)
+                    }
                   />
                 ) : (
                   runDetailView

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -1183,6 +1183,12 @@ export function SuiteIterationsView({
                   availableModels={availableModels}
                   suiteIterations={allIterations}
                   suiteRuns={runs}
+                  // The same opt-in and project gate the decision card beside
+                  // it rides. With this false the trace pane issues no chain
+                  // request at all.
+                  trialChainEnabled={Boolean(
+                    evaluateDecisionSummary && projectId,
+                  )}
                   isDirectGuest={isDirectGuest}
                   ensureServersReady={ensureServersReady}
                   projectServers={projectServers}

--- a/mcpjam-inspector/client/src/components/evals/test-case-iterations-table.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-case-iterations-table.tsx
@@ -6,7 +6,9 @@ import { cn } from "@/lib/utils";
 import { computeIterationResult } from "./pass-criteria";
 import { evalStatusLeftBorderClasses } from "./helpers";
 import { IterationDetails } from "./iteration-details";
+import { summarizeTrialChain } from "@/components/evaluate/stage-trial-model";
 import type { EvalCase, EvalIteration } from "./types";
+import type { EvalRunDecisionChain } from "@mcpjam/sdk/contract";
 
 interface TestCaseIterationsTableProps {
   testCase: EvalCase;
@@ -23,6 +25,18 @@ interface TestCaseIterationsTableProps {
    * primary question.
    */
   sortMode?: "failing-first" | "chronological";
+  /**
+   * Where each trial's chain stopped, by iteration id.
+   *
+   * A LOOKUP the caller supplies, not a read this table performs: the chain is
+   * scoped by RUN, and only the run-scoped host of this table knows which run
+   * its rows belong to. The cross-run view passes nothing rather than issuing
+   * one read per run to fill a column.
+   *
+   * Returning `undefined` means "not loaded", which is not "no chain" — an
+   * unloaded row renders no chip rather than a false absence.
+   */
+  chainFor?: (iterationId: string) => EvalRunDecisionChain | undefined;
 }
 
 function formatTimeAgo(timestamp: number): string {
@@ -53,6 +67,7 @@ export function TestCaseIterationsTable({
   label = "Iterations",
   emptyState = "No iterations found for this test.",
   sortMode = "failing-first",
+  chainFor,
 }: TestCaseIterationsTableProps) {
   const [openIterationId, setOpenIterationId] = useState<string | null>(null);
 
@@ -158,6 +173,26 @@ export function TestCaseIterationsTable({
                       <span className="text-xs font-medium truncate">
                         {snapshot?.title ?? "Iteration"}
                       </span>
+                      {(() => {
+                        // Where value stopped, in one line. Absent for a row
+                        // whose chain has not loaded, and for one the chain
+                        // says nothing about.
+                        const chain = chainFor?.(iteration._id);
+                        const summary = chain
+                          ? summarizeTrialChain(chain)
+                          : null;
+                        return summary ? (
+                          <span
+                            className={cn(
+                              "shrink-0 text-[10px]",
+                              summary.toneClass,
+                            )}
+                            data-testid="iteration-chain-summary"
+                          >
+                            {summary.label}
+                          </span>
+                        ) : null;
+                      })()}
                     </div>
                   </div>
                   <div className="flex items-center gap-4 text-xs text-muted-foreground shrink-0">

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -1235,10 +1235,13 @@ export function TestTemplateEditor({
   const openTrialRun = useMemo(() => {
     const runId =
       replayIteration?.suiteRunId ??
-      [routeCompareAnchorIteration, ...recentIterations, lastSavedIteration]
-        .find(
-          (it): it is EvalIteration => !!it && !!(it.blob || it.chatSessionId),
-        )?.suiteRunId;
+      [
+        routeCompareAnchorIteration,
+        ...recentIterations,
+        lastSavedIteration,
+      ].find(
+        (it): it is EvalIteration => !!it && !!(it.blob || it.chatSessionId),
+      )?.suiteRunId;
     if (!runId) return null;
     return suiteRuns.find((run) => run._id === runId) ?? null;
   }, [
@@ -1277,7 +1280,6 @@ export function TestTemplateEditor({
     if (!runId) return undefined;
     return suiteRuns.find((run) => run._id === runId)?.namedHostId;
   }, [replayIteration, suiteRuns]);
-
 
   // When viewing a past iteration, point Quick Run at the host THAT iteration
   // ran on, so a Retry / Quick Run targets the same host (e.g. the ChatGPT

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -55,6 +55,8 @@ import { AssertPickChooser, type AssertPick } from "./assert-pick-chooser";
 import { CaseRunsHistory } from "./runs/case-runs-history";
 import { ReplayedScenarioPane } from "./runs/replayed-scenario-pane";
 import { IterationDetails } from "./iteration-details";
+import { TrialChainPanel } from "@/components/evaluate/trial-chain-panel";
+import { useEvalRunIterationChains } from "@/hooks/use-eval-run-iteration-chains";
 import { resolveIterationJudge } from "./goal-completion-presentation";
 import { CompareRunChatSurface } from "./compare-run-chat-surface";
 import { EvalTraceSurface } from "./eval-trace-surface";
@@ -227,6 +229,15 @@ interface TestTemplateEditorProps {
   selectedTestCaseId: string;
   connectedServerNames: Set<string>;
   projectId: string | null;
+  /**
+   * Read each opened trial's user-value chain, and show it above its trace.
+   *
+   * The editor is the one host of `IterationDetails` that can: it resolves the
+   * replayed iteration's RUN from `suiteRuns` and holds the project id, which
+   * is exactly what the chain read needs and what the other four hosts lack.
+   * Off by default, and off issues no request.
+   */
+  trialChainEnabled?: boolean;
   availableModels: ModelDefinition[];
   /**
    * Iterations for the entire suite, already subscribed by the parent via
@@ -840,6 +851,7 @@ export function TestTemplateEditor({
   onSelectTab,
   openCompareFromRoute = false,
   openCompareIterationId = null,
+  trialChainEnabled = false,
   isDirectGuest = false,
   ensureServersReady,
   projectServers,
@@ -1204,6 +1216,60 @@ export function TestTemplateEditor({
     });
   }, [quickRunHostOptions]);
 
+  /**
+   * The RUN whose trial the drill-in is showing, and that trial's chain.
+   *
+   * ABOVE THE EARLY RETURN, and that placement is load-bearing rather than
+   * stylistic: this component returns a loading state before `currentTestCase`
+   * resolves, so a hook called below it runs on some renders and not others —
+   * which React reports as "rendered more hooks than during the previous
+   * render". A test caught exactly that.
+   *
+   * The run is resolved here for the same reason `replayHostId` is: an
+   * iteration knows its `suiteRunId` and nothing else about the run, and the
+   * chain read needs the run's status and revision to know whether there is
+   * anything to read and when to re-read it. The candidate order mirrors
+   * `latestTracedIteration` below — the replayed trial first, then whichever
+   * traced iteration the drill-in would fall back to.
+   */
+  const openTrialRun = useMemo(() => {
+    const runId =
+      replayIteration?.suiteRunId ??
+      [routeCompareAnchorIteration, ...recentIterations, lastSavedIteration]
+        .find(
+          (it): it is EvalIteration => !!it && !!(it.blob || it.chatSessionId),
+        )?.suiteRunId;
+    if (!runId) return null;
+    return suiteRuns.find((run) => run._id === runId) ?? null;
+  }, [
+    replayIteration,
+    routeCompareAnchorIteration,
+    recentIterations,
+    lastSavedIteration,
+    suiteRuns,
+  ]);
+
+  const trialChains = useEvalRunIterationChains({
+    projectId,
+    run: openTrialRun,
+    enabled: trialChainEnabled,
+  });
+
+  /**
+   * The chain panel for one opened trial, or nothing.
+   *
+   * Built here and passed DOWN as a node: `IterationDetails` has five hosts
+   * and only this one can answer which run the trial belongs to.
+   */
+  const trialChainSlotFor = (iteration: EvalIteration | null) => {
+    if (!iteration) return null;
+    const chain = trialChains.chains.get(iteration._id);
+    // An absent KEY is "not loaded", which is not "no chain" — a trial the
+    // walk has not reached renders nothing rather than a false absence.
+    if (!chain) return null;
+    return <TrialChainPanel chain={chain} resetKey={iteration._id} />;
+  };
+
   // The host a replayed iteration actually ran on (its suite run's
   // `namedHostId`) — i.e. the matrix column the user clicked to open it.
   const replayHostId = useMemo(() => {
@@ -1211,6 +1277,7 @@ export function TestTemplateEditor({
     if (!runId) return undefined;
     return suiteRuns.find((run) => run._id === runId)?.namedHostId;
   }, [replayIteration, suiteRuns]);
+
 
   // When viewing a past iteration, point Quick Run at the host THAT iteration
   // ran on, so a Retry / Quick Run targets the same host (e.g. the ChatGPT
@@ -2862,6 +2929,7 @@ export function TestTemplateEditor({
     latestTracedIteration,
     suiteRuns,
   );
+
   const latestAvailableResult = latestAvailableIteration
     ? computeIterationResult(latestAvailableIteration)
     : null;
@@ -3375,6 +3443,7 @@ export function TestTemplateEditor({
                       serverNames={effectiveSuiteServers}
                       layoutMode="full"
                       judgeCase={replayJudgeCase}
+                      trialChainSlot={trialChainSlotFor(replayIteration)}
                     />
                   </div>
                 ) : liveRecordMode && !showSpecOverride ? (
@@ -3475,6 +3544,7 @@ export function TestTemplateEditor({
                         serverNames={effectiveSuiteServers}
                         layoutMode="full"
                         judgeCase={latestTracedJudgeCase}
+                        trialChainSlot={trialChainSlotFor(latestTracedIteration)}
                       />
                     </div>
                   </div>

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/stage-trial-model.test.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/stage-trial-model.test.ts
@@ -24,6 +24,7 @@ import {
   UNRECOGNIZED_STATE_LABEL,
   defaultSelectedTrialStage,
   deriveTrialStageChip,
+  summarizeTrialChain,
   toTrialCardViews,
 } from "../stage-trial-model";
 
@@ -163,6 +164,44 @@ describe("the trial card row", () => {
     expect(cards.map((card) => card.chip.label)).toEqual(
       USER_VALUE_STAGES.map((stage) => USER_VALUE_STAGE_OUTCOMES[stage]),
     );
+  });
+});
+
+describe("summarizeTrialChain", () => {
+  it("names the stage a trial broke at", () => {
+    const summary = summarizeTrialChain(
+      verifiedChain(chainOf({ response: "failed" }), "response"),
+    );
+    expect(summary?.label).toContain(USER_VALUE_STAGE_LABELS.response);
+    expect(summary?.toneClass).toContain("destructive");
+  });
+
+  it("says the request was satisfied only when user value actually passed", () => {
+    expect(summarizeTrialChain(verifiedChain(chainOf()))?.label).toBe(
+      USER_VALUE_STAGE_OUTCOMES.userValue,
+    );
+
+    // No failed stage, but nothing measured the last link either. "Satisfied"
+    // here would claim an outcome from an absence of evidence.
+    const unmeasured = USER_VALUE_STAGES.map((stage) =>
+      row({ stage, state: "notMeasured", reason: "blockedByPolicy" }),
+    );
+    const summary = summarizeTrialChain(verifiedChain(unmeasured));
+    expect(summary?.label).toBe(STAGE_STATE_LABELS.notMeasured);
+    expect(summary?.toneClass).not.toContain("success");
+  });
+
+  it("says a withheld chain is withheld, and an absent one nothing at all", () => {
+    expect(
+      summarizeTrialChain({
+        status: "unverified",
+        analyzerVersion: 8,
+      } as EvalRunDecisionChain)?.label,
+    ).toBe("chain withheld");
+    // Nothing to say beats a placeholder that reads as a finding.
+    expect(
+      summarizeTrialChain({ status: "absent" } as EvalRunDecisionChain),
+    ).toBeNull();
   });
 });
 

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/stage-trial-model.test.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/stage-trial-model.test.ts
@@ -1,0 +1,213 @@
+/**
+ * The per-trial chip vocabulary, and the one invariant it must never break.
+ *
+ * The sibling of `stage-chain-model.test.ts`, guarding the same rule over a
+ * different population: a run's stage may be unmeasured across many trials, a
+ * single trial's stage may be unmeasured on its own, and NEITHER may render as
+ * a pass. The `passWords` regex is copied verbatim from that file on purpose —
+ * two surfaces that disagree about what counts as a pass word would each be
+ * individually green while the product says "healthy" somewhere.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  STAGE_STATES,
+  STAGE_STATE_LABELS,
+  USER_VALUE_STAGES,
+  USER_VALUE_STAGE_LABELS,
+  USER_VALUE_STAGE_OUTCOMES,
+  type EvalRunDecisionChain,
+  type StageResultRow,
+  type StageState,
+  type UserValueStage,
+} from "@mcpjam/sdk/contract";
+import {
+  UNRECOGNIZED_STATE_LABEL,
+  defaultSelectedTrialStage,
+  deriveTrialStageChip,
+  toTrialCardViews,
+} from "../stage-trial-model";
+
+function row(overrides: Partial<StageResultRow> = {}): StageResultRow {
+  return { stage: "response", state: "passed", ...overrides } as StageResultRow;
+}
+
+/** Six rows in chain order, all passed unless overridden by stage. */
+function chainOf(
+  states: Partial<Record<UserValueStage, StageState>> = {},
+): StageResultRow[] {
+  return USER_VALUE_STAGES.map((stage) =>
+    row({ stage, state: states[stage] ?? "passed" }),
+  );
+}
+
+function verifiedChain(
+  rows: StageResultRow[],
+  firstFailedStage?: UserValueStage,
+): EvalRunDecisionChain {
+  return {
+    status: "verified",
+    stages: rows,
+    analyzerVersion: 8,
+    ...(firstFailedStage ? { firstFailedStage } : {}),
+  } as EvalRunDecisionChain;
+}
+
+describe("deriveTrialStageChip", () => {
+  it("says the OUTCOME for a passed stage, not the word 'passed'", () => {
+    const chip = deriveTrialStageChip(row({ stage: "call", state: "passed" }));
+    expect(chip.kind).toBe("passed");
+    expect(chip.label).toBe(USER_VALUE_STAGE_OUTCOMES.call);
+    expect(chip.toneClass).toContain("success");
+  });
+
+  it("says only the state word for a failed stage — the reason stays off the chip", () => {
+    const chip = deriveTrialStageChip(
+      row({ state: "failed", reason: "toolError" }),
+    );
+    expect(chip.kind).toBe("failed");
+    expect(chip.label).toBe(STAGE_STATE_LABELS.failed);
+    // The reason belongs on the detail card, where a sentence fits.
+    expect(chip.label).not.toContain("tool error");
+    expect(chip.toneClass).toContain("destructive");
+  });
+
+  it.each([
+    ["notReached" as const],
+    ["notMeasured" as const],
+    ["notApplicable" as const],
+  ])("renders %s in its own words, in a neutral tone", (state) => {
+    const chip = deriveTrialStageChip(row({ state }));
+    expect(chip.kind).toBe("unmeasured");
+    // Read from the contract's map, never a hardcoded sentence.
+    expect(chip.label).toBe(STAGE_STATE_LABELS[state]);
+    expect(chip.toneClass).toContain("muted");
+    expect(chip.toneClass).not.toContain("amber");
+  });
+
+  it("degrades rather than throwing on a state this build has no word for", () => {
+    const chip = deriveTrialStageChip(
+      row({ state: "judgeDeferred" as StageState }),
+    );
+    expect(chip.kind).toBe("unmeasured");
+    expect(chip.label).toBe(UNRECOGNIZED_STATE_LABEL);
+    expect(chip.toneClass).not.toContain("success");
+  });
+
+  it("INVARIANT: only a passed row ever wears a pass word", () => {
+    // The same regex as the aggregate chip's invariant, deliberately. It
+    // includes the six outcome verbs, so an outcome phrase leaking onto a
+    // non-passed row is caught, not just the literal word "passed".
+    const passWords =
+      /\b(pass|passed|ok|healthy|good|connected|discovered|selected|made|returned|satisfied)\b/i;
+    const states: StageState[] = [
+      ...STAGE_STATES.filter((state) => state !== "passed"),
+      "judgeDeferred" as StageState,
+    ];
+    for (const state of states) {
+      for (const stage of USER_VALUE_STAGES) {
+        const chip = deriveTrialStageChip(row({ stage, state }));
+        const where = `${stage}/${state}`;
+        expect(chip.kind, where).not.toBe("passed");
+        expect(chip.toneClass, where).not.toContain("success");
+        expect(chip.label, where).not.toMatch(passWords);
+      }
+    }
+  });
+
+  it("never renders a percentage or a wire spelling", () => {
+    for (const state of STAGE_STATES) {
+      const chip = deriveTrialStageChip(row({ state }));
+      expect(chip.label).not.toMatch(/%/);
+      expect(chip.label).not.toMatch(/[a-z][A-Z]/);
+    }
+  });
+
+  it("never produces the aggregate-only kinds", () => {
+    // `mixed` needs two trials and `noTrials` describes a run. Neither can
+    // mean anything about one row, so neither may be reachable from one.
+    for (const state of STAGE_STATES) {
+      const chip = deriveTrialStageChip(row({ state }));
+      expect(["passed", "failed", "unmeasured"]).toContain(chip.kind);
+    }
+  });
+});
+
+describe("the trial card row", () => {
+  it("renders six cards in chain order with 01..06 ordinals", () => {
+    const cards = toTrialCardViews(chainOf());
+    expect(cards.map((card) => card.stage)).toEqual([...USER_VALUE_STAGES]);
+    expect(cards.map((card) => card.ordinal)).toEqual([
+      "01",
+      "02",
+      "03",
+      "04",
+      "05",
+      "06",
+    ]);
+    expect(cards[0]?.label).toBe(USER_VALUE_STAGE_LABELS.connection);
+  });
+
+  it("NEVER SORTS — position is meaning, so a reordered chain stays reordered", () => {
+    // `notReached` is derived from position upstream. Quietly re-sorting here
+    // would repair a broken payload into a different, plausible-looking claim.
+    const reversed = [...chainOf()].reverse();
+    const cards = toTrialCardViews(reversed);
+    expect(cards.map((card) => card.stage)).toEqual(
+      [...USER_VALUE_STAGES].reverse(),
+    );
+    expect(cards[0]?.ordinal).toBe("01");
+  });
+
+  it("carries the delivery story across a clean trial", () => {
+    const cards = toTrialCardViews(chainOf());
+    expect(cards.map((card) => card.chip.label)).toEqual(
+      USER_VALUE_STAGES.map((stage) => USER_VALUE_STAGE_OUTCOMES[stage]),
+    );
+  });
+});
+
+describe("defaultSelectedTrialStage", () => {
+  it("opens on the contract's firstFailedStage, never a re-derived one", () => {
+    // The rows say `selection` failed too, but the contract named `response`.
+    // The contract wins: a second derivation that disagreed would look
+    // authoritative while being wrong.
+    const chain = verifiedChain(
+      chainOf({ selection: "failed", response: "failed" }),
+      "response",
+    );
+    expect(defaultSelectedTrialStage(chain)).toBe("response");
+  });
+
+  it("opens nothing on a delivered trial", () => {
+    expect(defaultSelectedTrialStage(verifiedChain(chainOf()))).toBeNull();
+  });
+
+  it("opens the explained row when NO stage failed — the setup-abort shape", () => {
+    // A policy block or setup abort measures nothing anywhere, and the only
+    // thing worth reading is the reason. Leaving it closed hides the single
+    // sentence that explains the trial.
+    const rows = USER_VALUE_STAGES.map((stage) =>
+      row({ stage, state: "notMeasured", reason: "blockedByPolicy" }),
+    );
+    expect(defaultSelectedTrialStage(verifiedChain(rows))).toBe("connection");
+  });
+
+  it("still opens nothing when the unmeasured rows explain nothing", () => {
+    const rows = USER_VALUE_STAGES.map((stage) =>
+      row({ stage, state: "notApplicable" }),
+    );
+    expect(defaultSelectedTrialStage(verifiedChain(rows))).toBeNull();
+  });
+
+  it("opens nothing for a withheld or absent chain", () => {
+    expect(
+      defaultSelectedTrialStage({
+        status: "unverified",
+        analyzerVersion: 8,
+      } as EvalRunDecisionChain),
+    ).toBeNull();
+    expect(
+      defaultSelectedTrialStage({ status: "absent" } as EvalRunDecisionChain),
+    ).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/trial-stage-detail-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/trial-stage-detail-card.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * The per-trial "what happened" card.
+ *
+ * The assertions guard the two things that would mislead a reader most: a wire
+ * spelling reaching the screen in place of a sentence, and a statistic being
+ * manufactured out of one observation.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  STAGE_REASON_LABELS,
+  STAGE_STATE_LABELS,
+  USER_VALUE_STAGE_QUESTIONS,
+  type StageResultRow,
+} from "@mcpjam/sdk/contract";
+import { TrialStageDetailCard } from "../trial-stage-detail-card";
+
+afterEach(cleanup);
+
+function row(overrides: Partial<StageResultRow> = {}): StageResultRow {
+  return { stage: "response", state: "failed", ...overrides } as StageResultRow;
+}
+
+describe("TrialStageDetailCard", () => {
+  it("asks the stage's own question and answers it in words", () => {
+    render(<TrialStageDetailCard row={row({ reason: "toolError" })} />);
+
+    const card = screen.getByTestId("trial-stage-detail-card");
+    expect(card).toHaveTextContent(USER_VALUE_STAGE_QUESTIONS.response);
+    expect(screen.getByTestId("trial-stage-state")).toHaveTextContent(
+      STAGE_STATE_LABELS.failed,
+    );
+    expect(screen.getByTestId("trial-stage-reason")).toHaveTextContent(
+      STAGE_REASON_LABELS.toolError,
+    );
+    // The wire spelling rides as an attribute, never as prose.
+    expect(screen.getByTestId("trial-stage-reason")).toHaveAttribute(
+      "data-reason",
+      "toolError",
+    );
+    expect(card.textContent).not.toContain("toolError");
+  });
+
+  it("omits the reason line when the row recorded none", () => {
+    render(<TrialStageDetailCard row={row({ state: "notReached" })} />);
+    expect(screen.queryByTestId("trial-stage-reason")).toBeNull();
+    expect(screen.getByTestId("trial-stage-state")).toHaveTextContent(
+      STAGE_STATE_LABELS.notReached,
+    );
+  });
+
+  it("NEVER manufactures a rate from one observation", () => {
+    const card = render(
+      <TrialStageDetailCard row={row({ state: "passed" })} />,
+    ).container;
+    // "100% (1/1)" over a single row is a statistic invented from one trial.
+    expect(card.textContent).not.toMatch(/%/);
+    expect(card.textContent).not.toMatch(/\b1\s*\/\s*1\b/);
+  });
+
+  it("renders this row's own evidence, and only this row's", () => {
+    render(
+      <TrialStageDetailCard
+        row={row({
+          evidence: {
+            spanIds: ["tool-call_abc"],
+            promptIndexes: [2],
+            predicateReasons: ["expected a non-empty result"],
+          },
+        })}
+      />,
+    );
+
+    const card = screen.getByTestId("trial-stage-detail-card");
+    expect(card).toHaveTextContent("span ids tool-call_abc");
+    expect(card).toHaveTextContent("prompt indexes 2");
+    expect(
+      screen.getByTestId("trial-stage-predicate-reasons"),
+    ).toHaveTextContent("expected a non-empty result");
+  });
+
+  it("shows a next action only when the caller supplies one", () => {
+    const { rerender } = render(<TrialStageDetailCard row={row()} />);
+    expect(screen.queryByTestId("trial-stage-next-action")).toBeNull();
+
+    rerender(
+      <TrialStageDetailCard
+        row={row()}
+        nextAction="inspect the tool response returned by the server"
+      />,
+    );
+    expect(screen.getByTestId("trial-stage-next-action")).toHaveTextContent(
+      "inspect the tool response returned by the server",
+    );
+  });
+
+  it("degrades on a state this build has no word for", () => {
+    render(
+      <TrialStageDetailCard
+        row={row({ state: "judgeDeferred" as StageResultRow["state"] })}
+      />,
+    );
+    expect(screen.getByTestId("trial-stage-state")).toHaveTextContent(
+      "state not recognized",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/evaluate/stage-trial-model.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/stage-trial-model.ts
@@ -159,5 +159,51 @@ export function defaultSelectedTrialStage(
   return explained?.stage ?? null;
 }
 
+/**
+ * One trial's chain in ONE LINE, for a list row that has no space for six.
+ *
+ * The row-level counterpart of the card row: same facts, same words, chosen
+ * so a reader scanning a table sees where each trial stopped without opening
+ * anything. `null` when there is nothing to say — the caller renders nothing
+ * rather than a placeholder, because a row whose chain has not loaded and a
+ * row whose trial delivered are different things and neither is a dash.
+ *
+ * NO REASON HERE either, for the reason the chip gives: reasons are sentences
+ * and this is a table cell.
+ */
+export function summarizeTrialChain(
+  chain: EvalRunDecisionChain,
+): { label: string; toneClass: string } | null {
+  if (chain.status === "unverified") {
+    return {
+      label: "chain withheld",
+      toneClass: STAGE_CHIP_TONE_CLASS.unmeasured,
+    };
+  }
+  if (chain.status === "absent") return null;
+  if (chain.firstFailedStage) {
+    return {
+      label: `broke at ${USER_VALUE_STAGE_LABELS[chain.firstFailedStage]}`,
+      toneClass: STAGE_CHIP_TONE_CLASS.failed,
+    };
+  }
+  // No failed stage. Say so only when the chain actually ran the distance —
+  // a trial whose stages were never measured has not "satisfied" anything.
+  const userValue = chain.stages.find((row) => row.stage === "userValue");
+  if (userValue?.state === "passed") {
+    return {
+      label: USER_VALUE_STAGE_OUTCOMES.userValue,
+      toneClass: STAGE_CHIP_TONE_CLASS.passed,
+    };
+  }
+  const measured = chain.stages.find((row) => row.state !== "notApplicable");
+  return measured
+    ? {
+        label: STAGE_STATE_LABELS.notMeasured,
+        toneClass: STAGE_CHIP_TONE_CLASS.unmeasured,
+      }
+    : null;
+}
+
 /** The chain's stages, re-exported so a renderer need not reach past this. */
 export { USER_VALUE_STAGES };

--- a/mcpjam-inspector/client/src/components/evaluate/stage-trial-model.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/stage-trial-model.ts
@@ -1,0 +1,163 @@
+/**
+ * The chip on one stage card for ONE TRIAL, derived from that trial's own row.
+ *
+ * PURE — no React, no fetching, no clock, and no arithmetic at all. The sibling
+ * of `stage-chain-model.ts`, which does the same job for a run's aggregate
+ * tallies, and it exists because the two questions are genuinely different:
+ *
+ *   - a RUN's stage is a population ("2 of 3 measured trials failed here");
+ *   - a TRIAL's stage is a single verdict ("this one failed here").
+ *
+ * A trial has no denominator, and inventing one — rendering "100% (1/1)" over a
+ * single row — would manufacture a statistic out of one observation. So this
+ * module never counts anything: it maps the row's `state` to a chip and stops.
+ *
+ * ── The rule that shapes the branches, restated for a single row ─────────────
+ *
+ * `STAGE_STATES` has five members and three of them are NOT verdicts:
+ * `notReached`, `notMeasured` and `notApplicable` each say a different kind of
+ * "nothing was decided here". Reporting any of them as healthy is the
+ * misreading the five-state vocabulary exists to prevent, so only `passed`
+ * earns a pass word and a success tone.
+ *
+ * ── Why the reason is NOT on the chip ────────────────────────────────────────
+ *
+ * Some `STAGE_REASON_LABELS` entries are whole sentences (the unavailable
+ * match-verdict one runs past a hundred characters), and six cards at their
+ * minimum width inside a diagnostic row would wrap into unreadable columns.
+ * The aggregate `failed` chip already omits reasons for the same reason. It
+ * also keeps the pass-word invariant total over the five STATES rather than
+ * dependent on the 29-member reason vocabulary — two reason labels contain the
+ * word "made", which the invariant's own regex matches. The detail card owns
+ * the reason, where there is room to read it.
+ */
+import {
+  STAGE_STATE_LABELS,
+  USER_VALUE_STAGES,
+  USER_VALUE_STAGE_LABELS,
+  USER_VALUE_STAGE_OUTCOMES,
+  type EvalRunDecisionChain,
+  type StageResultRow,
+  type UserValueStage,
+} from "@mcpjam/sdk/contract";
+import {
+  STAGE_CHIP_TONE_CLASS,
+  type StageCardView,
+  type StageChip,
+} from "./stage-chain-model";
+
+/**
+ * The words for a state this build has no label for.
+ *
+ * DEGRADE, NEVER THROW. A deployment can serve rows produced by an analyzer
+ * newer than this bundle, and the honest answer to "what is `judgeDeferred`?"
+ * is that this reader does not know — not a crash, and emphatically not a
+ * guess that renders as a pass. Same posture as the shared session chain's
+ * `UNKNOWN_STATE_META`.
+ */
+export const UNRECOGNIZED_STATE_LABEL = "state not recognized";
+
+/**
+ * The chip for one stage of one trial, from its row's state alone.
+ *
+ * Total over `StageState`, and deliberately written as an exhaustive switch so
+ * a sixth member of the vocabulary breaks the build here rather than falling
+ * through to a default that reads as fine.
+ */
+export function deriveTrialStageChip(row: StageResultRow): StageChip {
+  switch (row.state) {
+    case "passed":
+      return {
+        kind: "passed",
+        // The OUTCOME phrase, not the word "passed" — the map is documented as
+        // being for a stage measured as passed, which is exactly this branch,
+        // and it makes the row read as the delivery story ("Session connected
+        // → Tools and resources discovered → Request satisfied") instead of
+        // six identical words.
+        label: USER_VALUE_STAGE_OUTCOMES[row.stage],
+        toneClass: STAGE_CHIP_TONE_CLASS.passed,
+      };
+    case "failed":
+      return {
+        kind: "failed",
+        // The state word alone. See the header: the reason lives on the detail
+        // card, where a sentence fits.
+        label: STAGE_STATE_LABELS.failed,
+        toneClass: STAGE_CHIP_TONE_CLASS.failed,
+      };
+    case "notReached":
+    case "notMeasured":
+    case "notApplicable":
+      return {
+        kind: "unmeasured",
+        label: STAGE_STATE_LABELS[row.state],
+        // NEUTRAL. An unmeasured stage is an absence of evidence about the
+        // server, not a warning about it.
+        toneClass: STAGE_CHIP_TONE_CLASS.unmeasured,
+      };
+    default:
+      return {
+        kind: "unmeasured",
+        label: UNRECOGNIZED_STATE_LABEL,
+        toneClass: STAGE_CHIP_TONE_CLASS.unmeasured,
+      };
+  }
+}
+
+/**
+ * One trial's six rows as cards, in the order the chain gave them.
+ *
+ * POSITION IS MEANING: `notReached` is derived from a row's position in
+ * `USER_VALUE_STAGES`, so a reordered row list is a different claim about
+ * which stages were blocked. This maps AS GIVEN and never sorts — the contract
+ * already guarantees six rows in chain order, and if a payload ever breaks
+ * that guarantee the right outcome is a visibly wrong ordinal, not a silently
+ * repaired one.
+ */
+export function toTrialCardViews(
+  rows: readonly StageResultRow[],
+): StageCardView[] {
+  return rows.map((row, index) => ({
+    stage: row.stage,
+    ordinal: String(index + 1).padStart(2, "0"),
+    label: USER_VALUE_STAGE_LABELS[row.stage],
+    chip: deriveTrialStageChip(row),
+  }));
+}
+
+/**
+ * Which stage to open on for a trial, or `null` for none.
+ *
+ * THE CONTRACT'S OWN `firstFailedStage` whenever it has one, never re-derived.
+ * The server decided where this chain stopped; scanning for the first `failed`
+ * row here would be a second derivation of the same fact, and the day the two
+ * disagree the UI would be the one that is wrong while looking authoritative.
+ *
+ * When the contract established NO first failed stage, this opens the first
+ * non-passing row that carries a reason. That is the setup-abort and
+ * policy-block shape: every stage reads `not measured` and the only thing a
+ * reader wants — WHY nothing was measured — sits in a row's `reason`. Leaving
+ * it closed hides the one sentence that explains the trial behind a click
+ * nobody knows to make.
+ *
+ * It is a choice of which card to OPEN, never a claim that the stage failed:
+ * the chip on that card still says `not measured`, and the row above still
+ * says no first failed stage was established.
+ *
+ * `null` for the two non-verified statuses (there are no rows to open) and for
+ * a trial that was delivered end to end — that raises no "what happened"
+ * question, so auto-opening a card would manufacture one.
+ */
+export function defaultSelectedTrialStage(
+  chain: EvalRunDecisionChain,
+): UserValueStage | null {
+  if (chain.status !== "verified") return null;
+  if (chain.firstFailedStage) return chain.firstFailedStage;
+  const explained = chain.stages.find(
+    (row) => row.state !== "passed" && row.reason !== undefined,
+  );
+  return explained?.stage ?? null;
+}
+
+/** The chain's stages, re-exported so a renderer need not reach past this. */
+export { USER_VALUE_STAGES };

--- a/mcpjam-inspector/client/src/components/evaluate/trial-chain-panel.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/trial-chain-panel.tsx
@@ -1,0 +1,100 @@
+/**
+ * One trial's chain, as the card row plus its "what happened" card.
+ *
+ * The shared body behind both per-trial surfaces: the diagnostic row on the
+ * run page, and the trace pane a reader lands on from "View trace". Same
+ * components, same selection rule, same words — a second arrangement of the
+ * same six cards is a second place for them to disagree.
+ *
+ * ── Selection: `undefined` is not `null` ─────────────────────────────────────
+ *
+ * `undefined` means the reader has not chosen, so the default is derived AT
+ * RENDER TIME; `null` means they closed the card and it stays closed. The
+ * distinction is load-bearing here rather than merely tidy: on the trace pane
+ * the chain arrives AFTER mount, so a state initialized once from an empty
+ * chain would compute `null` and never auto-open the break.
+ */
+import { useEffect, useState, type ReactNode } from "react";
+import type {
+  EvalRunDecisionChain,
+  UserValueStage,
+} from "@mcpjam/sdk/contract";
+import { StageChainCards } from "./stage-chain-cards";
+import { TrialStageDetailCard } from "./trial-stage-detail-card";
+import {
+  defaultSelectedTrialStage,
+  toTrialCardViews,
+} from "./stage-trial-model";
+
+export function TrialChainPanel({
+  chain,
+  nextAction,
+  /** Resets the reader's selection when the pane swaps to another trial. */
+  resetKey,
+  heading,
+}: {
+  chain: EvalRunDecisionChain | null | undefined;
+  nextAction?: string;
+  resetKey?: string;
+  heading?: ReactNode;
+}) {
+  const [chosenStage, setChosenStage] = useState<
+    UserValueStage | null | undefined
+  >(undefined);
+
+  // A different trial is a different chain: carrying a selection across would
+  // open a stage the new trial may not have broken at.
+  useEffect(() => setChosenStage(undefined), [resetKey]);
+
+  // Nothing to say YET is not the same as nothing to say. A pane whose read
+  // has not landed renders nothing rather than an absent-chain notice, which
+  // would be a claim about the trial rather than about the read.
+  if (!chain) return null;
+
+  if (chain.status !== "verified") {
+    return (
+      <div
+        className="rounded-md border border-border/60 p-3"
+        data-testid="trial-chain-unavailable"
+        data-chain-status={chain.status}
+      >
+        {heading}
+        <p className="text-[11px] text-muted-foreground">
+          {chain.status === "unverified"
+            ? // Withheld on purpose, and the reason is worth stating: the rows
+              // exist and did not validate, so showing them would publish a
+              // chain the server declined to vouch for.
+              "This trial's stage chain did not validate, so it is withheld."
+            : "This trial recorded no stage chain."}
+        </p>
+      </div>
+    );
+  }
+
+  const cards = toTrialCardViews(chain.stages);
+  const selectedStage =
+    chosenStage === undefined ? defaultSelectedTrialStage(chain) : chosenStage;
+  const selectedRow =
+    chain.stages.find((row) => row.stage === selectedStage) ?? null;
+
+  return (
+    <div data-testid="trial-chain-panel">
+      {heading}
+      <StageChainCards
+        cards={cards}
+        selected={selectedStage}
+        onSelect={(stage) =>
+          setChosenStage(selectedStage === stage ? null : stage)
+        }
+      />
+      {selectedRow ? (
+        <TrialStageDetailCard
+          row={selectedRow}
+          {...(nextAction && selectedRow.stage === chain.firstFailedStage
+            ? { nextAction }
+            : {})}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evaluate/trial-stage-detail-card.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/trial-stage-detail-card.tsx
@@ -1,0 +1,134 @@
+/**
+ * "What happened" for the one stage a reader selected, on ONE TRIAL.
+ *
+ * The per-trial sibling of `StageDetailCard`. Same frame — the eyebrow, the
+ * stage label, the contract's question — and a different body, because the two
+ * cards answer different questions about different populations:
+ *
+ *   - `StageDetailCard` explains a RUN's stage: three rates over a population,
+ *     a reason histogram, exclusion counts.
+ *   - this explains a TRIAL's stage: one state, one reason, that row's own
+ *     evidence.
+ *
+ * ── What is deliberately absent ──────────────────────────────────────────────
+ *
+ * No `RateCell`. A rate needs a denominator and one trial is not a population;
+ * "100% (1/1)" would be a statistic manufactured from a single observation.
+ * No latency: it is deliberately NOT a field on `StageResultRow` (see the
+ * stage-measurements contract), and inventing one from elsewhere would attach
+ * a timing claim to a row that never carried it. No findings slot: a trial IS
+ * the finding, so there is nothing to fill it with.
+ *
+ * ── Nothing here diagnoses ───────────────────────────────────────────────────
+ *
+ * The state, the reason and the evidence are read off the row. `nextAction` is
+ * the contract's own field, passed in by the caller that holds the diagnostic
+ * — never recomputed here from a failure category, because the wording that
+ * handles a verdict/chain disagreement is decided by logic this component
+ * cannot see.
+ */
+import {
+  STAGE_REASON_LABELS,
+  STAGE_STATE_LABELS,
+  USER_VALUE_STAGE_LABELS,
+  USER_VALUE_STAGE_QUESTIONS,
+  type StageResultRow,
+} from "@mcpjam/sdk/contract";
+import { describeStageRowEvidence } from "../evals/run-decision-summary-presentation";
+import { UNRECOGNIZED_STATE_LABEL } from "./stage-trial-model";
+
+export function TrialStageDetailCard({
+  row,
+  nextAction,
+}: {
+  row: StageResultRow;
+  /**
+   * The operator's next step, when the caller has one for THIS stage.
+   *
+   * Optional because it belongs to the diagnostic rather than to the row: a
+   * surface reading a trial's chain without its decision summary has no
+   * next action to offer, and offering a made-up one would be worse than
+   * offering none.
+   */
+  nextAction?: string;
+}) {
+  // No `?? row.state` fallback: printing a wire spelling at a human is the
+  // failure the label maps exist to prevent, and this build genuinely does not
+  // know what a state it has no label for means.
+  const stateLabel = STAGE_STATE_LABELS[row.state] ?? UNRECOGNIZED_STATE_LABEL;
+  const reasonLabel = row.reason ? STAGE_REASON_LABELS[row.reason] : null;
+  const evidence = describeStageRowEvidence(row);
+  const predicateReasons = row.evidence?.predicateReasons ?? [];
+
+  return (
+    <div
+      className="mt-2 rounded-md border border-border/60 p-3"
+      data-testid="trial-stage-detail-card"
+      data-stage={row.stage}
+      data-state={row.state}
+    >
+      <h5 className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        What happened
+      </h5>
+
+      <p className="mt-1 text-xs font-medium text-foreground">
+        {USER_VALUE_STAGE_LABELS[row.stage]}
+      </p>
+      {/* The QUESTION this stage answers, in the contract's own words. */}
+      <p className="text-[11px] text-muted-foreground">
+        {USER_VALUE_STAGE_QUESTIONS[row.stage]}
+      </p>
+
+      <p
+        className="mt-2 text-[11px] text-foreground"
+        data-testid="trial-stage-state"
+      >
+        {stateLabel}
+      </p>
+      {reasonLabel ? (
+        // The wire spelling rides as an attribute so a test and a later join
+        // can match on it; only the words are rendered.
+        <p
+          className="mt-0.5 text-[11px] text-muted-foreground"
+          data-testid="trial-stage-reason"
+          data-reason={row.reason}
+        >
+          {reasonLabel}
+        </p>
+      ) : null}
+
+      {predicateReasons.length > 0 ? (
+        <ul
+          className="mt-1.5 space-y-0.5"
+          data-testid="trial-stage-predicate-reasons"
+        >
+          {predicateReasons.map((reason, index) => (
+            // Authored elsewhere and not guaranteed unique, so the index is
+            // part of the key rather than the string alone.
+            <li
+              key={`${index}-${reason}`}
+              className="text-[10px] text-muted-foreground/80"
+            >
+              {reason}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {evidence ? (
+        <p className="mt-1.5 text-[10px] text-muted-foreground/80">
+          {evidence}
+        </p>
+      ) : null}
+
+      {nextAction ? (
+        <p
+          className="mt-1.5 text-[10px] text-muted-foreground"
+          data-testid="trial-stage-next-action"
+        >
+          Next action: {nextAction}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-eval-run-iteration-chains.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-eval-run-iteration-chains.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * The per-run chain read's gating and its walk.
+ *
+ * The assertions that matter are the ones about SILENCE: with the caller's
+ * switch off, no project, or a run that has not finished, this must issue no
+ * request at all — that is what keeps every non-Evaluate mount of the views
+ * downstream at exactly zero reads.
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchChains = vi.fn();
+vi.mock("@/lib/apis/eval-run-iterations-api", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/apis/eval-run-iterations-api")
+  >("@/lib/apis/eval-run-iterations-api");
+  return {
+    ...actual,
+    fetchEvalRunIterationChains: (...args: unknown[]) => fetchChains(...args),
+  };
+});
+
+import { useEvalRunIterationChains } from "../use-eval-run-iteration-chains";
+
+const terminalRun = {
+  _id: "run_1",
+  status: "completed",
+  result: "failed",
+  completedAt: 1_700_000_000_000,
+};
+
+function chainPage(ids: string[], nextCursor?: string) {
+  return {
+    items: ids.map((id) => ({
+      iterationId: id,
+      chain: { status: "verified", stages: [], analyzerVersion: 8 },
+    })),
+    ...(nextCursor ? { nextCursor } : {}),
+  };
+}
+
+beforeEach(() => {
+  fetchChains.mockReset();
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useEvalRunIterationChains", () => {
+  it("reads a terminal run's chains and keys them by iteration", async () => {
+    fetchChains.mockResolvedValue(chainPage(["iter_1", "iter_2"]));
+
+    const { result } = renderHook(() =>
+      useEvalRunIterationChains({
+        projectId: "proj_1",
+        run: terminalRun,
+        enabled: true,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.chains.get("iter_1")?.status).toBe("verified");
+    expect(result.current.chains.size).toBe(2);
+    expect(result.current.walkExhausted).toBe(true);
+  });
+
+  it.each([
+    ["the caller's switch is off", { enabled: false, projectId: "proj_1" }],
+    ["there is no project", { enabled: true, projectId: null }],
+  ])("issues NO request when %s", async (_label, target) => {
+    renderHook(() =>
+      useEvalRunIterationChains({
+        projectId: target.projectId,
+        run: terminalRun,
+        enabled: target.enabled,
+      }),
+    );
+
+    await Promise.resolve();
+    expect(fetchChains).not.toHaveBeenCalled();
+  });
+
+  it("issues no request while the run is still going", async () => {
+    renderHook(() =>
+      useEvalRunIterationChains({
+        projectId: "proj_1",
+        run: { ...terminalRun, status: "running" },
+        enabled: true,
+      }),
+    );
+
+    await Promise.resolve();
+    expect(fetchChains).not.toHaveBeenCalled();
+  });
+
+  it("re-reads when a late judge changes the run's revision", async () => {
+    fetchChains.mockResolvedValue(chainPage(["iter_1"]));
+    const { rerender } = renderHook(
+      (props: { run: typeof terminalRun }) =>
+        useEvalRunIterationChains({
+          projectId: "proj_1",
+          run: props.run,
+          enabled: true,
+        }),
+      { initialProps: { run: terminalRun } },
+    );
+    await waitFor(() => expect(fetchChains).toHaveBeenCalledTimes(1));
+
+    // A terminal run is not frozen: the verdict summary changing means the
+    // cached chains describe an older reading.
+    rerender({ run: { ...terminalRun, verdictSummary: { v: 2 } } as never });
+    await waitFor(() => expect(fetchChains).toHaveBeenCalledTimes(2));
+  });
+
+  it("follows the cursor, and says so when it ran out of pages first", async () => {
+    fetchChains.mockImplementation((params: { cursor?: string }) =>
+      Promise.resolve(
+        params.cursor
+          ? chainPage(["iter_2"])
+          : chainPage(["iter_1"], "cursor_2"),
+      ),
+    );
+
+    const { result } = renderHook(() =>
+      useEvalRunIterationChains({
+        projectId: "proj_1",
+        run: terminalRun,
+        enabled: true,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.chains.size).toBe(2);
+    expect(result.current.walkExhausted).toBe(true);
+  });
+
+  it("reports a failed read without inventing empty chains", async () => {
+    const { EvalRunIterationsError } = await vi.importActual<
+      typeof import("@/lib/apis/eval-run-iterations-api")
+    >("@/lib/apis/eval-run-iterations-api");
+    fetchChains.mockRejectedValue(
+      new EvalRunIterationsError("routeUnavailable", "nope"),
+    );
+
+    const { result } = renderHook(() =>
+      useEvalRunIterationChains({
+        projectId: "proj_1",
+        run: terminalRun,
+        enabled: true,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe("routeUnavailable");
+    // An unreadable route is not a run whose trials have no chains.
+    expect(result.current.chains.size).toBe(0);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-eval-run-iteration-chains.ts
+++ b/mcpjam-inspector/client/src/hooks/use-eval-run-iteration-chains.ts
@@ -127,7 +127,8 @@ export function useEvalRunIterationChains({
             },
             controller.signal,
           );
-          for (const item of page.items) chains.set(item.iterationId, item.chain);
+          for (const item of page.items)
+            chains.set(item.iterationId, item.chain);
           cursor = page.nextCursor;
           pages += 1;
         } while (cursor && pages < ITERATION_CHAIN_PAGE_CAP);

--- a/mcpjam-inspector/client/src/hooks/use-eval-run-iteration-chains.ts
+++ b/mcpjam-inspector/client/src/hooks/use-eval-run-iteration-chains.ts
@@ -1,0 +1,177 @@
+/**
+ * Every trial's chain for one run, keyed by iteration.
+ *
+ * ── Why this is a second read and not a widening of the first ────────────────
+ *
+ * D9's decision summary already carries per-trial chains and the run page
+ * already fetches it — for NON-PASSING trials only, by contract. A reader who
+ * opens a trial that passed gets nothing from it, and that is not an oversight
+ * to patch there: diagnostics are evidence beneath a verdict. So the chains
+ * for the whole population come from the iterations resource instead, and the
+ * two are joined by iteration id at the point of use.
+ *
+ * ── Keyed on the run's REVISION, not just its status ─────────────────────────
+ *
+ * A terminal run is not frozen. An asynchronous judge landing after the run
+ * stopped rewrites `judgePending` into `judgeObserved`, which is a different
+ * chain for the same trial. This keys its cache on the same revision marker
+ * the decision-summary store uses, so the two reads refresh together — one
+ * trial showing two different chains during a stale window is exactly the
+ * disagreement the single-chain-type rule exists to prevent.
+ *
+ * ── Off by default, and silent when off ──────────────────────────────────────
+ *
+ * Gated on the caller's own switch, a project id and a terminal run. With any
+ * of them missing this issues NO request at all, so every non-Evaluate mount
+ * of the views that use it stays at exactly zero.
+ */
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  EvalRunIterationsError,
+  fetchEvalRunIterationChains,
+  isEvalRunIterationsError,
+  type EvalRunIterationsFailureKind,
+} from "@/lib/apis/eval-run-iterations-api";
+import {
+  evalRunDecisionRevision,
+  isTerminalEvalRunStatus,
+} from "@/lib/evals/eval-decision-summary-store";
+import type { EvalRunDecisionChain } from "@mcpjam/sdk/contract";
+
+/**
+ * How many pages this will walk on its own.
+ *
+ * The route's own page cap makes nearly every run a single request, and the
+ * SDK's fallback walk stops at a fixed count for the same reason: an unbounded
+ * loop over a cursor the server keeps issuing is a way to hang a browser tab
+ * on a pathological run. Reaching the cap is not an error — it leaves
+ * `walkExhausted` false, and a row past the last page renders NOTHING rather
+ * than "no chain".
+ */
+export const ITERATION_CHAIN_PAGE_CAP = 10;
+
+export interface EvalRunIterationChainsState {
+  status: "disabled" | "loading" | "ready" | "error";
+  /** Chains by iteration id. Absent key = not loaded, NOT "no chain". */
+  chains: Map<string, EvalRunDecisionChain>;
+  error: EvalRunIterationsFailureKind | null;
+  /** Whether every page the server offered has been read. */
+  walkExhausted: boolean;
+  scannedIterations: number;
+}
+
+const EMPTY: EvalRunIterationChainsState = {
+  status: "disabled",
+  chains: new Map(),
+  error: null,
+  walkExhausted: false,
+  scannedIterations: 0,
+};
+
+export interface EvalRunIterationChainsTarget {
+  projectId: string | null | undefined;
+  run:
+    | {
+        _id: string;
+        status: string;
+        result?: string | null;
+        completedAt?: number | null;
+        verdictPolicyVersion?: unknown;
+        verdictSummary?: unknown;
+        goalCompletionStatus?: string | null;
+      }
+    | null
+    | undefined;
+  /** The caller's own switch — the existing Evaluate opt-in. */
+  enabled: boolean;
+}
+
+export function useEvalRunIterationChains({
+  projectId,
+  run,
+  enabled,
+}: EvalRunIterationChainsTarget): EvalRunIterationChainsState {
+  const terminal = isTerminalEvalRunStatus(run?.status);
+  const active = Boolean(enabled && projectId && run && terminal);
+  // The revision is part of the identity, so a judge landing after the run
+  // terminalized re-reads instead of serving a chain that has since changed.
+  const revision = run ? evalRunDecisionRevision(run) : "";
+  const key = active ? `${projectId}:${run?._id}:${revision}` : "";
+
+  const [state, setState] = useState<EvalRunIterationChainsState>(EMPTY);
+  // What the last completed read was for, so a resolved response for a run the
+  // reader has already navigated away from is discarded rather than rendered.
+  const currentKey = useRef("");
+
+  useEffect(() => {
+    currentKey.current = key;
+    if (!active || !projectId || !run) {
+      setState(EMPTY);
+      return;
+    }
+
+    const controller = new AbortController();
+    setState({ ...EMPTY, status: "loading" });
+
+    (async () => {
+      const chains = new Map<string, EvalRunDecisionChain>();
+      let cursor: string | undefined;
+      let pages = 0;
+      try {
+        do {
+          const page = await fetchEvalRunIterationChains(
+            {
+              projectId,
+              runId: run._id,
+              ...(cursor ? { cursor } : {}),
+            },
+            controller.signal,
+          );
+          for (const item of page.items) chains.set(item.iterationId, item.chain);
+          cursor = page.nextCursor;
+          pages += 1;
+        } while (cursor && pages < ITERATION_CHAIN_PAGE_CAP);
+      } catch (error) {
+        if (controller.signal.aborted || currentKey.current !== key) return;
+        setState({
+          status: "error",
+          chains: new Map(),
+          error: isEvalRunIterationsError(error)
+            ? error.kind
+            : ("requestFailed" as EvalRunIterationsFailureKind),
+          walkExhausted: false,
+          scannedIterations: 0,
+        });
+        return;
+      }
+      if (controller.signal.aborted || currentKey.current !== key) return;
+      setState({
+        status: "ready",
+        chains,
+        error: null,
+        // OUR OWN fact, and named as such: we followed every cursor offered.
+        // It is not a claim that the server considers the set complete.
+        walkExhausted: cursor === undefined,
+        scannedIterations: chains.size,
+      });
+    })().catch(() => {
+      // `fetchEvalRunIterationChains` rethrows a caller abort untouched, and
+      // an abort is not a failure to report.
+      if (!controller.signal.aborted && currentKey.current === key) {
+        setState({
+          status: "error",
+          chains: new Map(),
+          error: "requestFailed",
+          walkExhausted: false,
+          scannedIterations: 0,
+        });
+      }
+    });
+
+    return () => controller.abort();
+  }, [active, key, projectId, run?._id]);
+
+  return useMemo(() => state, [state]);
+}
+
+export { EvalRunIterationsError };

--- a/mcpjam-inspector/client/src/lib/__tests__/session-token.eval-chain.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/session-token.eval-chain.test.ts
@@ -56,6 +56,11 @@ describe("authFetch bearer on the eval chain routes", () => {
     // D5c — stage analytics, both the suite page and the run-scoped reader.
     "/api/v1/projects/proj_1/eval-suites/suite_1/stage-analytics",
     "/api/v1/projects/proj_1/eval-runs/run_1/stage-analytics",
+    // The per-trial chains: one page of iterations, each carrying its own
+    // stage rows. MOVED here from the negative list below — it was correctly
+    // pinned as unreachable until a reader needed it, and the entry it now
+    // requires is the one that would otherwise 401 as "could not be loaded".
+    "/api/v1/projects/proj_1/eval-runs/run_1/iterations",
   ]) {
     it(`attaches the bearer to ${path}`, async () => {
       await sessionToken.authFetch(path, { method: "GET" });
@@ -75,7 +80,6 @@ describe("authFetch bearer on the eval chain routes", () => {
     // The blanket prefix these patterns exist to avoid: a sibling
     // project-scoped route must NOT inherit the UI's bearer.
     "/api/v1/projects/proj_1/eval-runs/run_1",
-    "/api/v1/projects/proj_1/eval-runs/run_1/iterations",
     "/api/v1/projects/proj_1/eval-suites/suite_1",
     "/api/v1/projects/proj_1/eval-suites/suite_1/runs",
     // Paths that merely start the same way.
@@ -86,6 +90,13 @@ describe("authFetch bearer on the eval chain routes", () => {
     "/api/v1/projects/proj_1/eval-suites/suite_1/stage-analytics/overall",
     // The run-scoped suffix is a closed set, not a wildcard.
     "/api/v1/projects/proj_1/eval-runs/run_1/insights",
+    // Granting the iterations LIST must not grant what hangs beneath it. A
+    // trace is a transcript and steps are authored results; both are read by
+    // other paths with their own auth, and a pattern that swallowed them
+    // would be the blanket prefix these tests exist to catch.
+    "/api/v1/projects/proj_1/eval-runs/run_1/iterations/iter_1/trace",
+    "/api/v1/projects/proj_1/eval-runs/run_1/iterations/iter_1",
+    "/api/v1/projects/proj_1/eval-runs/run_1/steps",
   ]) {
     it(`does NOT attach the bearer to ${path}`, async () => {
       await sessionToken.authFetch(path, { method: "GET" });

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/eval-run-iterations-api.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/eval-run-iterations-api.test.ts
@@ -1,0 +1,175 @@
+/**
+ * The iterations read, and the two things it must not do.
+ *
+ * It exists to cover the population D9's diagnostics exclude by contract — the
+ * trials that PASSED — so the assertions concentrate on the places where a
+ * convenient shortcut would produce a chain nobody may believe:
+ *
+ *   - validating rows one at a time instead of the whole derivation, which
+ *     admits five rows or six out of order and turns a positional claim
+ *     (`notReached`) into a false one;
+ *   - reading an undeployed route as a run with no chains.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authFetch = vi.fn();
+vi.mock("@/lib/session-token", () => ({
+  authFetch: (...args: unknown[]) => authFetch(...args),
+}));
+
+import {
+  fetchEvalRunIterationChains,
+  isEvalRunIterationsError,
+} from "../eval-run-iterations-api";
+import { USER_VALUE_STAGES } from "@mcpjam/sdk/contract";
+
+function rows(overrides: Record<string, string> = {}) {
+  return USER_VALUE_STAGES.map((stage) => ({
+    stage,
+    state: overrides[stage] ?? "passed",
+    reason: "observed",
+  }));
+}
+
+function iteration(extra: Record<string, unknown> = {}) {
+  return {
+    id: "iter_1",
+    iterationNumber: 1,
+    status: "completed",
+    result: "passed",
+    stageResults: rows(),
+    stageAnalyzerVersion: 8,
+    ...extra,
+  };
+}
+
+function respondWith(body: unknown, status = 200) {
+  authFetch.mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+}
+
+beforeEach(() => {
+  authFetch.mockReset();
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchEvalRunIterationChains", () => {
+  it("returns a verified chain for a PASSING trial — the population D9 omits", async () => {
+    respondWith({ items: [iteration()] });
+
+    const page = await fetchEvalRunIterationChains({
+      projectId: "proj_1",
+      runId: "run_1",
+    });
+
+    expect(page.items).toHaveLength(1);
+    expect(page.items[0]?.iterationId).toBe("iter_1");
+    expect(page.items[0]?.chain.status).toBe("verified");
+  });
+
+  it("reads the run-scoped iterations path, and lets authFetch own the bearer", async () => {
+    respondWith({ items: [] });
+    await fetchEvalRunIterationChains({ projectId: "proj_1", runId: "run_1" });
+
+    const url = String(authFetch.mock.calls[0]?.[0]);
+    expect(url).toContain("/api/v1/projects/proj_1/eval-runs/run_1/iterations");
+    // The client's own Authorization is stripped before the shim runs, so the
+    // header has exactly one owner.
+    const headers = new Headers(
+      (authFetch.mock.calls[0]?.[1] as RequestInit)?.headers,
+    );
+    expect(headers.get("authorization")).toBeNull();
+  });
+
+  it("REFUSES a derivation that is not six rows in chain order", async () => {
+    // Row-level validation would accept both of these. The whole-derivation
+    // parse is what makes a positional claim safe to render as card 01..06.
+    respondWith({
+      items: [iteration({ stageResults: rows().slice(0, 5) })],
+    });
+    const short = await fetchEvalRunIterationChains({
+      projectId: "proj_1",
+      runId: "run_1",
+    });
+    expect(short.items[0]?.chain.status).toBe("unverified");
+
+    respondWith({
+      items: [iteration({ stageResults: [...rows()].reverse() })],
+    });
+    const reordered = await fetchEvalRunIterationChains({
+      projectId: "proj_1",
+      runId: "run_1",
+    });
+    expect(reordered.items[0]?.chain.status).toBe("unverified");
+  });
+
+  it("carries the server's own quarantine through as unverified", async () => {
+    respondWith({
+      items: [
+        iteration({ stageResults: undefined, stageResultsUnverified: true }),
+      ],
+    });
+    const page = await fetchEvalRunIterationChains({
+      projectId: "proj_1",
+      runId: "run_1",
+    });
+    expect(page.items[0]?.chain.status).toBe("unverified");
+  });
+
+  it("says absent when no derivation was ever offered", async () => {
+    respondWith({ items: [iteration({ stageResults: undefined })] });
+    const page = await fetchEvalRunIterationChains({
+      projectId: "proj_1",
+      runId: "run_1",
+    });
+    expect(page.items[0]?.chain.status).toBe("absent");
+  });
+
+  it("separates an undeployed route from a run that is not there", async () => {
+    // A bare 404 from a router that never had this path…
+    authFetch.mockResolvedValue(new Response("Not Found", { status: 404 }));
+    await expect(
+      fetchEvalRunIterationChains({ projectId: "proj_1", runId: "run_1" }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        isEvalRunIterationsError(error) && error.kind === "routeUnavailable",
+    );
+
+    // …versus the route's own answer about a run.
+    respondWith({ code: "NOT_FOUND", message: "Eval run not found" }, 404);
+    await expect(
+      fetchEvalRunIterationChains({ projectId: "proj_1", runId: "run_1" }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        isEvalRunIterationsError(error) && error.kind === "notFound",
+    );
+  });
+
+  it("rejects a row with no iteration id rather than joining it to the wrong trial", async () => {
+    respondWith({ items: [iteration({ id: undefined })] });
+    await expect(
+      fetchEvalRunIterationChains({ projectId: "proj_1", runId: "run_1" }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        isEvalRunIterationsError(error) && error.kind === "invalidContract",
+    );
+  });
+
+  it("passes the page cursor through and hands the next one back", async () => {
+    respondWith({ items: [iteration()], nextCursor: "cursor_2" });
+    const page = await fetchEvalRunIterationChains({
+      projectId: "proj_1",
+      runId: "run_1",
+      cursor: "cursor_1",
+      limit: 50,
+    });
+    expect(String(authFetch.mock.calls[0]?.[0])).toContain("cursor=cursor_1");
+    expect(page.nextCursor).toBe("cursor_2");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/eval-run-iterations-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/eval-run-iterations-api.ts
@@ -1,0 +1,234 @@
+/**
+ * One run's iterations, read for the CHAIN each one carries.
+ *
+ * ── Why this read exists at all ──────────────────────────────────────────────
+ *
+ * D9's decision summary carries a per-trial chain, and the browser already
+ * fetches it — but for NON-PASSING trials only. That filter is in the contract
+ * assembler and is deliberate: diagnostics are evidence beneath a verdict, and
+ * a trial that passed is not evidence of anything going wrong. It does mean a
+ * reader who opens a passing trial has nothing to read, which is the gap this
+ * closes: the iterations resource projects the same stage columns over every
+ * row of the run, passing included.
+ *
+ * ── One chain type, one validator ────────────────────────────────────────────
+ *
+ * The rows are handed to the CONTRACT's own `assembleEvalRunDecisionChain`,
+ * the same function D9's summary is built from. Two consequences, both the
+ * point:
+ *
+ *   - the result is `EvalRunDecisionChain` — the type the decision card and
+ *     the trial cards already render. No adapter type, no second shape;
+ *   - the whole derivation is validated, not the rows one at a time. Row-level
+ *     validation would accept five rows, or six out of order, and a renderer
+ *     that numbers cards by position would then publish a different claim
+ *     about which stages were blocked, because `notReached` is derived from
+ *     POSITION.
+ *
+ * ── The bearer has one owner ─────────────────────────────────────────────────
+ *
+ * Same shim as the stage-analytics reader: the client's own `Authorization` is
+ * stripped and `authFetch` supplies the real one. The route needs an entry in
+ * `HOSTED_AUTH_PATH_PATTERNS`; without it this ships no header at all and the
+ * 401 surfaces as "could not be loaded", which reads as a backend outage.
+ */
+import {
+  assembleEvalRunDecisionChain,
+  type EvalRunDecisionChain,
+} from "@mcpjam/sdk/contract";
+import { PlatformApiClient, isPlatformApiError } from "@mcpjam/sdk/platform";
+import { authFetch } from "@/lib/session-token";
+
+export type EvalRunIterationsFailureKind =
+  | "notFound"
+  | "routeUnavailable"
+  | "invalidContract"
+  | "requestFailed";
+
+export class EvalRunIterationsError extends Error {
+  readonly kind: EvalRunIterationsFailureKind;
+  readonly status?: number;
+
+  constructor(
+    kind: EvalRunIterationsFailureKind,
+    message: string,
+    options: { status?: number; cause?: unknown } = {},
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "EvalRunIterationsError";
+    this.kind = kind;
+    if (options.status !== undefined) this.status = options.status;
+  }
+}
+
+export function isEvalRunIterationsError(
+  error: unknown,
+): error is EvalRunIterationsError {
+  return error instanceof EvalRunIterationsError;
+}
+
+/** One trial's chain, keyed by the iteration it belongs to. */
+export interface EvalRunIterationChain {
+  iterationId: string;
+  chain: EvalRunDecisionChain;
+}
+
+export interface EvalRunIterationChainsPage {
+  items: EvalRunIterationChain[];
+  /** Absent means this was the last page. */
+  nextCursor?: string;
+}
+
+const iterationsFetch: typeof fetch = (input, init) => {
+  const headers = new Headers(init?.headers);
+  headers.delete("authorization");
+  return authFetch(input as Parameters<typeof authFetch>[0], {
+    ...init,
+    headers,
+  });
+};
+
+function client(): PlatformApiClient {
+  return new PlatformApiClient({
+    baseUrl: "/api/v1",
+    // Empty on purpose — `iterationsFetch` strips it and `authFetch` supplies
+    // the real one, so the bearer has exactly one owner.
+    getAuth: () => "",
+    fetch: iterationsFetch,
+  });
+}
+
+/**
+ * A deployment without the route, as opposed to a run that is not there.
+ *
+ * Same discrimination the stage-analytics reader makes, and needed for the
+ * same reason: `STATUS_FALLBACK_CODES` maps a bare 404 to `NOT_FOUND` exactly
+ * like an enveloped one, so only the code's SOURCE separates "this build does
+ * not serve that" from "no such run".
+ */
+function isRouteUnavailable(
+  status: number,
+  code: string,
+  codeSource?: "envelope" | "status",
+): boolean {
+  return (
+    code === "FEATURE_NOT_SUPPORTED" ||
+    code === "NOT_IMPLEMENTED" ||
+    status === 501 ||
+    status === 405 ||
+    (status === 404 && codeSource === "status")
+  );
+}
+
+export async function fetchEvalRunIterationChains(
+  params: {
+    projectId: string;
+    runId: string;
+    cursor?: string;
+    limit?: number;
+  },
+  signal?: AbortSignal,
+): Promise<EvalRunIterationChainsPage> {
+  let raw: unknown;
+  try {
+    raw = await client().listEvalRunIterations(
+      {
+        projectId: params.projectId,
+        runId: params.runId,
+        ...(params.cursor ? { cursor: params.cursor } : {}),
+        ...(params.limit !== undefined ? { limit: params.limit } : {}),
+      },
+      { signal },
+    );
+  } catch (error) {
+    // A caller's abort is the caller's, not a failure of the read.
+    if (signal?.aborted) throw error;
+    if (isPlatformApiError(error)) {
+      if (isRouteUnavailable(error.status, error.code, error.codeSource)) {
+        throw new EvalRunIterationsError(
+          "routeUnavailable",
+          "This deployment does not serve eval run iterations.",
+          { status: error.status, cause: error },
+        );
+      }
+      if (error.status === 404) {
+        throw new EvalRunIterationsError("notFound", error.message, {
+          status: error.status,
+          cause: error,
+        });
+      }
+      throw new EvalRunIterationsError("requestFailed", error.message, {
+        status: error.status,
+        cause: error,
+      });
+    }
+    throw new EvalRunIterationsError(
+      "requestFailed",
+      error instanceof Error ? error.message : String(error),
+      { cause: error },
+    );
+  }
+
+  const envelope = raw as { items?: unknown; nextCursor?: unknown } | null;
+  if (
+    !envelope ||
+    typeof envelope !== "object" ||
+    !Array.isArray(envelope.items)
+  ) {
+    throw new EvalRunIterationsError(
+      "invalidContract",
+      "The iterations response was not a page envelope.",
+    );
+  }
+  if (
+    envelope.nextCursor !== undefined &&
+    typeof envelope.nextCursor !== "string"
+  ) {
+    throw new EvalRunIterationsError(
+      "invalidContract",
+      "The iterations page cursor was not a string.",
+    );
+  }
+
+  const items: EvalRunIterationChain[] = [];
+  for (const row of envelope.items) {
+    const iteration = row as {
+      id?: unknown;
+      stageResults?: unknown;
+      firstFailedStage?: unknown;
+      failureCategory?: unknown;
+      stageAnalyzerVersion?: unknown;
+      stageResultsUnverified?: unknown;
+    } | null;
+    if (!iteration || typeof iteration !== "object") {
+      throw new EvalRunIterationsError(
+        "invalidContract",
+        "An iterations page entry was not an object.",
+      );
+    }
+    // IDENTITY, not shape. A row with no id cannot be joined to anything on
+    // screen, and joining it to the wrong trial is worse than dropping it.
+    if (typeof iteration.id !== "string" || iteration.id.length === 0) {
+      throw new EvalRunIterationsError(
+        "invalidContract",
+        "An iterations page entry carried no iteration id.",
+      );
+    }
+    items.push({
+      iterationId: iteration.id,
+      // The contract decides `verified` / `unverified` / `absent`. Nothing
+      // here inspects the rows itself, which is what keeps this reader from
+      // becoming a second opinion about whether a chain may be believed.
+      chain: assembleEvalRunDecisionChain(
+        iteration as Parameters<typeof assembleEvalRunDecisionChain>[0],
+      ),
+    });
+  }
+
+  return {
+    items,
+    ...(typeof envelope.nextCursor === "string"
+      ? { nextCursor: envelope.nextCursor }
+      : {}),
+  };
+}

--- a/mcpjam-inspector/client/src/lib/apis/eval-run-iterations-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/eval-run-iterations-api.ts
@@ -40,10 +40,7 @@ import { PlatformApiClient, isPlatformApiError } from "@mcpjam/sdk/platform";
 import { authFetch } from "@/lib/session-token";
 
 export type EvalRunIterationsFailureKind =
-  | "notFound"
-  | "routeUnavailable"
-  | "invalidContract"
-  | "requestFailed";
+  "notFound" | "routeUnavailable" | "invalidContract" | "requestFailed";
 
 export class EvalRunIterationsError extends Error {
   readonly kind: EvalRunIterationsFailureKind;

--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -409,6 +409,15 @@ const HOSTED_AUTH_PATH_PATTERNS = [
   // while the API is fine.
   /^\/api\/v1\/projects\/[^/]+\/eval-runs\/[^/]+\/(decision-summary|stage-analytics)$/,
   /^\/api\/v1\/projects\/[^/]+\/eval-suites\/[^/]+\/stage-analytics$/,
+  // One page of a run's iterations, each carrying its own stage rows — the
+  // only read that covers a PASSING trial's chain, which D9's diagnostics
+  // exclude by contract.
+  //
+  // Anchored at `iterations` on purpose: the trace and the per-iteration
+  // resource beneath it are a transcript and a row, read elsewhere with their
+  // own auth, and a pattern that swallowed them would be the blanket prefix
+  // this list exists to avoid. The eval-chain test pins all three.
+  /^\/api\/v1\/projects\/[^/]+\/eval-runs\/[^/]+\/iterations$/,
 ];
 
 function pathMatchesHostedPrefix(pathname: string): boolean {

--- a/sdk/src/contract/decision-summary.ts
+++ b/sdk/src/contract/decision-summary.ts
@@ -895,6 +895,28 @@ function uncategorisedNextAction(
     : DECISION_SUMMARY_VERDICT_CHAIN_DISAGREEMENT_NEXT_ACTION;
 }
 
+/**
+ * One iteration's stage rows, as the chain a reader may believe.
+ *
+ * EXPORTED because a second surface needs the SAME answer. D9's diagnostics
+ * cover non-passing trials only — the filter is deliberate and lives in
+ * `assembleDiagnostics` — so a reader that wants a PASSING trial's chain has
+ * to go to the iterations resource, and it must arrive at `verified` /
+ * `unverified` / `absent` by exactly this route.
+ *
+ * The whole DERIVATION is parsed, never the rows one at a time. Row-level
+ * validation accepts five rows, or six in the wrong order, and a renderer that
+ * numbers cards by position would then publish a different claim about which
+ * stages were blocked — `notReached` is derived from POSITION. The
+ * six-rows-in-order refinement lives in `stageDerivationSchema`, and this is
+ * the only client-reachable way to apply it.
+ */
+export function assembleEvalRunDecisionChain(
+  iteration: EvalRunDecisionIterationInput
+): EvalRunDecisionChain {
+  return assembleChain(iteration);
+}
+
 function assembleChain(
   iteration: EvalRunDecisionIterationInput
 ): EvalRunDecisionChain {

--- a/sdk/src/contract/index.ts
+++ b/sdk/src/contract/index.ts
@@ -524,6 +524,7 @@ export {
   EVAL_RUN_DECISION_VERDICT_SOURCE_LABELS,
   EVAL_RUN_MEASUREMENT_UNITS,
   EVAL_RUN_MEASUREMENT_UNIT_LABELS,
+  assembleEvalRunDecisionChain,
   assembleEvalRunDecisionSummary,
   decisionDiagnosticFailureCategory,
   decisionDiagnosticFirstFailedStage,


### PR DESCRIPTION
## Every trial gets a chain

[#4536](https://github.com/MCPJam/inspector/pull/4536) made the run-level funnel legible: six numbered stage cards on the suite page, opened on the first break. But a funnel is a **population** statistic, and the question a reader actually arrives with is narrower — *this* trial did not deliver value, how far did it get and why.

That answer already existed. It was six lines of flat text inside a collapsed diagnostic row (`Connection: passed`, `Response: failed — the server reported a tool error`), on the run page only, for non-passing trials only. A trial that **passed** had no chain anywhere in the product.

> Every failing trial should show a funnel as to why user value wasn't achieved.

This is that, in four steps.

## The correction this rests on

The six cards were never counts-coupled. `StageChainCards` is a pure function of `StageCardView[]` + selection and ships here **unchanged**. Only two things knew about counts: the chip derivation and the detail card's three rate cells.

A trial has no denominator and does not want one. Its stage is one of five states, which is *more* legible than a rate — `100% (1/1)` over a single observation is a statistic manufactured from one trial.

## Four commits, one per step

| Commit | What it does |
|---|---|
| [`982b824`](https://github.com/MCPJam/inspector/commit/982b824) | Failing trials get cards where the six text lines were |
| [`17689ae`](https://github.com/MCPJam/inspector/commit/17689ae) | Read every trial's chain, including the ones that passed |
| [`305b19f`](https://github.com/MCPJam/inspector/commit/305b19f) | The trace pane opens with the chain, not just the transcript |
| [`7c3d9c7`](https://github.com/MCPJam/inspector/commit/7c3d9c7) | The run's case table says where each trial stopped |

Each is independently reviewable and its message carries the reasoning. They land as commits rather than a stack because `branches:` in `test.yml`/`lint.yml` filters on a PR's **base** — the trap those files document — so a stack would merge three of these four having never been built.

### 1. Cards, not lines

`deriveTrialStageChip` is a state→chip function with no arithmetic, written as an exhaustive switch so a sixth `StageState` breaks the build rather than falling through to something that reads as fine.

**The reason stays off the chip.** Some reason labels are whole sentences; six cards at minimum width would wrap into unreadable columns; the aggregate `failed` chip already omits them. It also keeps the "never says passed when nothing was decided" invariant total over the five **states** rather than dependent on the 29-member reason vocabulary — two reason labels contain the word "made", which that invariant's own regex matches.

**Which card opens is a UI choice; where the chain stopped is the contract's.** The default is `firstFailedStage`, read from the chain and never re-derived by scanning rows — the day a second derivation disagreed, the UI would be the one that was wrong while looking authoritative.

A test caught a real regression here: moving reasons off the chip had hidden the policy-block explanation entirely, because that shape has *no* `firstFailedStage` and so nothing auto-opened. The default now falls back to the first non-passing row carrying a reason — a choice of which card to open, not a claim that the stage failed.

`describeDiagnosticChain.stageLines` is **deleted** rather than left behind: after this its only consumer was the test pinning it, and a second unrendered rendering of the same rows is what drifts out of step with the one on screen.

### 2. The read that covers passing trials

D9's diagnostics filter to non-passing trials in the contract assembler, deliberately. The iterations resource projects the same stage columns over every row — verified against production, where all ten trials of a real run came back carrying six rows each.

**One chain type, one validator.** Rows go through the contract's own assembler, now exported as `assembleEvalRunDecisionChain` — the same function D9's summary is built from. So the result is `EvalRunDecisionChain`, the type the cards already render (no adapter), and the **whole derivation** is validated rather than the rows one at a time. Row-level validation accepts five rows, or six out of order, and a renderer numbering cards `01`–`06` by position would then publish a different claim about which stages were blocked. A test feeds it both shapes and pins that they come back `unverified`.

**Three absences stay three facts:** a bare 404 is a deployment without the route, an enveloped `NOT_FOUND` is a run that is not there, a row with no derivation is `absent`.

**Keyed on the run's revision**, not just terminal status — a terminal run is not frozen, and a late judge rewrites `judgePending` into `judgeObserved`.

The allowlist entry is a **move**, not an addition: `session-token.eval-chain.test.ts` already pinned this path in the *negative* list, and now pins that the trace and per-iteration paths beneath it are still not granted. Without it the read ships no `Authorization` and the 401 reads as a backend outage — that has happened three times on this surface.

### 3. The trace pane

"View trace" lands a reader on one trial's transcript, and the answer they came for was not on that screen. It is now above it.

`IterationDetails` does not fetch it — it has five hosts and knows only its iteration, not the run, project, or flag. It takes a slot; the one host that can answer those builds the node; the other four issue no request.

**The hooks sit above the early return**, and that is load-bearing: the editor returns a loading state before its test case resolves, so a hook below it runs on some renders and not others. A test caught exactly that on the first draft.

### 4. The case table

One line per row — `broke at Tool response`, `Request satisfied`, `chain withheld` — from the same read, so the table costs one request rather than one per row. The table takes a **lookup**, not a run: only the run-scoped host knows which run its rows belong to, and the cross-run view passes nothing.

Three shades of nothing stay distinct: not loaded renders no chip; withheld says so; and `Request satisfied` appears **only when user value actually passed** — a policy-blocked trial has no failed stage either, and calling that satisfied would claim an outcome from an absence of evidence.

## Verification

- **270 test files, 2830 tests pass** (`client/src/components/evals`, `components/evaluate`, `hooks`); typecheck clean on all source.
- New: `stage-trial-model.test.ts` (20), `trial-stage-detail-card.test.tsx` (6), `eval-run-iterations-api.test.ts` (8), `use-eval-run-iteration-chains.test.tsx` (7), plus the allowlist flip and rewritten decision-card assertions.
- The per-trial invariant copies the aggregate one's `passWords` regex **verbatim** — two surfaces disagreeing about what counts as a pass word would each be individually green while the product said "healthy" somewhere.

**Two bugs found by the tests, both mine, both fixed:** the rules-of-hooks violation above, and the policy-block regression in step 1.

**Not verified:** end-to-end against a live deployment. Local dev is on a Convex deployment that predates [backend#1212](https://github.com/MCPJam/mcpjam-backend/pull/1212), so its stored chains for the recovery shape are quarantined — which is itself worth seeing, since the per-trial view is exactly where that trial becomes visible (D9's validator never rejected it).

**Pre-existing, untouched:** `scenario-chat-transcript` fails and 5 type errors sit in editor test files, both confirmed present at `HEAD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches eval decision UX and a new authenticated API read with strict chain validation; mistakes could misrepresent where trials failed or show stale chains after late judge updates, though revision-keyed caching and contract assembly mitigate that.
> 
> **Overview**
> **Every trial can show the same six-stage user-value story** — not only failing trials in the run decision card. Diagnostics still come from D9 for non-passing trials; **passing trials** get chains from a new **run iterations** fetch that assembles rows through exported **`assembleEvalRunDecisionChain`** so the UI keeps one `EvalRunDecisionChain` shape and whole-derivation validation (wrong row count/order → `unverified`).
> 
> **Run decision diagnostics** replace flat stage lines with **`StageChainCards`** + **`TrialStageDetailCard`**, defaulting selection to the contract’s `firstFailedStage` (with the policy-block fallback). **`describeDiagnosticChain.stageLines`** is removed to avoid drift.
> 
> **Trace pane** (`IterationDetails` **`trialChainSlot`**) and **run-scoped case tables** show the chain above the transcript and a one-line chip (`broke at …`, `Request satisfied`, `chain withheld`) via **`useEvalRunIterationChains`** — one paged read per run, gated on Evaluate + project + terminal run, cache keyed on run **revision** like the decision summary. **`authFetch`** allowlist adds **`…/eval-runs/…/iterations`** (not child trace paths).
> 
> New pure helpers in **`stage-trial-model`**, **`TrialChainPanel`**, and **`eval-run-iterations-api`**; tests cover chips, hooks, API errors (route vs not found vs absent), and rules-of-hooks placement in the template editor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c3d9c7e382ae9ecad1e6f39d65858dc6c521de6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Every trial's user-value chain now renders as numbered stage cards wherever a trial appears, replacing the flat text lines that showed only non-passing trials on the run page. Passing trials get a visible chain for the first time.

- A new iterations read fetches every trial's chain, keyed on the run's revision so late judge updates re-read.
- The read is silent unless the Evaluate opt-in, a project id, and a finished run are present.
- The trace pane opens with the chain above the transcript.
- The run's case table shows where each trial stopped in one line, from the same read.
- The `/iterations` route joins `authFetch`'s bearer allowlist; the trace and per-iteration paths beneath it stay excluded.
- Four changesets cover the card row, the read, the trace pane, and the table chip.

<sup>Written for commit 7c3d9c7e382ae9ecad1e6f39d65858dc6c521de6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

