### PR TITLE
spike(local-harness): native Claude Code end to end, prototype fixes, and the implementation handoff

### DIFF
--- a/mcpjam-inspector/docs/local-harness-spike-handoff.md
+++ b/mcpjam-inspector/docs/local-harness-spike-handoff.md
@@ -1,0 +1,213 @@
+# Local Claude Code (native on the user's machine) — spike results and cloud-agent handoff
+
+**Date:** 2026-09-01 · **Author:** Claude, from spikes run on the maintainer's Mac (Apple Silicon, macOS 24.6, load avg ~20 during runs)
+**Supersedes for execution:** `~/.claude/plans/jazzy-hugging-cookie-tl.md` (TL review plan) and `jazzy-hugging-cookie.md` (detailed design). Those remain the design rationale; this file is what the implementer executes.
+
+## Context
+
+MCPJam's Claude Code host runs the real Claude Code agent, but only inside an E2B computer, and only from a server that is a computers data plane. The desktop app and `npx @mcpjam/inspector` are not data planes, so today a local user cannot run Claude Code at all. PR #4532 merged a supervised-native foundation (`mcpjam-inspector/server/utils/harness/local/`) that can run an official vendor harness as a supervised host process, but it is dark (`MCPJAM_LOCAL_HARNESS_ENABLED`, default off), structurally unable to run (placeholder digests, empty conformance version), and not wired into the turn path.
+
+The TL decided (2026-09-01): ship for **both Electron and npx**; target **every platform Electron ships** (Windows stays excluded until whole-tree cleanup exists there); **direct checkout** with Claude Code's own approvals; a **robust** brokered model credential; **as performant as possible**; **Claude Code only**.
+
+I ran the I0 spike end to end on this machine against a mock Anthropic upstream behind a loopback gateway (no real credential was available; the auto-mode classifier correctly refused reading the Convex gateway key). Everything below is measured or observed, not inferred. The spike code, the prototype fixes, and the logs live in a git worktree (see "Where things are"). **Nothing is committed yet** — step 0 is to commit and push that branch so a cloud agent can read it.
+
+## What the spike proved
+
+| Capability | Result |
+|---|---|
+| Consent → availability → supervised provider → `HarnessAgent` + `createClaudeCode` with the real `@ai-sdk/harness-claude-code@1.0.100` | Works; provider id `mcpjam-local-supervised`; no E2B calls |
+| Bridge start under the pack's own Node 24.20.0 binary, loopback-only, verified by the provider's exposure probe | Works; the negative test (bridge left binding 0.0.0.0) is refused and leaves no process behind |
+| Real native `claude` 2.1.245 binary spawned by the agent SDK, model calls through the loopback gateway with a per-session capability; upstream key never in any child env or on disk | Verified (canary string absent from all child envs and session files) |
+| Read tool (free), Bash tool with approval pause → `suspendTurn` → `createSession({continueFrom})` → `continueStream` | Works; suspend+continue 3 ms |
+| `detach()` → `createSession({resumeFrom})` → next turn remembers history (`--resume`) | Works; model saw 3 user turns after resume |
+| Clean `stop()`, `destroy()`, abort mid-turn, Inspector crash + fresh-process janitor reclaim | Work **after** the fixes below (two of them were broken in the merged foundation) |
+| Checkout hygiene | With the prototyped work-dir layout the user's checkout gains nothing; all bridge/CLI state is in the owner-only session dir |
+
+### Measured timings (mock upstream; excludes model latency)
+
+| Stage | Measured | Note |
+|---|---|---|
+| Bare bridge spawn → listening | 134–154 ms | `spike/timing-decomp.mts` |
+| Full-tree SHA-256 digest of the 515 MB pack (5,462 files) | 620–1,500 ms | warm vs loaded machine |
+| Digests per session start **today** | 5 | consent path 2, availability 2, pre-spawn re-verify 1 |
+| Exposure probe (`assertBridgeLoopbackOnly`) on this Mac | **11 s** | 10 link-local `fe80::` addresses × sequential 500 ms timeout; 0 ms when only routable addresses exist |
+| Session ready (create → bridge verified) | 0.83 s best / 12–14 s loaded | the difference is the two items above |
+| First turn on a cold machine (first ever `claude` launch) | 2.8 s | page cache; later cold sessions 0.4–1.0 s |
+| Warm turn (Read / Bash+approval / resumed COUNT) | 270–800 ms | CLI is spawned per turn and exits after it |
+| Clean stop (after fix) | ~60 ms graceful | |
+| Destroy with an orphaned CLI child (after fix) | 2.0 s | SIGTERM grace on the CLI |
+| Janitor reclaim of an orphaned tree from a crashed Inspector | 70 ms | |
+| Idle footprint of a detached session | bridge node ~60–115 MB RSS, no CLI resident | CLI ~355 MB RSS only while a turn runs |
+
+With D7 and D8 fixed, session start is ~150 ms bridge + one digest (≤1 s) — well inside a 1.5 s p95 SLO on supported hardware.
+
+## Facts that change the plan (verified)
+
+1. **Claude Code is a native binary now.** `@anthropic-ai/claude-code@2.1.245` is a wrapper whose postinstall copies a 376 MB Mach-O from `@anthropic-ai/claude-code-darwin-arm64`; `@anthropic-ai/claude-agent-sdk@0.3.245` ships the **same binary** (identical sha256) in `claude-agent-sdk-darwin-arm64` and spawns it directly (`pathToClaudeCodeExecutable` defaults to its own platform package; error "Native CLI binary for <platform> not found" otherwise). The SDK's `manifest.json` lists per-platform checksums (darwin-arm64/x64, linux-x64/arm64, musl). The binary is Anthropic Developer-ID signed with hardened runtime. Only the AI SDK **bridge** (`bridge.mjs`) needs Node.
+2. **Electron cannot be the Node launcher.** `forge.config.ts` sets fuse `RunAsNode: false`, so the foundation's `node-launcher.ts` "electron-as-node" branch is dead in packaged builds. The pack must carry a Node binary. nodejs.org `node-v24.20.0-darwin-arm64` is Node.js Foundation Developer-ID signed (hardened runtime) and worked as the launcher in every run.
+3. **pnpm output needs post-processing.** `pnpm install --frozen-lockfile --node-linker=hoisted` against the adapter's verbatim `package.json`/`pnpm-lock.yaml`/`pnpm-workspace.yaml` installs in ~5 s but leaves `.bin` symlinks (the digest refuses symlinks) and 758 MB. Removing `.bin` dirs and the unused `@anthropic-ai/claude-code` wrapper + its platform package gives 515 MB, symlink-free. Nothing in the bridge or SDK references the wrapper.
+4. **The bridge binds `0.0.0.0`** (`new WebSocketServer({ port, host: "0.0.0.0" })`). The provider byte-compares the adapter's recipe `bridge.mjs` against the bundle copy, so the bridge file cannot be patched. A launcher wrapper (`launcher.mjs`: patches `net.Server.prototype.listen` to force 127.0.0.1, then imports `./bridge.mjs`) works because `bridge.mjs` runs at import time and parses `process.argv.slice(2)`.
+5. **The closed command grammar was incomplete for the stable line.** The framework issues `printf "%s" "$HOME"` before every bridge start (`resolveSandboxHomeDir`), and `writeSkills` runs on **every prompt turn even with zero skills**, issuing `mv -f 'manifest.tmp' 'manifest'`, `test ! -e '<skillDir>'`, `rm -rf -- '<skillDir>'…` under `$HOME/.claude/skills`. None were translated; every local session failed closed at translation.
+6. **macOS reports an exiting process's command as `(node)`.** The birth identity is `lstart|argv`; on stop the adapter makes the bridge exit itself, `ps` shows `(node)`, the compare says `not-owned`, the supervisor refuses to signal, and every clean stop was recorded as an escape (`processes.json` state `failed`).
+7. **Abort orphans the CLI.** On abort the bridge exits before the supervisor signals; the root is gone at first look, the group is live, and the design deliberately refuses to signal an unanchored group. The 357 MB `claude` child kept running.
+8. **The agent framework forbids working in the workspace root.** `sandboxConfig.workDir` must be a relative proper subdirectory of the provider's `defaultWorkingDirectory` ("." and absolute paths are rejected). With the workspace as default dir, Claude ran in `<workspace>/claude-code-<sessionId>` and the bridge wrote `.agent-runs/<id>/bridge/start-config.json` (**mode 0644, containing the session model capability and full env**) plus `event-log.ndjson` (full transcript) into the user's checkout.
+9. **Exposure probe cost** (item 9 in the table): `nonLoopbackLocalAddresses()` includes `fe80::` link-local addresses that cannot be connected without a scope id; each waits the full timeout, sequentially.
+10. **The CLI probes `HEAD /api/hello`** on `ANTHROPIC_BASE_URL` with no auth before its first request. The gateway must answer that path without a capability (the spike's 401 did not block the run, but it is noise and may affect the CLI's "API reachable" heuristics).
+11. The adapter warns "sandbox does not support request transformations … falling back to less secure credential forwarding": with our provider the model auth reaches the CLI as env (`ANTHROPIC_API_KEY`/`ANTHROPIC_BASE_URL`) over the bridge's start message. That is why the child must only ever hold a session capability, never the lease.
+12. `CLAUDE_CODE_TMPDIR` passed through the adapter `env` is honored by the CLI (its temp went under the synthetic home). The bridge process itself does not get adapter env; the SDK's `extractFromBunfs` hardcodes `/tmp` on darwin unless `CLAUDE_CODE_TMPDIR` is in the bridge env → also put it in `scopedEnv`.
+13. The runtime identity, consent, availability, supervisor, janitor, grants and confinement code all behaved as designed; no security-relevant defect was found in them beyond items 6–8.
+
+## Prototyped fixes (uncommitted, on the spike worktree; all 15 foundation test files run, 14 tests fail because they encode the old behaviour)
+
+| ID | Defect | Prototype location | Status |
+|---|---|---|---|
+| D1 | `printf "%s" "$HOME"` untranslated | `command-translation.ts`: `HOME_PROBE` → `{kind:"reply", stdout: ctx.syntheticHome}` | validated |
+| D2 | `mv -f` / `test ! -e` / `rm -rf --` untranslated | `command-translation.ts`: new arms `rename` / `probe-absent` / `remove`, operands must be under the synthetic home; `supervised-provider.ts` executes them with `node:fs` (`rename`, `stat`, `rm`) | validated on every turn |
+| D3 | exiting `(node)` identity → `not-owned` | `process-identity.ts`: `sameBirthIdentity()` accepts an lstart match when the current command is the parenthesised form; used in `terminateOwnedProcessGroup` and `isSameProcess` | clean stop now `graceful`, registry empty |
+| D4 | abort orphans the CLI | `process-identity.ts`: `listGroupMembers()`, `terminateOwnedProcess()`; `supervisor.ts`: `LiveProcess.orphanSnapshot` taken on root `exit`, settled member-by-member in `stopSession` when the group outcome is `unknown` | abort test: child settled `graceful`, group empty, state dir removed |
+| D5 | work-dir layout / checkout pollution | `supervised-provider.ts`: `defaultWorkingDirectory = <sessionStateDir>/work`, `work/project` symlink → granted workspace, translator context resolved against `work`; agent `sandboxConfig.workDir: "project"` | Claude's `pwd` = real checkout; checkout gains nothing |
+| D6 | bridge binds 0.0.0.0 | `spike/bundle-launcher.mjs` (ships in the pack as `launcher.mjs`); `command-translation.ts` `CommandTranslationContext.bridgeLauncherPath` (provider passes `runtime.launcherPath`); manifest `launcherRelativePath: "launcher.mjs"` | validated + negative test |
+| D7 | exposure probe 11 s | not fixed; measured in `spike/probe-timing.mts` | design below |
+| D8 | 5 digests per session start | not fixed; measured in `spike/timing-decomp.mts` | design below |
+| D9 | electron-as-node launcher dead | not fixed | design below |
+| D10 | capability persisted 0644 in checkout | fixed by D5 (now under the 0700 session dir) | keep short TTL + revoke |
+| D11 | `HEAD /api/hello` | gateway design | |
+
+## Design deltas (what the implementer builds differently from the TL plan)
+
+### Runtime pack (replaces "managed bundle inside the install")
+One signed, per-platform **runtime pack** = verbatim adapter recipe files (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `bridge.mjs` byte-identical to the adapter's `dist/bridge/index.mjs`) + `launcher.mjs` + hoisted symlink-free `node_modules` pruned of the wrapper + `bin/node` (official nodejs.org build, v24 LTS). Build script prototype: `spike/build-bundle.sh`. Size ~515 MB on disk, roughly 150–200 MB compressed. It is **downloaded on demand** ("Install local runtime" is an explicit step in the consent flow; digest-verified against the signed pack manifest; atomic activation into a versioned directory; rollback = keep previous version), for **both** distributions: the npm package cannot carry it, Electron notarization should not be coupled to a third-party 376 MB binary, and Claude Code updates decouple from Inspector releases. Location: Electron `app.getPath("userData")/local-harness/runtime/<packVersion>/claude-code`; npx `~/.mcpjam/harness-local/runtime/<packVersion>/claude-code`. `runtimeRoot` for the foundation = that versioned dir. The pack manifest records: adapter version, vendor package versions (from the SDK's own `manifest.json` checksums), tree digest, Node version, build provenance. The compatibility manifest gets the real `bundleDigest`, `launcherRelativePath: "launcher.mjs"`, `bridgeBundleDigest`, and a non-empty `lifecycleConformanceVersion` only after the conformance job passes.
+
+### Node launcher
+Always the pack's `bin/node` (covered by the digest), for npx too; delete or deprecate the `electron-as-node` branch of `node-launcher.ts` (D9). `resolveNodeLauncher({ execPath: <pack>/bin/node })` is what the spike used.
+
+### Verification cost (D8)
+Full digest once per **process** per pack version (at availability), cached in memory keyed by canonical root + pack version; before every spawn re-verify with a stat snapshot (path, size, mtime, ino, mode of every entry, captured during the full digest) and full-hash only `launcher.mjs`, `bridge.mjs`, `bin/node`, and the native `claude` binary is optional (0.3 s) — behind a config knob defaulting to the stat snapshot. Also stop computing the digest twice inside `resolveLocalHarnessAvailability` (`resolveManagedBundle` then `revalidateRuntime` re-hash the same tree back to back).
+
+### Exposure probe (D7)
+Probe all non-loopback addresses **in parallel**, skip `fe80::/10` link-local addresses that carry no scope id (or append `%<ifname>` from `os.networkInterfaces()`), keep the 500 ms timeout, and additionally read the bound address from the OS (`lsof -nP -a -p <pid> -iTCP -sTCP:LISTEN` on darwin, `/proc/net/tcp*` on linux) and fail if anything other than a loopback address is listed. Keep the connect probe as the enforcing check.
+
+### Brokered model access (B1)
+Backend (mcpjam-backend, Convex): new lease `delivery: 'inspector-loopback-gateway'`. The Inspector server process (never the renderer) registers an instance key once at consent (`POST /web/harness/local-instance/register` with `machineId`; key held in the OS keystore on Electron via `safeStorage`, owner-only file for npx). `POST /web/harness/model-broker/start` with that delivery returns the lease **to the inspector** plus `proxyBaseUrl`; all existing bindings (user, org, project, harness, protocol, model allowlist, budgets, expiry, max active leases) stay; add `machineId` and `sessionGeneration`. Every upstream request from the inspector's loopback gateway carries `Authorization: Bearer <lease>` and `x-mcpjam-pop: <ts>.<nonce>.<hmac-sha256(instanceKey, method\npath\nts\nnonce)>`; the proxy verifies the PoP against the registered key before reading the body, rejects skew > 60 s and replayed nonces (TTL store keyed by jti+nonce), and revokes on stop/abort/timeout/consent revoke/generation change. Spike prototype of both halves: `spike/local-gateway.mjs` (client) and `spike/mock-anthropic.mjs` (verifier). Gateway rules: bind 127.0.0.1 only, random port, validate `Host`, reject any `Origin`, allow only `POST /v1/messages*` (+ `count_tokens`) and answer `HEAD /api/hello` with 200 without a capability, constant-time compare of the per-session capability (`ANTHROPIC_API_KEY` in the child), byte limits, never log bodies or headers, revoke = refuse further requests. The child's `ANTHROPIC_BASE_URL` is the gateway.
+
+### Work-dir layout (D5) and MCP delivery
+Adopt the session-owned `work/` + `project` symlink layout from the spike. Deliver the host's MCP servers through `createClaudeCode({ mcpServers })` (the bridge passes them to the SDK) instead of `deliverMcpServers` writing `.mcp.json` into the session work dir, which would land in the user's checkout under this layout.
+
+### Session policy (decision 4, recommended)
+Attended only. After a clean turn `detach()` keeps the bridge warm (60–115 MB, no CLI) for **15 minutes** idle, then `stop()` persists the resume state (continuity survives via `--resume` from the synthetic home); `destroy()` at consent expiry (12 h grant TTL) or explicit stop. On Inspector restart the janitor **terminates** orphaned trees (never adopts) in v1. Abort = `destroy()`.
+
+### Windows
+Stays refused by `supportsOwnershipProof('win32')` with the existing `ownership-unprovable` message. Follow-up PR: Job Object helper (create-suspended → assign kill-on-close job → resume) plus per-member identity via `wmic`/PowerShell `CreationDate`, conformance on a `windows-latest` runner. Not in the first release.
+
+### What a cloud agent can verify without a Mac
+The whole spike (mock upstream, gateway, bridge, native CLI) is platform-portable: the SDK ships linux-x64/arm64 binaries and nodejs.org ships linux tarballs. Add a CI job on `ubuntu-latest` that builds the linux pack and runs the spike scenarios (full, no-launcher, abort, orphan-a/b) — that is the conformance suite's seed. macOS-only facts (`(node)` identity, `ps -g`, Seatbelt) get a `macos-latest` job. The maintainer reruns the macOS scripts locally when asked.
+
+## Reuse map (verified paths; copy these patterns rather than inventing new ones)
+
+Client (`mcpjam-inspector/client/src/`):
+- `hooks/useComputerEngine.ts` — the candidate race (`storedPref → server defaultEngine → local → cloud`) producing **two** answers: `engine` (consent-gated, drives execution) and `selectedEngine` (consent-blind, drives which face renders). The harness target selector needs the same split so picking "Native" before consenting shows the consent sheet instead of bouncing to Hosted.
+- `hooks/useComputersEnabled.ts` — `useLocalComputerEnabled()` fail-closed flag gate (`=== true`); add `useLocalHarnessEnabled()` for the `local-harness-enabled` flag the same way.
+- `hooks/useLocalComputerConsent.ts` + `lib/local-computer-consent.ts` — pure `useSyncExternalStore` projection of localStorage, **no client verify loop** (earlier verify-on-mount versions grew five race guards for zero safety); mint/persist split; token-scoped revoke. Copy wholesale for the harness grant token (`x-mcpjam-local-harness-grant`, `grants.ts`).
+- `lib/computer-engine-storage.ts` — per-project storage keys (not a shared map) for the target choice.
+- `components/computer/LocalComputerConsentGate.tsx` and `LocalComputerView.tsx` — the blunt "not a sandbox" copy, the `shown → granted | denied` content-free funnel, and the "Forget & re-authorize" recovery path. The harness consent sheet adds runtime version + digest, workspace display root, permission profile, and expiry.
+- `components/chat-v2/thread/parts/tool-part.tsx` `readToolRunLocation()` (line ~1164) — provenance read from the frozen raw output; the run-location pill is itself flag-gated. Reuse for "ran natively on this machine" attribution.
+- `hooks/use-chat-session.ts` lines ~2761-2785 and ~2939 — where the local-consent header and `computerEngine` body are attached, scoped to `/api/mcp/chat-v2` only (`!shouldUseOrgAwareChatApi`). The harness target ids travel the same way; the grant token as a header, never in the body.
+- `lib/session-token.ts` `HOSTED_AUTH_PATH_PREFIXES` (line ~296) — **every new `/api/mcp/...` route must be added here** or `authFetch` attaches no bearer and the route 401s for every WorkOS-signed-in user (this exact bug shipped once as PR #4515). Never set `Authorization` manually.
+
+Server (`mcpjam-inspector/server/`):
+- `routes/mcp/computers.ts` — the middleware stack template for loopback routes: `/api/mcp` mount (inspector session token) + `bearerAuthMiddleware` + `requireVerifiedAuth()` + explicit guest 403 + kill-switch 404; note the terminal-mint route needed its own identical stack because the wildcard did not cover it.
+- `utils/computers/local-consent.ts` — hash-only persistence, `timingSafeEqual`, mutation lock with lock-free verify; the harness twin already exists in `utils/harness/local/grants.ts`.
+- `routes/web/computers.ts` `GET /api/web/computers/config` — open endpoint returning `engines` + `capabilities` + tri-state `defaultEngine`; extend with `harnessTargets: { localNative: { available, status, runtime: { packVersion, adapterVersion, vendorVersions, digest } | null, workspaceDisplayRoot } }` (tilde display roots only, never absolute home paths).
+- `utils/computers/engine.ts` — `resolvePersonalComputerEngine` / `coercePersonalEngineForActor`: an explicit `local` that cannot be honoured resolves `unavailable`, never silently cloud; `utils/harness/local/availability.ts` is already its harness twin.
+- `middleware/origin-validation.ts` `isAllowedRequestOrigin()` (line ~106) — re-check inside handlers; absent `Origin` is rejected there.
+- `utils/computers/local-terminal-auth.ts` — single-use 60 s nonces bound to project + consent fingerprint; the pattern for any WebSocket/stream the local target opens.
+- `utils/mcpjam-stream-handler.ts` `MCPJamHandlerOptions` (line ~562) — has `harness`, `harnessSandboxBinding`, `computerWorkdir`, `builtInTools` but **no field for a local harness target**: PR 5 adds `harnessExecutionTarget?: { kind: "local-native"; workspaceGrantId; runtimeId; permissionProfile; policyVersion; grantToken }` (opaque ids only) and threads it from both `routes/mcp/chat-v2.ts` (body parsed ~1143-1174 for `computerEngine`; harness dispatch ~1363 and ~1609-1620 never reads it today) and `routes/web/chat-v2.ts`.
+- `utils/harness/run-harness-turn.ts` `runHarnessTurn(options: MCPJamHandlerOptions, streamSink)` (line ~549); the single provider construction point is `createE2BHarnessSandboxProvider` at ~1698 with the workdir resolution just above it — the branch point.
+
+Electron (`mcpjam-inspector/src/`):
+- `preload.ts` exposes `electronAPI.files.openDialog(options)`; `ipc/files/file-listeners.ts` spreads caller options last, so `{ properties: ["openDirectory"] }` already works with **no preload change**. `window.isElectron` / `window.isElectronPackaged` tell the renderer where it runs. The picker result must go main-process → `registerWorkspaceGrant` → opaque id; add a sender-identity check like `ipc/app/app-listeners.ts` for the new privileged channel. No directory picker exists anywhere today.
+
+Docs: `docs/local-computer-engine.md` headings (What it is / Pieces / Trust model / Actor and route enumeration / Kill switch / Cloud-only surfaces / Terminal degrade / Analytics / Flag targeting / Launch-rollback checklist) are the template; analytics events must be registered in `shared/analytics-events.ts` (a ratchet test forbids raw `posthog.capture`) with enum/boolean/count props only. Cite `server/utils/harness/local/README.md` rather than restating it.
+
+## Review notes (self-review; the critique agent hit a session rate limit)
+
+- Ordering holds: PR 1 and PR 2 depend on nothing; PR 3 (backend) must deploy before PR 4's gateway can obtain a lease; PR 5 needs PR 1, 2 and 4; PR 6 needs everything. Merged ≠ deployed for the backend (prod deploys on inspector release promote) — sequence the deploys explicitly.
+- Symlink work-dir layout: the link lives in the 0700 session dir and resolves into the workspace root, one of the two confinement roots, so no path outside the grant becomes reachable through the Inspector file API; the vendor process already has the OS user's authority, so the layout adds no new exposure. Keep the hop cap in `confine.ts`.
+- Loopback gateway threat: the per-session capability reaches the CLI as env and is persisted in the bridge's `start-config.json` (0644 inside the 0700 session dir); any same-user process could present it to the gateway during the session. Mitigations already in the design: short session TTL, revoke on every terminal path, lease budgets, per-user rate limit. Recommended hardening in PR 4: the gateway resolves the connecting socket's peer pid (`lsof -nP -iTCP:<srcport>` on darwin, `/proc/net/tcp` + `/proc/<pid>/fd` on linux) and only serves pids in the supervised tree.
+- Windows must be its own PR (Job Object helper + per-member identity + `windows-latest` conformance); do not let it block the macOS/Linux release.
+- A cloud agent cannot run the macOS-only checks; the Linux CI job in PR 6 is how it gets evidence, and the maintainer reruns the macOS scripts on request. The `(node)` identity fix and the `ps -g` group probe are darwin-specific and need the `macos-latest` job.
+
+## Implementation sequence (one PR per step, each fail-closed until the next lands)
+
+**Step 0 (maintainer, after approving this plan):** commit the worktree `spike/local-harness-native` and push to `mcpjam` (MCPJam/inspector) so the agent can read the prototypes and logs.
+
+**PR 1 — Foundation fixes from the spike** (inspector, `server/utils/harness/local/`)
+- Land D1–D6 as reviewed code (the prototypes are annotated `SPIKE`; rewrite comments, keep behaviour), plus D7 and D8 designs above, plus `CLAUDE_CODE_TMPDIR` in `scopedEnv` (item 12).
+- Update `ADAPTER_COMMAND_SHAPES.framework`; add the new arms to `TranslatedCommand`; keep `bridgeLauncherPath` optional (tests that pin the `bridge.mjs` remap stay meaningful for a pack without a launcher).
+- Tests: fix the 14 failing tests (list in `spike` log `run vitest server/utils/harness/local`): `command-translation.test.ts` (grammar list, "rejects the retired $HOME probe" is now wrong), `supervised-provider.test.ts` (work-dir layout + launcher path expectations), `supervisor.test.ts` ("retains ownership when the root exits naturally before stop" now expects the tree to be settled from the snapshot). Add tests for `sameBirthIdentity`, `listGroupMembers`, `terminateOwnedProcess`, the skills shapes (in and outside the synthetic home), the symlinked work dir (confinement still holds), and the parallel probe.
+- Acceptance: `npx vitest run server/utils/harness/local` green; the spike scripts still pass on macOS (maintainer) and on the Linux CI job.
+
+**PR 2 — Runtime pack + installer + manifest** (inspector + CI)
+- `scripts/build-local-harness-pack.mjs` from `spike/build-bundle.sh` (per platform: darwin-arm64, darwin-x64, linux-x64, linux-arm64); verify the native binary against the SDK `manifest.json` checksum; SBOM + license report for the pack; sign the pack manifest; upload as a release artifact.
+- Installer: `server/utils/harness/local/runtime-install.ts` — download → verify digest → extract into `<runtimeRoot>/<packVersion>` → activate atomically; never during a session start; exposes status (`absent | downloading | verifying | ready | corrupt`) to the availability route.
+- Manifest: real digests, `launcherRelativePath: "launcher.mjs"`, conformance version set by the CI job's output.
+- Acceptance: a fresh machine can install the pack and `resolveLocalHarnessAvailability` returns a plan; digest cache makes a second session start do zero full digests.
+
+**PR 3 — Backend broker delivery mode** (mcpjam-backend)
+- `harnessModelLease.ts`: delivery union `'e2b-network-transform' | 'inspector-loopback-gateway'`; instance-key registration table; PoP verification in the model proxy; replay store with TTL; revoke path; audit events; per-user/per-instance rate limits; tests for replay, cross-session, route confusion, skew, revoke.
+- Deploy order: backend before PR 4 (the inspector's gateway is dead code until this exists).
+
+**PR 4 — Inspector gateway, routes, IPC, UI, flag**
+- `server/utils/harness/local/model-gateway.ts` from `spike/local-gateway.mjs`; instance key storage; lease fetch via the new delivery mode.
+- Loopback-only, session-authenticated, Origin-checked routes mirroring `computers/local-consent` (availability, workspace grant, consent grant/revoke, runtime install/status, stop-all); Electron: main-process `dialog.showOpenDialog` → IPC → `registerWorkspaceGrant`; renderer never sees a path.
+- UI: target selector "Hosted / Native on this machine" (labels from `executionTargetLabel`), consent sheet showing runtime version + digest, workspace display root, permission profile, target guarantees (`targetHasHostContainment() === false` copy), consent expiry; PostHog flag `local-harness-enabled` (client, fail-closed, dark).
+- Acceptance: renderer cannot submit paths/argv/env; audit records carry ids only.
+
+**PR 5 — Turn integration**
+- `run-harness-turn.ts`: resolve the target before continuity claim / broker start / any E2B work; branch once (`cloud` → existing E2B path unchanged; `local-native` → availability plan → supervisor + provider + gateway); include `runtimeId`, `workspaceGrantId`, `policyVersion`, target kind in the continuity fingerprint; thread through create/turn/approval continuation/resume/detach/stop/abort; permission mode always explicit (`workspace-edits` → `allow-edits`; hosts with `requireToolApproval` → `allow-reads`, the only mode under which MCP tools pause); MCP servers via adapter `mcpServers`; lease revoke on every terminal path; timing fields renamed so E2B-only labels are not reused.
+- Both chat routes (`web/chat-v2`, `mcp/chat-v2`) must thread identically (memory: the desktop hits the mcp route).
+- Acceptance: the TL validation scenario (plan §9) passes with a real credential on the maintainer's Mac; logs show zero E2B calls for a local turn.
+
+**PR 6 — Conformance, telemetry, docs, rollout**
+- CI: `ubuntu-latest` + `macos-latest` jobs running the spike scenarios against the built pack (`full`, `no-launcher`, `abort`, `orphan-a/b`, probe timing budget); record `lifecycleConformanceVersion` from the job.
+- Telemetry (ids and outcomes only): target resolve, runtime verify, consent, gateway ready, spawn, bridge ready, first model byte, completion; SLOs: session start ≤ 1.5 s p95, warm resume overhead ≤ 300 ms p95.
+- Docs: rewrite `docs/inspector/claude-code-host.mdx` ("no local fallback" is no longer true), add `mcpjam-inspector/docs/local-harness.md` modelled on `local-computer-engine.md` (launch/rollback checklist, flags, kill switch).
+- Rollout: flag off at ship → `@mcpjam.com` dogfood → `deployment = self_hosted` cohort; kill switch `MCPJAM_LOCAL_HARNESS_ENABLED`; gateway revocation as the remote brake.
+
+## Verification (how to rerun the spikes)
+
+All paths below assume the worktree `/Users/marcelojimenezrocabado/mcpjam-inspector/worktrees/local-harness-spike` (symlinked `node_modules`) and the scratch root `S=/private/tmp/claude-501/-Users-marcelojimenezrocabado-mcpjam-inspector/0ea5eb59-a323-46b4-957d-fd3774eac40d/scratchpad/local-harness-spike` (pack at `$S/runtime/claude-code`, isolated `HOME=$S/home`, workspace `$S/workspace`, logs `$S/logs/`).
+
+```bash
+cd worktrees/local-harness-spike/mcpjam-inspector
+# rebuild the pack from the installed adapter + a nodejs.org node binary
+server/utils/harness/local/spike/build-bundle.sh node_modules/@ai-sdk/harness-claude-code/dist/bridge "$S/runtime" "$S/node-runtime/node-v24.20.0-darwin-arm64/bin/node"
+# end-to-end: read tool, bash+approval, detach+resume continuity, stop, hygiene checks (JSON report at the end)
+HOME="$S/home" SPIKE_ROOT="$S" npx tsx server/utils/harness/local/spike/run-native-turn.ts full
+# negative: bridge without the loopback launcher must be refused
+HOME="$S/home" SPIKE_ROOT="$S" npx tsx server/utils/harness/local/spike/run-native-turn.ts no-launcher
+# abort mid-turn (CLI child must die), crash + janitor reclaim
+HOME="$S/home" SPIKE_ROOT="$S" npx tsx server/utils/harness/local/spike/run-lifecycle.ts abort
+HOME="$S/home" SPIKE_ROOT="$S" npx tsx server/utils/harness/local/spike/run-lifecycle.ts orphan-a && HOME="$S/home" SPIKE_ROOT="$S" npx tsx server/utils/harness/local/spike/run-lifecycle.ts orphan-b
+# cost decomposition
+SPIKE_ROOT="$S" npx tsx server/utils/harness/local/spike/timing-decomp.mts
+npx tsx server/utils/harness/local/spike/probe-timing.mts
+npx vitest run server/utils/harness/local
+```
+
+Expected: `full` ends with findings `after stop: surviving pids=[]`, `registry records after stop: 0`, `new entries in workspace after session: []`, `continuity: model saw 3 user turns`; `no-launcher` fails with "accepted a connection on a non-loopback address" and `pgrep -f launcher.mjs` is empty; `abort` prints `surviving pids: []`, `state dir exists after destroy: false`. A real-model run needs an Anthropic-protocol upstream: point `GW_UPSTREAM` at an HTTPS upstream (the spike gateway is http-only; switch to `https.request`) and set `GW_UPSTREAM_KEY` from the maintainer's environment, never from the repo.
+
+## Assumptions and open items
+
+- Default local permission profile `workspace-edits` (`allow-edits`): edits inside the workspace run free, Bash pauses; hosts with `requireToolApproval` map to `allow-reads` so MCP tools pause too (per `registry.ts`).
+- `.mcp.json` is not written into the checkout; if the adapter `mcpServers` path proves insufficient for the proxy-token headers, write it under `work/project/.mcp.json` only with the user's explicit opt-in.
+- Pack delivery is download-on-demand for both distributions (recommendation; the alternative of shipping it inside the DMG adds ~150 MB per release and couples notarization to Anthropic's binary).
+- Windows deferred; Linux native supported from the first release if the Linux CI conformance job passes.
+- The 12 h grant TTL and 15 min idle keep-warm are recommendations; tune from telemetry.
+- Timings above were measured under load average ~20; treat them as upper bounds.
+
+## Where things are
+
+- Worktree: `/Users/marcelojimenezrocabado/mcpjam-inspector/worktrees/local-harness-spike` on branch `spike/local-harness-native` (from `main` @ 8058434cc2), **uncommitted**: 4 modified foundation files (`command-translation.ts`, `process-identity.ts`, `supervised-provider.ts`, `supervisor.ts`, +305/−10, `[spike-trace]` console logs included) and `server/utils/harness/local/spike/` (9 files: `build-bundle.sh`, `bundle-launcher.mjs`, `local-gateway.mjs`, `mock-anthropic.mjs`, `run-native-turn.ts`, `run-lifecycle.ts`, `group-settle.mts`, `timing-decomp.mts`, `probe-timing.mts`).
+- Scratch (session-local, not committed): pack, Node runtime tarball, isolated HOME with grants/registry/session state, logs `run-full-1..11.log`, `run-no-launcher.log`, `lifecycle-*.log`.
+- Related memory: `project_local_harness_program.md`; TL plan `~/.claude/plans/jazzy-hugging-cookie-tl.md`; foundation README `mcpjam-inspector/server/utils/harness/local/README.md`.

--- a/mcpjam-inspector/server/utils/harness/local/command-translation.ts
+++ b/mcpjam-inspector/server/utils/harness/local/command-translation.ts
@@ -68,7 +68,12 @@ export type TranslatedCommand =
   /** Create directories (recursive, owner-only). Paths are already confined. */
   | { kind: "mkdir"; paths: readonly string[] }
   /** Answer on stdout with no process at all — the framework's `pwd` probe. */
-  | { kind: "reply"; stdout: string }
+  | { kind: "reply"; stdout: string; exitCode?: number }
+  /** SPIKE: framework skills-write shapes (stable line, every prompt turn).
+   *  All three operate ONLY inside the synthetic home. */
+  | { kind: "rename"; from: string; to: string }
+  | { kind: "remove"; paths: readonly string[] }
+  | { kind: "probe-absent"; path: string }
   /** A command the managed runtime bundle already satisfies. No process runs;
    *  `reason` is recorded so an operator can see WHY nothing happened. */
   | { kind: "noop"; reason: string }
@@ -124,6 +129,12 @@ export interface CommandTranslationContext {
   bootstrapOverlayDir: string;
   /** Absolute path to the Node launcher shipped/verified with the bundle. */
   nodeExecutable: string;
+  /**
+   * SPIKE: the script the bridge launch actually runs, when the bundle ships a
+   * launcher wrapper (loopback patch) in front of the verbatim `bridge.mjs`.
+   * Absent, the launch runs the remapped `bridge.mjs` itself.
+   */
+  bridgeLauncherPath?: string;
   /** Absolute canonical session root: the granted workspace, and the session's
    *  `defaultWorkingDirectory`. Every writable operand must live under it or
    *  under the session state directory, and it is the default cwd for `exec`. */
@@ -155,7 +166,21 @@ export const ADAPTER_COMMAND_SHAPES: Readonly<
   // Issued by `@ai-sdk/harness` itself, for every adapter. The two `mkdir`s
   // pass their path through the environment rather than the command string,
   // which is why those two shapes have no interpolation to inspect.
-  framework: ['mkdir -p "$BOOTSTRAP_DIR"', 'mkdir -p "$WORK_DIR"', "pwd"],
+  framework: [
+    'mkdir -p "$BOOTSTRAP_DIR"',
+    'mkdir -p "$WORK_DIR"',
+    "pwd",
+    // SPIKE FINDING: the stable framework (`resolveSandboxHomeDir`, utils) probes
+    // the child home with this exact string before every bridge start. It was
+    // missing here, so every local session failed closed at translation.
+    'printf "%s" "$HOME"',
+    // SPIKE FINDING: `writeSkills` (utils/write-skills, stable line) runs on
+    // EVERY prompt turn, even with zero skills, and issues these three shapes
+    // against the child's $HOME/.claude/skills. None were translated before.
+    "mv -f '<manifest>.tmp' '<manifest>'",
+    "test ! -e '<skillDir>'",
+    "rm -rf -- '<skillDir>' …",
+  ],
   "claude-code": [
     "pnpm install --frozen-lockfile --store-dir .pnpm-store",
     "./node_modules/.bin/claude --version",
@@ -177,6 +202,8 @@ export const ADAPTER_COMMAND_SHAPES: Readonly<
  * `pwd` would mean starting a shell to learn a value we already hold.
  */
 const PWD_PROBE = "pwd";
+/** The framework's home-directory probe (`resolveSandboxHomeDir`). */
+const HOME_PROBE = 'printf "%s" "$HOME"';
 
 /**
  * The framework's two environment-indirected `mkdir`s. The path travels in
@@ -384,6 +411,74 @@ export function classifyBootstrapPath(
   );
 }
 
+// SPIKE: the framework's skills writer. Every operand must live inside the
+// synthetic home — that is the only place the stable line writes skills — so a
+// shape that names anything else is refused even though it would confine.
+function assertUnderSyntheticHome(
+  path: string,
+  ctx: CommandTranslationContext,
+  command: string,
+): void {
+  const home = normalize(ctx.syntheticHome);
+  const p = normalize(path);
+  if (p === home || !p.startsWith(home + "/")) {
+    throw new CommandTranslationError(
+      `path operand ${JSON.stringify(path)} is outside the session's synthetic ` +
+        `home; the skills-write shapes are only honoured there`,
+      command,
+    );
+  }
+}
+
+async function translateSkillsMove(
+  command: string,
+  ctx: CommandTranslationContext,
+): Promise<TranslatedCommand> {
+  const ops = splitQuotedTokens(command.slice("mv -f ".length), command);
+  if (ops.length !== 2) {
+    throw new CommandTranslationError("mv -f needs exactly two operands", command);
+  }
+  for (const p of ops) {
+    assertPlainPathOperand(p, command);
+    assertUnderSyntheticHome(p, ctx, command);
+  }
+  return {
+    kind: "rename",
+    from: await ctx.confine(ops[0]!),
+    to: await ctx.confine(ops[1]!),
+  };
+}
+
+async function translateSkillsProbe(
+  command: string,
+  ctx: CommandTranslationContext,
+): Promise<TranslatedCommand> {
+  const ops = splitQuotedTokens(command.slice("test ! -e ".length), command);
+  if (ops.length !== 1) {
+    throw new CommandTranslationError("test ! -e needs exactly one operand", command);
+  }
+  assertPlainPathOperand(ops[0]!, command);
+  assertUnderSyntheticHome(ops[0]!, ctx, command);
+  return { kind: "probe-absent", path: await ctx.confine(ops[0]!) };
+}
+
+async function translateSkillsRemove(
+  command: string,
+  ctx: CommandTranslationContext,
+): Promise<TranslatedCommand> {
+  const ops = splitQuotedTokens(command.slice("rm -rf -- ".length), command);
+  if (ops.length === 0) {
+    throw new CommandTranslationError("rm -rf -- with no operands", command);
+  }
+  const paths: string[] = [];
+  for (const p of ops) {
+    assertPlainPathOperand(p, command);
+    assertUnderSyntheticHome(p, ctx, command);
+    paths.push(await ctx.confine(p));
+  }
+  return { kind: "remove", paths };
+}
+
 /** Translate a `mkdir -p …` command. */
 async function translateMkdir(
   command: string,
@@ -487,7 +582,9 @@ async function matchBridgeLaunch(
     );
   }
 
-  const args: string[] = [remapBootstrapPath(expectedBridge, ctx)];
+  const args: string[] = [
+    ctx.bridgeLauncherPath ?? remapBootstrapPath(expectedBridge, ctx),
+  ];
   for (let i = 0; i < flags.length; i += 1) {
     const flag = tokens[1 + i * 2]!;
     const value = tokens[2 + i * 2]!;
@@ -551,6 +648,10 @@ export async function translateAdapterCommand(
   if (command === PWD_PROBE) {
     return { kind: "reply", stdout: ctx.sessionRoot };
   }
+  // SPIKE: answer the framework's `$HOME` probe from the synthetic home, no shell.
+  if (command === HOME_PROBE) {
+    return { kind: "reply", stdout: ctx.syntheticHome };
+  }
 
   // The framework's environment-indirected mkdirs. The operand never appears
   // in the command text, so it is read from the environment the caller passed
@@ -601,6 +702,10 @@ export async function translateAdapterCommand(
   if (command.startsWith("mkdir -p ")) {
     return translateMkdir(command, ctx);
   }
+  // SPIKE: skills-write shapes (see ADAPTER_COMMAND_SHAPES.framework).
+  if (command.startsWith("mv -f ")) return translateSkillsMove(command, ctx);
+  if (command.startsWith("test ! -e ")) return translateSkillsProbe(command, ctx);
+  if (command.startsWith("rm -rf -- ")) return translateSkillsRemove(command, ctx);
 
   throw new CommandTranslationError(
     `command is not one of the ${ctx.harnessId} adapter shapes this Inspector ` +

--- a/mcpjam-inspector/server/utils/harness/local/process-identity.ts
+++ b/mcpjam-inspector/server/utils/harness/local/process-identity.ts
@@ -255,6 +255,105 @@ export function supportsOwnershipProof(
  * Answers false — never "probably" — when the platform cannot prove it. Every
  * caller treats false as "do not touch this pid".
  */
+/**
+ * SPIKE FINDING + FIX: on macOS a process that is exiting (argv memory already
+ * torn down, not yet a zombie) is reported by ps with its command as "(comm)".
+ * The recorded identity carries the full argv, so a byte compare answered
+ * "not-owned" for our own bridge the moment the adapter told it to exit — and
+ * every clean stop was then reported as an escape. The start time is still
+ * exact in that state, so an identity whose lstart matches and whose current
+ * command is the parenthesised form is accepted as the same process.
+ */
+export function sameBirthIdentity(
+  recorded: ProcessBirthIdentity,
+  current: ProcessBirthIdentity,
+): boolean {
+  if (recorded === current) return true;
+  const r = /^darwin:([^|]+)\|([\s\S]*)$/.exec(recorded);
+  const c = /^darwin:([^|]+)\|([\s\S]*)$/.exec(current);
+  if (r === null || c === null) return false;
+  return r[1] === c[1] && /^\([^()]+\)$/.test(c[2]!);
+}
+
+/**
+ * SPIKE: enumerate the live members of a process group with their birth
+ * identities. Called at the instant the ROOT exits, while the group id
+ * provably still belongs to this tree, so a later stop can verify and signal
+ * each member individually instead of refusing to touch an unanchored group.
+ */
+export async function listGroupMembers(
+  pgid: number,
+  platform: NodeJS.Platform = process.platform,
+): Promise<Array<{ pid: number; identity: ProcessBirthIdentity }> | null> {
+  let pids: number[] = [];
+  if (platform === "darwin") {
+    const out = await new Promise<string | null>((resolve) => {
+      execFile(
+        "/bin/ps",
+        ["-o", "pid=,state=", "-g", String(pgid)],
+        { timeout: PS_TIMEOUT_MS, maxBuffer: 64 * 1024, encoding: "utf8", env: {} },
+        (error, stdout) => resolve(error ? (error as { code?: number }).code === 1 ? "" : null : String(stdout)),
+      );
+    });
+    if (out === null) return null;
+    pids = out
+      .split("\n")
+      .map((l) => l.trim().split(/\s+/))
+      .filter((f) => f.length >= 2 && /^\d+$/.test(f[0]!) && !isDeadState(f[1]!.charAt(0)))
+      .map((f) => Number(f[0]));
+  } else if (platform === "linux") {
+    let entries: string[];
+    try { entries = await readdir("/proc"); } catch { return null; }
+    for (const entry of entries) {
+      if (!/^\d+$/.test(entry)) continue;
+      let raw: string;
+      try { raw = await readFile(`/proc/${entry}/stat`, "utf8"); } catch { continue; }
+      const parsed = parseProcStatGroup(raw);
+      if (parsed !== null && parsed.pgrp === pgid && !isDeadState(parsed.state.charAt(0))) pids.push(Number(entry));
+    }
+  } else {
+    return null;
+  }
+  const members: Array<{ pid: number; identity: ProcessBirthIdentity }> = [];
+  for (const pid of pids) {
+    if (pid === pgid) continue;
+    const identity = await readProcessBirthIdentity(pid, platform);
+    if (identity !== null) members.push({ pid, identity });
+  }
+  return members;
+}
+
+/** SPIKE: terminate ONE process whose birth identity is known: verify, then
+ *  SIGTERM, wait, SIGKILL. Never signals a pid whose identity changed. */
+export async function terminateOwnedProcess(args: {
+  pid: number;
+  identity: ProcessBirthIdentity;
+  graceMs: number;
+  platform?: NodeJS.Platform;
+}): Promise<"already-gone" | "not-owned" | "graceful" | "forced" | "escaped" | "unknown"> {
+  const platform = args.platform ?? process.platform;
+  const initial = await probeProcess(args.pid, platform);
+  if (initial.state === "gone") return "already-gone";
+  if (initial.state === "unknown") return "unknown";
+  if (!sameBirthIdentity(args.identity, initial.identity)) return "not-owned";
+  const waitGone = async (ms: number): Promise<boolean> => {
+    const until = Date.now() + ms;
+    while (Date.now() < until) {
+      const p = await probeProcess(args.pid, platform);
+      if (p.state === "gone") return true;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    return false;
+  };
+  try { process.kill(args.pid, "SIGTERM"); } catch { return "already-gone"; }
+  if (await waitGone(args.graceMs)) return "graceful";
+  const again = await probeProcess(args.pid, platform);
+  if (again.state === "gone") return "graceful";
+  if (again.state === "alive" && !sameBirthIdentity(args.identity, again.identity)) return "not-owned";
+  try { process.kill(args.pid, "SIGKILL"); } catch { return "graceful"; }
+  return (await waitGone(500)) ? "forced" : "escaped";
+}
+
 export async function isSameProcess(
   pid: number,
   expected: ProcessBirthIdentity,
@@ -591,7 +690,7 @@ export async function terminateOwnedProcessGroup(args: {
     // announce a stopped session over a tree that may still be running.
     return { outcome: "unknown", reason: initial.reason };
   }
-  if (initial.identity !== args.birthIdentity) {
+  if (!sameBirthIdentity(args.birthIdentity, initial.identity)) {
     // Pid reuse: this is somebody else's process now. Emphatically do not
     // signal it.
     return { outcome: "not-owned" };

--- a/mcpjam-inspector/server/utils/harness/local/spike/build-bundle.sh
+++ b/mcpjam-inspector/server/utils/harness/local/spike/build-bundle.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPIKE: build the managed Claude Code runtime bundle the way CI will.
+#   build-bundle.sh <adapter-bridge-dir> <out-root> <node-binary>
+# Produces <out-root>/claude-code with: verbatim adapter recipe files
+# (package.json, pnpm-lock.yaml, pnpm-workspace.yaml, bridge.mjs), the
+# Inspector launcher wrapper, a hoisted symlink-free node_modules pruned of the
+# unused `@anthropic-ai/claude-code` wrapper, and the Node launcher at bin/node.
+set -euo pipefail
+ADAPTER_BRIDGE="$1"; OUT_ROOT="$2"; NODE_BIN="$3"
+B="$OUT_ROOT/claude-code"; STORE="$OUT_ROOT/.pnpm-store"
+rm -rf "$B"; mkdir -p "$B" "$STORE"
+cp "$ADAPTER_BRIDGE/package.json" "$ADAPTER_BRIDGE/pnpm-lock.yaml" "$ADAPTER_BRIDGE/pnpm-workspace.yaml" "$B/"
+cp "$ADAPTER_BRIDGE/index.mjs" "$B/bridge.mjs"            # verbatim: the provider compares bytes
+cp "$(dirname "$0")/bundle-launcher.mjs" "$B/launcher.mjs"  # Inspector-owned loopback wrapper
+( cd "$B" && pnpm install --frozen-lockfile --node-linker=hoisted --store-dir "$STORE" --ignore-scripts )
+# The SDK resolves its OWN platform package binary; the wrapper package is
+# only used by the adapter's `--version` probe, which the translator no-ops.
+rm -rf "$B/node_modules/@anthropic-ai/claude-code" "$B"/node_modules/@anthropic-ai/claude-code-*
+# pnpm bin shims are symlinks; the digest refuses symlinks and nothing uses them.
+find "$B" -type d -name .bin -prune -exec rm -rf {} +
+rm -f "$B/node_modules/.modules.yaml" "$B/node_modules/.pnpm-workspace-state-v1.json"
+mkdir -p "$B/bin"; cp "$NODE_BIN" "$B/bin/node"; chmod 755 "$B/bin/node"
+test "$(find "$B" -type l | wc -l)" -eq 0 || { echo "symlinks remain"; exit 1; }
+echo "bundle at $B: $(du -sh "$B" | cut -f1), $(find "$B" -type f | wc -l | tr -d ' ') files"

--- a/mcpjam-inspector/server/utils/harness/local/spike/bundle-launcher.mjs
+++ b/mcpjam-inspector/server/utils/harness/local/spike/bundle-launcher.mjs
@@ -1,0 +1,17 @@
+// Inspector-owned launcher: forces every listener the bridge opens onto
+// loopback, then runs the adapter's verbatim bridge.mjs. The bridge itself
+// stays byte-identical to the pinned adapter's copy (the provider compares it).
+import net from "node:net";
+const LOOPBACK = "127.0.0.1";
+const wild = (h) => h === undefined || h === null || h === "" || h === "0.0.0.0" || h === "::";
+const origListen = net.Server.prototype.listen;
+net.Server.prototype.listen = function patchedListen(...args) {
+  if (args.length > 0 && typeof args[0] === "object" && args[0] !== null && !("fd" in args[0]) && !("path" in args[0])) {
+    if (wild(args[0].host)) args[0] = { ...args[0], host: LOOPBACK };
+  } else if (typeof args[0] === "number" || (typeof args[0] === "string" && /^\d+$/.test(args[0]))) {
+    if (typeof args[1] === "string") { if (wild(args[1])) args[1] = LOOPBACK; }
+    else args.splice(1, 0, LOOPBACK);
+  }
+  return origListen.apply(this, args);
+};
+await import("./bridge.mjs");

--- a/mcpjam-inspector/server/utils/harness/local/spike/group-settle.mts
+++ b/mcpjam-inspector/server/utils/harness/local/spike/group-settle.mts
@@ -1,0 +1,25 @@
+// Micro-test: what does terminateOwnedProcessGroup report when the ROOT exits
+// on its own (a) leaving nothing behind, (b) leaving a child in its group?
+import { spawn } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { readProcessBirthIdentity, terminateOwnedProcessGroup, probeProcessGroup } from "../process-identity.js";
+const execFileP = promisify(execFile);
+const NODE = process.argv[2]!;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+async function groupPs(pgid: number) { try { return (await execFileP("ps", ["-o", "pid=,pgid=,stat=,command=", "-ax"])).stdout.split("\n").filter((l) => l.split(/\s+/).filter(Boolean)[1] === String(pgid)).map((l) => l.trim().slice(0, 90)); } catch { return []; } }
+async function run(label: string, script: string) {
+  const child = spawn(NODE, ["-e", script], { detached: true, stdio: "ignore" });
+  const pid = child.pid!;
+  const identity = (await readProcessBirthIdentity(pid, "darwin"))!;
+  await sleep(1500); // let the leader exit on its own
+  console.log(`\n[${label}] leader ${pid} exited on its own; group now:`, await groupPs(pid));
+  console.log(`[${label}] probeProcessGroup:`, await probeProcessGroup(pid, "darwin"));
+  const outcome = await terminateOwnedProcessGroup({ pid, birthIdentity: identity, graceMs: 1000, platform: "darwin" });
+  console.log(`[${label}] terminateOwnedProcessGroup:`, JSON.stringify(outcome));
+  const after = await groupPs(pid);
+  console.log(`[${label}] group after:`, after);
+  for (const l of after) { const p = Number(l.split(/\s+/)[0]); try { process.kill(p, "SIGKILL"); } catch {} }
+}
+await run("a-clean-exit", "setTimeout(()=>{}, 300)");
+await run("b-child-left-behind", "require('child_process').spawn('/bin/sleep',['30'],{stdio:'ignore'}).unref(); setTimeout(()=>process.exit(0), 300)");

--- a/mcpjam-inspector/server/utils/harness/local/spike/local-gateway.mjs
+++ b/mcpjam-inspector/server/utils/harness/local/spike/local-gateway.mjs
@@ -1,0 +1,56 @@
+// Loopback model gateway for the local-harness spike (B1 client half).
+// The child (Claude Code) is pointed at THIS server with a per-session
+// capability token as its API key. The real upstream credential lives only in
+// this process. Every upstream request carries a proof-of-possession header
+// (HMAC over method, path, timestamp, nonce) so a stolen capability token alone
+// is useless without the instance key.
+import http from "node:http";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+const port = Number(process.env.GW_PORT ?? 0);
+const upstream = new URL(process.env.GW_UPSTREAM);
+const sessionCapability = process.env.GW_SESSION_CAPABILITY;
+const upstreamKey = process.env.GW_UPSTREAM_KEY ?? "";
+const popSecret = process.env.GW_POP_SECRET ?? "";
+if (!sessionCapability) throw new Error("GW_SESSION_CAPABILITY required");
+const stats = { requests: 0, rejected: 0, upstreamMs: [], bytesIn: 0, bytesOut: 0 };
+const log = (...a) => console.error("[gw]", ...a);
+let revoked = false;
+
+function capabilityOk(req) {
+  const presented = req.headers["x-api-key"] ?? (req.headers.authorization ?? "").replace(/^Bearer\s+/i, "");
+  if (typeof presented !== "string") return false;
+  const a = Buffer.from(presented); const b = Buffer.from(sessionCapability);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+function pop(method, path) {
+  const ts = String(Date.now()); const nonce = randomBytes(12).toString("hex");
+  const mac = createHmac("sha256", popSecret).update(`${method}\n${path}\n${ts}\n${nonce}`).digest("hex");
+  return `${ts}.${nonce}.${mac}`;
+}
+const server = http.createServer((req, res) => {
+  stats.requests += 1;
+  if (revoked || !capabilityOk(req)) {
+    stats.rejected += 1; log("REJECT", revoked ? "revoked" : "bad capability", req.method, req.url);
+    res.writeHead(401, { "content-type": "application/json" }); res.end(JSON.stringify({ type: "error", error: { type: "authentication_error", message: "capability rejected" } })); return;
+  }
+  const headers = { ...req.headers };
+  delete headers.host; delete headers["x-api-key"]; delete headers.authorization; delete headers["content-length"];
+  headers["x-api-key"] = upstreamKey;
+  headers["x-mcpjam-pop"] = pop(req.method, req.url);
+  const t0 = performance.now();
+  const up = http.request({ hostname: upstream.hostname, port: upstream.port, path: req.url, method: req.method, headers }, (upRes) => {
+    stats.upstreamMs.push(Math.round(performance.now() - t0));
+    res.writeHead(upRes.statusCode, upRes.headers);
+    upRes.on("data", (c) => { stats.bytesOut += c.length; });
+    upRes.pipe(res);
+  });
+  up.on("error", (e) => { log("upstream error", e.message); res.writeHead(502); res.end(); });
+  req.on("data", (c) => { stats.bytesIn += c.length; });
+  req.pipe(up);
+});
+process.on("SIGUSR2", () => { revoked = true; log("capability REVOKED"); });
+process.on("SIGTERM", () => { console.log(JSON.stringify({ stats })); process.exit(0); });
+server.listen(port, "127.0.0.1", () => {
+  console.log(JSON.stringify({ port: server.address().port }));
+});

--- a/mcpjam-inspector/server/utils/harness/local/spike/mock-anthropic.mjs
+++ b/mcpjam-inspector/server/utils/harness/local/spike/mock-anthropic.mjs
@@ -1,0 +1,122 @@
+// Mock Anthropic Messages API upstream for the local-harness spike.
+// Deterministic: the scenario is chosen from the LAST user text message.
+//   "READFILE <path>"  -> tool_use Read {file_path}
+//   "BASH <cmd>"       -> tool_use Bash {command}
+//   "WRITE <path>"     -> tool_use Write {file_path, content}
+//   "COUNT"            -> text: number of user turns seen in this request (continuity probe)
+//   anything else      -> text echo
+// After a tool_result arrives, answers with a final text summarising the result.
+// Verifies the gateway's proof-of-possession header when MOCK_POP_SECRET is set.
+import http from "node:http";
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const port = Number(process.env.MOCK_PORT ?? 0);
+const popSecret = process.env.MOCK_POP_SECRET ?? "";
+const seenNonces = new Set();
+const log = (...a) => console.error("[mock]", ...a);
+let requestCount = 0;
+
+function sse(res, events) {
+  res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+  for (const [event, data] of events) {
+    res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+  }
+  res.end();
+}
+function textEvents(id, text, inputTokens) {
+  return [
+    ["message_start", { type: "message_start", message: { id, type: "message", role: "assistant", model: "claude-haiku-4-5", content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: inputTokens, output_tokens: 1 } } }],
+    ["content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }],
+    ["content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text } }],
+    ["content_block_stop", { type: "content_block_stop", index: 0 }],
+    ["message_delta", { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 12 } }],
+    ["message_stop", { type: "message_stop" }],
+  ];
+}
+function toolEvents(id, name, input, inputTokens) {
+  const json = JSON.stringify(input);
+  return [
+    ["message_start", { type: "message_start", message: { id, type: "message", role: "assistant", model: "claude-haiku-4-5", content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: inputTokens, output_tokens: 1 } } }],
+    ["content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }],
+    ["content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: `Using ${name}.` } }],
+    ["content_block_stop", { type: "content_block_stop", index: 0 }],
+    ["content_block_start", { type: "content_block_start", index: 1, content_block: { type: "tool_use", id: `toolu_${id}`, name, input: {} } }],
+    ["content_block_delta", { type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: json } }],
+    ["content_block_stop", { type: "content_block_stop", index: 1 }],
+    ["message_delta", { type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 30 } }],
+    ["message_stop", { type: "message_stop" }],
+  ];
+}
+function lastUserText(messages) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m.role !== "user") continue;
+    if (typeof m.content === "string") return { text: m.content, toolResult: null };
+    const blocks = Array.isArray(m.content) ? m.content : [];
+    const tr = blocks.find((b) => b.type === "tool_result");
+    if (tr) return { text: null, toolResult: tr };
+    const t = blocks.filter((b) => b.type === "text").map((b) => b.text).join("\n");
+    return { text: t, toolResult: null };
+  }
+  return { text: "", toolResult: null };
+}
+function verifyPop(req) {
+  if (!popSecret) return { ok: true };
+  const h = req.headers["x-mcpjam-pop"];
+  if (typeof h !== "string") return { ok: false, why: "missing x-mcpjam-pop" };
+  const [ts, nonce, mac] = h.split(".");
+  if (!ts || !nonce || !mac) return { ok: false, why: "malformed" };
+  if (Math.abs(Date.now() - Number(ts)) > 60_000) return { ok: false, why: "clock skew" };
+  if (seenNonces.has(nonce)) return { ok: false, why: "replay" };
+  const expected = createHmac("sha256", popSecret).update(`${req.method}\n${req.url}\n${ts}\n${nonce}`).digest("hex");
+  const a = Buffer.from(mac, "hex"); const b = Buffer.from(expected, "hex");
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return { ok: false, why: "bad mac" };
+  seenNonces.add(nonce);
+  return { ok: true };
+}
+const server = http.createServer((req, res) => {
+  requestCount += 1;
+  const chunks = [];
+  req.on("data", (c) => chunks.push(c));
+  req.on("end", () => {
+    const pop = verifyPop(req);
+    if (!pop.ok) { log("POP REJECT", pop.why, req.method, req.url); res.writeHead(401); res.end(JSON.stringify({ error: pop.why })); return; }
+    if (req.method === "POST" && req.url?.startsWith("/v1/messages")) {
+      if (req.url.includes("count_tokens")) { res.writeHead(200, { "content-type": "application/json" }); res.end(JSON.stringify({ input_tokens: 42 })); return; }
+      let body = {};
+      try { body = JSON.parse(Buffer.concat(chunks).toString("utf8")); } catch {}
+      const messages = Array.isArray(body.messages) ? body.messages : [];
+      const userTurns = messages.filter((m) => m.role === "user" && (typeof m.content === "string" || (Array.isArray(m.content) && m.content.some((b) => b.type === "text")))).length;
+      const id = `msg_${requestCount}`;
+      const { text, toolResult } = lastUserText(messages);
+      const tools = Array.isArray(body.tools) ? body.tools.map((t) => t.name) : [];
+      log(`#${requestCount} model=${body.model} stream=${body.stream} msgs=${messages.length} userTurns=${userTurns} tools=${tools.length} last=${toolResult ? "tool_result" : JSON.stringify((text ?? "").slice(0, 60))}`);
+      const inputTokens = 100 + messages.length * 10;
+      if (toolResult) {
+        const content = Array.isArray(toolResult.content) ? toolResult.content.map((b) => b.text ?? "").join("") : String(toolResult.content ?? "");
+        return sse(res, textEvents(id, `TOOL RESULT RECEIVED: ${content.slice(0, 200)}`, inputTokens));
+      }
+      const t = (text ?? "").trim();
+      if (t.split("\n").some((l) => /^SLOW\b/.test(l))) {
+        log("SLOW scenario: holding the response 8s");
+        setTimeout(() => sse(res, textEvents(id, "SLOW DONE", inputTokens)), 8000);
+        return;
+      }
+      const m = /^(READFILE|BASH|WRITE|COUNT)\b\s*(.*)$/s.exec(t.split("\n").filter((l) => /^(READFILE|BASH|WRITE|COUNT)\b/.test(l)).pop() ?? "");
+      if (m) {
+        const [, kind, arg] = m;
+        if (kind === "READFILE") return sse(res, toolEvents(id, "Read", { file_path: arg.trim() }, inputTokens));
+        if (kind === "BASH") return sse(res, toolEvents(id, "Bash", { command: arg.trim() }, inputTokens));
+        if (kind === "WRITE") return sse(res, toolEvents(id, "Write", { file_path: arg.trim(), content: "written by spike\n" }, inputTokens));
+        if (kind === "COUNT") return sse(res, textEvents(id, `USER_TURNS=${userTurns}`, inputTokens));
+      }
+      return sse(res, textEvents(id, `ECHO: ${t.slice(0, 80)}`, inputTokens));
+    }
+    log("UNKNOWN ROUTE", req.method, req.url);
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "not found" }));
+  });
+});
+server.listen(port, "127.0.0.1", () => {
+  console.log(JSON.stringify({ port: server.address().port }));
+});

--- a/mcpjam-inspector/server/utils/harness/local/spike/probe-timing.mts
+++ b/mcpjam-inspector/server/utils/harness/local/spike/probe-timing.mts
@@ -1,0 +1,14 @@
+import net from "node:net";
+import { nonLoopbackLocalAddresses, assertBridgeLoopbackOnly } from "../bridge-endpoint.js";
+const addrs = nonLoopbackLocalAddresses();
+console.log("non-loopback local addresses:", JSON.stringify(addrs));
+const server = net.createServer(); await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+const port = (server.address() as net.AddressInfo).port;
+for (const a of addrs) {
+  const t = performance.now();
+  await new Promise<void>((resolve) => { const s = net.connect({ port, host: a.address ?? a, family: (a.family === "IPv6" || String(a).includes(":")) ? 6 : 4 } as any); s.setTimeout(8000); s.once("connect", () => { console.log(`  ${a.address ?? a}: CONNECTED (bad) ${Math.round(performance.now() - t)}ms`); s.destroy(); resolve(); }); s.once("error", (e: any) => { console.log(`  ${a.address ?? a}: ${e.code} ${Math.round(performance.now() - t)}ms`); resolve(); }); s.once("timeout", () => { console.log(`  ${a.address ?? a}: TIMEOUT ${Math.round(performance.now() - t)}ms`); s.destroy(); resolve(); }); });
+}
+const t2 = performance.now();
+await assertBridgeLoopbackOnly({ port, readinessTimeoutMs: 5000, isBridgeAlive: async () => true } as any);
+console.log(`assertBridgeLoopbackOnly total: ${Math.round(performance.now() - t2)}ms`);
+server.close();

--- a/mcpjam-inspector/server/utils/harness/local/spike/run-lifecycle.ts
+++ b/mcpjam-inspector/server/utils/harness/local/spike/run-lifecycle.ts
@@ -1,0 +1,141 @@
+/**
+ * SPIKE LIFECYCLE RUNNER — abort mid-turn, orphan recovery, destroy.
+ *   HOME=<scratch>/home SPIKE_ROOT=<scratch> npx tsx run-lifecycle.ts abort
+ *   HOME=... npx tsx run-lifecycle.ts orphan-a   # starts a session, then dies without stopping it
+ *   HOME=... npx tsx run-lifecycle.ts orphan-b   # a fresh supervisor reclaims the orphan
+ */
+import { spawn, execFile } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { mkdir, readFile, writeFile, stat } from "node:fs/promises";
+import net from "node:net";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { HarnessAgent } from "@ai-sdk/harness/agent";
+import { createClaudeCode } from "@ai-sdk/harness-claude-code";
+import { LocalHarnessSupervisor } from "../supervisor.js";
+import { createSupervisedLocalHarnessProvider, sessionStateDirFor } from "../supervised-provider.js";
+import { resolveLocalHarnessAvailability } from "../availability.js";
+import { getLocalMachineId, grantLocalHarnessConsent, localHarnessStateRoot, registerWorkspaceGrant } from "../grants.js";
+import { computeTreeDigest, resolveManagedBundle } from "../runtime-identity.js";
+import { resolveNodeLauncher } from "../node-launcher.js";
+import { LOCAL_HARNESS_MANIFEST } from "../compatibility.js";
+import { LOCAL_HARNESS_POLICY_VERSION } from "../targets.js";
+import { listProcessRecords } from "../process-registry.js";
+
+const execFileP = promisify(execFile);
+const ROOT = process.env.SPIKE_ROOT!;
+const MODE = process.argv[2] ?? "abort";
+const RUNTIME_ROOT = join(ROOT, "runtime");
+const BUNDLE = join(RUNTIME_ROOT, "claude-code");
+const WORKSPACE = join(ROOT, "workspace");
+const SPIKE_DIR = new URL(".", import.meta.url).pathname;
+const CAPABILITY = `cap_${randomBytes(24).toString("base64url")}`;
+const POP_SECRET = randomBytes(32).toString("hex");
+const ORPHAN_FILE = join(ROOT, "orphan.json");
+const log = (...a: unknown[]) => console.log("[lifecycle]", ...a);
+const alive = (pid: number) => { try { process.kill(pid, 0); return true; } catch { return false; } };
+async function descendants(pid: number): Promise<number[]> {
+  const out: number[] = [];
+  const walk = async (p: number) => {
+    let kids = ""; try { kids = (await execFileP("pgrep", ["-P", String(p)])).stdout; } catch { return; }
+    for (const k of kids.split("\n").map((s) => Number(s.trim())).filter(Boolean)) { out.push(k); await walk(k); }
+  };
+  await walk(pid); return out;
+}
+async function psLine(pid: number) { try { return (await execFileP("ps", ["-o", "pid=,ppid=,pgid=,rss=,command=", "-p", String(pid)])).stdout.trim(); } catch { return ""; } }
+async function startChild(script: string, env: Record<string, string>) {
+  const child = spawn(process.execPath, [join(SPIKE_DIR, script)], { env: { PATH: process.env.PATH ?? "", ...env }, stdio: ["ignore", "pipe", "pipe"], detached: true });
+  child.stderr!.on("data", () => {});
+  const port = await new Promise<number>((resolve, reject) => {
+    let buf = ""; child.stdout!.on("data", (c) => { buf += String(c); const line = buf.split("\n")[0]; if (line?.includes("port")) resolve(JSON.parse(line).port); });
+    child.on("exit", (code) => reject(new Error(`${script} exited ${code}`)));
+  });
+  child.unref();
+  return { child, port };
+}
+const freePort = () => new Promise<number>((resolve) => { const s = net.createServer(); s.listen(0, "127.0.0.1", () => { const p = (s.address() as net.AddressInfo).port; s.close(() => resolve(p)); }); });
+
+async function setup() {
+  const mock = await startChild("mock-anthropic.mjs", { MOCK_POP_SECRET: POP_SECRET });
+  const gw = await startChild("local-gateway.mjs", { GW_UPSTREAM: `http://127.0.0.1:${mock.port}`, GW_SESSION_CAPABILITY: CAPABILITY, GW_UPSTREAM_KEY: "upstream-key", GW_POP_SECRET: POP_SECRET });
+  await mkdir(WORKSPACE, { recursive: true });
+  await writeFile(join(WORKSPACE, "hello.txt"), "hello\n");
+  const ws = await registerWorkspaceGrant(WORKSPACE); if (!ws.ok) throw new Error(ws.message);
+  const digest = await computeTreeDigest(BUNDLE);
+  const bridgeBytes = await readFile(join(BUNDLE, "bridge.mjs"));
+  const base = LOCAL_HARNESS_MANIFEST["claude-code"];
+  const manifest = { ...base, runtime: { ...(base.runtime as any), bundleDigest: digest, launcherRelativePath: "launcher.mjs" }, lifecycleConformanceVersion: "spike-2026-09-01", bridgeBundleDigest: `sha256:${createHash("sha256").update(bridgeBytes).digest("hex")}` } as typeof base;
+  const rt = await resolveManagedBundle({ manifest, runtimeRoot: RUNTIME_ROOT, platform: "darwin" }); if (!rt.ok) throw new Error(rt.message);
+  const machineId = await getLocalMachineId();
+  const target = { kind: "local-native" as const, machineId, workspaceGrantId: ws.grant.workspaceGrantId, harnessId: "claude-code" as const, runtimeId: rt.runtime.runtimeId, permissionProfile: "workspace-edits" as const, policyVersion: LOCAL_HARNESS_POLICY_VERSION };
+  const grant = await grantLocalHarnessConsent({ userId: "spike-user", machineId, projectId: "spike-project", workspaceGrantId: target.workspaceGrantId, harnessId: "claude-code", targetKind: "local-native", runtimeId: target.runtimeId, permissionProfile: target.permissionProfile, policyVersion: LOCAL_HARNESS_POLICY_VERSION });
+  const adapterVersion = JSON.parse(await readFile(new URL("../../../../../../node_modules/@ai-sdk/harness-claude-code/package.json", import.meta.url), "utf8")).version;
+  const availability = await resolveLocalHarnessAvailability({ target, actor: { isGuest: false, isScenarioSession: false, isJourneySession: false }, userId: "spike-user", projectId: "spike-project", grantToken: grant.token, runtimeRoot: RUNTIME_ROOT, installedAdapterVersion: adapterVersion, manifests: { "claude-code": manifest }, killSwitchEnabled: true, hosted: false });
+  if (!availability.available) throw new Error(`${availability.status}: ${availability.message}`);
+  const plan = availability.plan;
+  const supervisor = new LocalHarnessSupervisor();
+  const launcher = resolveNodeLauncher({ execPath: join(plan.runtime.rootPath, "bin", "node"), isElectron: false });
+  const bridgePort = await freePort();
+  const sessionId = `life-${MODE}-${Date.now()}`;
+  const sessionStateDir = sessionStateDirFor(localHarnessStateRoot(), sessionId);
+  let bridgePid = -1;
+  const provider = createSupervisedLocalHarnessProvider({ harnessId: "claude-code", manifest: plan.manifest, runtime: plan.runtime, supervisor, launcher, workspacePath: plan.workspacePath, workspaceGrantId: target.workspaceGrantId, sessionStateDir, targetKind: "local-native", bridgePort, bridgeReadinessTimeoutMs: 30_000, onBridgeStarted: async ({ pid }) => { bridgePid = pid; } });
+  const harness = createClaudeCode({ model: "haiku", auth: { ANTHROPIC_API_KEY: CAPABILITY, ANTHROPIC_BASE_URL: `http://127.0.0.1:${gw.port}` }, thinking: { type: "disabled" }, env: { CLAUDE_CODE_EFFORT_LEVEL: "unset", DISABLE_TELEMETRY: "1", DISABLE_AUTOUPDATER: "1", CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1", CLAUDE_CODE_TMPDIR: join(sessionStateDir, "home", "tmp") }, startupTimeoutMs: 90_000 });
+  const agent: any = new HarnessAgent({ harness: harness as any, sandbox: provider, permissionMode: plan.permissionMode, instructions: "Spike." });
+  const session = await agent.createSession({ sessionId });
+  return { agent, session, supervisor, sessionId, sessionStateDir, bridgePid: () => bridgePid, mock, gw };
+}
+
+async function main() {
+  if (MODE === "orphan-b") {
+    const supervisor = new LocalHarnessSupervisor();
+    const orphan = JSON.parse(await readFile(ORPHAN_FILE, "utf8"));
+    log("orphan record from previous run:", orphan, "alive now:", orphan.pids.filter(alive));
+    const t = performance.now();
+    const result = await supervisor.reclaimOrphans();
+    log(`reclaimOrphans in ${Math.round(performance.now() - t)}ms:`, JSON.stringify(result));
+    await new Promise((r) => setTimeout(r, 500));
+    log("orphan pids alive after reclaim:", orphan.pids.filter(alive), "(expect [])");
+    log("registry records now:", (await listProcessRecords()).length);
+    for (const pid of orphan.helperPids ?? []) { try { process.kill(pid, "SIGTERM"); } catch {} }
+    return;
+  }
+  const ctx = await setup();
+  const bridgePid = ctx.bridgePid();
+  log(`session ready; bridge pid ${bridgePid}: ${await psLine(bridgePid)}`);
+
+  if (MODE === "orphan-a") {
+    const ac = new AbortController();
+    const res: any = await ctx.agent.stream({ session: ctx.session, prompt: "SLOW", abortSignal: ac.signal });
+    const reader = (async () => { try { for await (const _ of res.fullStream) {} } catch {} })();
+    await new Promise((r) => setTimeout(r, 2500));
+    const kids = await descendants(bridgePid);
+    log("mid-turn tree:", bridgePid, kids); for (const p of [bridgePid, ...kids]) log("  ", await psLine(p));
+    await writeFile(ORPHAN_FILE, JSON.stringify({ sessionId: ctx.sessionId, pids: [bridgePid, ...kids], helperPids: [ctx.mock.child.pid, ctx.gw.child.pid] }));
+    log("registry records:", (await listProcessRecords()).length, "— exiting WITHOUT stopping (simulated Inspector crash)");
+    void reader;
+    process.exit(0);
+  }
+
+  // abort: start a slow turn, verify the CLI child exists, abort + destroy, verify the tree is gone.
+  const ac = new AbortController();
+  const tStart = performance.now();
+  const res: any = await ctx.agent.stream({ session: ctx.session, prompt: "SLOW", abortSignal: ac.signal });
+  const reader = (async () => { const parts: string[] = []; try { for await (const part of res.fullStream) parts.push(String(part.type)); } catch (e: any) { parts.push(`THROW:${e?.name ?? e}`); } return parts; })();
+  await new Promise((r) => setTimeout(r, 2500));
+  const kids = await descendants(bridgePid);
+  log("mid-turn tree:", bridgePid, kids); for (const p of [bridgePid, ...kids]) log("  ", await psLine(p));
+  const tAbort = performance.now();
+  ac.abort(new Error("user cancelled"));
+  const parts = await reader;
+  log(`stream ended ${Math.round(performance.now() - tAbort)}ms after abort; parts=${parts.join(",")}`);
+  const tDestroy = performance.now();
+  await ctx.session.destroy();
+  log(`destroy took ${Math.round(performance.now() - tDestroy)}ms (turn started ${Math.round(tDestroy - tStart)}ms ago)`);
+  await new Promise((r) => setTimeout(r, 400));
+  log("surviving pids:", [bridgePid, ...kids].filter(alive), "(expect [])");
+  log("state dir exists after destroy:", await stat(ctx.sessionStateDir).then(() => true, () => false), "(expect false)");
+  log("registry records:", (await listProcessRecords()).length, "(expect 0)");
+  ctx.gw.child.kill("SIGTERM"); ctx.mock.child.kill("SIGTERM");
+}
+main().catch((e) => { console.error("[lifecycle] FAILED", e?.stack ?? e); process.exit(1); });

--- a/mcpjam-inspector/server/utils/harness/local/spike/run-native-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/local/spike/run-native-turn.ts
@@ -1,0 +1,331 @@
+/**
+ * SPIKE RUNNER — drives the merged local-harness foundation end to end on this
+ * machine against a mock Anthropic upstream behind a loopback gateway.
+ *
+ *   HOME=<scratch>/home SPIKE_ROOT=<scratch> npx tsx run-native-turn.ts [full|no-launcher]
+ *
+ * Nothing here is product code. It exists to pin facts for the implementation:
+ * timings, process-tree behaviour, what lands where, and what breaks.
+ */
+import { spawn, execFile } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import net from "node:net";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { HarnessAgent } from "@ai-sdk/harness/agent";
+import { createClaudeCode } from "@ai-sdk/harness-claude-code";
+import { LocalHarnessSupervisor } from "../supervisor.js";
+import {
+  createSupervisedLocalHarnessProvider,
+  sessionStateDirFor,
+} from "../supervised-provider.js";
+import { resolveLocalHarnessAvailability } from "../availability.js";
+import {
+  getLocalMachineId,
+  grantLocalHarnessConsent,
+  localHarnessStateRoot,
+  registerWorkspaceGrant,
+  revokeLocalHarnessGrants,
+} from "../grants.js";
+import { computeTreeDigest, resolveManagedBundle } from "../runtime-identity.js";
+import { resolveNodeLauncher } from "../node-launcher.js";
+import { LOCAL_HARNESS_MANIFEST } from "../compatibility.js";
+import { LOCAL_HARNESS_POLICY_VERSION } from "../targets.js";
+import { listProcessRecords } from "../process-registry.js";
+import { probeProcessGroup, probeProcess } from "../process-identity.js";
+
+const execFileP = promisify(execFile);
+const ROOT = process.env.SPIKE_ROOT!;
+const MODE = (process.argv[2] ?? "full") as "full" | "no-launcher";
+const RUNTIME_ROOT = join(ROOT, "runtime");
+const BUNDLE = join(RUNTIME_ROOT, "claude-code");
+const WORKSPACE = join(ROOT, "workspace");
+const SPIKE_DIR = new URL(".", import.meta.url).pathname;
+const UPSTREAM_KEY_CANARY = `upstream-canary-${randomBytes(8).toString("hex")}`;
+const CAPABILITY = `cap_${randomBytes(24).toString("base64url")}`;
+const POP_SECRET = randomBytes(32).toString("hex");
+
+const t0 = performance.now();
+const marks: Record<string, number> = {};
+const mark = (name: string) => {
+  marks[name] = Math.round(performance.now() - t0);
+  console.log(`[spike] +${marks[name]}ms ${name}`);
+};
+const findings: string[] = [];
+const note = (s: string) => {
+  findings.push(s);
+  console.log(`[finding] ${s}`);
+};
+
+async function startChild(script: string, env: Record<string, string>) {
+  const child = spawn(process.execPath, [join(SPIKE_DIR, script)], {
+    env: { PATH: process.env.PATH ?? "", ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stderr: string[] = [];
+  child.stderr!.on("data", (c) => stderr.push(...String(c).split("\n").filter(Boolean)));
+  const port = await new Promise<number>((resolve, reject) => {
+    let buf = "";
+    child.stdout!.on("data", (c) => {
+      buf += String(c);
+      const line = buf.split("\n")[0];
+      if (line?.includes("port")) resolve(JSON.parse(line).port);
+    });
+    child.on("exit", (code) => reject(new Error(`${script} exited ${code}`)));
+  });
+  return { child, port, stderr };
+}
+const freePort = () =>
+  new Promise<number>((resolve) => {
+    const s = net.createServer();
+    s.listen(0, "127.0.0.1", () => {
+      const p = (s.address() as net.AddressInfo).port;
+      s.close(() => resolve(p));
+    });
+  });
+const alive = (pid: number) => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+async function descendants(pid: number): Promise<number[]> {
+  const out: number[] = [];
+  const walk = async (p: number) => {
+    let kids = "";
+    try {
+      kids = (await execFileP("pgrep", ["-P", String(p)])).stdout;
+    } catch {
+      return;
+    }
+    for (const k of kids.split("\n").map((s) => Number(s.trim())).filter(Boolean)) {
+      out.push(k);
+      await walk(k);
+    }
+  };
+  await walk(pid);
+  return out;
+}
+async function psLine(pid: number, withEnv = false) {
+  try {
+    const args = withEnv ? ["-E", "-o", "command=", "-p", String(pid)] : ["-o", "command=", "-p", String(pid)];
+    return (await execFileP("ps", args)).stdout.trim();
+  } catch {
+    return "";
+  }
+}
+async function listeners(pid: number) {
+  try {
+    return (await execFileP("lsof", ["-nP", "-a", "-p", String(pid), "-iTCP", "-sTCP:LISTEN"])).stdout
+      .split("\n").slice(1).filter(Boolean).map((l) => l.split(/\s+/).slice(-2).join(" "));
+  } catch {
+    return [];
+  }
+}
+
+type TurnResult = { text: string; parts: Record<string, number>; firstPartMs: number; firstTextMs: number; finishMs: number; approvals: number; errors: string[] };
+async function runTurn(label: string, agent: any, sessionRef: { s: any }, prompt: string): Promise<TurnResult> {
+  const start = performance.now();
+  const parts: Record<string, number> = {};
+  const errors: string[] = [];
+  const toolCalls = new Map<string, any>();
+  let text = "";
+  let firstPartMs = -1, firstTextMs = -1, approvals = 0;
+  let res: any = await agent.stream({ session: sessionRef.s, prompt });
+  let stream: AsyncIterable<any> = res.fullStream;
+  for (let round = 0; round < 4; round++) {
+    let paused: any = null;
+    for await (const part of stream) {
+      const type = String(part.type);
+      parts[type] = (parts[type] ?? 0) + 1;
+      if (firstPartMs < 0) firstPartMs = Math.round(performance.now() - start);
+      if (type === "text-delta") {
+        text += part.text ?? part.textDelta ?? part.delta ?? "";
+        if (firstTextMs < 0) firstTextMs = Math.round(performance.now() - start);
+      }
+      if (type === "tool-call") toolCalls.set(part.toolCallId, part);
+      if (type === "tool-approval-request") { paused = part; break; }
+      if (type === "error") {
+        const err: any = part.error;
+        errors.push(String(err?.message ?? err ?? part) + (err?.command ? " || command=" + JSON.stringify(err.command) : ""));
+      }
+    }
+    if (!paused) break;
+    approvals += 1;
+    const tc = toolCalls.get(paused.toolCallId) ?? { toolCallId: paused.toolCallId, toolName: paused.toolName ?? "Bash", input: paused.input ?? {} };
+    console.log(`[spike] ${label}: approval requested for ${tc.toolName} ${JSON.stringify(tc.input).slice(0, 80)} — suspending + continuing`);
+    const tSusp = performance.now();
+    const cont = await sessionRef.s.suspendTurn();
+    sessionRef.s = await agent.createSession({ sessionId: sessionRef.s.sessionId, continueFrom: cont });
+    res = await agent.continueStream({
+      session: sessionRef.s,
+      toolApprovalContinuations: [{
+        approvalResponse: { type: "tool-approval-response", approvalId: paused.approvalId, approved: true },
+        toolCall: { type: "tool-call", toolCallId: tc.toolCallId, toolName: tc.toolName, input: tc.input },
+      }],
+    });
+    console.log(`[spike] ${label}: suspend+continue took ${Math.round(performance.now() - tSusp)}ms`);
+    stream = res.fullStream;
+  }
+  const finishMs = Math.round(performance.now() - start);
+  console.log(`[spike] ${label}: ${finishMs}ms parts=${JSON.stringify(parts)} text=${JSON.stringify(text.slice(0, 120))}`);
+  return { text, parts, firstPartMs, firstTextMs, finishMs, approvals, errors };
+}
+
+async function main() {
+  mark("start");
+  const mock = await startChild("mock-anthropic.mjs", { MOCK_POP_SECRET: POP_SECRET });
+  const gw = await startChild("local-gateway.mjs", {
+    GW_UPSTREAM: `http://127.0.0.1:${mock.port}`, GW_SESSION_CAPABILITY: CAPABILITY,
+    GW_UPSTREAM_KEY: UPSTREAM_KEY_CANARY, GW_POP_SECRET: POP_SECRET,
+  });
+  const gatewayUrl = `http://127.0.0.1:${gw.port}`;
+  mark("gateway_ready");
+
+  await mkdir(WORKSPACE, { recursive: true });
+  await writeFile(join(WORKSPACE, "hello.txt"), "hello from the spike workspace\n");
+  const before = new Set(await readdir(WORKSPACE));
+  const ws = await registerWorkspaceGrant(WORKSPACE);
+  if (!ws.ok) throw new Error(ws.message);
+
+  const tDigest = performance.now();
+  const digest = await computeTreeDigest(BUNDLE);
+  marks.bundle_digest_ms = Math.round(performance.now() - tDigest);
+  const bridgeBytes = await readFile(join(BUNDLE, "bridge.mjs"));
+  const base = LOCAL_HARNESS_MANIFEST["claude-code"];
+  const manifest = {
+    ...base,
+    runtime: { ...(base.runtime as any), bundleDigest: digest, launcherRelativePath: MODE === "no-launcher" ? "bridge.mjs" : "launcher.mjs" },
+    lifecycleConformanceVersion: "spike-2026-09-01",
+    bridgeBundleDigest: `sha256:${createHash("sha256").update(bridgeBytes).digest("hex")}`,
+  } as typeof base;
+  const rt = await resolveManagedBundle({ manifest, runtimeRoot: RUNTIME_ROOT, platform: "darwin" });
+  if (!rt.ok) throw new Error(`${rt.status}: ${rt.message}`);
+  const machineId = await getLocalMachineId();
+  const target = {
+    kind: "local-native" as const, machineId, workspaceGrantId: ws.grant.workspaceGrantId, harnessId: "claude-code" as const,
+    runtimeId: rt.runtime.runtimeId, permissionProfile: "workspace-edits" as const, policyVersion: LOCAL_HARNESS_POLICY_VERSION,
+  };
+  const grant = await grantLocalHarnessConsent({
+    userId: "spike-user", machineId, projectId: "spike-project", workspaceGrantId: target.workspaceGrantId,
+    harnessId: "claude-code", targetKind: "local-native", runtimeId: target.runtimeId,
+    permissionProfile: target.permissionProfile, policyVersion: LOCAL_HARNESS_POLICY_VERSION,
+  });
+  mark("consent_granted");
+
+  const adapterVersion = JSON.parse(await readFile(new URL("../../../../../../node_modules/@ai-sdk/harness-claude-code/package.json", import.meta.url), "utf8")).version;
+  const tAvail = performance.now();
+  const availability = await resolveLocalHarnessAvailability({
+    target, actor: { isGuest: false, isScenarioSession: false, isJourneySession: false }, userId: "spike-user", projectId: "spike-project",
+    grantToken: grant.token, runtimeRoot: RUNTIME_ROOT, installedAdapterVersion: adapterVersion,
+    manifests: { "claude-code": manifest }, killSwitchEnabled: true, hosted: false,
+  });
+  marks.availability_ms = Math.round(performance.now() - tAvail);
+  if (!availability.available) throw new Error(`availability: ${availability.status}: ${availability.message}`);
+  const plan = availability.plan;
+  mark("availability_ok");
+  console.log(`[spike] permissionMode=${plan.permissionMode} runtimeId=${plan.runtime.runtimeId} workspace=${plan.workspacePath}`);
+
+  const supervisor = new LocalHarnessSupervisor();
+  const janitor = await supervisor.reclaimOrphans();
+  console.log(`[spike] janitor: ${JSON.stringify(janitor).slice(0, 200)}`);
+  const launcher = resolveNodeLauncher({ execPath: join(plan.runtime.rootPath, "bin", "node"), isElectron: false });
+  const bridgePort = await freePort();
+  const sessionId = `spike-${Date.now()}`;
+  const sessionStateDir = sessionStateDirFor(localHarnessStateRoot(), sessionId);
+  let bridgePid = -1;
+  const provider = createSupervisedLocalHarnessProvider({
+    harnessId: "claude-code", manifest: plan.manifest, runtime: plan.runtime, supervisor, launcher,
+    workspacePath: plan.workspacePath, workspaceGrantId: target.workspaceGrantId, sessionStateDir,
+    targetKind: "local-native", bridgePort, bridgeReadinessTimeoutMs: 30_000,
+    onBridgeStarted: async ({ pid }) => { bridgePid = pid; mark("bridge_listening_verified_loopback"); },
+  });
+  const harness = createClaudeCode({
+    model: "haiku",
+    auth: { ANTHROPIC_API_KEY: CAPABILITY, ANTHROPIC_BASE_URL: gatewayUrl },
+    thinking: { type: "disabled" },
+    env: {
+      CLAUDE_CODE_EFFORT_LEVEL: "unset", DISABLE_TELEMETRY: "1", DISABLE_AUTOUPDATER: "1",
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1", CLAUDE_CODE_TMPDIR: join(sessionStateDir, "home", "tmp"),
+    },
+    startupTimeoutMs: 90_000,
+  });
+  const agent: any = new HarnessAgent({
+    harness: harness as any, sandbox: provider, permissionMode: plan.permissionMode, instructions: "You are a spike.",
+    // Work-dir layout: "project" is the symlink to the granted workspace inside
+    // session state, so Claude Code's cwd resolves to the user's checkout.
+    sandboxConfig: { workDir: "project" },
+  });
+
+  mark("create_session_start");
+  const sessionRef = { s: await agent.createSession({ sessionId }) };
+  mark("session_ready");
+  console.log(`[spike] sessionWorkDir=${sessionRef.s.sessionWorkDir ?? "(n/a)"} bridgePid=${bridgePid}`);
+
+  const turn1 = await runTurn("turn1-read", agent, sessionRef, `READFILE ${join(plan.workspacePath, "hello.txt")}`);
+  mark("turn1_done");
+
+  // Process-tree + hygiene inspection while the session is live.
+  const kids = await descendants(bridgePid);
+  console.log(`[spike] tree: bridge ${bridgePid} -> ${JSON.stringify(kids)}`);
+  for (const pid of [bridgePid, ...kids]) console.log(`  ${pid}: ${(await psLine(pid)).slice(0, 160)}`);
+  const envDump = (await Promise.all([bridgePid, ...kids].map((p) => psLine(p, true)))).join("\n");
+  note(`upstream key in any child env: ${envDump.includes(UPSTREAM_KEY_CANARY) ? "LEAKED" : "absent (good)"}`);
+  note(`session capability in child env: ${envDump.includes(CAPABILITY) ? "present (env delivery fallback, as designed)" : "absent"}`);
+  note(`bridge listeners: ${JSON.stringify(await listeners(bridgePid))}`);
+  const homeLeak = envDump.match(/HOME=([^\s]+)/g)?.slice(0, 2);
+  note(`child HOME values: ${JSON.stringify(homeLeak)}`);
+  const stateFiles = await execFileP("find", [sessionStateDir, "-type", "f"]).then((r) => r.stdout.split("\n").filter(Boolean));
+  const stateBlob = (await Promise.all(stateFiles.map((f) => readFile(f, "utf8").catch(() => "")))).join("\n");
+  note(`upstream key in session state files: ${stateBlob.includes(UPSTREAM_KEY_CANARY) ? "LEAKED" : "absent (good)"}; capability persisted in state: ${stateBlob.includes(CAPABILITY) ? "yes" : "no"} (${stateFiles.length} files)`);
+
+  const turn2 = await runTurn("turn2-bash-approval", agent, sessionRef, "BASH pwd");
+  mark("turn2_done");
+
+  const tDetach = performance.now();
+  const resumeState = await sessionRef.s.detach();
+  marks.detach_ms = Math.round(performance.now() - tDetach);
+  note(`after detach: bridge alive=${alive(bridgePid)} descendants=${JSON.stringify(await descendants(bridgePid))}`);
+  const tResume = performance.now();
+  const s2 = await agent.createSession({ sessionId, resumeFrom: resumeState });
+  marks.resume_session_ms = Math.round(performance.now() - tResume);
+  const ref2 = { s: s2 };
+  const turn3 = await runTurn("turn3-count-after-resume", agent, ref2, "COUNT");
+  mark("turn3_done");
+  const m = /USER_TURNS=(\d+)/.exec(turn3.text);
+  note(`continuity: model saw ${m?.[1] ?? "?"} user turns after detach+resume (expect >= 3)`);
+
+  const treeBefore = [bridgePid, ...(await descendants(bridgePid))];
+  const groupPs = async (pgid: number) => execFileP("ps", ["-o", "pid=,pgid=,stat=,command=", "-ax"]).then((r) => r.stdout.split("\n").filter((l) => l.split(/\s+/).filter(Boolean)[1] === String(pgid)).map((l) => l.trim().slice(0, 100)), () => []);
+  note(`pre-stop: root probe=${JSON.stringify(await probeProcess(bridgePid, "darwin"))} group=${await probeProcessGroup(bridgePid, "darwin")} members=${JSON.stringify(await groupPs(bridgePid))}`);
+  const tStop = performance.now();
+  let stopError: string | undefined;
+  try { await ref2.s.stop(); } catch (e: any) { stopError = String(e?.message ?? e); }
+  marks.stop_ms = Math.round(performance.now() - tStop);
+  note(`stop() ${stopError ? "THREW: " + stopError : "resolved"}; root alive=${alive(bridgePid)} group=${await probeProcessGroup(bridgePid, "darwin")} members=${JSON.stringify(await groupPs(bridgePid))}`);
+  await new Promise((r) => setTimeout(r, 300));
+  note(`second supervisor.stopSession: ${JSON.stringify(await supervisor.stopSession(sessionId))}`);
+  note(`after stop: surviving pids=${JSON.stringify(treeBefore.filter(alive))} (expect [])`);
+  note(`registry records after stop: ${(await listProcessRecords()).length}`);
+
+  const after = (await readdir(WORKSPACE)).filter((e) => !before.has(e));
+  note(`new entries in workspace after session: ${JSON.stringify(after)}`);
+  note(`.harness-bootstrap in workspace: ${(await stat(join(WORKSPACE, ".harness-bootstrap")).then(() => "PRESENT (bad)", () => "absent (good)"))}`);
+
+  gw.child.kill("SIGTERM");
+  await new Promise((r) => setTimeout(r, 200));
+  mock.child.kill("SIGTERM");
+  await revokeLocalHarnessGrants();
+  const report = { mode: MODE, marks, turn1, turn2, turn3, findings, gateway: gw.stderr.slice(-8), mock: mock.stderr.slice(-12) };
+  console.log("\n=====REPORT=====\n" + JSON.stringify(report, null, 2));
+}
+
+main().catch(async (e) => {
+  console.error("[spike] FAILED:", e?.stack ?? e);
+  console.error("[spike] marks:", JSON.stringify(marks));
+  console.error("[spike] findings:", JSON.stringify(findings, null, 1));
+  process.exit(1);
+});

--- a/mcpjam-inspector/server/utils/harness/local/spike/timing-decomp.mts
+++ b/mcpjam-inspector/server/utils/harness/local/spike/timing-decomp.mts
@@ -1,0 +1,18 @@
+// Decompose session-start cost: full-tree digest vs bare bridge spawn-to-listen.
+import { spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import net from "node:net";
+import { join } from "node:path";
+import { computeTreeDigest } from "../runtime-identity.js";
+const ROOT = process.env.SPIKE_ROOT!; const B = join(ROOT, "runtime", "claude-code");
+const freePort = () => new Promise<number>((r) => { const s = net.createServer(); s.listen(0, "127.0.0.1", () => { const p = (s.address() as net.AddressInfo).port; s.close(() => r(p)); }); });
+const waitListen = (port: number) => new Promise<number>((resolve) => { const t0 = performance.now(); const tick = () => { const sock = net.connect(port, "127.0.0.1"); sock.once("connect", () => { sock.destroy(); resolve(Math.round(performance.now() - t0)); }); sock.once("error", () => { sock.destroy(); setTimeout(tick, 5); }); }; tick(); });
+for (let i = 0; i < 3; i++) { const t = performance.now(); await computeTreeDigest(B); console.log(`digest #${i + 1}: ${Math.round(performance.now() - t)}ms`); }
+for (let i = 0; i < 3; i++) {
+  const port = await freePort(); const dir = join(ROOT, "timing", `s${i}`); await mkdir(join(dir, "bridge"), { recursive: true });
+  const t = performance.now();
+  const child = spawn(join(B, "bin", "node"), [join(B, "launcher.mjs"), "--workdir", dir, "--bridge-state-dir", join(dir, "bridge")], { env: { PATH: "/usr/bin:/bin", HOME: dir, BRIDGE_CHANNEL_TOKEN: "t", BRIDGE_WS_PORT: String(port) }, stdio: ["ignore", "ignore", "ignore"], detached: true });
+  const ms = await waitListen(port);
+  console.log(`bridge spawn->listen #${i + 1}: ${ms}ms (total ${Math.round(performance.now() - t)}ms)`);
+  process.kill(-child.pid!, "SIGKILL");
+}

--- a/mcpjam-inspector/server/utils/harness/local/supervised-provider.ts
+++ b/mcpjam-inspector/server/utils/harness/local/supervised-provider.ts
@@ -34,7 +34,7 @@
  * survive into product copy.
  */
 import { randomUUID } from "node:crypto";
-import { mkdir, open, realpath, rename, rm, stat } from "node:fs/promises";
+import { lstat, mkdir, open, realpath, rename, rm, stat, symlink } from "node:fs/promises";
 import { basename, dirname, join, posix, resolve, sep } from "node:path";
 import type {
   HarnessV1NetworkSandboxSession,
@@ -367,6 +367,19 @@ export function createSupervisedLocalHarnessProvider(
   // ours lives in disposable session state instead of the user's checkout, so
   // a local session leaves no adapter scaffolding behind.
   const bootstrapOverlay = join(opts.sessionStateDir, "bootstrap");
+  // SPIKE (work-dir layout): the framework insists that the agent works in a
+  // proper SUBDIRECTORY of the session's default working directory, and it puts
+  // its own `.agent-runs/<session>` and `.harness-bootstrap` references under
+  // that directory too. Making the granted workspace the default working
+  // directory therefore (a) ran Claude Code in `<workspace>/claude-code-<id>`
+  // instead of the user's checkout, and (b) wrote bridge state — including the
+  // session's model capability in start-config.json, mode 0644 — into the
+  // checkout. So the default working directory is now session-owned state,
+  // and the workspace is reached through the relative work dir "project",
+  // a symlink to the granted path. Every operand is still confined: the link
+  // resolves INTO the workspace root, which is one of the two allowed roots.
+  const workRoot = join(opts.sessionStateDir, "work");
+  const WORKSPACE_LINK_NAME = "project";
 
   const buildSession = async (
     sessionId: string,
@@ -379,6 +392,17 @@ export function createSupervisedLocalHarnessProvider(
       await mkdir(dir, { recursive: true, mode: 0o700 });
     }
     await mkdir(bootstrapOverlay, { recursive: true, mode: 0o700 });
+    await mkdir(workRoot, { recursive: true, mode: 0o700 });
+    const workspaceLink = join(workRoot, WORKSPACE_LINK_NAME);
+    try {
+      const existing = await lstat(workspaceLink);
+      if (!existing.isSymbolicLink()) {
+        throw new Error(`${workspaceLink} exists and is not the workspace link`);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      await symlink(opts.workspacePath, workspaceLink);
+    }
 
     // The two roots the Inspector file API will touch, and nothing else.
     //
@@ -406,14 +430,18 @@ export function createSupervisedLocalHarnessProvider(
       // default working directory — so the translator matches the string the
       // adapters will actually emit.
       adapterBootstrapDir: posix.resolve(
-        opts.workspacePath,
+        workRoot,
         opts.manifest.adapterBootstrapDir,
       ),
       managedBundleRoot: opts.runtime.rootPath,
       adapterBootstrapFiles: opts.manifest.adapterBootstrapFiles,
       bootstrapOverlayDir: bootstrapOverlay,
       nodeExecutable: opts.launcher.executable,
-      sessionRoot: opts.workspacePath,
+      // SPIKE: run the manifest launcher (loopback wrapper) instead of the
+      // remapped bridge.mjs, which stays byte-identical for the recipe compare.
+      bridgeLauncherPath: opts.runtime.launcherPath,
+      // The framework's default working directory (and the bridge's cwd).
+      sessionRoot: workRoot,
       syntheticHome,
       // The same symlink-aware check the file API uses. The translator awaits
       // it for every session-scoped operand, including the bridge's own
@@ -546,7 +574,33 @@ export function createSupervisedLocalHarnessProvider(
     ): Promise<{ exitCode: number; stdout: string; stderr: string }> => {
       switch (translated.kind) {
         case "reply":
-          return { exitCode: 0, stdout: translated.stdout, stderr: "" };
+          return {
+            exitCode: translated.exitCode ?? 0,
+            stdout: translated.stdout,
+            stderr: "",
+          };
+        // SPIKE: the framework's skills writer, executed with node:fs, no shell.
+        case "rename": {
+          await rename(translated.from, translated.to);
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        case "remove": {
+          for (const path of translated.paths) {
+            await rm(path, { recursive: true, force: true });
+          }
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        case "probe-absent": {
+          try {
+            await stat(translated.path);
+            return { exitCode: 1, stdout: "", stderr: "" };
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+              return { exitCode: 0, stdout: "", stderr: "" };
+            }
+            throw error;
+          }
+        }
         case "noop":
           logger.debug("[local-harness] adapter command satisfied by bundle", {
             reason: translated.reason,
@@ -594,7 +648,7 @@ export function createSupervisedLocalHarnessProvider(
       // session's artefacts stay identifiable inside the user's own checkout.
       // Staged materialization with diff-based apply-back is a separate step
       // and is not pretended here.
-      defaultWorkingDirectory: opts.workspacePath,
+      defaultWorkingDirectory: workRoot,
       description:
         `Supervised local ${opts.harnessId} process on this machine. ` +
         `Working directory ${opts.workspacePath}. Bridge on loopback port ` +
@@ -815,7 +869,9 @@ export function createSupervisedLocalHarnessProvider(
       // implementation would be strictly worse than its absence.
 
       stop: async () => {
+        console.log(`[spike-trace] provider.stop() called t=${Date.now() % 100000} live=${opts.supervisor.liveProcessCount(sessionId)}`);
         const result = await opts.supervisor.stopSession(sessionId);
+        console.log(`[spike-trace] provider.stop() result=${JSON.stringify(result)} t=${Date.now() % 100000}`);
         if (!result.stopped) {
           throw new Error(
             `${result.escaped} supervised process tree(s) survived termination ` +
@@ -824,7 +880,9 @@ export function createSupervisedLocalHarnessProvider(
         }
       },
       destroy: async () => {
+        console.log(`[spike-trace] provider.destroy() called t=${Date.now() % 100000} live=${opts.supervisor.liveProcessCount(sessionId)}`);
         const result = await opts.supervisor.stopSession(sessionId);
+        console.log(`[spike-trace] provider.destroy() result=${JSON.stringify(result)} t=${Date.now() % 100000}`);
         if (!result.stopped) {
           throw new Error(
             `${result.escaped} supervised process tree(s) survived termination ` +

--- a/mcpjam-inspector/server/utils/harness/local/supervisor.ts
+++ b/mcpjam-inspector/server/utils/harness/local/supervisor.ts
@@ -31,8 +31,11 @@ import { isAbsolute } from "node:path";
 import { logger } from "../../logger.js";
 import { assertArgvAllowed } from "./argv-policy.js";
 import {
+  listGroupMembers,
+  probeProcessGroup,
   readProcessBirthIdentity,
   supportsOwnershipProof,
+  terminateOwnedProcess,
   terminateOwnedProcessGroup,
   type ProcessBirthIdentity,
 } from "./process-identity.js";
@@ -107,6 +110,14 @@ interface LiveProcess {
    * `stopSession` proves the whole group empty.
    */
   exited: boolean;
+  /**
+   * SPIKE: members of the root's process group, enumerated with their birth
+   * identities at the instant the root exited — the one moment the group id
+   * provably still belongs to this tree. A later stop verifies and signals
+   * each of them individually, so a bridge that exits on its own no longer
+   * strands the vendor CLI it spawned.
+   */
+  orphanSnapshot: Promise<Array<{ pid: number; identity: string }> | null> | null;
 }
 
 function bufferedStream(maxBytes: number): {
@@ -410,7 +421,14 @@ export class LocalHarnessSupervisor {
       });
       recordExit(-1);
     });
+    child.on("exit", () => {
+      // SPIKE: snapshot the group the instant the root leaves it.
+      if (request.role === "root" && entry !== undefined && entry.orphanSnapshot === null) {
+        entry.orphanSnapshot = listGroupMembers(entry.pid, this.platform).catch(() => null);
+      }
+    });
     child.on("close", (code, signal) => {
+      console.log(`[spike-trace] child close pid=${pid} role=${request.role} code=${code} signal=${signal} t=${Date.now() % 100000}`);
       // A signalled exit reports 124 — the conventional timeout code — so a
       // caller reading only the exit code still sees a failure, not a clean 0.
       recordExit(code ?? (signal ? 124 : 1));
@@ -433,6 +451,7 @@ export class LocalHarnessSupervisor {
       role: request.role,
       killed: false,
       exited: exitResult !== null,
+      orphanSnapshot: null,
     };
     bucket.add(entry);
     // Registered: it is counted by `bucket.size` from here, so the pending
@@ -686,7 +705,21 @@ export class LocalHarnessSupervisor {
       // `unknown`, `escaped`, and `not-owned` all retain their entry so an
       // operator or a later retry still has the handle; none authorizes a
       // successful stop.
-      for (const { entry, result } of outcomes) {
+      for (const { entry, result: initialResult } of outcomes) {
+        let result = initialResult;
+        console.log(`[spike-trace] stopSession(${sessionId}) pid=${entry.pid} role=${entry.role} exited=${entry.exited} outcome=${JSON.stringify(result)} t=${Date.now() % 100000}`);
+        // SPIKE: an unanchored live group is settled member by member from the
+        // snapshot taken when the root exited.
+        if (result.outcome === "unknown" && entry.orphanSnapshot !== null) {
+          const members = (await entry.orphanSnapshot) ?? [];
+          const settled: string[] = [];
+          for (const m of members) {
+            settled.push(`${m.pid}:${await terminateOwnedProcess({ pid: m.pid, identity: m.identity, graceMs: this.limits.terminationGraceMs, platform: this.platform })}`);
+          }
+          const after = await probeProcessGroup(entry.pid, this.platform);
+          console.log(`[spike-trace] orphan settle members=${JSON.stringify(settled)} groupAfter=${after}`);
+          if (after === "empty") result = { outcome: "forced" };
+        }
         if (
           result.outcome === "already-gone" ||
           result.outcome === "graceful" ||


### PR DESCRIPTION
**Not for merge.** This branch is the I0 spike for running the real Claude Code agent natively on a user's own machine, plus the handoff document a follow-up agent executes. Everything under `server/utils/harness/local/spike/` is spike tooling and the four foundation edits are annotated `SPIKE`; none of it is product code yet. Fourteen foundation tests fail on this branch because they pin behaviour the spike proved wrong — PR 1 of the handoff fixes them.

Read `mcpjam-inspector/docs/local-harness-spike-handoff.md` first. It carries the measured timings, the reuse map, and the PR 1–6 sequence.

## What ran

The merged supervised-native foundation (#4532), the real `@ai-sdk/harness-claude-code@1.0.100`, and the native Claude Code 2.1.245 binary, end to end on macOS against a mock Anthropic upstream behind a loopback gateway. Consent, availability, provider, bridge, tool calls, approval pause and resume, detach plus resume continuity, stop, abort, and crash recovery all work. No E2B calls, no `/login`, and the upstream key never reached a child process or disk.

## Foundation defects found

| | Defect | Fix prototyped |
|---|---|---|
| D1/D2 | The closed grammar missed the stable framework's `$HOME` probe and the per-turn skills-write shapes (`mv -f`, `test ! -e`, `rm -rf --`), so every local session failed closed | new translator arms, executed with `node:fs`, operands confined to the synthetic home |
| D3 | macOS reports an exiting process as `(node)`, so the argv-based identity compare called our own bridge not-owned and every clean stop was recorded as an escape | tolerant compare on a start-time match |
| D4 | Aborting a turn orphaned the 357 MB Claude child, because the bridge exits before the supervisor signals and the group is then unanchored | snapshot group members with identities at root exit, settle each individually |
| D5 | The agent framework rejects the workspace root as a work dir, so Claude ran in a subdirectory and the bridge wrote its state, including the session model capability at mode 0644, into the user's checkout | session-owned work dir with a `project` symlink into the checkout |
| D6 | The vendor bridge binds `0.0.0.0` and cannot be patched, since the provider byte-compares it against the pack | a launcher wrapper forces loopback in front of the verbatim bridge |

Two more are measured but unfixed here and designed in the handoff: five full-tree digests per session start, and an exposure probe that costs 11 s waiting on link-local addresses.

## Verifying

The handoff's Verification section lists every command. The scripts need a runtime pack built by `spike/build-bundle.sh` and run against an isolated `HOME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Not for merge: this spike proves the real Claude Code agent can run natively on a user's machine, end to end, against a mock Anthropic upstream behind a loopback gateway. Consent, availability, tool calls, approval pause/resume, detach, stop, abort, and crash recovery all work — no E2B, no `/login`, and the upstream key never reaches a child process or disk.

The merged supervised-native foundation failed closed on every local session. This branch prototypes fixes for six defects and ships the handoff document `mcpjam-inspector/docs/local-harness-spike-handoff.md` with measured timings, a reuse map, and the PR 1–6 implementation sequence.

**Breaking changes**
- The four foundation edits are annotated `SPIKE`; all spike tooling lives under `server/utils/harness/local/spike/`.
- 14 foundation tests fail because they pin behavior the spike proved wrong — PR 1 of the handoff fixes them.

**Defects found and prototyped**
- The closed grammar missed the framework's `$HOME` probe and per-turn skills-write shapes, so every session failed closed.
- macOS reports exiting processes as `(node)`, so every clean stop was recorded as an escape.
- Aborting a turn orphaned the 357 MB Claude child; snapshotting group members at root exit fixes it.
- The framework rejects the workspace root as a work dir, so the bridge wrote its state into the user's checkout.
- The vendor bridge binds `0.0.0.0` and can't be patched; a launcher wrapper forces loopback.
- Two more issues (five full-tree digests per session start, an 11 s exposure probe) are measured and designed in the handoff.

<sup>Written for commit 7d45e18ab80dfc844afbd621e23a79916059d0f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

