### PR TITLE
fix(github-checks): re-list repositories when the bindings change

### DIFF
--- a/.changeset/github-checks-listing-follows-bindings.md
+++ b/.changeset/github-checks-listing-follows-bindings.md
@@ -1,0 +1,19 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Connecting a GitHub account fills the repository picker, without a reload
+
+Finishing an installation claim in Settings → Integrations → GitHub left the page saying **"No repositories available. Connect a GitHub account above first."** The bind had succeeded: the backend was already answering with every repository the App could reach. Only a manual reload showed them. Looking at that list is the first thing anyone does after connecting an account, and it was telling them their bind had not worked.
+
+**The listing is a one-shot read of a live fact.** Repositories come from an action, which nothing re-runs on its own; which installations the organization holds comes from a query, which updates itself. The effect that fetched the listing depended on the organization, on availability, and on two memoized callbacks — and completing a bind changes none of them, so it never ran again.
+
+It now also depends on the bindings, through a **stable key** rather than the array: a Convex subscription hands back a fresh array on every delivery, including one re-sending identical rows, so depending on the array itself would ask GitHub again on every poll. The key is each binding's opaque installation reference and its status, sorted. That is exactly what changes which repositories the App can reach — an account connected, one disconnected, or one that GitHub suspended or removed — and nothing else: row order, account logins and timestamps do not move it.
+
+Three things the surface already guaranteed still hold, and one is now stated more precisely:
+
+- **A slow answer for the previous organization still cannot land on the new one.** The in-flight guard became a generation rather than a per-run flag, because the two rules differ: a re-run that merely learns the bindings' first answer must leave a request in flight alone, while one that supersedes it must guarantee that answer can never arrive.
+- **The picker still resets when the organization changes** — the connect sends the current organization id, so a selection carried across would be submitted against an organization the repository does not belong to. It deliberately does **not** reset when a binding changes: the organization has not changed, and a repository that disappeared from the refreshed listing cannot be submitted anyway.
+- **The bindings query answering for the first time is not a change.** It is not subscribed until availability says `enabled`, so it always answers after the first listing was requested — treating that as news would ask GitHub twice on every page load.
+
+The suite page's own connect section had the same staleness. No bind starts there, so the reported sequence cannot happen on it, but a binding changing elsewhere — another admin, a second tab, a webhook suspending an installation — left it just as stale. It follows the same key now.

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 const {
   mockAvailability,
   mockRepos,
+  mockBindings,
   mockConnectRepo,
   mockConnectVerifiedRepo,
   mockListInstallationRepos,
@@ -15,6 +16,9 @@ const {
     value: undefined as { state: "enabled" | "disabled" } | undefined,
   },
   mockRepos: { value: undefined as any[] | undefined },
+  // The org's installations, on a live query. What the listing below is a
+  // function of, and the only thing that changes when an account is connected.
+  mockBindings: { value: undefined as any[] | undefined },
   // The unverified connect the backend still exposes for the two-deploy
   // window. Handed to the component so that reaching for it is a recorded
   // call rather than a crash — "never called" is the assertion.
@@ -52,6 +56,7 @@ vi.mock("@/hooks/useGithubChecksSettings", () => ({
   useGithubChecksSettings: () => ({
     availability: mockAvailability.value,
     repos: mockRepos.value,
+    bindings: mockBindings.value,
     connectRepo: mockConnectRepo,
     connectVerifiedRepo: mockConnectVerifiedRepo,
     listInstallationRepos: mockListInstallationRepos,
@@ -369,5 +374,103 @@ describe("SuiteGithubChecksSection repository identity", () => {
     >;
     expect(sent).not.toHaveProperty("installationRef");
     expect(sent.repositoryId).toBe(301);
+  });
+});
+
+/**
+ * The listing is a one-shot ACTION over installations that arrive on a LIVE
+ * QUERY, exactly as on the settings page. No bind starts from here — that flow
+ * lives in Settings and navigates away — but a binding still changes under an
+ * open suite: another admin connects an account, the same person does it in a
+ * second tab, or a webhook suspends one. This section used to keep offering
+ * whatever it read when the page opened.
+ */
+describe("SuiteGithubChecksSection binding changes", () => {
+  function renderWithBindings(bindings: unknown[] | undefined) {
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = [];
+    mockBindings.value = bindings;
+    return render(
+      <SuiteGithubChecksSection
+        suiteId="suite-1"
+        projectId="proj-1"
+        organizationId="org-1"
+      />
+    );
+  }
+
+  it("re-lists when an account is connected elsewhere", async () => {
+    mockListInstallationRepos.mockReset();
+    mockListInstallationRepos
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([{ repositoryId: 401, fullName: "acme/widgets" }]);
+
+    const user = userEvent.setup();
+    const { rerender } = renderWithBindings([]);
+    await waitFor(() =>
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1)
+    );
+
+    mockBindings.value = [
+      {
+        installationRef: "bind-acme",
+        accountLogin: "acme",
+        accountType: "Organization",
+        status: "active",
+        boundAt: 1,
+        statusChangedAt: 1,
+      },
+    ];
+    rerender(
+      <SuiteGithubChecksSection
+        suiteId="suite-1"
+        projectId="proj-1"
+        organizationId="org-1"
+      />
+    );
+
+    await waitFor(() =>
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2)
+    );
+    await user.click(screen.getByLabelText("Repository"));
+    expect(
+      await screen.findByRole("option", { name: "acme/widgets" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not re-list when the query re-delivers the same bindings", async () => {
+    mockListInstallationRepos.mockReset();
+    mockListInstallationRepos.mockResolvedValue([
+      { repositoryId: 402, fullName: "acme/widgets" },
+    ]);
+    const rows = () => [
+      {
+        installationRef: "bind-acme",
+        accountLogin: "acme",
+        accountType: "Organization",
+        status: "active",
+        boundAt: 1,
+        statusChangedAt: 1,
+      },
+    ];
+
+    const { rerender } = renderWithBindings(rows());
+    await waitFor(() =>
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1)
+    );
+
+    // A fresh array with identical content, which is what every delivery of a
+    // Convex subscription looks like.
+    mockBindings.value = rows();
+    rerender(
+      <SuiteGithubChecksSection
+        suiteId="suite-1"
+        projectId="proj-1"
+        organizationId="org-1"
+      />
+    );
+    await act(async () => {});
+
+    expect(mockListInstallationRepos).toHaveBeenCalledTimes(1);
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Github, Plus } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
@@ -13,6 +13,7 @@ import { useAppNavigate } from "@/lib/app-navigation";
 import { githubChecksWriteErrorMessage } from "@/lib/github-checks-errors";
 import {
   findRepoByPickerValue,
+  installationBindingsKey,
   pickerLabelFor,
   pickerValueFor,
   shouldShowAccountLabels,
@@ -59,8 +60,13 @@ export function SuiteGithubChecksSection({
   organizationId?: string | null;
 }) {
   const appNavigate = useAppNavigate();
-  const { availability, repos, connectVerifiedRepo, listInstallationRepos } =
-    useGithubChecksSettings(organizationId);
+  const {
+    availability,
+    repos,
+    bindings,
+    connectVerifiedRepo,
+    listInstallationRepos,
+  } = useGithubChecksSettings(organizationId);
 
   const [installationRepos, setInstallationRepos] = useState<
     InstallationRepo[] | null
@@ -89,31 +95,95 @@ export function SuiteGithubChecksSection({
 
   const isEnabled = availability?.state === "enabled";
 
+  // The same staleness the settings page has, reached from the other side. No
+  // bind STARTS here — that flow lives in Settings and leaves this page — but a
+  // binding can still change under an open suite: another admin connects an
+  // account, the same person does it in a second tab, or a GitHub webhook
+  // suspends or removes one. The picker would go on offering, or go on failing
+  // to offer, whatever it read when the page opened.
+  const bindingsKey = useMemo(
+    () => installationBindingsKey(bindings),
+    [bindings]
+  );
+
+  // The bindings key the listing on screen (or in flight) was fetched under.
+  // `null` means "not asked yet" in `listedBindingsKeyRef` and "the query has
+  // not answered" in `bindingsKey`, which is why `hasListedRef` is separate:
+  // the first fetch happens BEFORE the bindings query answers — it is not even
+  // subscribed until availability says `enabled` — and reading that first
+  // answer as a change would ask GitHub twice on every visit.
+  const hasListedRef = useRef(false);
+  const listedBindingsKeyRef = useRef<string | null>(null);
+  // Which listing request is still welcome. A generation rather than a per-run
+  // `cancelled` flag: adopting the bindings' first answer must leave a request
+  // in flight alone, while superseding one must guarantee it can never land.
+  const listingGenerationRef = useRef(0);
+
+  useEffect(
+    () => () => {
+      listingGenerationRef.current += 1;
+      hasListedRef.current = false;
+      listedBindingsKeyRef.current = null;
+    },
+    []
+  );
+
   useEffect(() => {
-    let cancelled = false;
-    setInstallationRepos(null);
-    setPickerRepo("");
-    setPickerPolicy("");
     if (!isEnabled) {
-      return () => {
-        cancelled = true;
-      };
+      listingGenerationRef.current += 1;
+      hasListedRef.current = false;
+      listedBindingsKeyRef.current = null;
+      setInstallationRepos(null);
+      setPickerRepo("");
+      setPickerPolicy("");
+      return;
     }
+
+    if (hasListedRef.current) {
+      // Already listed, so this run is about the bindings. Nothing to do when
+      // the query has not answered, or answered with the same installations in
+      // the same states — a live query hands back a fresh array on every
+      // delivery, and that is not news.
+      if (
+        bindingsKey === null ||
+        bindingsKey === listedBindingsKeyRef.current
+      ) {
+        return;
+      }
+      if (listedBindingsKeyRef.current === null) {
+        // First answer, describing what the request already in flight was made
+        // against. Adopt it as the baseline; do not fetch, and do not bump the
+        // generation, so that request still lands.
+        listedBindingsKeyRef.current = bindingsKey;
+        return;
+      }
+      // A REAL change. The listing is re-read, but the selection is left alone:
+      // the suite has not changed, and `handleConnect` re-resolves the picked
+      // value against the refreshed listing before it sends anything.
+    } else {
+      setPickerRepo("");
+      setPickerPolicy("");
+    }
+
+    const generation = (listingGenerationRef.current += 1);
+    hasListedRef.current = true;
+    listedBindingsKeyRef.current = bindingsKey;
+    setInstallationRepos(null);
+
     void listInstallationRepos()
       .then((repositories) => {
-        if (!cancelled) setInstallationRepos(repositories);
+        if (listingGenerationRef.current !== generation) return;
+        setInstallationRepos(repositories);
       })
       .catch(() => {
         // Silent here, unlike the settings page. This section is incidental to
         // the suite you came to look at, and a toast about GitHub you did not
         // ask about would be noise; the picker simply stays empty and the
         // manage link still works.
-        if (!cancelled) setInstallationRepos([]);
+        if (listingGenerationRef.current !== generation) return;
+        setInstallationRepos([]);
       });
-    return () => {
-      cancelled = true;
-    };
-  }, [isEnabled, listInstallationRepos]);
+  }, [isEnabled, bindingsKey, listInstallationRepos]);
 
   if (!isEnabled) return null;
 

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate } from "react-router";
 import { useConvexAuth } from "convex/react";
 import { ChevronLeft, Github, Plus, Trash2 } from "lucide-react";
@@ -41,6 +41,7 @@ import {
 import { redirectToGithub } from "@/lib/github-external-redirect";
 import {
   findRepoByPickerValue,
+  installationBindingsKey,
   pickerLabelFor,
   pickerValueFor,
   shouldShowAccountLabels,
@@ -299,44 +300,145 @@ export function GithubChecksRoute({
     toast.error(githubChecksWriteErrorMessage(error));
   }, []);
 
+  /**
+   * The signal that says the offerable repositories have gone stale.
+   *
+   * `listInstallationRepos` is an action — a one-shot read that nothing re-runs
+   * on its own — while `bindings` is a live query. Deriving one stable string
+   * from the other is what lets the listing follow a bind without a reload; see
+   * `installationBindingsKey` for why it is a key rather than the array.
+   */
+  const bindingsKey = useMemo(
+    () => installationBindingsKey(bindings),
+    [bindings]
+  );
+
+  // Switching organizations must not carry a selection across: the connect
+  // sends the CURRENT org id, so a picked repository left over from the
+  // previous org would be submitted against an org it does not belong to.
+  //
+  // Deliberately SEPARATE from the listing effect below, which now also runs
+  // when the bindings change. Connecting an account, or one being suspended
+  // elsewhere, is not a reason to throw away a half-made choice — the
+  // organization it belongs to has not changed. And a repository that
+  // disappears from the refreshed listing cannot be submitted anyway:
+  // `handleConnect` re-resolves the picked value against the listing and
+  // refuses when it no longer resolves.
   useEffect(() => {
-    // Switching orgs must not let the previous org's in-flight result land on
-    // the new one: `connectVerifiedRepo` sends the CURRENT org id, so a stale
-    // selection would be submitted against an org that repo does not belong to.
-    // Reset the picker and ignore any completion after cleanup.
-    let cancelled = false;
-    setInstallationRepos(null);
-    setInstallationReposFailed(false);
     setPickerRepo("");
     setPickerSuite("");
     setPickerPolicy("");
+  }, [activeOrganizationId]);
 
+  /**
+   * What the listing on screen (or in flight) was fetched for.
+   *
+   * The effect below now runs for two different reasons, and only one of them
+   * is a reason to ask GitHub again. `bindings` is not queried until
+   * availability says `enabled` (see `useGithubChecksSettings`), so it is still
+   * `undefined` on the render that starts the FIRST fetch and answers a round
+   * trip later — reading that first answer as a change would double every cold
+   * load, for installations the fetch already in flight had read anyway.
+   */
+  const listedForRef = useRef<{
+    organizationId: string | null | undefined;
+    bindingsKey: string | null;
+  } | null>(null);
+
+  /**
+   * Which listing request the page is still willing to accept.
+   *
+   * A GENERATION rather than a per-run `cancelled` flag, because the two are
+   * not the same rule and the difference is load-bearing: a re-run that only
+   * adopts the bindings' first answer must leave the request already in flight
+   * alone, while a re-run that supersedes it — a different organization, an
+   * actual change in the bindings, availability going away — must make sure its
+   * answer can never land. Only the second bumps this.
+   */
+  const listingGenerationRef = useRef(0);
+
+  // Nothing that was asked for on behalf of THIS instance may land after it is
+  // gone. `handleWriteError` toasts, and `toast` is global: a failure for a page
+  // the user has left is noise they cannot act on. Clearing the record as well
+  // is what lets React 18 StrictMode's mount-cleanup-mount fetch again rather
+  // than trust a listing that was thrown away.
+  useEffect(
+    () => () => {
+      listingGenerationRef.current += 1;
+      listedForRef.current = null;
+    },
+    []
+  );
+
+  useEffect(() => {
     if (availability?.state !== "enabled") {
-      return () => {
-        cancelled = true;
-      };
+      listingGenerationRef.current += 1;
+      listedForRef.current = null;
+      setInstallationRepos(null);
+      setInstallationReposFailed(false);
+      // The surface going away takes the selection with it, as it always did.
+      // Nothing renders it in this state, but coming back with a repository
+      // chosen from a listing that is no longer on screen would be a choice
+      // made against nothing.
+      setPickerRepo("");
+      setPickerSuite("");
+      setPickerPolicy("");
+      return;
     }
+
+    const listedFor = listedForRef.current;
+    if (listedFor && listedFor.organizationId === activeOrganizationId) {
+      // Same organization, so this run is about the bindings.
+      if (bindingsKey === null || bindingsKey === listedFor.bindingsKey) {
+        // Either the query has not answered, or it re-delivered rows that
+        // describe the same installations in the same states. Nothing the
+        // listing depends on has moved.
+        return;
+      }
+      if (listedFor.bindingsKey === null) {
+        // The listing was requested before the query had answered, so its first
+        // answer is not a change: it describes the installations that request
+        // was already made against. Adopt it as the baseline — comparing
+        // against it is what makes the NEXT bind a change — and deliberately do
+        // not bump the generation, so the request in flight still lands.
+        listedForRef.current = {
+          organizationId: activeOrganizationId,
+          bindingsKey,
+        };
+        return;
+      }
+    }
+
+    // Switching orgs must not let the previous org's in-flight result land on
+    // the new one: `connectVerifiedRepo` sends the CURRENT org id, so a stale
+    // selection would be submitted against an org that repo does not belong to.
+    const generation = (listingGenerationRef.current += 1);
+    listedForRef.current = {
+      organizationId: activeOrganizationId,
+      bindingsKey,
+    };
+    setInstallationRepos(null);
+    setInstallationReposFailed(false);
 
     void listInstallationRepos()
       .then((repositories) => {
-        if (!cancelled) setInstallationRepos(repositories);
+        if (listingGenerationRef.current !== generation) return;
+        setInstallationRepos(repositories);
       })
       .catch((error) => {
-        if (cancelled) return;
+        if (listingGenerationRef.current !== generation) return;
         setInstallationReposFailed(true);
         handleWriteError(error);
       });
-
-    return () => {
-      cancelled = true;
-    };
-    // `activeOrganizationId` is listed even though nothing in the body reads it
-    // directly: the org IS what this effect resets for, and depending only on
-    // the callback's identity would tie the reset to a memoization detail of
-    // the hook rather than to the switch itself.
+    // `activeOrganizationId` is listed for the same reason it always was: the
+    // org IS what this effect re-reads for, and depending only on the
+    // callback's identity would tie that to a memoization detail of the hook
+    // rather than to the switch itself. The body reads it now as well, to tell
+    // an org switch apart from a change in the bindings.
   }, [
     activeOrganizationId,
     availability?.state,
+    bindingsKey,
     listInstallationRepos,
     handleWriteError,
   ]);

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -953,6 +953,198 @@ describe("GithubChecksRoute organization switching", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
+// BINDING CHANGES — the listing has to follow them
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// The offerable repositories come from an ACTION: a one-shot read that nothing
+// re-runs on its own. What decides its answer — which installations this
+// organization holds — arrives on a LIVE QUERY. So connecting an account has to
+// be what re-reads the listing, and the bug that says otherwise is not subtle:
+// a claim that succeeded server-side, repositories waiting behind it, and a
+// page still saying "Connect a GitHub account above first" until a reload.
+//
+// The other half is just as load-bearing. A Convex subscription hands back a
+// fresh array on every delivery, including one that re-sends identical rows, so
+// anything that watched the array itself would ask GitHub again on every poll.
+describe("GithubChecksRoute binding changes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = [];
+    mockSuites.value = [
+      { _id: "suite-1", name: "Fixture suite", projectId: "proj-1" },
+    ];
+    mockOrgsLoading.value = false;
+    mockAuthLoading.value = false;
+    mockBindings.value = [];
+    mockListInstallationRepos.mockReset();
+    mockConnectVerifiedRepo.mockReset();
+    mockConnectVerifiedRepo.mockResolvedValue({ configId: "cfg-new" });
+  });
+
+  it("re-lists repositories when an account is connected, with no reload", async () => {
+    mockListInstallationRepos
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([repo("acme/widgets", { accountLogin: "acme" })]);
+
+    const user = userEvent.setup();
+    const { rerender } = render(routeTree("org-1"));
+
+    // Where the user starts: nothing connected, so nothing to offer.
+    expect(
+      await screen.findByText(
+        /No repositories available\. Connect a GitHub account above first\./
+      )
+    ).toBeInTheDocument();
+    expect(mockListInstallationRepos).toHaveBeenCalledTimes(1);
+
+    // The bind lands. NOTHING else about this page changes — same org, still
+    // enabled, same memoized callbacks — which is exactly why the listing used
+    // to sit there stale.
+    mockBindings.value = [binding("acme")];
+    rerender(routeTree("org-1"));
+
+    await waitFor(() =>
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2)
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/No repositories available/)
+      ).not.toBeInTheDocument()
+    );
+    await user.click(screen.getByLabelText("Repository"));
+    expect(
+      await screen.findByRole("option", { name: "acme/widgets" })
+    ).toBeInTheDocument();
+  });
+
+  it("re-lists when a binding's status changes, not only when one appears", async () => {
+    mockBindings.value = [binding("acme")];
+    mockListInstallationRepos.mockResolvedValue([repo("acme/widgets")]);
+
+    const { rerender } = render(routeTree("org-1"));
+    await waitFor(() =>
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1)
+    );
+
+    // Suspended, removed and unbound each stop an installation answering for
+    // its repositories, so the set being unchanged is not the question.
+    mockBindings.value = [binding("acme", { status: "suspended" })];
+    rerender(routeTree("org-1"));
+
+    await waitFor(() =>
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2)
+    );
+  });
+
+  it("does not re-list when the live query re-delivers the same bindings", async () => {
+    mockBindings.value = [binding("acme"), binding("beta")];
+    mockListInstallationRepos.mockResolvedValue([repo("acme/widgets")]);
+
+    const { rerender } = render(routeTree("org-1"));
+    await waitFor(() =>
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1)
+    );
+
+    // A new array, equal content, and the rows in the other order — all three
+    // are ordinary for a subscription and none of them is a change.
+    mockBindings.value = [binding("beta"), binding("acme")];
+    rerender(routeTree("org-1"));
+    await act(async () => {});
+
+    expect(mockListInstallationRepos).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-list when the bindings query answers for the first time", async () => {
+    // `undefined` is the state every cold load starts in: the bindings query is
+    // not even subscribed until availability says `enabled`, so it answers
+    // AFTER the first listing was asked for. That answer describes the same
+    // installations that request was made against — reading it as a change
+    // would double every page load.
+    mockBindings.value = undefined;
+    mockListInstallationRepos.mockResolvedValue([repo("acme/widgets")]);
+
+    const { rerender } = render(routeTree("org-1"));
+    await waitFor(() =>
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1)
+    );
+
+    mockBindings.value = [binding("acme")];
+    rerender(routeTree("org-1"));
+    await act(async () => {});
+
+    expect(mockListInstallationRepos).toHaveBeenCalledTimes(1);
+    // …and the listing that was in flight is still the one on screen.
+    expect(
+      await screen.findByRole("combobox", { name: "Repository" })
+    ).toBeInTheDocument();
+  });
+
+  it("still resets the picker on an org switch, and still drops the stale listing", async () => {
+    // The org-switch guarantees have to survive the refetch machinery: the
+    // reset moved out of the listing effect, and the in-flight guard is now a
+    // generation rather than a per-run flag.
+    mockBindings.value = [binding("acme")];
+    let resolveStale: ((repos: unknown[]) => void) | undefined;
+    mockListInstallationRepos
+      .mockResolvedValueOnce([repo("acme/widgets")])
+      // The refetch caused by the bind below, left hanging so that the ORG
+      // SWITCH happens while it is still in flight.
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStale = resolve as (repos: unknown[]) => void;
+          })
+      )
+      .mockResolvedValue([repo("beta/gadgets", { accountLogin: "beta" })]);
+
+    const user = userEvent.setup();
+    const { rerender } = render(routeTree("org-1"));
+    await waitFor(() =>
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1)
+    );
+    await chooseOption(user, "Repository", "acme/widgets");
+    await chooseOption(user, "Outage policy", "Fail closed");
+
+    // A second account is connected: the listing is re-read, and the choice
+    // just made is deliberately KEPT — the organization it belongs to has not
+    // changed, and losing it would punish someone for someone else's bind.
+    mockBindings.value = [binding("acme"), binding("beta")];
+    rerender(routeTree("org-1"));
+    await waitFor(() =>
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2)
+    );
+    expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
+      "Fail closed"
+    );
+
+    // Now the org changes while that refetch is still in flight.
+    rerender(routeTree("org-2"));
+    await waitFor(() =>
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(3)
+    );
+    expect(screen.getByLabelText("Repository")).toHaveTextContent(
+      "Select a repository"
+    );
+    expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
+      "Select an outage policy"
+    );
+
+    // org-1's answer, arriving late. It must not repopulate org-2's picker.
+    await act(async () => {
+      resolveStale?.([repo("acme/widgets")]);
+    });
+    await user.click(screen.getByLabelText("Repository"));
+    expect(
+      await screen.findByRole("option", { name: "beta/gadgets" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "acme/widgets" })
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
 // GITHUB ACCOUNTS — the org ↔ installation binding surface
 // ═══════════════════════════════════════════════════════════════════════════
 //

--- a/mcpjam-inspector/client/src/lib/github-repo-picker.ts
+++ b/mcpjam-inspector/client/src/lib/github-repo-picker.ts
@@ -1,5 +1,6 @@
 import type {
   GithubCheckOutagePolicy,
+  GithubInstallationBinding,
   InstallationRepo,
 } from "@/hooks/useGithubChecksSettings";
 
@@ -7,12 +8,51 @@ import type {
  * The repository-picker rules, in one place.
  *
  * Two surfaces offer the same picker — the settings page and the suite's own
- * section — and all three rules below are a CONTRACT WITH THE BACKEND rather
- * than a presentation detail: which value selects a repository, and what the
- * verified connect is told about it. Written twice, they drift the first time
- * either side gains a field, and the failure mode is not a broken build but a
- * connect that names the wrong installation.
+ * section — and the rules below are a CONTRACT WITH THE BACKEND rather than a
+ * presentation detail: which value selects a repository, what the verified
+ * connect is told about it, and when the offered list has gone stale. Written
+ * twice, they drift the first time either side gains a field, and the failure
+ * mode is not a broken build but a connect that names the wrong installation.
  */
+
+/**
+ * A STABLE description of the installations an organization holds.
+ *
+ * Both surfaces fetch the offerable repositories through an ACTION, which is a
+ * one-shot read: nothing re-runs it on its own. What changes its answer is the
+ * set of installations bound to the organization, and that arrives on a live
+ * query — so this is the signal an effect watches to know the listing on screen
+ * has gone stale. Without it, a page that was open across a bind keeps
+ * rendering the empty listing it fetched before the account was connected.
+ *
+ * It cannot be the bindings ARRAY. That comes from a Convex subscription, whose
+ * identity changes on every delivery including one that re-sends byte-identical
+ * rows, so an effect keyed on it would ask GitHub again on every update. Two
+ * things, and only these two, change which repositories the App can reach:
+ *
+ *   - WHICH installations are bound (`installationRef`), and
+ *   - WHAT STATE each one is in (`status`) — `suspended`, `removed` and
+ *     `unbound` each stop an installation answering for its repositories, so a
+ *     status change matters even though the set is unchanged.
+ *
+ * Sorted, so row ORDER cannot masquerade as a change. `accountLogin`, `boundAt`
+ * and `statusChangedAt` are excluded deliberately: none of them changes what
+ * the App can reach, and a key that moves for a reason the listing does not
+ * care about is a refetch nobody asked for.
+ *
+ * `undefined` — the query has not answered yet — returns `null` rather than the
+ * empty-set key. "We have not been told" is not "there are none", and a caller
+ * that cannot tell them apart would read the first answer as a change.
+ */
+export function installationBindingsKey(
+  bindings: readonly GithubInstallationBinding[] | undefined
+): string | null {
+  if (bindings === undefined) return null;
+  return bindings
+    .map((binding) => `${binding.installationRef}:${binding.status}`)
+    .sort()
+    .join("|");
+}
 
 /**
  * Find the entry a picker value refers to.


### PR DESCRIPTION
## The bug

A GitHub App installation claim completed in **Settings → Integrations → GitHub**. The bind succeeded — the backend immediately returned every connectable repository for that organization — and the page went on rendering:

> No repositories available. Connect a GitHub account above first.

A manual reload fixed it. Looking at that list is the first thing anyone does after connecting an account, so the surface was telling people their bind had failed at the exact moment it had worked.

## Why

The repository listing comes from an **action** — `listInstallationRepos`, a one-shot read that nothing re-runs on its own. What decides its answer, the set of installations bound to the organization, comes from a **live query**. The effect that fetched the listing depended on:

```
[activeOrganizationId, availability?.state, listInstallationRepos, handleWriteError]
```

Completing a bind changes none of those. Same organization, availability already `enabled`, both callbacks memoized — so the effect never ran again and the component kept its pre-bind (empty) listing for the life of the page.

## The fix

The listing now also depends on the bindings, through a **stable key** rather than the array. A Convex subscription hands back a fresh array on every delivery — including one re-sending byte-identical rows — so depending on the array itself would ask GitHub again on every poll.

The key (`installationBindingsKey`, in `client/src/lib/github-repo-picker.ts`, shared by both surfaces) is each binding's opaque `installationRef` paired with its `status`, **sorted**:

- `installationRef` — an installation appearing or disappearing changes what can be reached;
- `status` — `suspended`, `removed` and `unbound` each stop an installation answering for its repositories, so a status change counts even when the set does not move;
- sorted, so row order cannot masquerade as a change;
- `accountLogin`, `boundAt` and `statusChangedAt` are excluded: none of them changes what the App can reach.
- `undefined` (the query has not answered) maps to `null`, never to the empty-set key. "Not told" is not "there are none".

### What was deliberately preserved

- **A slow answer for the previous organization still cannot land on the new one.** The in-flight guard became a *generation* rather than a per-run `cancelled` flag, because the two rules are genuinely different: a re-run that only adopts the bindings' first answer must leave the request already in flight alone, while a re-run that supersedes it — different org, real change in the bindings, availability going away, unmount — must guarantee its answer can never arrive.
- **`activeOrganizationId` stays in the deps**, for the reason the old comment gave. The body reads it now as well, to tell an org switch apart from a bindings change; the comment says so rather than being left false.
- **The tri-state availability handling is untouched**: `undefined` renders nothing, only an explicit `disabled` redirects.

### Two judgement calls

**Resetting the picker on a binding change: no.** The reset moved into its own effect keyed on `activeOrganizationId`. Switching organizations must clear the selection — the connect sends the *current* org id, so a leftover pick would be submitted against an org the repository does not belong to. A binding changing is not that: the organization has not changed, and throwing away a half-made choice because a colleague connected an account is a punishment for someone else's action. It is safe as well as kinder — `handleConnect` re-resolves the picked value against the refreshed listing and refuses with a toast when it no longer resolves, so a repository that vanished cannot be submitted.

**The bindings query's FIRST answer is not a change.** That query is not subscribed until availability says `enabled`, so it always answers *after* the first listing was requested — treating it as news would ask GitHub twice on every cold page load and blank the picker in between, for installations that request was already made against. The page records what the listing on screen (or in flight) was fetched for and adopts that first answer as its baseline without refetching and without invalidating the request in flight.

### The suite page

`suite-github-checks-section.tsx` **had the same staleness**, reached from the other side, and is fixed the same way. No bind *starts* there — that flow lives in Settings and navigates away — so the exact reported sequence is not reachable on it. But a binding still changes under an open suite: another admin connects an account, the same person does it in a second tab, or a GitHub webhook suspends or removes one. Its picker would go on offering, or go on failing to offer, whatever it read when the page opened.

## Verification

- **Red-test probe.** Stashing only the implementation hunks (the two components and the shared helper), leaving the tests, fails 3 of the 5 new route tests: `expected "spy" to be called 2 times, but got 1 times` — a binding appearing, a binding's status changing, and the org-switch test at its "the bind re-lists" step. The suite-section test fails the same way. The two negative tests (identical re-poll, first answer) pass without the fix, as they must: they guard against the fix over-firing, not against the bug.
- `client/src/components/settings/__tests__/github-checks-route.test.tsx` — 62 passing (5 new).
- `client/src/components/settings/__tests__/github-install-callback-route.test.tsx` — 19 passing.
- `client/src/components/evals/__tests__/suite-github-checks-section.test.tsx` — 17 passing (2 new).
- `tsc --noEmit -p client/tsconfig.typecheck.json` — clean.
- Changeset added.

Error copy for this surface stays in `client/src/lib/github-checks-errors.ts`; nothing new was inlined. `server/routes/v1/eval-checks.ts` and the hook's `SUITES_QUERY` call are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvWWcFe2mWKLa3AV8u1X4e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes async listing fetch and race handling on GitHub integration UI paths; mistakes could show wrong repos or drop user selections, but no auth or data-store changes.
> 
> **Overview**
> Fixes the repository picker staying empty after a successful GitHub account connect until reload. **Settings → Integrations → GitHub** and the suite connect section now **re-run** `listInstallationRepos` when installation bindings actually change, not only on org or availability changes.
> 
> Adds shared **`installationBindingsKey`** in `github-repo-picker.ts`: a sorted `installationRef:status` string so Convex subscription array churn does not spam GitHub. Listing fetch logic uses a **generation** guard so stale org/bindings responses cannot land after superseding events, while the bindings query’s **first** answer after cold load does not trigger a duplicate fetch.
> 
> Org switches still clear picker selections; binding-only updates refresh the list but keep in-progress picks (connect re-validates against the new listing). New tests cover re-list on connect/status change, no re-list on identical re-polls or first bindings answer, and org-switch + stale in-flight behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7c57cd4c1036563ae2c6b12f5710700f0b01936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitHub checks repository picker going stale after connecting a GitHub account. The settings page and the suite section now re-list available repositories when bindings change, instead of showing "No repositories available" until a manual reload.

- The listing effect now depends on a stable key built from each binding's `installationRef` and `status` (sorted); depending on the array itself would refetch on every Convex delivery, since each one is a fresh array.
- The bindings query's first answer is adopted as a baseline, not a change, so cold page loads don't fetch twice.
- The in-flight guard became a generation counter so a slow answer from the previous org can't land on the new one.
- The picker still resets on org switch, but deliberately not on binding change — a repository that vanished from the refreshed list can't be submitted anyway.
- The suite page's connect section had the same staleness and follows the same key.

<sup>Written for commit e7c57cd4c1036563ae2c6b12f5710700f0b01936. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

