### PR TITLE
fix(v1): resolve the installation reference before connecting a Checks repo

### DIFF
--- a/.changeset/eval-checks-connect-installation-ref.md
+++ b/.changeset/eval-checks-connect-installation-ref.md
@@ -1,0 +1,36 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Connecting a GitHub Checks repository works from the CLI and MCP again
+
+`POST /v1/organizations/:organizationId/eval-check-repos` refused every connect
+with "Repository is not accessible to the MCPJam GitHub App." — while the GET on
+the same route listed that exact repository as `connectable` one request
+earlier. Two commands, one truth, and they disagreed.
+
+`connectVerifiedRepo` reads an ABSENT `installationRef` not as "pick one for me"
+but as a selector: it means the pinned compatibility branch, which resolves the
+deployment-level `GITHUB_CHECKS_INSTALLATION_ID` env var. That var is a
+deliberately retired migration pin and is unset in production, so the branch
+resolved nothing and refused. The web picker never landed there — it sends the
+reference and the numeric repository id it read out of the repository listing.
+Every agent surface did, because it has no picker to read.
+
+The POST now resolves the name against the same `listInstallationRepos` the GET
+exposes, and sends the `installationRef` and `repositoryId` that listing carries.
+Matching is on trim + lowercase, the spelling the backend stores and looks a row
+up under, so a correctly-typed `Acme/Widgets` is no longer refused. A repository
+the listing does not hold is refused with the route's existing flat sentence and
+no candidate names — a repository that does not exist and one the App cannot see
+have to read identically, or the endpoint becomes an oracle for private
+repository names. A name that matches two entries is refused rather than
+resolved by guessing: the backend deduplicates its fan-out by numeric repository
+id, not by name, so one name across two bindings is a real shape.
+
+A failed listing now fails the request instead of falling through. Continuing
+without a reference would have taken the retired branch and produced that same
+"not accessible" refusal for what is actually a GitHub blip — sending an admin
+off to re-install an App that is installed fine. The backend's own "Could not
+list repositories from GitHub." keeps its wording, and with it the advice to
+retry.

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-checks.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-checks.test.ts
@@ -65,6 +65,23 @@ const CONFIG_ROW = {
   updatedAt: 2,
 };
 
