### PR TITLE
feat(evals): suite dashboard layout and navigation iteration

### DIFF
--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -7,14 +7,6 @@ import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@mcpjam/design-system/breadcrumb";
 import { EvalsEmptyHero } from "./evals/evals-empty-hero";
 import {
   runExcalidrawQuickstart,
@@ -196,7 +188,7 @@ function EvalsTabContent({
     environmentIds: string[] | null;
   }) => Promise<unknown>;
 
-  const selectedSuiteId =
+  const routeSuiteId =
     route.type === "suite-overview" ||
     route.type === "run-detail" ||
     route.type === "test-detail" ||
@@ -204,6 +196,13 @@ function EvalsTabContent({
     route.type === "suite-edit"
       ? route.suiteId
       : null;
+  /** Suite to keep visible under the create dialog while `/evals/create` is open. */
+  const [createOverlaySuiteId, setCreateOverlaySuiteId] = useState<
+    string | null
+  >(null);
+  const selectedSuiteId =
+    routeSuiteId ??
+    (route.type === "create" ? createOverlaySuiteId : null);
   const selectedTestId =
     route.type === "test-detail" || route.type === "test-edit"
       ? route.testId
@@ -333,10 +332,35 @@ function EvalsTabContent({
   );
 
   useEffect(() => {
+    if (route.type !== "create") {
+      setCreateOverlaySuiteId(null);
+    }
+  }, [route.type]);
+
+  // Deep-linked `/evals/create` should still show a suite behind the dialog.
+  useEffect(() => {
+    if (route.type !== "create" || createOverlaySuiteId) {
+      return;
+    }
+    if (overviewQueries.isOverviewLoading) {
+      return;
+    }
+    const mostRecent = sortSuiteOverviewEntries(visibleSuites, "recently_run")[0];
+    if (mostRecent) {
+      setCreateOverlaySuiteId(mostRecent.suite._id);
+    }
+  }, [
+    route.type,
+    createOverlaySuiteId,
+    overviewQueries.isOverviewLoading,
+    visibleSuites,
+  ]);
+
+  useEffect(() => {
     if (route.type === "list" || route.type === "create") {
       return;
     }
-    if (!selectedSuiteId) {
+    if (!routeSuiteId) {
       return;
     }
     if (overviewQueries.isOverviewLoading) {
@@ -349,7 +373,7 @@ function EvalsTabContent({
     overviewQueries.isOverviewLoading,
     route.type,
     selectedSuiteEntry,
-    selectedSuiteId,
+    routeSuiteId,
   ]);
 
   // No standalone suites list: landing on /evals jumps straight into the most
@@ -405,8 +429,12 @@ function EvalsTabContent({
 
   const handleOpenCreateSuite = useCallback(() => {
     setCreateSuitePrefillName(null);
+    const fallbackSuiteId =
+      sortSuiteOverviewEntries(visibleSuites, "recently_run")[0]?.suite._id ??
+      null;
+    setCreateOverlaySuiteId(routeSuiteId ?? fallbackSuiteId);
     navigatePlaygroundEvalsRoute({ type: "create" });
-  }, []);
+  }, [routeSuiteId, visibleSuites]);
 
   const [isQuickstartRunning, setIsQuickstartRunning] = useState(false);
 
@@ -456,12 +484,23 @@ function EvalsTabContent({
 
   const showQuickstart = Boolean(handleConnect);
 
-  const handleCreateDialogChange = useCallback((open: boolean) => {
-    if (!open) {
-      setCreateSuitePrefillName(null);
-      navigatePlaygroundEvalsRoute({ type: "list" }, { replace: true });
-    }
-  }, []);
+  const handleCreateDialogChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        setCreateSuitePrefillName(null);
+        const returnSuiteId = createOverlaySuiteId;
+        if (returnSuiteId) {
+          navigatePlaygroundEvalsRoute(
+            { type: "suite-overview", suiteId: returnSuiteId },
+            { replace: true },
+          );
+        } else {
+          navigatePlaygroundEvalsRoute({ type: "list" }, { replace: true });
+        }
+      }
+    },
+    [createOverlaySuiteId],
+  );
 
   const handleCreateSuite = useCallback(
     async (payload: CreateSuitePayload) => {
@@ -527,16 +566,6 @@ function EvalsTabContent({
   const handleSelectSuite = useCallback((suiteId: string) => {
     navigatePlaygroundEvalsRoute({ type: "suite-overview", suiteId });
   }, []);
-
-  const handleNavigateToSuiteOverview = useCallback(() => {
-    if (!selectedSuiteId) return;
-    navigatePlaygroundEvalsRoute({
-      type: "suite-overview",
-      suiteId: selectedSuiteId,
-    });
-  }, [selectedSuiteId]);
-
-  const isSuiteOverviewRoute = route.type === "suite-overview";
 
   // Shared by the Generate button (below, on the selected suite) and the
   // agent's generateEvalTests command (any resolved suite): one
@@ -988,7 +1017,8 @@ function EvalsTabContent({
       route.type === "run-detail" ||
       route.type === "test-detail" ||
       route.type === "test-edit" ||
-      route.type === "suite-edit");
+      route.type === "suite-edit" ||
+      (route.type === "create" && createOverlaySuiteId != null));
 
   const selectedTestCase = useMemo(() => {
     if (!selectedTestId) return null;
@@ -997,85 +1027,48 @@ function EvalsTabContent({
     );
   }, [selectedTestId, suiteDetails]);
 
-  const renderPlaygroundBreadcrumb = () => {
+  const renderPlaygroundHeaderNav = () => {
     if (!hasDetailRoute || !selectedSuite) return null;
-    const selectedSuiteName =
-      stripTimestampSuffix(selectedSuite.name || "") || "Untitled suite";
+
+    const isSuiteOverviewRoute = route.type === "suite-overview";
+    const nestedLabel =
+      route.type === "run-detail"
+        ? `Run ${formatRunId(route.runId)}`
+        : route.type === "test-detail" || route.type === "test-edit"
+          ? selectedTestCase?.title ??
+            (isDraftTestCaseId(selectedTestId) ? "New case" : "Case")
+          : route.type === "suite-edit"
+            ? "Settings"
+            : null;
 
     return (
-      <Breadcrumb className="min-w-0 flex-1">
-        <BreadcrumbList className="min-w-0 flex-nowrap">
-          <BreadcrumbItem>
-            <SuiteSwitcher
-              suites={visibleSuites}
-              currentSuiteId={selectedSuite._id}
-              onSelectSuite={handleSelectSuite}
-              onCreateSuite={handleOpenCreateSuite}
-              onDeleteSuite={handlers.handleDelete}
-              canDeleteSuite={(suite) => canDeleteArtifact(suite.createdBy)}
-            />
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem className="max-w-[min(220px,32vw)] min-w-0 sm:max-w-[280px]">
-            {isSuiteOverviewRoute ? (
-              <BreadcrumbPage
-                className="truncate font-medium"
-                title={selectedSuiteName}
-              >
-                {selectedSuiteName}
-              </BreadcrumbPage>
-            ) : (
-              <BreadcrumbLink asChild>
-                <button
-                  type="button"
-                  onClick={handleNavigateToSuiteOverview}
-                  title={selectedSuiteName}
-                  className="inline-flex max-w-full border-0 bg-transparent p-0 font-medium truncate"
-                >
-                  {selectedSuiteName}
-                </button>
-              </BreadcrumbLink>
-            )}
-          </BreadcrumbItem>
-          {route.type === "run-detail" ? (
-            <>
-              <BreadcrumbSeparator />
-              <BreadcrumbItem>
-                <BreadcrumbPage className="truncate font-medium">
-                  Run {formatRunId(route.runId)}
-                </BreadcrumbPage>
-              </BreadcrumbItem>
-            </>
-          ) : null}
-          {route.type === "test-detail" || route.type === "test-edit" ? (
-            <>
-              <BreadcrumbSeparator />
-              <BreadcrumbItem className="max-w-[min(220px,32vw)] min-w-0">
-                <BreadcrumbPage
-                  className="truncate font-medium"
-                  title={
-                    selectedTestCase?.title ??
-                    (isDraftTestCaseId(selectedTestId) ? "New case" : "Case")
-                  }
-                >
-                  {selectedTestCase?.title ??
-                    (isDraftTestCaseId(selectedTestId) ? "New case" : "Case")}
-                </BreadcrumbPage>
-              </BreadcrumbItem>
-            </>
-          ) : null}
-          {route.type === "suite-edit" ? (
-            <>
-              <BreadcrumbSeparator />
-              <BreadcrumbItem>
-                <BreadcrumbPage className="truncate font-medium">
-                  Settings
-                </BreadcrumbPage>
-              </BreadcrumbItem>
-            </>
-          ) : null}
-        </BreadcrumbList>
-      </Breadcrumb>
+      <>
+        <SuiteSwitcher
+          suites={visibleSuites}
+          currentSuiteId={selectedSuite._id}
+          onSelectSuite={handleSelectSuite}
+          onCreateSuite={handleOpenCreateSuite}
+          onDeleteSuite={handlers.handleDelete}
+          canDeleteSuite={(suite) => canDeleteArtifact(suite.createdBy)}
+          hideFooterCreate
+        />
+        {!isSuiteOverviewRoute && nestedLabel ? (
+          <>
+            <span
+              className="shrink-0 text-sm text-muted-foreground"
+              aria-hidden
+            >
+              /
+            </span>
+            <span
+              className="min-w-0 truncate text-sm font-medium text-foreground"
+              title={nestedLabel}
+            >
+              {nestedLabel}
+            </span>
+          </>
+        ) : null}
+      </>
     );
   };
 
@@ -1184,6 +1177,7 @@ function EvalsTabContent({
           canDeleteRuns={canDeleteRuns}
           canDeleteRun={(run) => canDeleteArtifact(run.createdBy)}
           hideRunActions
+          omitOverviewIdentity
           evalRunsDisabledReason={evalRunsDisabledReason}
           onDeleteTestCasesBatch={handleDeleteTestCasesBatch}
           onRunTestCase={(testCase, opts) => {
@@ -1230,7 +1224,9 @@ function EvalsTabContent({
       projectId={projectId}
       isDirectGuest={isDirectGuest}
       header={
-        <EvalsHeader mode="suites">{renderPlaygroundBreadcrumb()}</EvalsHeader>
+        <EvalsHeader mode="suites" onCreateSuite={handleOpenCreateSuite}>
+          {renderPlaygroundHeaderNav()}
+        </EvalsHeader>
       }
     >
       <>

--- a/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
@@ -401,7 +401,7 @@ describe("EvalsTab", () => {
     });
   });
 
-  it("navigates back to suite overview from the breadcrumb on test detail", async () => {
+  it("shows suite switcher and nested case label on test detail", () => {
     mocks.route.current = {
       type: "test-detail",
       suiteId: "suite-a",
@@ -412,15 +412,14 @@ describe("EvalsTab", () => {
         makeQueryState(selectedSuiteId),
     );
 
-    const user = userEvent.setup();
     render(<EvalsTab projectId="ws-1" />);
 
-    await user.click(screen.getByRole("button", { name: "Suite suite-a" }));
-
-    expect(mocks.navigatePlaygroundEvalsRoute).toHaveBeenCalledWith({
-      type: "suite-overview",
-      suiteId: "suite-a",
-    });
+    expect(
+      screen.getByRole("button", {
+        name: /Switch suite \(current: Suite suite-a\)/,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Case")).toBeInTheDocument();
   });
 
   it("redirects invalid suite routes back to the eval list", async () => {

--- a/mcpjam-inspector/client/src/components/environment-composer/__tests__/models-pill.test.tsx
+++ b/mcpjam-inspector/client/src/components/environment-composer/__tests__/models-pill.test.tsx
@@ -41,25 +41,45 @@ function renderPill(
 }
 
 describe("modelsPillTriggerLabel", () => {
-  it("names Client defaults, plus extras, or a model count", () => {
+  const catalog = [
+    { id: "google/gemini-2.5-flash", name: "Gemini 2.5 Flash" },
+    { id: "anthropic/claude-haiku-4.5", name: "Claude Haiku 4.5" },
+  ];
+
+  it("uses literal model names on the pill trigger", () => {
     expect(
-      modelsPillTriggerLabel({
-        includeClientDefaults: true,
-        explicitModelIds: [],
-      })
-    ).toBe("Client defaults");
+      modelsPillTriggerLabel(
+        {
+          includeClientDefaults: true,
+          explicitModelIds: [],
+        },
+        {
+          clientDefaultLabel: "anthropic/claude-haiku-4.5",
+          availableModels: catalog,
+        }
+      )
+    ).toBe("Claude Haiku 4.5");
     expect(
-      modelsPillTriggerLabel({
-        includeClientDefaults: true,
-        explicitModelIds: ["a", "b"],
-      })
-    ).toBe("Client defaults +2");
+      modelsPillTriggerLabel(
+        {
+          includeClientDefaults: true,
+          explicitModelIds: ["google/gemini-2.5-flash"],
+        },
+        {
+          clientDefaultLabel: "anthropic/claude-haiku-4.5",
+          availableModels: catalog,
+        }
+      )
+    ).toBe("Claude Haiku 4.5 +1");
     expect(
-      modelsPillTriggerLabel({
-        includeClientDefaults: false,
-        explicitModelIds: ["a", "b"],
-      })
-    ).toBe("2 models");
+      modelsPillTriggerLabel(
+        {
+          includeClientDefaults: false,
+          explicitModelIds: ["google/gemini-2.5-flash", "anthropic/claude-haiku-4.5"],
+        },
+        { availableModels: catalog }
+      )
+    ).toBe("Gemini 2.5 Flash +1");
   });
 });
 

--- a/mcpjam-inspector/client/src/components/environment-composer/environment-composer.tsx
+++ b/mcpjam-inspector/client/src/components/environment-composer/environment-composer.tsx
@@ -64,9 +64,23 @@ export const DEFAULT_COMPOSER_SLOTS: ComposerSlot[] = [
   "computers",
 ];
 
+/** Evals "where it runs" row: client fan-out beside the model axis. */
+export const EVALS_RUNS_COMPOSER_SLOTS: ComposerSlot[] = ["clients", "models"];
+
+/** Evals suite setup row: saved environments plus shared stack slots. */
+export const EVALS_SUITE_SETUP_COMPOSER_SLOTS: ComposerSlot[] = [
+  "environments",
+  "servers",
+  "skills",
+  "computers",
+];
+
 export const EVALS_COMPOSER_SLOTS: ComposerSlot[] = [
-  ...DEFAULT_COMPOSER_SLOTS,
-  "models",
+  "environments",
+  ...EVALS_RUNS_COMPOSER_SLOTS,
+  "servers",
+  "skills",
+  "computers",
 ];
 
 export function EnvironmentComposer({
@@ -82,6 +96,7 @@ export function EnvironmentComposer({
   className,
   slots = DEFAULT_COMPOSER_SLOTS,
   clientDefaultLabel,
+  showTargetCount = true,
   emptyServerLabel = "Server group · client default",
   serverInfoText = "Optional shared server group for every client in this setup.",
 }: {
@@ -101,6 +116,8 @@ export function EnvironmentComposer({
   slots?: readonly ComposerSlot[];
   /** Secondary text on the Client-defaults row (previewed host's model). */
   clientDefaultLabel?: string | null;
+  /** Fan-out budget line under the strip. Off for compact headers (eval suite). */
+  showTargetCount?: boolean;
   /**
    * Empty-state label and info tooltip for the servers pill. The defaults are
    * the strip's own wording, where the group is genuinely optional; a surface
@@ -420,7 +437,7 @@ export function EnvironmentComposer({
             : "These environments don't share one setup — they differ by client or by their server group, skills or image — so editing the stack would change what some of them run. Change the environment selection instead."}
         </p>
       ) : null}
-      {modelsEnabled && !disabled ? (
+      {showTargetCount && modelsEnabled && !disabled ? (
         <p
           className="text-[11px] text-muted-foreground"
           data-testid={testId("target-count")}

--- a/mcpjam-inspector/client/src/components/environment-composer/models-pill.tsx
+++ b/mcpjam-inspector/client/src/components/environment-composer/models-pill.tsx
@@ -63,8 +63,12 @@ export function ModelsPill({
   const staleExplicit = explicit.filter((id) => !catalogIds.has(id));
   const includeDefaults = value.includeClientDefaults;
   const triggerLabel = useMemo(
-    () => modelsPillTriggerLabel(value),
-    [value]
+    () =>
+      modelsPillTriggerLabel(value, {
+        clientDefaultLabel,
+        availableModels,
+      }),
+    [availableModels, clientDefaultLabel, value]
   );
 
   const replaceSoleChoice = canReplaceSoleChoice(budget);
@@ -263,13 +267,41 @@ export function ModelsPill({
   );
 }
 
-export function modelsPillTriggerLabel(value: ModelSelection): string {
-  const n = value.explicitModelIds.length;
-  if (value.includeClientDefaults && n === 0) return "Client defaults";
-  if (value.includeClientDefaults && n > 0) return `Client defaults +${n}`;
-  if (n === 1) return "1 model";
-  if (n > 1) return `${n} models`;
-  return "No models · pick some";
+export type ModelsPillTriggerLabelOptions = {
+  /** Previewed host model id or display string — shown on the pill, not in copy. */
+  clientDefaultLabel?: string | null;
+  availableModels?: ReadonlyArray<{ id: string | number; name: string }>;
+};
+
+function resolveModelDisplayName(
+  modelId: string,
+  availableModels: ReadonlyArray<{ id: string | number; name: string }>
+): string {
+  const catalog = availableModels.find((model) => String(model.id) === modelId);
+  return compactModelLabel(catalog?.name ?? modelId) || modelId;
+}
+
+/** Pill trigger copy — literal model names; dropdown keeps "Client defaults". */
+export function modelsPillTriggerLabel(
+  value: ModelSelection,
+  options?: ModelsPillTriggerLabelOptions
+): string {
+  const availableModels = options?.availableModels ?? [];
+  const names: string[] = [];
+
+  if (value.includeClientDefaults) {
+    const fromCatalog = options?.clientDefaultLabel
+      ? resolveModelDisplayName(options.clientDefaultLabel, availableModels)
+      : null;
+    names.push(fromCatalog ?? "Default model");
+  }
+  for (const modelId of value.explicitModelIds) {
+    names.push(resolveModelDisplayName(modelId, availableModels));
+  }
+
+  if (names.length === 0) return "No models · pick some";
+  if (names.length === 1) return names[0]!;
+  return `${names[0]!} +${names.length - 1}`;
 }
 
 function wouldExceedBudget(

--- a/mcpjam-inspector/client/src/components/evals/__tests__/metric-strip-data.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/metric-strip-data.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildCellMetricStripData } from "../metric-strip-data";
+import {
+  buildCellMetricStripData,
+  formatMetricStripCollapsedSummary,
+} from "../metric-strip-data";
 
 describe("buildCellMetricStripData", () => {
   it("aggregates headline latency and pass counts across runs", () => {
@@ -48,5 +51,51 @@ describe("buildCellMetricStripData", () => {
     expect(data?.latest.latencyP50).toBe(17_200);
     expect(data?.latest.latencyP95).toBe(17_200);
     expect(data?.showTrend).toBe(false);
+  });
+});
+
+describe("formatMetricStripCollapsedSummary", () => {
+  it("includes pass counts, latency, tokens, and tool calls", () => {
+    const summary = formatMetricStripCollapsedSummary({
+      latest: {
+        passRate: 25,
+        passed: 2,
+        total: 8,
+        failed: 6,
+        latencyP50: 19_700,
+        latencyP95: 27_100,
+        tokens: 24_500,
+        toolCalls: 14,
+      },
+      series: [],
+      delta: null,
+      showTrend: false,
+    });
+
+    expect(summary).toBe(
+      "6 failing · 25% · 2/8 passed · P50 19.7s · P95 27.1s · 24.5k tokens · 14 tool calls",
+    );
+  });
+
+  it("shows an all-passing headline when nothing failed", () => {
+    const summary = formatMetricStripCollapsedSummary({
+      latest: {
+        passRate: 100,
+        passed: 8,
+        total: 8,
+        failed: 0,
+        latencyP50: 1_200,
+        latencyP95: 2_400,
+        tokens: 900,
+        toolCalls: 3,
+      },
+      series: [],
+      delta: null,
+      showTrend: false,
+    });
+
+    expect(summary).toBe(
+      "All passing · 100% · 8/8 passed · P50 1.20s · P95 2.40s · 900 tokens · 3 tool calls",
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-environment-composer-bar.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-environment-composer-bar.test.tsx
@@ -23,7 +23,7 @@ const {
   onUpdateMock,
   toastError,
 } = vi.hoisted(() => ({
-  flags: { environments: true },
+  flags: { environments: true, modelMatrix: false },
   environmentsRef: { current: [] as any[] },
   ensureAdhocMock: vi.fn(),
   setSuiteEnvironmentsMock: vi.fn(async () => ({})),
@@ -52,13 +52,30 @@ vi.mock("@/hooks/useProjectEnvironments", () => ({
   useProjectEnvironments: (projectId: string | null) =>
     projectId ? environmentsRef.current : undefined,
   useEnsureAdhocEnvironments: () => ensureAdhocMock,
-  useModelMatrixCapability: () => false,
+  useModelMatrixCapability: () => flags.modelMatrix,
+}));
+vi.mock("@/hooks/use-model-matrix-capability", () => ({
+  useModelMatrixCapability: () => flags.modelMatrix,
+}));
+vi.mock("@/hooks/use-previewed-client-id", () => ({
+  usePreviewedHostId: () => ["host-1"] as const,
+}));
+vi.mock("@/hooks/use-available-models", () => ({
+  useAvailableModels: () => ({
+    availableModels: [
+      { id: "anthropic/claude-haiku-4.5", name: "Claude Haiku 4.5" },
+    ],
+  }),
 }));
 vi.mock("@/hooks/useClients", () => ({
   useHostList: () => ({
     hosts: [
-      { hostId: "host-1", name: "Claude" },
-      { hostId: "host-2", name: "Cursor" },
+      {
+        hostId: "host-1",
+        name: "Claude",
+        modelId: "anthropic/claude-haiku-4.5",
+      },
+      { hostId: "host-2", name: "Cursor", modelId: "gpt-4" },
     ],
     isLoading: false,
   }),
@@ -92,7 +109,7 @@ const suite = (over: Partial<EvalSuite> = {}): EvalSuite =>
   }) as EvalSuite;
 
 function renderBar(over: Partial<EvalSuite> = {}, props: any = {}) {
-  render(
+  return render(
     <SuiteEnvironmentComposerBar
       suite={suite(over)}
       onUpdate={onUpdateMock}
@@ -108,6 +125,7 @@ beforeEach(() => {
   // from an earlier case would otherwise leak into every case after it.
   setSuiteEnvironmentsMock.mockResolvedValue({});
   flags.environments = true;
+  flags.modelMatrix = false;
   environmentsRef.current = [];
   ensureAdhocMock.mockImplementation(
     async (args: { stacks: Array<{ hostId: string }> }) =>
@@ -140,6 +158,55 @@ describe("SuiteEnvironmentComposerBar — environment mode", () => {
     expect(screen.getByTestId("suite-env-clients-picker")).toHaveTextContent(
       /claude/i,
     );
+  });
+
+  it("shows the models picker beside clients when model matrix is enabled", () => {
+    flags.modelMatrix = true;
+    renderBar({
+      hostAttachments: [
+        { namedHostId: "host-1", enabledOptionalServerIds: [] },
+      ] as any,
+    });
+
+    expect(screen.getByTestId("suite-env-clients-picker")).toBeInTheDocument();
+    expect(screen.getByTestId("suite-env-models-picker")).toBeInTheDocument();
+    expect(screen.getByTestId("suite-env-models-picker")).toHaveTextContent(
+      /claude haiku 4\.5/i,
+    );
+  });
+
+  it("shows the models picker when project environments are off but model matrix is on", () => {
+    flags.environments = false;
+    flags.modelMatrix = true;
+    renderBar({
+      hostAttachments: [
+        { namedHostId: "host-1", enabledOptionalServerIds: [] },
+      ] as any,
+    });
+
+    expect(screen.getByTestId("suite-env-models-picker")).toBeInTheDocument();
+  });
+
+  it("selecting a model resolves, writes, and keeps the strip interactive", async () => {
+    flags.modelMatrix = true;
+    renderBar({
+      hostAttachments: [
+        { namedHostId: "host-1", enabledOptionalServerIds: [] },
+        { namedHostId: "host-2", enabledOptionalServerIds: [] },
+      ] as any,
+    });
+
+    fireEvent.click(screen.getByTestId("suite-env-models-picker"));
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /claude haiku 4\.5/i }),
+    );
+
+    await waitFor(() => expect(setSuiteEnvironmentsMock).toHaveBeenCalled());
+    expect(ensureAdhocMock).toHaveBeenCalled();
+    expect(
+      screen.queryByTestId("suite-env-unresolved-hint"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("suite-env-models-picker")).not.toBeDisabled();
   });
 
   it("converts a legacy suite on the first edit", async () => {
@@ -206,6 +273,49 @@ describe("SuiteEnvironmentComposerBar — environment mode", () => {
     );
   });
 
+  it("stays editable after converting when project environments are off", async () => {
+    flags.environments = false;
+    flags.modelMatrix = true;
+    const { rerender } = renderBar({
+      hostAttachments: [
+        { namedHostId: "host-1", enabledOptionalServerIds: [] },
+      ] as any,
+    });
+
+    fireEvent.click(screen.getByTestId("suite-env-models-picker"));
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /claude haiku 4\.5/i }),
+    );
+
+    await waitFor(() => expect(setSuiteEnvironmentsMock).toHaveBeenCalled());
+
+    rerender(
+      <SuiteEnvironmentComposerBar
+        suite={
+          suite({
+            environmentIds: ["adhoc-host-1"],
+            hostAttachments: [
+              { namedHostId: "host-1", enabledOptionalServerIds: [] },
+            ] as any,
+          })
+        }
+        onUpdate={onUpdateMock}
+        onUpdateServerAttachment={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("suite-env-clients-picker")).not.toBeDisabled();
+    expect(screen.getByTestId("suite-env-models-picker")).not.toBeDisabled();
+  });
+
+  it("shows unresolved hint without locking the strip when attachments lag", () => {
+    environmentsRef.current = [];
+    renderBar({ environmentIds: ["env-live", "env-archived"] } as any);
+
+    expect(screen.getByTestId("suite-env-unresolved-hint")).toBeInTheDocument();
+    expect(screen.getByTestId("suite-env-clients-picker")).not.toBeDisabled();
+  });
+
   it("blocks edits while an attachment is archived, rather than dropping it", () => {
     environmentsRef.current = [
       {
@@ -219,10 +329,10 @@ describe("SuiteEnvironmentComposerBar — environment mode", () => {
     renderBar({ environmentIds: ["env-live", "env-archived"] } as any);
 
     expect(screen.getByTestId("suite-env-unresolved-hint")).toBeInTheDocument();
-    expect(screen.getByTestId("suite-env-clients-picker")).toBeDisabled();
+    expect(screen.getByTestId("suite-env-clients-picker")).not.toBeDisabled();
   });
 
-  it("waits for the environment list before allowing an edit", () => {
+  it("waits for the environment list before allowing an edit on an environment suite", () => {
     // Resolving against an empty live list would miss a matching NAMED
     // environment and mint an unnamed twin of it.
     environmentsRef.current = undefined as any;
@@ -356,7 +466,7 @@ describe("SuiteEnvironmentComposerBar — legacy mode", () => {
     expect(setSuiteEnvironmentsMock).not.toHaveBeenCalled();
   });
 
-  it("writes host attachments when project environments are off", async () => {
+  it("converts a legacy suite on the first edit when project environments are off", async () => {
     flags.environments = false;
     renderBar({
       hostAttachments: [
@@ -367,12 +477,8 @@ describe("SuiteEnvironmentComposerBar — legacy mode", () => {
     fireEvent.click(screen.getByTestId("suite-env-clients-picker"));
     fireEvent.click(screen.getByRole("checkbox", { name: /^cursor$/i }));
 
-    await waitFor(() => expect(onUpdateMock).toHaveBeenCalled());
-    expect(onUpdateMock).toHaveBeenCalledWith([
-      { namedHostId: "host-1", enabledOptionalServerIds: [] },
-      { namedHostId: "host-2", enabledOptionalServerIds: [] },
-    ]);
-    expect(setSuiteEnvironmentsMock).not.toHaveBeenCalled();
+    await waitFor(() => expect(setSuiteEnvironmentsMock).toHaveBeenCalled());
+    expect(onUpdateMock).not.toHaveBeenCalled();
   });
 
   it("refuses the last detach — a suite with no client cannot run", async () => {
@@ -389,10 +495,9 @@ describe("SuiteEnvironmentComposerBar — legacy mode", () => {
     expect(onUpdateMock).not.toHaveBeenCalled();
   });
 
-  it("is NOT editable for a suite that already attaches environments", () => {
-    // `buildSuiteRunPlans` prefers environmentIds, so a legacy client write here
-    // would report success and change nothing about what runs.
+  it("keeps the environment composer editable when project environments are off", () => {
     flags.environments = false;
+    flags.modelMatrix = true;
     renderBar({
       environmentIds: ["env-a"],
       hostAttachments: [
@@ -400,10 +505,7 @@ describe("SuiteEnvironmentComposerBar — legacy mode", () => {
       ] as any,
     } as any);
 
-    expect(
-      screen.queryByTestId("suite-env-clients-picker"),
-    ).not.toBeInTheDocument();
-    expect(screen.getByText("Claude")).toBeInTheDocument();
+    expect(screen.getByTestId("suite-env-clients-picker")).not.toBeDisabled();
   });
 
   it("renders read-only when the caller says so", () => {
@@ -417,9 +519,6 @@ describe("SuiteEnvironmentComposerBar — legacy mode", () => {
       { readOnly: true },
     );
 
-    expect(
-      screen.queryByTestId("suite-env-clients-picker"),
-    ).not.toBeInTheDocument();
-    expect(screen.getByText("Claude")).toBeInTheDocument();
+    expect(screen.getByTestId("suite-env-clients-picker")).toBeDisabled();
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-insights-collapsible.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-insights-collapsible.test.tsx
@@ -29,7 +29,7 @@ const completedRun = {
 };
 
 describe("SuiteInsightsCollapsible", () => {
-  it("shows the insight summary inline in a compact callout", () => {
+  it("shows the insight summary in a collapsible callout", () => {
     useRunInsightsMock.mockReturnValue({
       summary: "Insight body text",
       pending: false,
@@ -44,8 +44,34 @@ describe("SuiteInsightsCollapsible", () => {
     expect(screen.getByText("Run insights")).toBeInTheDocument();
     expect(screen.getByText("Insight body text")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Run insights/i }),
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: /Collapse Run insights/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("collapses to a one-line summary and hides the body", async () => {
+    const user = userEvent.setup();
+    useRunInsightsMock.mockReturnValue({
+      summary: "Insight body text",
+      pending: false,
+      failedGeneration: false,
+      requestRunInsights: vi.fn(),
+      unavailable: false,
+      requested: false,
+    });
+
+    renderWithProviders(<SuiteInsightsCollapsible runs={[completedRun]} />);
+
+    await user.click(
+      screen.getByRole("button", { name: /Collapse Run insights/i }),
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Expand Run insights/i }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Insight body text")).toHaveLength(1);
+    expect(
+      screen.getByRole("button", { name: /Expand Run insights/i }),
+    ).toHaveTextContent("Insight body text");
   });
 
   it("offers show more when the summary is long", async () => {

--- a/mcpjam-inspector/client/src/components/evals/evals-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/evals-header.tsx
@@ -1,26 +1,51 @@
 import type { ReactNode } from "react";
+import { Plus } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
 import { EvalsModeNav } from "./evals-mode-nav";
 import type { EvalsMode } from "@/lib/eval-route-url";
 
 /**
  * The Evaluate header strip, shared by both modes.
  *
- * It renders unconditionally — including on the list routes — because it now
- * carries the Suites | Runs switcher, which is how a user moves between the
- * two lenses. `children` is each mode's own breadcrumb trail on detail routes.
+ * One row: Suites | Runs on the left, suite navigation in the center (`children`),
+ * New suite pinned on the right. Detail routes pass a suite switcher (and optional
+ * nested trail) as `children` instead of a breadcrumb that repeats the suite name.
  */
 export function EvalsHeader({
   mode,
   children,
+  onCreateSuite,
 }: {
   mode: EvalsMode;
   children?: ReactNode;
+  onCreateSuite?: () => void;
 }) {
   return (
-    <div className="shrink-0 border-b border-border/60 bg-muted/15 px-4 py-2.5 sm:px-6">
-      <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+    <div
+      className="shrink-0 border-b border-border/60 bg-muted/15 px-4 py-2.5 sm:px-6"
+      data-testid="evals-header"
+    >
+      <div className="flex min-w-0 items-center gap-3 sm:gap-4">
         <EvalsModeNav mode={mode} />
-        {children}
+        {children ? (
+          <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+            {children}
+          </div>
+        ) : (
+          <div className="min-w-0 flex-1" />
+        )}
+        {onCreateSuite ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="shrink-0 gap-1.5"
+            onClick={onCreateSuite}
+          >
+            <Plus className="h-4 w-4" aria-hidden />
+            New suite
+          </Button>
+        ) : null}
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/evals/metric-strip-data.ts
+++ b/mcpjam-inspector/client/src/components/evals/metric-strip-data.ts
@@ -322,3 +322,26 @@ export function buildCaseMetricStripData(
   );
   return finalizeMetricStripData(series);
 }
+
+/** One-line headline for the collapsed suite metrics band. */
+export function formatMetricStripCollapsedSummary(
+  data: MetricStripData,
+): string {
+  const { latest } = data;
+  const verdict =
+    latest.failed > 0 ? `${latest.failed} failing` : "All passing";
+  const parts = [
+    verdict,
+    `${latest.passRate}%`,
+    `${latest.passed}/${latest.total} passed`,
+  ];
+  if (latest.latencyP50 != null) {
+    parts.push(`P50 ${formatDurationMs(latest.latencyP50)}`);
+  }
+  if (latest.latencyP95 != null) {
+    parts.push(`P95 ${formatDurationMs(latest.latencyP95)}`);
+  }
+  parts.push(`${formatCompactNumber(latest.tokens)} tokens`);
+  parts.push(`${formatCompactNumber(latest.toolCalls)} tool calls`);
+  return parts.join(" · ");
+}

--- a/mcpjam-inspector/client/src/components/evals/suite-dashboard-collapsible-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-dashboard-collapsible-section.tsx
@@ -1,0 +1,96 @@
+import { useState, type ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@mcpjam/design-system/collapsible";
+import { cn } from "@/lib/utils";
+import {
+  insightHighlightCompactLabelClass,
+  insightHighlightCompactSectionClass,
+} from "./insight-highlight-chrome";
+import { evalSurfaceCardClass } from "./eval-surface-chrome";
+
+/**
+ * Collapsible chrome for the suite dashboard bands above the results table.
+ * Keeps a one-line summary visible when collapsed so users can reclaim
+ * vertical space without losing the headline signal.
+ */
+export function SuiteDashboardCollapsibleSection({
+  label,
+  summary,
+  defaultOpen = true,
+  children,
+  trailing,
+  variant = "compact",
+  testId,
+}: {
+  label: string;
+  /** Shown beside the label when collapsed. */
+  summary?: ReactNode;
+  defaultOpen?: boolean;
+  children: ReactNode;
+  trailing?: ReactNode;
+  variant?: "compact" | "card";
+  testId?: string;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  const shellClass =
+    variant === "card"
+      ? evalSurfaceCardClass
+      : insightHighlightCompactSectionClass;
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className={cn(shellClass, "overflow-hidden")}
+      data-testid={testId}
+    >
+      <div
+        className={cn(
+          "flex items-center gap-2",
+          variant === "card" ? "px-4 py-2.5" : "px-3 py-2",
+        )}
+      >
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "flex min-w-0 flex-1 items-center gap-2 rounded-sm text-left outline-none",
+              "focus-visible:ring-2 focus-visible:ring-ring/40",
+            )}
+            aria-expanded={open}
+            aria-label={open ? `Collapse ${label}` : `Expand ${label}`}
+          >
+            <ChevronDown
+              className={cn(
+                "h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200",
+                !open && "-rotate-90",
+              )}
+              aria-hidden
+            />
+            <span className={insightHighlightCompactLabelClass}>{label}</span>
+            {!open && summary ? (
+              <span className="min-w-0 flex-1 truncate text-sm text-foreground/80">
+                {summary}
+              </span>
+            ) : null}
+          </button>
+        </CollapsibleTrigger>
+        {trailing ? (
+          <div
+            className="shrink-0"
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={(event) => event.stopPropagation()}
+          >
+            {trailing}
+          </div>
+        ) : null}
+      </div>
+      <CollapsibleContent>{children}</CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/suite-environment-composer-bar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-environment-composer-bar.tsx
@@ -20,12 +20,13 @@
  * Seeding never writes — only user edits do.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useMutation } from "convex/react";
+import { useConvexAuth, useMutation } from "convex/react";
 import { Globe, Server } from "lucide-react";
 import { ClientsPill } from "@/components/environment-composer/clients-pill";
 import {
   EnvironmentComposer,
-  EVALS_COMPOSER_SLOTS,
+  EVALS_RUNS_COMPOSER_SLOTS,
+  EVALS_SUITE_SETUP_COMPOSER_SLOTS,
 } from "@/components/environment-composer/environment-composer";
 import { SandboxImagePill } from "@/components/environment-composer/sandbox-image-pill";
 import {
@@ -46,6 +47,8 @@ import {
 } from "@/hooks/useProjectEnvironments";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import { useSkillsEnabled } from "@/hooks/useSkillsEnabled";
+import { useHostList } from "@/hooks/useClients";
+import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
 import { convexErrMessage } from "@/lib/convex-error";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
@@ -86,22 +89,39 @@ export function SuiteEnvironmentComposerBar({
    * this bar exists to remove. Show the legacy axes read-only instead.
    */
   const attachesEnvironments = (suite.environmentIds?.length ?? 0) > 0;
-  const editable =
-    !readOnly && Boolean(onUpdate) && !(attachesEnvironments && !envCapable);
+  /**
+   * Legacy bar writes `hostAttachments`, which `buildSuiteRunPlans` ignores once
+   * `environmentIds` exist — so block that path when the suite already attaches
+   * environments but this deployment cannot offer the composer.
+   *
+   * Environment mode writes through `setSuiteEnvironments` instead, so it must
+   * NOT inherit that gate: the first model/client edit converts a legacy suite
+   * into `environmentIds`, and applying the legacy guard afterward would lock
+   * the strip forever whenever project-environments is off.
+   */
+  const legacyEditable =
+    !readOnly &&
+    Boolean(onUpdate) &&
+    !(attachesEnvironments && !envCapable);
 
-  return envCapable && projectId ? (
+  // Any project-scoped suite uses the environment composer — including legacy
+  // hostAttachments suites — so the model axis matches create-suite ("Where it
+  // runs"). LegacyModeBar is only for suites with no project. Gating on
+  // `envCapable` alone hid the models pill whenever project-environments was
+  // off, even though create-suite still offered clients + models.
+  return projectId ? (
     <BarShell className={className} containerVariant={containerVariant}>
       <EnvironmentModeBar
         suite={suite}
         projectId={projectId}
-        disabled={!editable}
+        disabled={readOnly}
       />
     </BarShell>
   ) : (
     <BarShell className={className} containerVariant={containerVariant}>
       <LegacyModeBar
         suite={suite}
-        editable={editable}
+        editable={legacyEditable}
         onUpdate={onUpdate}
         onUpdateServerAttachment={onUpdateServerAttachment}
       />
@@ -173,12 +193,47 @@ function EnvironmentModeBar({
     () => (environments ?? []).filter((e) => !e.archivedAt),
     [environments]
   );
+  /**
+   * Rows returned by the last resolve, overlaid until the live query catches up.
+   * Without this, a successful write leaves `environmentIds` pointing at ad-hoc
+   * rows the list query has not delivered yet — every attachment reads as
+   * unresolved and the strip locks itself.
+   */
+  const [resolvedEnvOverlay, setResolvedEnvOverlay] = useState<
+    Map<string, NonNullable<(typeof liveEnvironments)[number]>>
+  >(() => new Map());
+  useEffect(() => {
+    setResolvedEnvOverlay((prev) => {
+      if (prev.size === 0) return prev;
+      const liveIds = new Set(liveEnvironments.map((e) => e.environmentId));
+      let changed = false;
+      const next = new Map(prev);
+      for (const id of prev.keys()) {
+        if (liveIds.has(id)) {
+          next.delete(id);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [liveEnvironments]);
+  const environmentsForComposer = useMemo(() => {
+    const byId = new Map(
+      liveEnvironments.map((env) => [env.environmentId, env])
+    );
+    for (const env of resolvedEnvOverlay.values()) {
+      if (!byId.has(env.environmentId)) byId.set(env.environmentId, env);
+    }
+    return [...byId.values()];
+  }, [liveEnvironments, resolvedEnvOverlay]);
   const attachedEnvironments = useMemo(
     () =>
       attachedIds
-        .map((id) => liveEnvironments.find((e) => e.environmentId === id))
+        .map((id) =>
+          environmentsForComposer.find((e) => e.environmentId === id)
+        )
         .filter((e): e is NonNullable<typeof e> => Boolean(e)),
-    [attachedIds, liveEnvironments]
+    [attachedIds, environmentsForComposer]
   );
   /** `undefined` until the query settles. `[]` would read as "none exist". */
   const environmentsLoading = environments === undefined;
@@ -258,32 +313,25 @@ function EnvironmentModeBar({
     // the slot as "client defaults", so the first pill edit resolves rows
     // without the override and silently moves the suite to another model.
     (!modelsEnabled && environmentsCarryModels(attachedEnvironments));
-  /**
-   * The capability probe has not answered yet. Distinct from `collapsesByHost`:
-   * nothing is wrong with the attachments, we just cannot yet tell whether the
-   * models slot exists — and until we can, `modelsEnabled` reads false, which
-   * is the same input that makes a model-bearing attachment look uneditable.
-   * Disabling (rather than declaring a collapse) keeps the hint from flashing
-   * on every load, matching how the environment list is handled above.
-   */
-  const modelCapabilityPending = Boolean(projectId) && modelMatrix === undefined;
-
   const [state, setState] = useState<EnvironmentComposerState>(seeded);
   const [saving, setSaving] = useState(false);
+  const stateRef = useRef(state);
+  stateRef.current = state;
   // Re-seed when the suite's own data changes (another tab, the settings sheet,
   // or our own write landing) — keyed on content so a new array identity from
   // the live query doesn't stomp what the user is mid-way through.
   const seedKey = JSON.stringify(seeded);
   useEffect(() => {
+    if (saving) return;
     setState(JSON.parse(seedKey) as EnvironmentComposerState);
-  }, [seedKey]);
+  }, [seedKey, saving]);
 
   // Version counter: a stale failure must not roll back state a newer
   // successful commit already wrote.
   const commitVersion = useRef(0);
   const commit = useCallback(
     async (next: EnvironmentComposerState) => {
-      const previous = state;
+      const previous = stateRef.current;
       const mine = ++commitVersion.current;
       setState(next);
       setSaving(true);
@@ -295,20 +343,29 @@ function EnvironmentModeBar({
         const emptied = !composerHasTarget(next);
         // Resolve BEFORE writing: a failure mid-way leaves at most some
         // deduped ad-hoc rows nothing points at, never a half-updated suite.
-        const environmentIds = emptied
+        const resolved = emptied
           ? null
-          : (
-              await resolveTargets({
-                state: next,
-                liveEnvironments,
-                max: MAX_SUITE_ENVIRONMENTS,
-              })
-            ).environmentIds;
+          : await resolveTargets({
+              state: next,
+              liveEnvironments: environmentsForComposer,
+              max: MAX_SUITE_ENVIRONMENTS,
+            });
+        if (resolved) {
+          setResolvedEnvOverlay((prev) => {
+            const overlay = new Map(prev);
+            for (const env of resolved.environments) {
+              overlay.set(env.environmentId, env);
+            }
+            return overlay;
+          });
+        }
         await setSuiteEnvironments({
           suiteId: suite._id,
           // The backend rejects an empty array; `null` is how a field clears.
           environmentIds:
-            environmentIds && environmentIds.length > 0 ? environmentIds : null,
+            resolved && resolved.environmentIds.length > 0
+              ? resolved.environmentIds
+              : null,
         });
       } catch (err) {
         if (commitVersion.current === mine) setState(previous);
@@ -320,36 +377,59 @@ function EnvironmentModeBar({
       }
     },
     [
-      liveEnvironments,
+      environmentsForComposer,
       resolveTargets,
       setSuiteEnvironments,
-      state,
       suite._id,
     ]
   );
 
+  const { isAuthenticated } = useConvexAuth();
+  const { hosts } = useHostList({ isAuthenticated, projectId });
+  const [previewedHostId] = usePreviewedHostId(projectId);
+  const clientDefaultLabel = useMemo(() => {
+    const attachedHostId =
+      previewedHostId ?? state.stack.hostIds[0] ?? null;
+    const host =
+      (attachedHostId
+        ? hosts.find((entry) => entry.hostId === attachedHostId)
+        : undefined) ?? hosts[0];
+    return host?.modelId ?? null;
+  }, [hosts, previewedHostId, state.stack.hostIds]);
+
+  const composerDisabled =
+    disabled ||
+    collapsesByHost ||
+    (environmentsLoading && attachedIds.length > 0);
+
+  const composerCommon = {
+    projectId,
+    environments: environmentsForComposer,
+    value: state,
+    onChange: (next: EnvironmentComposerState) => void commit(next),
+    maxTargets: MAX_SUITE_ENVIRONMENTS,
+    disabled: composerDisabled,
+    showTargetCount: false,
+    testIdPrefix: "suite-env",
+    clientDefaultLabel,
+  };
+
   return (
-    <div className="flex min-w-0 flex-col gap-1.5">
-      <div className="flex min-w-0 flex-wrap items-center gap-2">
+    <div
+      className="flex min-w-0 flex-col gap-1.5"
+      aria-busy={saving}
+      data-saving={saving ? "true" : undefined}
+    >
+      <div className="flex min-w-0 flex-wrap items-center gap-2 overflow-x-auto py-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         <EnvironmentComposer
-          projectId={projectId}
-          environments={liveEnvironments}
-          value={state}
-          onChange={(next) => void commit(next)}
-          maxTargets={MAX_SUITE_ENVIRONMENTS}
-          slots={EVALS_COMPOSER_SLOTS}
-          // Also disabled while the environment list is still loading: resolving
-          // against an empty live list would miss a matching NAMED environment
-          // and mint an unnamed twin of it.
-          disabled={
-            disabled ||
-            saving ||
-            environmentsLoading ||
-            modelCapabilityPending ||
-            unresolvedCount > 0 ||
-            collapsesByHost
-          }
-          testIdPrefix="suite-env"
+          {...composerCommon}
+          slots={EVALS_SUITE_SETUP_COMPOSER_SLOTS}
+          className="space-y-0"
+        />
+        <EnvironmentComposer
+          {...composerCommon}
+          slots={EVALS_RUNS_COMPOSER_SLOTS}
+          className="space-y-0"
         />
       </div>
       {unresolvedCount > 0 ? (
@@ -358,9 +438,9 @@ function EnvironmentModeBar({
           data-testid="suite-env-unresolved-hint"
         >
           {unresolvedCount === 1
-            ? "One attached environment is archived or unavailable."
-            : `${unresolvedCount} attached environments are archived or unavailable.`}{" "}
-          Detach it in suite settings before changing where this runs.
+            ? "One attached environment is archived or still loading."
+            : `${unresolvedCount} attached environments are archived or still loading.`}{" "}
+          Edits here will rewrite the suite&apos;s targets from the strip below.
         </p>
       ) : collapsesByHost ? (
         <p

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -122,6 +122,8 @@ interface SuiteHeaderProps {
   onSuiteHostAttachmentsUpdate?: (
     attachments: HostAttachmentDraft[]
   ) => Promise<void>;
+  /** When the global header shows the suite switcher, hide the duplicate title row. */
+  omitOverviewIdentity?: boolean;
   /** Playground run detail: compact KPI strip rendered beside the run title. */
   runDetailKpiStrip?: ReactNode;
   /**
@@ -176,6 +178,7 @@ export function SuiteHeader(props: SuiteHeaderProps) {
     runningTestCaseId = null,
     runsViewMode = "runs",
     onSuiteHostAttachmentsUpdate,
+    omitOverviewIdentity = false,
     runDetailKpiStrip,
     omitRunDetailIdentity = false,
   } = props;
@@ -942,45 +945,47 @@ export function SuiteHeader(props: SuiteHeaderProps) {
       className="mb-4 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2"
     >
       <div className="flex min-w-0 items-center gap-2">
-        <div className="min-w-0 max-w-[20rem] shrink overflow-hidden sm:max-w-md">
-          <div className="flex min-w-0 items-center gap-2">
-            {isEditingName ? (
-              <input
-                type="text"
-                value={editedName}
-                onChange={(e) => setEditedName(e.target.value)}
-                onBlur={handleNameBlur}
-                onKeyDown={handleNameKeyDown}
-                autoFocus
-                className="h-8 min-w-0 w-full max-w-full flex-1 rounded-md border border-input px-3 py-0 text-base font-semibold leading-none focus:outline-none focus:ring-2 focus:ring-ring md:text-lg"
-              />
-            ) : readOnlyConfig ? (
-              <h2
-                className="flex h-8 min-w-0 flex-1 items-center truncate px-2 text-base font-semibold leading-none md:text-lg"
-                title={suite.name}
-              >
-                {suite.name}
-              </h2>
-            ) : (
-              <Button
-                variant="ghost"
-                onClick={handleNameClick}
-                className="h-8 min-w-0 max-w-full flex-1 justify-start gap-0 px-2 text-left text-base font-semibold leading-none hover:bg-accent md:text-lg"
-                title={suite.name}
-              >
-                <span className="min-w-0 truncate text-left">{suite.name}</span>
-              </Button>
-            )}
-            {latestRunForMetadata ? (
-              <span className="shrink-0">
-                <CiMetadataDisplay
-                  ciMetadata={latestRunForMetadata.ciMetadata}
-                  compact={true}
+        {!omitOverviewIdentity ? (
+          <div className="min-w-0 max-w-[20rem] shrink overflow-hidden sm:max-w-md">
+            <div className="flex min-w-0 items-center gap-2">
+              {isEditingName ? (
+                <input
+                  type="text"
+                  value={editedName}
+                  onChange={(e) => setEditedName(e.target.value)}
+                  onBlur={handleNameBlur}
+                  onKeyDown={handleNameKeyDown}
+                  autoFocus
+                  className="h-8 min-w-0 w-full max-w-full flex-1 rounded-md border border-input px-3 py-0 text-base font-semibold leading-none focus:outline-none focus:ring-2 focus:ring-ring md:text-lg"
                 />
-              </span>
-            ) : null}
+              ) : readOnlyConfig ? (
+                <h2
+                  className="flex h-8 min-w-0 flex-1 items-center truncate px-2 text-base font-semibold leading-none md:text-lg"
+                  title={suite.name}
+                >
+                  {suite.name}
+                </h2>
+              ) : (
+                <Button
+                  variant="ghost"
+                  onClick={handleNameClick}
+                  className="h-8 min-w-0 max-w-full flex-1 justify-start gap-0 px-2 text-left text-base font-semibold leading-none hover:bg-accent md:text-lg"
+                  title={suite.name}
+                >
+                  <span className="min-w-0 truncate text-left">{suite.name}</span>
+                </Button>
+              )}
+              {latestRunForMetadata ? (
+                <span className="shrink-0">
+                  <CiMetadataDisplay
+                    ciMetadata={latestRunForMetadata.ciMetadata}
+                    compact={true}
+                  />
+                </span>
+              ) : null}
+            </div>
           </div>
-        </div>
+        ) : null}
         <div className="min-w-0 shrink">{suiteOverviewHostBar}</div>
         {overviewSettingsButton}
         {overviewSuiteNavButtons}

--- a/mcpjam-inspector/client/src/components/evals/suite-insights-collapsible.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-insights-collapsible.tsx
@@ -7,7 +7,7 @@ import { pickLatestCompletedRun } from "./helpers";
 import { useRunInsights } from "./use-run-insights";
 import { useRunGroupQuality } from "./use-run-group-quality";
 import { GroupFindingList } from "./run-group-diagnosis-presentation";
-import { InsightBannerShell } from "./insight-banner-shell";
+import { SuiteDashboardCollapsibleSection } from "./suite-dashboard-collapsible-section";
 import { insightHighlightNarrativeClass } from "./insight-highlight-chrome";
 
 /** A selected run group — when present, the banner shows cross-host diagnosis. */
@@ -58,6 +58,13 @@ function describeRunInsightsError(code: string | undefined): string {
 
 function summaryNeedsExpand(text: string): boolean {
   return text.replace(/\s+/g, " ").trim().length > SUMMARY_CLAMP_CHARS;
+}
+
+/** One-line headline for the collapsed insights band header. */
+function formatInsightCollapsedSummary(text: string, maxChars = 120): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, maxChars - 1).trim()}…`;
 }
 
 /**
@@ -172,9 +179,19 @@ function RunInsightsBanner({
     );
   }
 
+  const collapsedSummary = summary
+    ? formatInsightCollapsedSummary(summary)
+    : pending
+      ? "Generating insights vs your previous run…"
+      : requested
+        ? "Requesting insights…"
+        : formatInsightCollapsedSummary(narrative);
+
   return (
-    <InsightBannerShell
+    <SuiteDashboardCollapsibleSection
       label={title}
+      summary={collapsedSummary}
+      testId="suite-insights-collapsible"
       trailing={
         failedGeneration ? (
           <button
@@ -187,8 +204,8 @@ function RunInsightsBanner({
         ) : undefined
       }
     >
-      {body}
-    </InsightBannerShell>
+      <div className="px-3 pb-2.5 pt-0">{body}</div>
+    </SuiteDashboardCollapsibleSection>
   );
 }
 
@@ -286,9 +303,21 @@ function CrossHostInsightsBanner({ scope }: { scope: InsightGroupScope }) {
     );
   }
 
+  const collapsedSummary = summary
+    ? formatInsightCollapsedSummary(summary)
+    : !allRunsTerminal
+      ? "Cross-client diagnosis runs once every client in this group has finished."
+      : pending || requested
+        ? "Comparing clients…"
+        : error
+          ? formatInsightCollapsedSummary(error)
+          : "We'll compare how each client performed on this suite here.";
+
   return (
-    <InsightBannerShell
+    <SuiteDashboardCollapsibleSection
       label="Cross-client insights"
+      summary={collapsedSummary}
+      testId="suite-cross-host-insights-collapsible"
       trailing={
         error || failedGeneration ? (
           <button
@@ -301,8 +330,8 @@ function CrossHostInsightsBanner({ scope }: { scope: InsightGroupScope }) {
         ) : undefined
       }
     >
-      {body}
-    </InsightBannerShell>
+      <div className="px-3 pb-2.5 pt-0">{body}</div>
+    </SuiteDashboardCollapsibleSection>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -274,6 +274,7 @@ export function SuiteIterationsView({
   casesSidebarHidden,
   onShowCasesSidebar,
   omitSuiteHeader = false,
+  omitOverviewIdentity = false,
   suiteDetailOverview = false,
   evaluateDecisionSummary = false,
   alwaysShowEditIterationRows = false,
@@ -345,6 +346,8 @@ export function SuiteIterationsView({
   onShowCasesSidebar?: () => void;
   /** When true, hide {@link SuiteHeader} on run detail (e.g. CI where breadcrumbs + sidebar carry context). */
   omitSuiteHeader?: boolean;
+  /** When true, the global header shows the suite switcher — hide the duplicate title. */
+  omitOverviewIdentity?: boolean;
   /**
    * Evaluate (New) only: render {@link SuiteDetailOverview} — identity, run
    * history, cases — instead of the unified dashboard on suite overview.
@@ -1170,6 +1173,7 @@ export function SuiteIterationsView({
             onSuiteHostAttachmentsUpdate={
               readOnlyConfig ? undefined : handleUpdateHostAttachments
             }
+            omitOverviewIdentity={omitOverviewIdentity}
             omitRunDetailIdentity={omitRunDetailIdentity}
           />
         </div>

--- a/mcpjam-inspector/client/src/components/evals/suite-metric-strip.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-metric-strip.tsx
@@ -3,7 +3,9 @@ import { MetricStrip } from "./metric-strip";
 import {
   buildAggregateMetricStripData,
   buildSuiteMetricStripData,
+  formatMetricStripCollapsedSummary,
 } from "./metric-strip-data";
+import { SuiteDashboardCollapsibleSection } from "./suite-dashboard-collapsible-section";
 import type { EvalIteration, EvalSuiteRun } from "./types";
 
 /**
@@ -31,7 +33,26 @@ export function SuiteMetricStrip({
     [runs, allIterations, aggregate],
   );
 
+  const collapsedSummary = useMemo(
+    () => (data ? formatMetricStripCollapsedSummary(data) : null),
+    [data],
+  );
+
+  if (!data) return null;
+
   return (
-    <MetricStrip data={data} density="default" testId="suite-metric-strip" />
+    <SuiteDashboardCollapsibleSection
+      label="Metrics"
+      summary={collapsedSummary}
+      variant="card"
+      testId="suite-metric-strip-collapsible"
+    >
+      <MetricStrip
+        data={data}
+        density="default"
+        surface="embedded"
+        testId="suite-metric-strip"
+      />
+    </SuiteDashboardCollapsibleSection>
   );
 }

--- a/mcpjam-inspector/client/src/components/evals/suite-switcher.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-switcher.tsx
@@ -10,7 +10,6 @@ import { cn } from "@/lib/utils";
 import type { EvalSuite, EvalSuiteOverviewEntry } from "./types";
 import {
   formatOverviewRelativeTime,
-  getSuitePassFailCounts,
   stripTimestampSuffix,
   SuiteSourceBadge,
 } from "./suite-overview-presentation";
@@ -28,11 +27,13 @@ interface SuiteSwitcherProps {
    * is no membership to rank.
    */
   canDeleteSuite?: (suite: EvalSuite) => boolean;
+  /** Hide the footer create action when the header already pins New suite. */
+  hideFooterCreate?: boolean;
 }
 
 /**
- * Breadcrumb "Suites" label rendered as a dropdown — switching suites lives
- * here instead of a standalone list page. Search, jump, and create from one place.
+ * Suite picker for the Evaluate header — trigger shows the current suite name,
+ * not a generic "Suites" label. Search, jump, and optional create from the menu.
  */
 export function SuiteSwitcher({
   suites,
@@ -41,6 +42,7 @@ export function SuiteSwitcher({
   onCreateSuite,
   onDeleteSuite,
   canDeleteSuite,
+  hideFooterCreate = false,
 }: SuiteSwitcherProps) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -69,14 +71,23 @@ export function SuiteSwitcher({
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="inline-flex max-w-full items-center gap-1 truncate rounded-md px-1.5 py-0.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+          data-testid="suite-switcher-trigger"
+          className={cn(
+            "inline-flex h-8 max-w-[min(280px,50vw)] shrink-0 items-center gap-1.5 rounded-full border px-2 text-foreground outline-none transition-colors",
+            "border-border/60 bg-muted/40 hover:bg-muted/60 focus-visible:ring-2 focus-visible:ring-primary/50",
+          )}
           title={`Switch suite (current: ${currentName})`}
           aria-label={`Switch suite (current: ${currentName})`}
         >
-          <span>Suites</span>
+          <span className="grid size-5 shrink-0 place-items-center rounded-md bg-foreground text-[10px] font-semibold uppercase text-background">
+            {currentName.slice(0, 1)}
+          </span>
+          <span className="min-w-0 truncate text-xs font-medium">
+            {currentName}
+          </span>
           <ChevronDown
             className={cn(
-              "h-3.5 w-3.5 shrink-0 transition-transform",
+              "h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform",
               open && "rotate-180",
             )}
             aria-hidden
@@ -110,7 +121,6 @@ export function SuiteSwitcher({
             filtered.map((entry) => {
               const id = entry.suite._id;
               const isActive = id === currentSuiteId;
-              const counts = getSuitePassFailCounts(entry);
               const name =
                 stripTimestampSuffix(entry.suite.name || "") ||
                 "Untitled suite";
@@ -151,20 +161,6 @@ export function SuiteSwitcher({
                       </span>
                     </span>
                   </button>
-                  {counts ? (
-                    <span
-                      className={cn(
-                        "shrink-0 font-mono text-[11px] font-semibold tabular-nums",
-                        counts.passed >= counts.total
-                          ? "text-success"
-                          : counts.passed === 0
-                            ? "text-destructive"
-                            : "text-amber-600 dark:text-amber-400",
-                      )}
-                    >
-                      {counts.passed}/{counts.total}
-                    </span>
-                  ) : null}
                   {isActive ? (
                     <Check className="h-4 w-4 shrink-0 text-primary" />
                   ) : null}
@@ -196,21 +192,23 @@ export function SuiteSwitcher({
             })
           )}
         </div>
-        <div className="mt-1 border-t border-border/50 pt-1">
-          <button
-            type="button"
-            onClick={() => {
-              setOpen(false);
-              onCreateSuite();
-            }}
-            className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left text-[13px] font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-          >
-            <span className="grid size-7 shrink-0 place-items-center rounded-md border border-dashed border-border">
-              <Plus className="h-3.5 w-3.5" />
-            </span>
-            New suite
-          </button>
-        </div>
+        {!hideFooterCreate ? (
+          <div className="mt-1 border-t border-border/50 pt-1">
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                onCreateSuite();
+              }}
+              className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left text-[13px] font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+            >
+              <span className="grid size-7 shrink-0 place-items-center rounded-md border border-dashed border-border">
+                <Plus className="h-3.5 w-3.5" />
+              </span>
+              New suite
+            </button>
+          </div>
+        ) : null}
       </PopoverContent>
     </Popover>
   );

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/evals-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/evals-header.test.tsx
@@ -3,9 +3,16 @@ import { describe, expect, it, vi } from "vitest";
 import { EvalsHeader } from "../evals-header";
 
 describe("EvalsHeader", () => {
-  it("renders the Evaluate landing chrome and wires Create suite", () => {
+  it("renders Suites and Runs tabs with optional landing intro", () => {
     const onCreateSuite = vi.fn();
-    render(<EvalsHeader onCreateSuite={onCreateSuite} />);
+    render(
+      <EvalsHeader
+        onCreateSuite={onCreateSuite}
+        landingView="suites"
+        onLandingViewChange={vi.fn()}
+        showLandingIntro
+      />,
+    );
 
     expect(screen.getByTestId("evals-header")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Evaluate" })).toBeTruthy();
@@ -14,14 +21,14 @@ describe("EvalsHeader", () => {
         "We generate cases from live discovery, or describe behaviors in chat, or import your existing tests.",
       ),
     ).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /^suites$/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /^runs$/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /^suites$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^runs$/i })).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: /^create suite$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^new suite$/i }));
     expect(onCreateSuite).toHaveBeenCalledTimes(1);
   });
 
-  it("renders Suites and Runs tabs on the landing and switches the active view", () => {
+  it("switches landing views from the tab strip", () => {
     const onLandingViewChange = vi.fn();
     render(
       <EvalsHeader
@@ -40,80 +47,25 @@ describe("EvalsHeader", () => {
     expect(onLandingViewChange).toHaveBeenCalledWith("runs");
   });
 
-  it("renders a minimal Evaluate / title trail on detail routes", () => {
-    const onEvaluateClick = vi.fn();
+  it("renders center navigation children on detail routes", () => {
     render(
-      <EvalsHeader onCreateSuite={vi.fn()} onEvaluateClick={onEvaluateClick}>
+      <EvalsHeader onCreateSuite={vi.fn()} landingView="suites" onLandingViewChange={vi.fn()}>
         checkout-flow
       </EvalsHeader>,
     );
 
     expect(screen.queryByRole("heading", { name: "Evaluate" })).toBeNull();
-    expect(
-      screen.queryByText(/We generate cases from live discovery/i),
-    ).toBeNull();
-    expect(screen.queryByRole("button", { name: /^suites$/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /^runs$/i })).toBeNull();
-
-    const evaluate = screen.getByRole("button", { name: /^evaluate$/i });
-    expect(evaluate.className).toMatch(/text-muted-foreground/);
-    expect(evaluate.className).toMatch(/font-normal/);
-    expect(screen.getByText("/")).toBeTruthy();
-    const current = screen.getByRole("link", {
-      name: "checkout-flow",
-      current: "page",
-    });
-    expect(current.className).toMatch(/font-semibold/);
-    expect(
-      screen.queryByRole("button", { name: /^create suite$/i }),
-    ).toBeNull();
-
-    fireEvent.click(evaluate);
-    expect(onEvaluateClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("checkout-flow")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^new suite$/i })).toBeTruthy();
   });
 
-  it("hides Create suite when no handler is provided", () => {
-    render(<EvalsHeader />);
-
-    expect(
-      screen.queryByRole("button", { name: /^create suite$/i }),
-    ).toBeNull();
-  });
-
-  it("hides Create suite on detail routes even before the last crumb loads", () => {
+  it("hides New suite when no handler is provided", () => {
     render(
-      <EvalsHeader onCreateSuite={vi.fn()} isDetail>
-        {null}
-      </EvalsHeader>,
-    );
-
-    expect(screen.queryByRole("heading", { name: "Evaluate" })).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: /^create suite$/i }),
-    ).toBeNull();
-    // Both crumbs after "Evaluate" are conditional, so the separator has to be
-    // too — otherwise the trail reads "Evaluate /" until the title resolves.
-    expect(screen.queryByText("/")).toBeNull();
-  });
-
-  it("renders a clickable suite crumb so nested pages can go back", () => {
-    const onSuiteClick = vi.fn();
-    render(
-      <EvalsHeader
-        onEvaluateClick={vi.fn()}
-        parentCrumb={{ label: "checkout-flow", onClick: onSuiteClick }}
-      >
-        Pay invoice
-      </EvalsHeader>,
+      <EvalsHeader landingView="suites" onLandingViewChange={vi.fn()} />,
     );
 
     expect(
-      screen.queryByRole("button", { name: /^create suite$/i }),
+      screen.queryByRole("button", { name: /^new suite$/i }),
     ).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "checkout-flow" }));
-    expect(onSuiteClick).toHaveBeenCalledTimes(1);
-    expect(
-      screen.getByRole("link", { name: "Pay invoice", current: "page" }),
-    ).toBeTruthy();
   });
 });

--- a/mcpjam-inspector/client/src/components/evaluate/create-suite-page.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/create-suite-page.tsx
@@ -29,6 +29,7 @@ import { useHostList } from "@/hooks/useClients";
 import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
 import {
   EnvironmentComposer,
+  EVALS_RUNS_COMPOSER_SLOTS as EVALS_CREATE_RUNS_SLOTS,
   type ComposerSlot,
 } from "@/components/environment-composer/environment-composer";
 import {
@@ -73,11 +74,7 @@ export type CreateSuitePayload = {
 /** Servers as its own required field — one pill, matching the evals mock. */
 export const EVALS_CREATE_SERVER_SLOTS: readonly ComposerSlot[] = ["servers"];
 
-/** Where it runs: client + model side by side on the shared lego strip. */
-export const EVALS_CREATE_RUNS_SLOTS: readonly ComposerSlot[] = [
-  "clients",
-  "models",
-];
+export { EVALS_CREATE_RUNS_SLOTS };
 
 type CreateSuitePageProps = {
   onCancel: () => void;
@@ -422,6 +419,14 @@ export function CreateSuitePage({
                     disabled={isSaving}
                     testIdPrefix="create-suite"
                     slots={EVALS_CREATE_RUNS_SLOTS}
+                    clientDefaultLabel={
+                      (() => {
+                        const previewed =
+                          hosts.find((h) => h.hostId === previewedHostId) ??
+                          hosts[0];
+                        return previewed?.modelId ?? null;
+                      })()
+                    }
                   />
                 </div>
               </>

--- a/mcpjam-inspector/client/src/components/evaluate/evals-header.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/evals-header.tsx
@@ -2,21 +2,10 @@ import type { ReactNode } from "react";
 import { Plus } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@mcpjam/design-system/breadcrumb";
-import {
   ViewModeSelector,
   type ViewModeSelectorOption,
 } from "@/components/shared/view-mode-selector";
 import { cn } from "@/lib/utils";
-
-const EVALUATE_HEADER_DESCRIPTION =
-  "We generate cases from live discovery, or describe behaviors in chat, or import your existing tests.";
 
 export const EVAL_LANDING_VIEW_OPTIONS = [
   { value: "suites", label: "Suites" },
@@ -25,134 +14,76 @@ export const EVAL_LANDING_VIEW_OPTIONS = [
 
 export type EvalLandingView = (typeof EVAL_LANDING_VIEW_OPTIONS)[number]["value"];
 
-// Same tab chrome as swarm run Insights / Sessions (DetailPageHeader).
 const TAB_CLASSNAME =
-  "-ml-3 justify-start overflow-x-visible md:w-auto [&_button]:min-h-9 [&_button]:px-3 [&_button]:py-1.5 [&_button]:text-sm sm:[&_button]:min-h-9 sm:[&_button]:px-3.5 sm:[&_button]:text-sm md:[&_button]:min-h-9 lg:[&_button]:px-4";
-
-export type EvalsHeaderParentCrumb = {
-  label: string;
-  onClick: () => void;
-};
+  "shrink-0 justify-start overflow-x-visible [&_button]:min-h-9 [&_button]:px-3 [&_button]:py-1.5 [&_button]:text-sm sm:[&_button]:min-h-9 sm:[&_button]:px-3.5 sm:[&_button]:text-sm md:[&_button]:min-h-9 lg:[&_button]:px-4";
 
 /**
- * The Evaluate page header. Landing shows the title, description, Create
- * suite, and Suites | Runs tabs. Detail routes replace that chrome with a
- * trail: Evaluate / current page, or Evaluate / suite / current page when
- * drilled into a case or run.
+ * Evaluate (New) header — one compact row on every route:
+ * Suites | Runs on the left, suite navigation in the center, New suite on the right.
  */
 export function EvalsHeader({
   onCreateSuite,
   children,
-  parentCrumb,
   landingView,
   onLandingViewChange,
-  onEvaluateClick,
-  isDetail: isDetailProp,
+  showLandingIntro = false,
 }: {
   onCreateSuite?: () => void;
   children?: ReactNode;
-  parentCrumb?: EvalsHeaderParentCrumb;
   landingView?: EvalLandingView;
   onLandingViewChange?: (view: EvalLandingView) => void;
-  onEvaluateClick?: () => void;
-  /** When set, forces detail chrome even if the last crumb has not loaded. */
-  isDetail?: boolean;
+  /** Optional title block below the nav row on the suites landing only. */
+  showLandingIntro?: boolean;
 }) {
-  const isDetail = isDetailProp ?? Boolean(children || parentCrumb);
-  const showLandingTabs =
-    !isDetail && landingView != null && onLandingViewChange != null;
+  const showTabs =
+    landingView != null && onLandingViewChange != null;
 
   return (
     <div
-      className={cn(
-        "relative shrink-0 border-b border-border bg-muted/40 px-4 sm:px-6",
-        showLandingTabs ? "pt-4 pb-0" : "py-4",
-      )}
+      className="relative shrink-0 border-b border-border bg-muted/40 px-4 sm:px-6"
       data-testid="evals-header"
     >
-      <div className="flex min-w-0 items-center justify-between gap-4">
-        <div className="min-w-0 flex-1">
-          {isDetail ? (
-            <Breadcrumb className="min-w-0">
-              <BreadcrumbList className="min-w-0 flex-nowrap">
-                <BreadcrumbItem>
-                  <BreadcrumbLink asChild>
-                    <button
-                      type="button"
-                      onClick={onEvaluateClick}
-                      className="inline-flex border-0 bg-transparent p-0 font-normal text-muted-foreground hover:text-foreground"
-                    >
-                      Evaluate
-                    </button>
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                {/* Both crumbs below are conditional — a detail route whose
-                    title has not resolved yet (the header renders outside the
-                    details spinner) would otherwise read "Evaluate /". */}
-                {parentCrumb || children ? (
-                  <BreadcrumbSeparator className="text-muted-foreground">
-                    /
-                  </BreadcrumbSeparator>
-                ) : null}
-                {parentCrumb ? (
-                  <>
-                    <BreadcrumbItem className="max-w-[min(200px,40vw)] min-w-0">
-                      <BreadcrumbLink asChild>
-                        <button
-                          type="button"
-                          onClick={parentCrumb.onClick}
-                          className="inline-flex min-w-0 border-0 bg-transparent p-0 font-normal text-muted-foreground hover:text-foreground"
-                        >
-                          <span className="truncate">{parentCrumb.label}</span>
-                        </button>
-                      </BreadcrumbLink>
-                    </BreadcrumbItem>
-                    <BreadcrumbSeparator className="text-muted-foreground">
-                      /
-                    </BreadcrumbSeparator>
-                  </>
-                ) : null}
-                {children ? (
-                  <BreadcrumbItem className="max-w-[min(280px,50vw)] min-w-0">
-                    <BreadcrumbPage className="truncate font-semibold text-foreground">
-                      {children}
-                    </BreadcrumbPage>
-                  </BreadcrumbItem>
-                ) : null}
-              </BreadcrumbList>
-            </Breadcrumb>
-          ) : (
-            <>
-              <h1 className="text-xl font-semibold tracking-tight text-foreground">
-                Evaluate
-              </h1>
-              <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-                {EVALUATE_HEADER_DESCRIPTION}
-              </p>
-            </>
-          )}
-        </div>
-        {!isDetail && onCreateSuite ? (
+      <div className="flex min-w-0 items-center gap-3 py-2.5 sm:gap-4">
+        {showTabs ? (
+          <ViewModeSelector
+            value={landingView}
+            options={EVAL_LANDING_VIEW_OPTIONS}
+            onChange={onLandingViewChange}
+            ariaLabel="Evaluate view"
+            indicatorId="evals-landing"
+            className={TAB_CLASSNAME}
+          />
+        ) : null}
+        {children ? (
+          <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+            {children}
+          </div>
+        ) : (
+          <div className="min-w-0 flex-1" />
+        )}
+        {onCreateSuite ? (
           <Button
             type="button"
             size="sm"
+            variant="outline"
             className="shrink-0 gap-1.5"
             onClick={onCreateSuite}
           >
             <Plus className="h-4 w-4" aria-hidden />
-            Create suite
+            New suite
           </Button>
         ) : null}
       </div>
-      {showLandingTabs ? (
-        <ViewModeSelector
-          value={landingView}
-          options={EVAL_LANDING_VIEW_OPTIONS}
-          onChange={onLandingViewChange}
-          ariaLabel="Evaluate view"
-          indicatorId="evals-landing"
-          className={TAB_CLASSNAME}
-        />
+      {showLandingIntro ? (
+        <div className={cn("pb-4 pt-1")}>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">
+            Evaluate
+          </h1>
+          <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+            We generate cases from live discovery, or describe behaviors in chat,
+            or import your existing tests.
+          </p>
+        </div>
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Summary

- **More table space** — Metrics strip and run insights are collapsible, with a richer one-line summary when collapsed (pass rate, P95, tokens, tool calls).
- **Clearer navigation** — One header row: Suites | Runs tabs on the left, suite name dropdown in the center, **New suite** pinned top-right. Removed duplicate suite title row and confusing pass/fail fractions from the switcher.
- **Environment composer in suite header** — Model selector matches create-suite “Where it runs”; fixes for pills freezing after model selection and model names shown on the trigger pill.
- **Create suite modal** — Keeps the current suite dashboard visible behind the dialog instead of a blank loading state; cancel returns to the same suite.

## Test plan

- [ ] Open a suite on **Evaluate** (`/evals`) — metrics and insights collapse/expand; collapsed summary shows key stats
- [ ] Suite header: change clients/models without pills becoming unclickable
- [ ] Models pill trigger shows literal model names (dropdown still offers “Client defaults”)
- [ ] Header: switch suites via dropdown; **New suite** opens modal over current suite (not blank screen)
- [ ] Cancel create → returns to previous suite; submit create → navigates to new suite
- [ ] Nested routes (run detail, test case) show switcher + `/` trail segment
- [ ] `npm test -- --run` for evals header, suite switcher, suite composer bar, EvalsTab tests


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the evals suite dashboard to give tables more space and simplify navigation.

- Metrics and run insights are now collapsible, with a one-line summary (pass rate, P95, tokens, tool calls) when collapsed.
- The header is now a single row with Suites | Runs tabs, suite switcher dropdown, and a pinned "New suite" button; the duplicate suite title and pass/fail fractions are gone.
- The environment composer now matches create-suite's "Where it runs" layout, shows literal model names on the trigger pill instead of "Client defaults", and no longer freezes after selecting a model.
- Opening "New suite" keeps the current suite visible behind the dialog; cancel returns to the same suite, not a blank page.

<sup>Written for commit 62b4a78a4eae10b76fce680d950c29724b048c46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

