### PR TITLE
Environment secret grants reach the SDK's create and update operations

### DIFF
--- a/.changeset/environment-secret-selection-sdk.md
+++ b/.changeset/environment-secret-selection-sdk.md
@@ -1,0 +1,21 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/cli": patch
+---
+
+An environment's secret grant is reachable from the SDK, CLI and MCP again
+
+`secretSelection` is how a project secret is granted to the runs an environment launches. The API takes it on create and on update, the `/api/v1` route takes it on both, and `PlatformEnvironmentCreateBody` / `PlatformEnvironmentUpdateBody` have always declared it — but the two operation schemas in `platform/operations.ts` never did, so the only surfaces an agent or a script can use dropped it on the floor.
+
+Both halves were silent in the way that costs the most time:
+
+- **Create** parses through a `z.object`, which STRIPS what it does not declare. A create carrying a grant returned 201 with `secretSelection: null` and no error anywhere — the environment simply had no credentials, and the failure surfaced much later as a run refusing to start for want of a secret that had apparently been attached.
+- **Update** validated fine, but the at-least-one-field `.refine` did not list the field, so a PATCH changing ONLY the grant was rejected client-side with a message that enumerated eight other fields and not the one the caller had passed.
+
+Together those meant a secret could be attached by neither path: not on create, and not afterwards. The route's own comment says as much about what unclearable would cost — "an environment's credential grant can only ever grow, and revoking it would require deleting the environment" — and that was the state the SDK was in.
+
+The field now rides a single shared `secretSelectionInput` used by both operations, matching how `skillSelection` and `pluginVersionIds` are already shared, with the same tri-state on update: omit to leave unchanged, `null` to REVOKE, a value to replace. `secretIds: []` is rejected rather than read as "remove every credential" — that is what `null` is for.
+
+The CLI's `--file`/`--json` help on `environments create` and `environments update` listed every other body field but this one; it lists it now.
+
+Not changed: `ensure_adhoc_environment` and the run operations' `compose` still have no secrets axis, though the route accepts one. A composed stack cannot carry a grant, so a run that needs a credential still needs a named environment.