+/**
+ * One entry as `checkRepoConfigsNode:listInstallationRepos` returns it.
+ *
+ * `installationRef` is the opaque Convex row id of the binding the repository
+ * was enumerated through — never GitHub's installation id — and `repositoryId`
+ * is GitHub's numeric identity, which is what a connect is re-verified
+ * against. Both are SELECTORS the connect sends back; neither is a fact the
+ * backend takes on trust.
+ */
+const LISTED_REPO = {
+  fullName: "acme/widgets",
+  repositoryId: 4242,
+  installationRef: "inst_1",
+  accountLogin: "acme",
+  private: true,
+};
+
 function answer(
   queries: Record<string, unknown>,
   actions: Record<string, unknown> = {}
@@ -202,7 +219,13 @@ describe("POST eval-check-repos", () => {
   }
 
   it("connects through the VERIFIED action, never the deprecated mutation", async () => {
-    answer({}, { connectVerifiedRepo: { configId: "cfg_9" } });
+    answer(
+      {},
+      {
+        listInstallationRepos: [LISTED_REPO],
+        connectVerifiedRepo: { configId: "cfg_9" },
+      },
+    );
     const res = await connect({
       projectId: "proj_1",
       suiteId: "suite_1",
@@ -217,6 +240,41 @@ describe("POST eval-check-repos", () => {
       repo: "acme/widgets",
       outagePolicy: "fail_closed",
     });
+    // The unverified path cannot stamp an installation id, so a row created
+    // through it is permanently unverifiable. Nothing here may reach it.
+    const called = actionMock.mock.calls.map((call) => String(call[0]));
+    expect(called.some((name) => name.endsWith(":connectRepo"))).toBe(false);
+  });
+
+  it("forwards the installationRef AND repositoryId from the listing", async () => {
+    // THE BUG THIS FILE'S POST HALF EXISTS FOR.
+    //
+    // `connectVerifiedRepo` reads an ABSENT `installationRef` as "use the
+    // pinned compatibility branch", which resolves the retired
+    // `GITHUB_CHECKS_INSTALLATION_ID` env var. That var is unset in
+    // production, so a reference-less connect refused every time — while the
+    // GET beside this listed the very same repository as `connectable`. The
+    // web picker never hit it because it sends the reference it read out of
+    // the listing; every agent surface did, because it has no picker.
+    //
+    // So the assertion is on BOTH selectors, not just the ref: the ref picks
+    // the binding, and the numeric id is what GitHub's own answer is checked
+    // against, which is the guard that catches a rename-and-reuse race between
+    // the listing and this connect.
+    answer(
+      {},
+      {
+        listInstallationRepos: [LISTED_REPO],
+        connectVerifiedRepo: { configId: "cfg_9" },
+      },
+    );
+    const res = await connect({
+      projectId: "proj_1",
+      suiteId: "suite_1",
+      repo: "acme/widgets",
+      outagePolicy: "fail_closed",
+    });
+    expect(res.status).toBe(201);
     expect(actionMock).toHaveBeenCalledWith(
       "github/checkRepoConfigsNode:connectVerifiedRepo",
       {
@@ -225,12 +283,178 @@ describe("POST eval-check-repos", () => {
         suiteId: "suite_1",
         repoFullName: "acme/widgets",
         outagePolicy: "fail_closed",
-      }
+        installationRef: "inst_1",
+        repositoryId: 4242,
+      },
     );
-    // The unverified path cannot stamp an installation id, so a row created
-    // through it is permanently unverifiable. Nothing here may reach it.
+  });
+
+  it("matches the repository the way the backend keys it: case-insensitively", async () => {
+    // The stored key is `canonicalizeRepoFullName` — trim + lowercase — so
+    // `Acme/Widgets` and `acme/widgets` are one repository under one row. A
+    // case-sensitive match here would refuse a name a human typed correctly.
+    answer(
+      {},
+      {
+        listInstallationRepos: [LISTED_REPO],
+        connectVerifiedRepo: { configId: "cfg_9" },
+      },
+    );
+    const res = await connect({
+      projectId: "proj_1",
+      suiteId: "suite_1",
+      repo: "  Acme/Widgets  ",
+      outagePolicy: "fail_open",
+    });
+    expect(res.status).toBe(201);
+    expect(actionMock).toHaveBeenCalledWith(
+      "github/checkRepoConfigsNode:connectVerifiedRepo",
+      expect.objectContaining({
+        installationRef: "inst_1",
+        repositoryId: 4242,
+      }),
+    );
+  });
+
+  it("sends NEITHER selector for a listing entry that carries no reference", async () => {
+    // The pinned compatibility branch lists repositories without an
+    // `installationRef`. That branch only produces entries at all when the pin
+    // IS set, so sending nothing is correct AND functional there — and the
+    // backend documents "no reference" as a byte-identical path, which a
+    // stray `repositoryId` would quietly stop being.
+    answer(
+      {},
+      {
+        listInstallationRepos: [
+          { fullName: "acme/widgets", repositoryId: 4242 },
+        ],
+        connectVerifiedRepo: { configId: "cfg_9" },
+      },
+    );
+    const res = await connect({
+      projectId: "proj_1",
+      suiteId: "suite_1",
+      repo: "acme/widgets",
+      outagePolicy: "fail_closed",
+    });
+    expect(res.status).toBe(201);
+    expect(actionMock).toHaveBeenCalledWith(
+      "github/checkRepoConfigsNode:connectVerifiedRepo",
+      {
+        organizationId: ORG,
+        projectId: "proj_1",
+        suiteId: "suite_1",
+        repoFullName: "acme/widgets",
+        outagePolicy: "fail_closed",
+      },
+    );
+  });
+
+  it("refuses a repository the listing does not hold, without disclosing what it does", async () => {
+    answer(
+      {},
+      {
+        listInstallationRepos: [
+          { ...LISTED_REPO, fullName: "acme/secret-thing" },
+        ],
+        connectVerifiedRepo: { configId: "cfg_9" },
+      },
+    );
+    const res = await connect({
+      projectId: "proj_1",
+      suiteId: "suite_1",
+      repo: "acme/widgets",
+      outagePolicy: "fail_closed",
+    });
+    expect(res.status).toBe(404);
+    const raw = await res.text();
+    // ONE flat sentence for "does not exist", "is somebody else's" and "the
+    // App cannot see it". Telling them apart would answer "does this private
+    // repository exist" for anyone who can reach the route.
+    expect(raw).toContain(
+      "Repository, project or suite not found, or the MCPJam GitHub App cannot reach it.",
+    );
+    // And the candidates are not the caller's business either — an error that
+    // helpfully listed them would be the same oracle by another route.
+    expect(raw).not.toContain("secret-thing");
+    // Nothing was attempted: no GitHub verification round trip, no row.
     const called = actionMock.mock.calls.map((call) => String(call[0]));
-    expect(called.some((name) => name.endsWith(":connectRepo"))).toBe(false);
+    expect(called).not.toContain(
+      "github/checkRepoConfigsNode:connectVerifiedRepo",
+    );
+  });
+
+  it("refuses an AMBIGUOUS match rather than picking one", async () => {
+    // The backend deduplicates its fan-out across bindings by NUMERIC
+    // repository id, NOT by name, so two entries can legitimately carry one
+    // full name — a renamed repository whose freed name was taken in another
+    // account the App is also installed on. Picking either would stamp the row
+    // with an installation that may not be the one the caller meant, and the
+    // row's key is the name, so the mistake would only ever surface as checks
+    // that silently never run.
+    answer(
+      {},
+      {
+        listInstallationRepos: [
+          { ...LISTED_REPO, installationRef: "inst_1", repositoryId: 4242 },
+          { ...LISTED_REPO, installationRef: "inst_2", repositoryId: 9999 },
+        ],
+        connectVerifiedRepo: { configId: "cfg_9" },
+      },
+    );
+    const res = await connect({
+      projectId: "proj_1",
+      suiteId: "suite_1",
+      repo: "acme/widgets",
+      outagePolicy: "fail_closed",
+    });
+    expect(res.status).toBe(404);
+    expect(await res.text()).toContain(
+      "Repository, project or suite not found, or the MCPJam GitHub App cannot reach it.",
+    );
+    const called = actionMock.mock.calls.map((call) => String(call[0]));
+    expect(called).not.toContain(
+      "github/checkRepoConfigsNode:connectVerifiedRepo",
+    );
+  });
+
+  it("does NOT fall through to the broken no-reference path when the listing fails", async () => {
+    // The GET fails SOFT on this same call, because the connected list costs
+    // no GitHub round trip and must survive an outage. The POST cannot: there
+    // is nothing left to preserve, and continuing without a reference would
+    // take the retired compatibility branch and answer "not accessible" —
+    // turning a GitHub blip into the exact misleading refusal that sends an
+    // admin off to re-install an App which is installed fine.
+    //
+    // The backend's own refusal keeps its wording, so the caller is told to
+    // retry rather than to go and fix something that is not broken.
+    const refusal = Object.assign(
+      new Error("Could not list repositories from GitHub."),
+      { data: "Could not list repositories from GitHub." },
+    );
+    answer(
+      {},
+      {
+        listInstallationRepos: refusal,
+        connectVerifiedRepo: { configId: "cfg_9" },
+      },
+    );
+    const res = await connect({
+      projectId: "proj_1",
+      suiteId: "suite_1",
+      repo: "acme/widgets",
+      outagePolicy: "fail_closed",
+    });
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    const raw = await res.text();
+    expect(raw).toContain("Could not list repositories from GitHub.");
+    // The refusal that must NOT be produced for an outage.
+    expect(raw).not.toContain("cannot reach it");
+    // Nothing was written, and nothing tried the reference-less branch.
+    const called = actionMock.mock.calls.map((call) => String(call[0]));
+    expect(called).not.toContain(
+      "github/checkRepoConfigsNode:connectVerifiedRepo",
+    );
   });
 
   it("requires an explicit outage policy", async () => {

--- a/mcpjam-inspector/server/routes/v1/eval-checks.ts
+++ b/mcpjam-inspector/server/routes/v1/eval-checks.ts
@@ -32,8 +32,39 @@ import { translateConvexReadError } from "./convex-read-errors.js";
 import { translateConvexWriteError } from "./convex-errors.js";
 import { v1Resource } from "./envelope.js";
 import { reportRouteFailure } from "../../utils/route-error-report.js";
+import { logger } from "../../utils/logger.js";
 
 const evalChecks = new Hono();
+
+/**
+ * The one sentence this route answers with when the repository a caller named
+ * is not one it can connect.
+ *
+ * FLAT ON PURPOSE, and shared by the refusal below AND by the `notFoundMessage`
+ * the backend's own refusals are translated into, so the two cannot drift into
+ * two distinguishable answers. A repository that does not exist, one that
+ * exists in somebody else's account, and one this organization's installations
+ * cannot see must all read the same — otherwise the endpoint becomes an oracle
+ * for private repository names for anyone who can reach it. The backend words
+ * its half of this the same way and for the same reason; see
+ * `REPO_NOT_ACCESSIBLE_MESSAGE` in `github/checkRepoConfigsNode.ts`.
+ */
+const REPO_NOT_CONNECTABLE_MESSAGE =
+  "Repository, project or suite not found, or the MCPJam GitHub App cannot reach it.";
+
+/**
+ * The key a repository full name is compared on.
+ *
+ * Mirrors the backend's `canonicalizeRepoFullName` (trim + lowercase) exactly,
+ * because that is the spelling a connected row is STORED and looked up under.
+ * Matching case-sensitively here would refuse `Acme/Widgets` for a listing that
+ * says `acme/widgets` — the same repository, under the same stored key — and an
+ * agent surface types a name a human gave it rather than one it copied out of a
+ * picker.
+ */
+function canonicalRepoKey(raw: string): string {
+  return raw.trim().toLowerCase();
+}
 
 function convexClient(token: string): ConvexHttpClient {
   const url = process.env.CONVEX_URL;
@@ -203,6 +234,132 @@ evalChecks.post(
     const body = parseWithSchema(connectCheckRepoSchema, parsedBody);
     const client = convexClient(await getConvexBearerForRequest(c));
 
+    const writeErrorOptions = {
+      resource: "GitHub Checks repository",
+      // The backend words these refusals deliberately — "install the App on
+      // that repository" is different advice from "try again" — and it words
+      // them the same for a repository that does not exist as for one the
+      // App cannot see, on purpose: answering differently would turn this
+      // into an oracle for private repository names.
+      notFoundMessage: REPO_NOT_CONNECTABLE_MESSAGE,
+      fallbackMessage: "GitHub Checks connection rejected by the platform",
+      adminFailureIsForbidden: false,
+    };
+
+    // ── Resolve WHICH installation this repository is being connected through ─
+    //
+    // `connectVerifiedRepo` takes an optional `installationRef` naming one of
+    // the organization's active bindings. Sending nothing does not mean "pick
+    // one for me": it selects the action's PINNED COMPATIBILITY BRANCH, which
+    // resolves the deployment-level `GITHUB_CHECKS_INSTALLATION_ID` env var —
+    // deliberately retired, and unset in production. So every reference-less
+    // connect refused with "Repository is not accessible to the MCPJam GitHub
+    // App." while the GET on this very route listed that same repository as
+    // `connectable` one request earlier. The web UI never hit it because its
+    // picker sends the reference it read out of the listing; every agent
+    // surface did, because it has no picker to read.
+    //
+    // The fix is to do here what the picker does there: resolve the name
+    // against the same listing, and send the reference it carries. This route
+    // already exposes that listing on the GET beside this, so it grants a
+    // caller nothing they could not already enumerate — it just stops making
+    // them the one who has to carry infrastructure identifiers around.
+    let installationRepos: Array<Record<string, any>>;
+    try {
+      installationRepos = ((await client.action(
+        "github/checkRepoConfigsNode:listInstallationRepos" as any,
+        { organizationId } as any,
+      )) ?? []) as Array<Record<string, any>>;
+    } catch (error) {
+      // FAILS HARD, unlike the same call on the GET.
+      //
+      // There it fails soft to `connectable: null` because the connected list
+      // costs no GitHub call and must survive an outage. Here there is nothing
+      // to preserve: continuing without a reference would take the retired
+      // compatibility branch and answer "not accessible" — turning a GitHub
+      // blip into the exact misleading refusal this change exists to remove,
+      // and sending an admin off to re-install an App that is installed fine.
+      //
+      // Translated with the WRITE translator and the connect's own options, so
+      // no new copy is invented: the backend's own "Could not list
+      // repositories from GitHub." refusal keeps its retry advice, a
+      // membership or availability refusal maps exactly as the connect below
+      // would have mapped it, and a transport failure still answers 5xx. The
+      // read translator would flatten the first of those into a generic 502
+      // and page for somebody else's outage.
+      throw translateConvexWriteError(error, writeErrorOptions);
+    }
+
+    const wanted = canonicalRepoKey(body.repo);
+    const matches = installationRepos.filter(
+      (repo) =>
+        canonicalRepoKey(String(repo.fullName ?? repo.repoFullName ?? "")) ===
+        wanted,
+    );
+
+    if (matches.length > 1) {
+      // AMBIGUOUS, and refused rather than resolved by picking one.
+      //
+      // The backend deduplicates its fan-out across bindings by NUMERIC
+      // repository id, not by name, so two entries CAN carry one full name —
+      // a renamed repository whose freed name was taken in another account the
+      // App is also installed on, or one binding serving a stale listing.
+      // Picking either would stamp the row with an installation that may not
+      // be the one the caller meant, and the row's key is the name, so the
+      // mistake would only surface as checks that never run.
+      //
+      // The caller is told the same flat sentence as any other refusal: which
+      // accounts hold a same-named repository is exactly the kind of thing
+      // this endpoint must not narrate. The operator gets the diagnosis —
+      // `logger.warn` is Axiom-only, so a rare but confusing refusal becomes
+      // visible without paging anybody.
+      logger.warn("[v1.evalChecks] ambiguous repository selection", {
+        scope: "v1.evalChecks",
+        organizationId,
+        matches: matches.length,
+      });
+      throw new WebRouteError(
+        404,
+        ErrorCode.NOT_FOUND,
+        REPO_NOT_CONNECTABLE_MESSAGE,
+      );
+    }
+
+    const selected = matches[0];
+    if (!selected) {
+      // Not in the listing: the repository does not exist, is somebody else's,
+      // or no installation of this organization can reach it. ONE answer for
+      // all three — see `REPO_NOT_CONNECTABLE_MESSAGE`. The candidate list is
+      // never echoed back, for the same reason.
+      throw new WebRouteError(
+        404,
+        ErrorCode.NOT_FOUND,
+        REPO_NOT_CONNECTABLE_MESSAGE,
+      );
+    }
+
+    // ABSENT is a real, working case, not a failure to handle: entries listed
+    // through the pinned compatibility branch carry no `installationRef`, and
+    // that branch only produces entries at all when the pin IS set. So sending
+    // nothing there is both correct and functional, and it keeps "no
+    // reference" the byte-identical path the backend documents it as rather
+    // than a second, slightly different way to write a verified row.
+    const installationRef =
+      typeof selected.installationRef === "string" &&
+      selected.installationRef.length > 0
+        ? selected.installationRef
+        : undefined;
+    // Sent ALONGSIDE the ref and never without it — the action only consults it
+    // on the reference path, where it re-checks the id against GitHub's own
+    // answer and refuses a mismatch. That check is the point: it catches a
+    // rename-and-reuse race between the listing and this connect.
+    const repositoryId =
+      installationRef !== undefined &&
+      typeof selected.repositoryId === "number" &&
+      Number.isInteger(selected.repositoryId)
+        ? selected.repositoryId
+        : undefined;
+
     let result: { configId?: string } | null;
     try {
       result = await client.action(
@@ -213,21 +370,12 @@ evalChecks.post(
           suiteId: body.suiteId,
           repoFullName: body.repo,
           outagePolicy: body.outagePolicy,
+          ...(installationRef !== undefined ? { installationRef } : {}),
+          ...(repositoryId !== undefined ? { repositoryId } : {}),
         } as any,
       );
     } catch (error) {
-      throw translateConvexWriteError(error, {
-        resource: "GitHub Checks repository",
-        // The backend words these refusals deliberately — "install the App on
-        // that repository" is different advice from "try again" — and it words
-        // them the same for a repository that does not exist as for one the
-        // App cannot see, on purpose: answering differently would turn this
-        // into an oracle for private repository names.
-        notFoundMessage:
-          "Repository, project or suite not found, or the MCPJam GitHub App cannot reach it.",
-        fallbackMessage: "GitHub Checks connection rejected by the platform",
-        adminFailureIsForbidden: false,
-      });
+      throw translateConvexWriteError(error, writeErrorOptions);
     }
 
     return v1Resource(


### PR DESCRIPTION
## The bug

`POST /v1/organizations/:organizationId/eval-check-repos` refused every connect on production with:

> Repository is not accessible to the MCPJam GitHub App.

…while the **GET on the same route file** listed that exact repository as `connectable` one request earlier. Reproduced live against production with `mcpjam cloud eval checks list` (repo present in `connectable`) followed immediately by `mcpjam cloud eval checks connect` (refused). Two commands, one truth, and they disagreed.

## Root cause

`connectVerifiedRepo` (mcpjam-backend, `convex/github/checkRepoConfigsNode.ts`) takes two optional args the route was not sending:

```ts
installationRef: v.optional(v.id('githubAppInstallations'))
repositoryId:    v.optional(v.number())
```

An **absent** `installationRef` is a selector, not "pick one for me" — its handler opens with `if (args.installationRef === undefined)` and takes the *pinned compatibility branch*, which resolves the deployment-level `GITHUB_CHECKS_INSTALLATION_ID` env var. That var is a deliberately retired migration pin and is **unset on the production Convex deployment**, so the branch resolved `null` and threw `RepoNotAccessibleError`.

The web UI never landed there: its repository picker sends the `installationRef` and `repositoryId` it read out of the repository listing. Every agent surface (CLI and MCP) did, because it has no picker to read.

## The fix

The POST now resolves the repository through the same `github/checkRepoConfigsNode:listInstallationRepos` the GET already exposes, and forwards both selectors. Inspector route only — no SDK, CLI or backend change; the route already had everything it needed.

The listing call grants the caller nothing new: the GET beside it already enumerates exactly this, so the same actor could already read it. It just stops making them the one who has to carry infrastructure identifiers around.

### Decisions

**Matching — case-insensitive, on `fullName`.** Comparison is `trim().toLowerCase()`, mirroring the backend's own `canonicalizeRepoFullName` exactly. That is not a guess about GitHub semantics: it is the spelling a connected row is **stored and looked up under** (`assertGithubAddressableRepoFullName` → `assertValidRepoFullName` → `canonicalizeRepoFullName`). Matching case-sensitively would refuse a correctly-typed `Acme/Widgets` for a listing that spells it `acme/widgets` — the same repository, under the same stored key — and an agent types the name a human gave it, not one it copied out of a picker. No separate exact-match tier: the backend cannot represent two repositories differing only in case, since they collapse to one key.

**No match — the route's existing flat sentence, 404.** Refused with `REPO_NOT_CONNECTABLE_MESSAGE`, extracted from the `notFoundMessage` that was already inline on the `connectVerifiedRepo` catch, so the local refusal and the translated backend refusal are now literally one string and cannot drift into two distinguishable answers. A repository that does not exist, one in someone else's account, and one this org's installations cannot see all read the same, on purpose. **The candidate list is never echoed back** — an error that helpfully named the alternatives would be the same oracle by another route.

**Ambiguity — refused, not resolved.** I checked what the listing guarantees rather than assuming: `listInstallationRepos` deduplicates its cross-binding fan-out by **numeric `repositoryId`**, not by name (`const seen = new Set<number>()`). So two entries *can* legitimately carry one `fullName` — a renamed repository whose freed name was taken in another account the App is also installed on, or one binding serving a stale listing. Picking one would stamp the row with an installation that may not be the one the caller meant, and the row's key is the *name*, so the mistake would only ever surface as checks that silently never run. Two matches ⇒ the same flat refusal, plus a `logger.warn` (Axiom-only, no page) so an operator can actually diagnose an otherwise baffling refusal.

**Listing failure — fails hard, with the backend's own wording.** On the GET this call fails soft to `connectable: null` because the connected list costs no GitHub round trip and must survive an outage. Here there is nothing left to preserve, and continuing without a reference would take the retired branch and produce *exactly* the misleading "not accessible" this PR exists to remove — sending an admin off to re-install an App that is installed fine. Translated with `translateConvexWriteError` and **the connect's own options**, so no new copy is invented: the backend's `GithubChecksRefusal("Could not list repositories from GitHub.")` keeps its retry advice via the string-data branch, a membership or availability refusal maps exactly as the connect below would have mapped it, and a transport failure still answers 5xx. The *read* translator was the wrong tool — it would flatten the first of those into a generic 502 and page on somebody else's outage.

**A listing entry with no `installationRef`** (the pinned compatibility branch's own output) sends **neither** selector. That branch only produces entries at all when the pin *is* set, so sending nothing there is both correct and functional — and it keeps "no reference" the byte-identical path the backend explicitly documents it as, rather than a second, slightly different way to write a verified row. `repositoryId` is gated on the ref for the same reason (the action only consults it on the reference path).

**Preserved:** request schema, `.strict()` rejection of unknown keys, the required explicit `outagePolicy`, 201 + response shape, the guest boundary, and the rule that this route calls the *verified* action and never the deprecated `checkRepoConfigs:connectRepo`.

## Verification

**Red-test probe (done).** Stashed **only** `eval-checks.ts`, kept the test file, re-ran:

```
Test Files  1 failed (1)
     Tests  5 failed | 12 passed (17)
```

The five that failed are the five new behaviour claims:

| test | failure without the fix |
|---|---|
| forwards the installationRef AND repositoryId | called with the 5-key body; `installationRef`/`repositoryId` absent |
| matches case-insensitively | `repoFullName: "  Acme/Widgets  "`, no selectors |
| refuses an unknown repo non-disclosingly | `expected 201 to be 404` |
| refuses an ambiguous match | `expected 201 to be 404` |
| does not fall through when the listing fails | `expected 201 to be greater than or equal to 400` |

The sixth new test ("sends NEITHER selector for a listing entry that carries no reference") passes without the fix by construction — it pins the compat shape, which is what the old code always produced. Called out rather than dressed up as red.

Unstashed; all **17 pass**.

**Other checks**

- `npx tsc --noEmit -p server/tsconfig.json` — clean for both touched files (the repo has a pre-existing error baseline elsewhere; none of it is in `eval-checks*`).
- Prettier: `mcpjam-inspector/.prettierrc` exists (v2.8.8, `trailingComma: "all"`). Every line I added is prettier-clean under it. Both files were *already* non-conformant at `origin/main`, and I reverted the six pre-existing lines an accidental whole-file `--write` had swept, so the diff contains only lines I actually changed.
- No changeset-worthy surface change beyond the fix; one added under `.changeset/`.

**One thing that did not run:** `server/routes/v1/__tests__/sdk-coverage.test.ts` (and `agent-op-registry.test.ts`) fail at **collection** in my worktree — `Cannot find module '@ai-sdk/harness/agent'` — and they fail identically on a pristine `origin/main` tree in the same worktree, which I verified by stashing everything and re-running. It is the known symlinked-`node_modules` worktree artifact, not this change. On the substance they assert: `sdk-coverage` maps route *paths* to SDK method names and `agent-op-registry` maps the op to its proposal copy; this PR adds no route and changes no request shape, so `connectEvalCheckRepo` parity is untouched. (`server/services/plugins/shim/PluginShim.bundled.ts` was also missing until I ran `node scripts/bundle-plugin-shim.mjs` — that one is just the `pretest` step, skipped when invoking `vitest` directly.)

## Notes on the brief

- The "comment block immediately after the `connectVerifiedRepo` call" is precisely the `notFoundMessage` comment inside the catch's `translateConvexWriteError` options. That is the string I reused. Worth knowing that the sentence the CLI *actually saw* in production was the **backend's** `REPO_NOT_ACCESSIBLE_MESSAGE`, delivered as a **400** through the write translator's string-data branch — not this 404. So the no-match refusal changes status from 400 to 404 relative to today's (always-broken) behaviour. I judged that correct: 404 is the honest answer for "the resource you named is not among the ones you may connect", and the distinction it introduces — in your installation listing vs. not — is one the caller can already make with a GET on the same org, so it is not a new oracle.
- Everything else in the brief matched the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvWWcFe2mWKLa3AV8u1X4e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes org-scoped GitHub Checks connect behavior and error semantics (404 vs prior misleading 400) on a security-sensitive integration path, though scope is limited to the v1 eval-checks POST route and aligns with existing GET listing data.
> 
> **Overview**
> **Fixes CLI/MCP GitHub Checks connect** when the GET on the same route already listed the repo as connectable but POST returned “not accessible.” The POST handler now calls `listInstallationRepos` (same source as GET), matches the requested `owner/repo` with **trim + lowercase** (aligned with backend storage), and passes **`installationRef` and `repositoryId`** into `connectVerifiedRepo`—matching what the web picker already sent. Without those fields, the backend took a retired env-pin path that fails in production.
> 
> **New refusal behavior on POST:** no listing match or ambiguous duplicate names → **404** with a single shared `REPO_NOT_CONNECTABLE_MESSAGE` (no candidate repo names leaked). Listing errors **fail the request** with the backend’s “Could not list repositories from GitHub.” wording instead of falling through to the broken no-reference connect. Compatibility-listed repos with no `installationRef` still connect without selectors.
> 
> Tests cover selector forwarding, case-insensitive match, unknown/ambiguous repos, and listing failure; changeset notes the inspector patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8d7f675b5f1d7038db9a7a14f9320322b8fa863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `POST /v1/organizations/:organizationId/eval-check-repos` so connecting a Checks repo from the CLI and MCP works again. The route previously sent no `installationRef` or `repositoryId`, which made the backend take its retired compatibility branch and refuse every connect even when the GET on the same route listed the repo as connectable; it now resolves the repository through that same listing and forwards both selectors.

- Matching is case-insensitive on the trimmed full name, mirroring the backend's stored key, so `Acme/Widgets` matches a listing that spells it `acme/widgets`.
- A repo not in the listing is refused with the existing flat 404 sentence and no candidate names, so the endpoint does not disclose private repository names.
- A name matching two listing entries is refused rather than guessed, since the backend deduplicates by numeric repository id, not by name.
- A failed listing fails the request with the backend's own "Could not list repositories from GitHub." instead of falling through to the broken no-reference path.
- Route-only change; no SDK, CLI, or backend changes.

<sup>Written for commit e8d7f675b5f1d7038db9a7a14f9320322b8fa863. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