--- a/cli/src/commands/environments.ts
+++ b/cli/src/commands/environments.ts
@@ -285,7 +285,7 @@ export function registerEnvironmentsCommands(program: Command): void {
       )
       .option(
         "--file <path>",
-        "Environment JSON file with any of name/hostId/description/serverAttachmentId/modelId/skillSelection/pluginVersionIds/sandboxImageId (or - for stdin)"
+        "Environment JSON file with any of name/hostId/description/serverAttachmentId/modelId/skillSelection/secretSelection/pluginVersionIds/sandboxImageId (or - for stdin)"
       )
       .option("--json <json>", "Inline environment JSON (or @file, or -)").action(
     async (
@@ -457,7 +457,7 @@ export function registerEnvironmentsCommands(program: Command): void {
       environments
       .command("update")
       .description(
-        "Edit an environment. Only the fields you pass change; use --clear-model, or --file/--json with a null value, to clear serverAttachmentId, modelId, skillSelection, pluginVersionIds, or sandboxImageId"
+        "Edit an environment. Only the fields you pass change; use --clear-model, or --file/--json with a null value, to clear serverAttachmentId, modelId, skillSelection, secretSelection, pluginVersionIds, or sandboxImageId"
       )
       .requiredOption("--environment <id-or-name>", "Environment name or ID")
       .requiredOption(

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -1360,8 +1360,8 @@ export class PlatformApiClient {
 
   /**
    * Only the fields you pass change. Pass `null` for `serverAttachmentId`,
-   * `modelId`, `skillSelection`, or `pluginVersionIds` to CLEAR them; omitting
-   * a field leaves it alone.
+   * `modelId`, `skillSelection`, `secretSelection`, `pluginVersionIds`, or
+   * `sandboxImageId` to CLEAR them; omitting a field leaves it alone.
    */
   updateEnvironment(
     params: {

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -9140,6 +9140,32 @@ const pluginVersionIdsInput = z
     "Plugin VERSION IDs to pin. Narrow by design: the plugin must be installed and enabled, the version must be ready, at most one version per plugin, and none of its skills may carry supporting files."
   );
 
+/**
+ * The ONE secret-selection schema, shared by `create_project_environment` and
+ * `update_project_environment` so a grant means the same thing on both.
+ *
+ * Deliberately simpler than {@link skillSelectionInput}: no version pins,
+ * because a secret has exactly one current value and "pin the previous value"
+ * is the opposite of what rotation is for.
+ *
+ * `.min(1)` for the same reason every other selection has it: `[]` reads as
+ * "remove every credential" but the API rejects it, so revoking is `null` on
+ * update — a distinction worth an immediate validation error.
+ */
+const secretSelectionInput = z
+  .object({
+    mode: z.literal("explicit"),
+    secretIds: z
+      .array(z.string().trim().min(1))
+      .min(1)
+      .describe(
+        "Project SECRET ids this environment grants. The environment is the GRANT BOUNDARY: no selection means a run receives no secrets, and there is no \"all of them\" mode. A `sharing: \"user\"` secret still reaches only sessions its owner started."
+      ),
+  })
+  .describe(
+    "Which project secrets runs launched from this environment receive."
+  );
+
 const createEnvironmentInput = z.object({
   project: z
     .string()
@@ -9180,6 +9206,7 @@ const createEnvironmentInput = z.object({
       'Model this environment runs, overriding the model pinned on its host. Omit to inherit the host\'s. The id is stored verbatim — no alias canonicalization — so pass exactly the id you want the provider request to carry (e.g. "anthropic/claude-sonnet-4-5").'
     ),
   skillSelection: skillSelectionInput.optional(),
+  secretSelection: secretSelectionInput.optional(),
   pluginVersionIds: pluginVersionIdsInput.optional(),
   sandboxImageId: z
     .string()
@@ -9199,7 +9226,7 @@ export const createEnvironmentOperation: PlatformOperation<
   name: "create_project_environment",
   title: "Create an MCPJam project environment",
   description:
-    "Create a project environment: a named execution bundle of one host plus an optional standalone server group, pinned skills, and pinned plugin versions. Requires project admin.",
+    "Create a project environment: a named execution bundle of one host plus an optional standalone server group, pinned skills, granted project secrets, and pinned plugin versions. Requires project admin.",
   readOnly: false,
   permalink: derivePermalinks((result) => [environmentRef(result)]),
   inputSchema: createEnvironmentInput,
@@ -9223,6 +9250,9 @@ export const createEnvironmentOperation: PlatformOperation<
           ...(input.modelId !== undefined ? { modelId: input.modelId } : {}),
           ...(input.skillSelection !== undefined
             ? { skillSelection: input.skillSelection }
+            : {}),
+          ...(input.secretSelection !== undefined
+            ? { secretSelection: input.secretSelection }
             : {}),
           ...(input.pluginVersionIds !== undefined
             ? { pluginVersionIds: input.pluginVersionIds }
@@ -9695,6 +9725,12 @@ const updateEnvironmentInput = z
       .describe(
         "New pinned skill selection, or null to clear it. Omit to leave unchanged."
       ),
+    secretSelection: secretSelectionInput
+      .nullable()
+      .optional()
+      .describe(
+        "New credential grant, or null to REVOKE it entirely. Omit to leave unchanged. An empty `secretIds` is rejected — it is not a way to revoke."
+      ),
     pluginVersionIds: pluginVersionIdsInput
       .nullable()
       .optional()
@@ -9719,11 +9755,12 @@ const updateEnvironmentInput = z
       value.serverAttachmentId !== undefined ||
       value.modelId !== undefined ||
       value.skillSelection !== undefined ||
+      value.secretSelection !== undefined ||
       value.pluginVersionIds !== undefined ||
       value.sandboxImageId !== undefined,
     {
       message:
-        "Provide at least one of `name`, `description`, `hostId`, `serverAttachmentId`, `modelId`, `skillSelection`, `pluginVersionIds`, or `sandboxImageId` to update.",
+        "Provide at least one of `name`, `description`, `hostId`, `serverAttachmentId`, `modelId`, `skillSelection`, `secretSelection`, `pluginVersionIds`, or `sandboxImageId` to update.",
     }
   );
 export type UpdateEnvironmentInput = z.infer<typeof updateEnvironmentInput>;
@@ -9735,7 +9772,7 @@ export const updateEnvironmentOperation: PlatformOperation<
   name: "update_project_environment",
   title: "Update an MCPJam project environment",
   description:
-    "Edit a project environment. Only the fields you pass change; pass null for serverAttachmentId, modelId, skillSelection, or pluginVersionIds to clear them. Requires `expectedRevision` (read it first with get_project_environment) and project admin.",
+    "Edit a project environment. Only the fields you pass change; pass null for serverAttachmentId, modelId, skillSelection, secretSelection, pluginVersionIds, or sandboxImageId to clear them. Requires `expectedRevision` (read it first with get_project_environment) and project admin.",
   readOnly: false,
   permalink: derivePermalinks((result) => [environmentRef(result)]),
   inputSchema: updateEnvironmentInput,
@@ -9763,6 +9800,8 @@ export const updateEnvironmentOperation: PlatformOperation<
     if (input.modelId !== undefined) body.modelId = input.modelId;
     if (input.skillSelection !== undefined)
       body.skillSelection = input.skillSelection;
+    if (input.secretSelection !== undefined)
+      body.secretSelection = input.secretSelection;
     if (input.pluginVersionIds !== undefined)
       body.pluginVersionIds = input.pluginVersionIds;
     if (input.sandboxImageId !== undefined)

--- a/sdk/tests/platform/operations-environment-secret-grants.test.ts
+++ b/sdk/tests/platform/operations-environment-secret-grants.test.ts
@@ -1,0 +1,241 @@
+/**
+ * `secretSelection` on the environment operations — the field that grants a
+ * project secret to the runs an environment launches.
+ *
+ * Both halves of this were live bugs, and both were SILENT in the way that
+ * costs the most time: the create input schema strips unknown keys, so a
+ * `secretSelection` it did not declare vanished between the caller and the
+ * wire and the environment came back with no grant; and the update input's
+ * at-least-one-field refine did not list it, so a PATCH that changed only the
+ * grant was rejected client-side with a message that did not even name the
+ * field the caller had passed.
+ *
+ * The API and the `/api/v1` route accepted the field the whole time — only
+ * these schemas did not — so the tests assert what reaches the WIRE, not just
+ * that parsing succeeds.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  createEnvironmentOperation,
+  PlatformApiClient,
+  updateEnvironmentOperation,
+} from "../../src/platform/index.js";
+
+const PROJECT = {
+  id: "project-1",
+  name: "Acme",
+  description: null,
+  icon: null,
+  organizationId: "org-a",
+  visibility: null,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const ENVIRONMENT = {
+  id: "env-live",
+  projectId: PROJECT.id,
+  name: "Cursor Harness",
+  hostId: "host-1",
+  revision: 4,
+  archived: false,
+  createdAt: 1,
+  updatedAt: 2,
+};
+
+const GRANT = {
+  mode: "explicit" as const,
+  secretIds: ["secret-cursor-api-key"],
+};
+
+/** The bodies the operations actually PUT on the wire, in call order. */
+function makeClient(): {
+  client: PlatformApiClient;
+  bodies: Array<{ method: string; body: Record<string, unknown> }>;
+} {
+  const bodies: Array<{ method: string; body: Record<string, unknown> }> = [];
+  const fetchMock = vi.fn(async (target: unknown, init?: RequestInit) => {
+    const path = new URL(String(target)).pathname;
+    if (path === "/api/v1/projects") return Response.json({ items: [PROJECT] });
+    if (/^\/api\/v1\/projects\/[^/]+\/environments$/.test(path)) {
+      if (init?.method === "POST") {
+        bodies.push({
+          method: "POST",
+          body: JSON.parse(String(init.body)) as Record<string, unknown>,
+        });
+        return Response.json({ ...ENVIRONMENT, secretSelection: GRANT });
+      }
+      return Response.json({ items: [ENVIRONMENT] });
+    }
+    if (/^\/api\/v1\/projects\/[^/]+\/environments\/[^/]+$/.test(path)) {
+      if (init?.method === "PATCH") {
+        bodies.push({
+          method: "PATCH",
+          body: JSON.parse(String(init.body)) as Record<string, unknown>,
+        });
+        return Response.json({ ...ENVIRONMENT, revision: 5 });
+      }
+      return Response.json(ENVIRONMENT);
+    }
+    return Response.json(
+      { code: "NOT_FOUND", message: `No route for ${path}` },
+      { status: 404 }
+    );
+  });
+  const client = new PlatformApiClient({
+    baseUrl: "https://api.example.com/api/v1",
+    getAuth: () => "sk_test",
+    fetch: fetchMock as unknown as typeof fetch,
+  });
+  return { client, bodies };
+}
+
+describe("create_project_environment secretSelection", () => {
+  it("keeps the grant through parsing instead of stripping it", () => {
+    const result = createEnvironmentOperation.inputSchema.safeParse({
+      name: "Cursor Harness",
+      hostId: "host-1",
+      secretSelection: GRANT,
+    });
+
+    expect(result.success).toBe(true);
+    // The schema strips what it does not declare, so an undeclared field
+    // parsed "successfully" and then simply was not there.
+    expect(result.data?.secretSelection).toEqual(GRANT);
+  });
+
+  it("forwards the grant to the create call", async () => {
+    const { client, bodies } = makeClient();
+
+    await createEnvironmentOperation.execute(
+      { name: "Cursor Harness", hostId: "host-1", secretSelection: GRANT },
+      { client }
+    );
+
+    expect(bodies[0]?.method).toBe("POST");
+    expect(bodies[0]?.body.secretSelection).toEqual(GRANT);
+  });
+
+  it("omits the field entirely when no grant is asked for", async () => {
+    const { client, bodies } = makeClient();
+
+    await createEnvironmentOperation.execute(
+      { name: "Cursor Harness", hostId: "host-1" },
+      { client }
+    );
+
+    expect(bodies[0]?.body).not.toHaveProperty("secretSelection");
+  });
+
+  it("rejects an empty secretIds list — no grant is omission, not []", () => {
+    const result = createEnvironmentOperation.inputSchema.safeParse({
+      name: "Cursor Harness",
+      hostId: "host-1",
+      secretSelection: { mode: "explicit", secretIds: [] },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("update_project_environment secretSelection", () => {
+  const BASE = { environment: "env-live", expectedRevision: 4 };
+
+  it("satisfies the at-least-one-field refine on its own", () => {
+    const result = updateEnvironmentOperation.inputSchema.safeParse({
+      ...BASE,
+      secretSelection: GRANT,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("names itself in the refine message, so the list is not a lie", () => {
+    const result = updateEnvironmentOperation.inputSchema.safeParse(BASE);
+
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain("secretSelection");
+  });
+
+  it("forwards a grant as a replacement", async () => {
+    const { client, bodies } = makeClient();
+
+    await updateEnvironmentOperation.execute(
+      { ...BASE, secretSelection: GRANT },
+      { client }
+    );
+
+    expect(bodies[0]?.method).toBe("PATCH");
+    expect(bodies[0]?.body.secretSelection).toEqual(GRANT);
+  });
+
+  it("forwards an explicit null as a REVOKE", async () => {
+    const { client, bodies } = makeClient();
+
+    await updateEnvironmentOperation.execute(
+      { ...BASE, secretSelection: null },
+      { client }
+    );
+
+    // `null` has to survive as null: the tri-state is omitted = unchanged,
+    // null = revoke, value = replace, and a truthiness check would drop the
+    // revoke on the floor.
+    expect(bodies[0]?.body).toHaveProperty("secretSelection", null);
+  });
+
+  it("leaves the grant alone when the PATCH does not mention it", async () => {
+    const { client, bodies } = makeClient();
+
+    await updateEnvironmentOperation.execute(
+      { ...BASE, name: "Renamed" },
+      { client }
+    );
+
+    expect(bodies[0]?.body).not.toHaveProperty("secretSelection");
+  });
+
+  it("rejects an empty secretIds list — revoking is null", () => {
+    const result = updateEnvironmentOperation.inputSchema.safeParse({
+      ...BASE,
+      secretSelection: { mode: "explicit", secretIds: [] },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+// The siblings the same refine/forwarding gap would hit. They round-trip
+// today; this locks that in so the next clearable field added to the route
+// cannot quietly land on only one side again.
+describe("clearable siblings still round-trip", () => {
+  it.each([
+    ["skillSelection", { mode: "explicit", skillIds: ["skill-a"] }],
+    ["pluginVersionIds", ["plugin-version-1"]],
+    ["sandboxImageId", "image-1"],
+  ] as const)(
+    "%s survives create and can be the only PATCH field",
+    (field, value) => {
+      const created = createEnvironmentOperation.inputSchema.safeParse({
+        name: "Cursor Harness",
+        hostId: "host-1",
+        [field]: value,
+      });
+      expect(created.success).toBe(true);
+      expect(created.data?.[field]).toEqual(value);
+
+      const patched = updateEnvironmentOperation.inputSchema.safeParse({
+        environment: "env-live",
+        expectedRevision: 4,
+        [field]: value,
+      });
+      expect(patched.success).toBe(true);
+
+      const cleared = updateEnvironmentOperation.inputSchema.safeParse({
+        environment: "env-live",
+        expectedRevision: 4,
+        [field]: null,
+      });
+      expect(cleared.success).toBe(true);
+    }
+  );
+});


### PR DESCRIPTION
## What

`secretSelection` never existed on the SDK's `create_environment` / `update_environment` operation schemas, so **no agent surface could attach a project secret to an environment** — even though every other layer already supported it (`types.ts:2140/2171`, `client.ts:1294/1366`, the REST route at `server/routes/v1/environments.ts:438/465`, and the deployed Convex validator).

Two independent failures, both reproduced live against production:

1. **Silent drop on create.** `createEnvironmentInput` is a `z.object`, which strips undeclared keys — a create carrying a grant parsed "successfully" with the field already gone, returning `201` with `secretSelection: null`.
2. **Refine rejects a grant-only update.** The at-least-one-field `.refine` predicate and its message omitted the field, so `{"secretSelection": …}` failed client-side with `USAGE_ERROR: Provide at least one of \`name\`, …` — a list that conspicuously lacked `secretSelection`.

The route file already carries a comment (`environments.ts:452`) noting this is the one field where missing wiring hurts most, since "unchanged" and "cleared" have materially different security consequences. The SDK was in exactly that state.

## How it was found

A Cursor CLI harness eval run on production refused with `The Cursor CLI harness requires a CURSOR_API_KEY project secret in this environment`. The secret existed and the environment existed; the grant between them could not be created by any client path.

## Changes

- **`sdk/src/platform/operations.ts`** — one shared `secretSelectionInput` (declared beside `pluginVersionIdsInput`, mirroring `skillSelectionInput`), wired into create + its execute body, and into update as `.nullable().optional()` including the refine predicate, the refine message, and the `!== undefined` forwarding block — so an explicit `null` survives as a **revoke** rather than being dropped by a truthiness check.
- **`sdk/src/platform/client.ts`** — doc comment listing clearable fields was missing `secretSelection` and `sandboxImageId`. Doc only.
- **`cli/src/commands/environments.ts`** — `--file`/`--json` help text on create and update now lists `secretSelection`. Help text only; the CLI forwards the whole body, which is why the strip happened in the schema.
- **`sdk/tests/platform/operations-environment-secret-grants.test.ts`** (new, 13 tests) — asserts what reaches the **wire**, not just that parsing succeeds: create preserves/forwards/omits, rejects `secretIds: []`; update passes the refine alone, names itself in the message, forwards a value as replace and `null` as revoke, stays absent when unmentioned. Plus a parametrized block locking in `skillSelection` / `pluginVersionIds` / `sandboxImageId`.

## Verification

- `sdk/tests/platform/**` — 14 files, **318 passed**.
- **Non-vacuity checked**: with `operations.ts` reverted to `HEAD`, 7 of the 13 new tests fail (e.g. `expected { expectedRevision: 4 } to have property "secretSelection"`), reproducing both bugs.
- `npx tsc --noEmit -p sdk/tsconfig.json` clean. New test file passes prettier; `operations.ts`/`client.ts` were **not** reformatted (both already fail `format:check` at baseline — prettier-version drift).
- `server/routes/v1/__tests__/environments.test.ts` could not run in the worktree (missing generated `PluginShim.bundled.js` artifact — known worktree symlink issue, unrelated; the route is untouched).

## Related gaps found, deliberately not fixed here

1. **`ensure_adhoc_environment` / compose has no secrets axis.** The route accepts `secretSelection` (`environments.ts:500`), but `composeStackFields` / `resolveComposeStack` carry only `skills`/`pluginVersionIds` — same silent-drop class. Left out because `composeStackFields` is shared with the run operations, so a secrets axis widens into CLI `--compose-*` flags and the fan-out surface. **Consequence today: a composed/ad-hoc stack cannot carry a credential grant, so a harness run needing one requires a named environment.**
2. **No version-skew capability flag for secrets.** `PlatformEnvironmentCapabilities` has `modelOverrides` and `skillVersionPins` with a CLI probe; there is no equivalent for `secretSelection`, so an old backend yields an opaque validator error rather than a clean refusal. The route gates nothing either, and the current backend supports the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential-grant wiring for environments (security-sensitive), but behavior aligns with the existing API contract and fixes silent misconfiguration rather than altering server authorization.
> 
> **Overview**
> **Agents and CLI users can attach or revoke project secret grants on environments again.** The REST API already accepted `secretSelection`, but the SDK/MCP operation schemas did not—so creates silently dropped the field (Zod stripped it) and grant-only updates failed client-side validation.
> 
> The PR adds a shared **`secretSelectionInput`** on create and update (same tri-state as other clearable fields: omit = unchanged, `null` = revoke, value = replace). Empty `secretIds` is rejected; revocation uses `null`. Create/update **execute** paths forward the field to the API, and the update **at-least-one-field** refine includes `secretSelection`.
> 
> **CLI** `--file`/`--json` help and **SDK** `updateEnvironment` docs now mention `secretSelection`. New tests assert the grant reaches the wire on POST/PATCH, including `null` revoke.
> 
> **Out of scope:** ad-hoc/compose environments still cannot carry secret grants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f26b859b2537e00c3b88843de94e77101e4aae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Environment secret grants (`secretSelection`) were never wired into the SDK's create/update environment operations, so no client path could attach a project secret to an environment: create silently stripped the field and returned 201 with no grant, and update rejected grant-only PATCHes with a message that didn't even list the field. The field now works on both operations through a single shared input schema.

- Update supports the tri-state the route documents: omit leaves it unchanged, `null` revokes, a value replaces; `secretIds: []` is rejected.
- CLI `--file`/`--json` help and the client doc comment now list `secretSelection` as a clearable field.
- 13 new tests assert what reaches the wire and lock in that `skillSelection`, `pluginVersionIds`, and `sandboxImageId` still round-trip.

Not fixed here: `ensure_adhoc_environment` and the run operations' `compose` still accept no secrets axis, so a composed stack can't carry a credential grant — a run that needs a secret still requires a named environment.

<sup>Written for commit 1f26b859b2537e00c3b88843de94e77101e4aae1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

