### PR TITLE
Cursor harness: accept a brokered credential, unblocking hosted evals and swarms

### DIFF
--- a/.changeset/cursor-harness-brokered-credential.md
+++ b/.changeset/cursor-harness-brokered-credential.md
@@ -24,6 +24,14 @@ a fixed, obviously-fake placeholder so the CLI has something to send. Both
 refusals in the backend already say brokered secrets are fine on those surfaces;
 this is the inspector half.
 
+Availability is decided at the **environment**, which is the grant boundary the
+control plane actually composes a box's egress transform from — not project-wide.
+A correctly bound brokered `CURSOR_API_KEY` that the run's environment does not
+select is refused up front, naming the selection as the fix, instead of starting a
+turn that provisions a box and then fails Cursor's auth against the placeholder.
+Chat, swarm and eval launches all carry their environment id down to the harness
+turn for this.
+
 Materialized delivery is unchanged and still wins when both are configured — it
 is the one this process can prove reached the box. The refusal is still
 fail-closed and now names both deliveries and the exact binding a brokered

--- a/.changeset/cursor-harness-brokered-credential.md
+++ b/.changeset/cursor-harness-brokered-credential.md
@@ -1,0 +1,35 @@
+---
+"@mcpjam/inspector": patch
+---
+
+The Cursor CLI harness accepts a BROKERED credential, so it can run in hosted evals and swarms
+
+`harness: "cursor"` could not run in a hosted eval or a swarm in any
+configuration. It authenticates on the customer's own Cursor account
+(`modelAccess: "external-account"`), and the turn took its `CURSOR_API_KEY`
+exclusively from the project's MATERIALIZED secrets — but eval sandboxes and
+journey runs REFUSE an environment that selects a materialized secret
+(`materialized_secrets_unsupported` / `ENV_MATERIALIZED_SECRETS_UNSUPPORTED`),
+because only the chat path resolves and injects those values, so a
+runner-claimed attempt would run with the credential silently absent and score a
+healthy connector as broken. Configure the secret the turn demanded and the run
+was refused at sandbox reservation; leave it out and the turn was refused for a
+missing credential.
+
+An external-account credential can now be satisfied by a BROKERED project secret
+as well. On that path the plaintext never enters the inspector process or the
+sandbox: the backend composes the secret into the box's E2B egress transform,
+which overwrites the credential header outside the VM, and the box carries only
+a fixed, obviously-fake placeholder so the CLI has something to send. Both
+refusals in the backend already say brokered secrets are fine on those surfaces;
+this is the inspector half.
+
+Materialized delivery is unchanged and still wins when both are configured — it
+is the one this process can prove reached the box. The refusal is still
+fail-closed and now names both deliveries and the exact binding a brokered
+`CURSOR_API_KEY` needs (`api2.cursor.sh`, `Authorization`, `Bearer {}`), read off
+the adapter's own `credentialBrokering` declaration rather than invented. A
+brokered row bound to the wrong host is refused by name instead of reaching
+Cursor as a placeholder and coming back as an unexplained 401, and a brokered-only
+credential on a persistent project Computer is refused too — the control plane
+composes brokered secrets onto disposable boxes only.

--- a/.changeset/cursor-harness-brokered-credential.md
+++ b/.changeset/cursor-harness-brokered-credential.md
@@ -30,7 +30,11 @@ A correctly bound brokered `CURSOR_API_KEY` that the run's environment does not
 select is refused up front, naming the selection as the fix, instead of starting a
 turn that provisions a box and then fails Cursor's auth against the placeholder.
 Chat, swarm and eval launches all carry their environment id down to the harness
-turn for this.
+turn for this. Eval REPLAY is the one path that cannot: a replay inherits the
+source run's environment on the backend, but nothing projects that reference
+back out to the runner, so a replay refuses with copy that says exactly that and
+tells the reader to launch the suite directly — rather than blaming a secret or
+a selection that is already correct.
 
 Materialized delivery is unchanged and still wins when both are configured — it
 is the one this process can prove reached the box. The refusal is still

--- a/docs/inspector/claude-code-host.mdx
+++ b/docs/inspector/claude-code-host.mdx
@@ -75,7 +75,85 @@ Claude Code hosts are unaffected by all of the above — they use the runtime's 
 - For **Codex**: an MCPJam-provided OpenAI gpt-5 family model selected on the host.
 - A **signed-in project member** — guest sessions cannot run harness hosts.
 
-No credential configuration is needed. Broker delivery is on by default and the model proxy is always-on.
+No credential configuration is needed **for Claude Code and Codex**. Broker delivery is on by default and the model proxy is always-on.
+
+## Harness credentials on your own vendor account
+
+Not every harness runs on MCPJam's model access. A harness that authenticates
+against the **customer's own account with the runtime vendor** — the Cursor CLI
+host, which signs in with a `CURSOR_API_KEY` and bills every generation to that
+Cursor account — takes no MCPJam model lease at all. Its credential comes from a
+**project secret**, and the delivery you choose decides which surfaces can run it.
+
+| Delivery | Where the value lives | Works in chat | Works in hosted evals and swarms |
+|---|---|---|---|
+| **Brokered** (recommended) | Never leaves MCPJam's backend. The egress proxy injects it as a header on the way out of the sandbox; the sandbox holds a non-secret placeholder. | Ephemeral (scenario/eval/swarm) boxes only | **Yes** |
+| **Materialized** | Resolved by MCPJam's server and exported as an environment variable inside the sandbox. | Yes | **No** |
+
+Hosted eval and swarm launches **refuse** an environment that selects a
+materialized secret. That is deliberate: only the chat path resolves and injects
+materialized values, so on a runner-claimed attempt the credential would simply
+be missing and the run would report a healthy connector as broken. A brokered
+secret has no such problem — the backend composes it into the box's network
+policy and the runner does not participate.
+
+So for a Cursor CLI host that you intend to run in an eval suite or a swarm,
+**create the secret as brokered**, under **Project Settings → Secrets**, bound to:
+
+| Field | Value |
+|---|---|
+| Name | `CURSOR_API_KEY` |
+| Delivery | Brokered |
+| Hosts | `api2.cursor.sh` |
+| Header | `Authorization` |
+| Template | `Bearer {}` |
+
+Then select it into the environment the host runs in. A turn that finds neither a
+brokered nor a materialized credential is refused before the sandbox is touched,
+with a message naming the variable and both deliveries; a brokered secret bound to
+the wrong host is refused too, naming the host it found.
+
+<Note>
+  A **persistent project Computer** (the ordinary playground chat box) does not
+  receive brokered secrets today — they are composed onto the disposable boxes
+  that scenario, eval and swarm runs provision. Chat on a project Computer
+  therefore needs a **materialized** `CURSOR_API_KEY`. It is fine for one
+  environment to hold both.
+</Note>
+
+### Project secrets require KMS envelope encryption
+
+Storing **any** project secret requires the deployment to have envelope
+encryption turned on. Without it MCPJam refuses the write outright, with:
+
+> This deployment cannot store project secrets yet: envelope encryption
+> (SECRETS_KMS_WRITE) is not enabled.
+
+This is a deployment prerequisite, not a toggle: without envelope writes the
+stored value is not cryptographically bound to its project and its owner, and a
+credential store whose isolation rests on row checks alone is not the design.
+
+MCPJam Cloud has this configured. A **self-hosted or local development**
+deployment must set, on the Convex backend:
+
+| Variable | Purpose |
+|---|---|
+| `SECRETS_KMS_WRITE=1` | Turns envelope writes on. Nothing stores a project secret without it. |
+| `GCP_KMS_SA_EMAIL` | Service account that can use the key. |
+| `GCP_KMS_SA_PRIVATE_KEY` | That account's PKCS#8 PEM private key. |
+| `GCP_KMS_KEY_RESOURCE` | Full crypto key resource name (`projects/*/locations/*/keyRings/*/cryptoKeys/*`). |
+| `KMS_AAD_ENVIRONMENT` | The environment label bound into the additional authenticated data. |
+
+Set the four key variables **before** turning `SECRETS_KMS_WRITE` on, and prove
+the key actually works first — four correctly spelled variables are not the same
+as a usable key, and every way that can fail (missing IAM permission, wrong
+region, a private key truncated by a dashboard field) looks like success until
+the first real write. Reads are unaffected: a deployment holding older secrets
+keeps opening them.
+
+Until KMS is configured, a self-hosted deployment cannot store a
+`CURSOR_API_KEY` in either delivery, and so cannot run the Cursor CLI host.
+
 
 ## Billing
 

--- a/docs/inspector/claude-code-host.mdx
+++ b/docs/inspector/claude-code-host.mdx
@@ -128,6 +128,15 @@ message that names the fix:
 | Brokered secret exists but the environment does not select it | Says so, and asks you to select it into that environment — not to create a second one |
 | The host is not running from a Project Environment at all | Says there is no grant boundary, so no brokered secret can reach the box |
 | Brokered secret bound to the wrong host | Names the host it found and the host the runtime needs |
+| The run is a **replay** of an earlier eval run | Says MCPJam cannot confirm the credential for a replay, and that nothing about the secret needs changing — launch the suite directly instead |
+
+<Note>
+  **Replaying** an eval run cannot verify a brokered credential. A replay keeps
+  the original run's environment internally, but MCPJam's runner is not told
+  which environment that was, so it cannot check the grant before the sandbox
+  starts and refuses rather than guess. Launch the suite directly to run a
+  Cursor CLI host; nothing about the secret or the environment needs to change.
+</Note>
 
 <Note>
   A **persistent project Computer** (the ordinary playground chat box) does not

--- a/docs/inspector/claude-code-host.mdx
+++ b/docs/inspector/claude-code-host.mdx
@@ -1,13 +1,19 @@
 ---
-title: "Claude Code and Codex hosts"
-description: "Run the real Claude Code or Codex agent inside your project's Computer — observe native tools, MCP client, and execution behavior directly"
+title: "Harness hosts: Claude Code, Codex, and Cursor"
+description: "Run a real agent runtime — Claude Code, Codex, or the Cursor CLI — inside your project's Computer, and observe native tools, MCP client, and execution behavior directly"
 icon: "terminal"
 ---
 
-MCPJam supports two harness hosts that run a real agent runtime inside your project's Computer (a cloud Linux sandbox) instead of MCPJam's emulated chat loop. You are observing the actual runtime — its native tools, its own agent loop, its real execution behavior — not a simulation of it.
+A harness host runs a real agent runtime inside your project's Computer (a cloud Linux sandbox) instead of MCPJam's emulated chat loop. You are observing the actual runtime — its native tools, its own agent loop, its real execution behavior — not a simulation of it.
+
+Two of them run on **MCPJam's model access**, and everything below — turn mechanics, host settings, billing, failure modes — describes those two:
 
 - **Claude Code** — runs the real Claude Code agent with Anthropic models. Supports selected MCP servers and native tool approval.
 - **Codex** — runs the real Codex CLI agent with OpenAI gpt-5 family models. Supports skills and selected MCP servers (through a host-executed relay — see the caveat below).
+
+The third runs on **your own vendor account**:
+
+- **Cursor CLI** — runs the real Cursor agent, signed in with your own `CURSOR_API_KEY` and billed to that Cursor account. MCPJam mints no model lease for it, so it needs a credential the other two do not. This page documents that credential in [Harness credentials on your own vendor account](#harness-credentials-on-your-own-vendor-account); its turn mechanics and host settings are not covered here yet.
 
 <Note>
   The Claude Code and Codex hosts are available to organizations where the
@@ -85,9 +91,9 @@ host, which signs in with a `CURSOR_API_KEY` and bills every generation to that
 Cursor account — takes no MCPJam model lease at all. Its credential comes from a
 **project secret**, and the delivery you choose decides which surfaces can run it.
 
-| Delivery | Where the value lives | Works in chat | Works in hosted evals and swarms |
+| Delivery | Where the value lives | Works in playground chat | Works in hosted evals and swarms |
 |---|---|---|---|
-| **Brokered** (recommended) | Never leaves MCPJam's backend. The egress proxy injects it as a header on the way out of the sandbox; the sandbox holds a non-secret placeholder. | Ephemeral (scenario/eval/swarm) boxes only | **Yes** |
+| **Brokered** (recommended) | Never leaves MCPJam's backend. The egress proxy injects it as a header on the way out of the sandbox; the sandbox holds a non-secret placeholder. | **No** — playground chat runs on your persistent project Computer, and brokered secrets are composed only onto the disposable boxes an eval, swarm or scenario run provisions | **Yes** |
 | **Materialized** | Resolved by MCPJam's server and exported as an environment variable inside the sandbox. | Yes | **No** |
 
 Hosted eval and swarm launches **refuse** an environment that selects a
@@ -108,10 +114,20 @@ So for a Cursor CLI host that you intend to run in an eval suite or a swarm,
 | Header | `Authorization` |
 | Template | `Bearer {}` |
 
-Then select it into the environment the host runs in. A turn that finds neither a
-brokered nor a materialized credential is refused before the sandbox is touched,
-with a message naming the variable and both deliveries; a brokered secret bound to
-the wrong host is refused too, naming the host it found.
+Then **select it into the environment the host runs in**. That selection is the
+grant, not a formality: brokered secrets are composed onto a box from its
+environment's selection, so a secret the environment does not grant is never
+delivered no matter how it is bound.
+
+Every way that can go wrong is refused **before the sandbox is touched**, with a
+message that names the fix:
+
+| What is wrong | What the turn says |
+|---|---|
+| Neither delivery configured | Names the variable and both deliveries, and points at Project Settings → Secrets |
+| Brokered secret exists but the environment does not select it | Says so, and asks you to select it into that environment — not to create a second one |
+| The host is not running from a Project Environment at all | Says there is no grant boundary, so no brokered secret can reach the box |
+| Brokered secret bound to the wrong host | Names the host it found and the host the runtime needs |
 
 <Note>
   A **persistent project Computer** (the ordinary playground chat box) does not

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -2571,6 +2571,18 @@ export async function prepareEvalRun(
       // `selectedServerIds`) via `resolveExecutionContext`. `hostPolicy`
       // is the POLICY subset extracted upstream; this is the rest.
       suiteHostConfig,
+      // The run's PROJECT ENVIRONMENT — the same id echoed to
+      // `startSuiteRunWithRecorder` above, so it is exactly what the run's
+      // `configSnapshot.environmentRef` records and therefore exactly what
+      // `resolveGrantForSandbox` will derive for each iteration's box.
+      //
+      // Threaded for the HARNESS path's external-account credential check: a
+      // BROKERED project secret is composed onto an iteration's box only when
+      // THIS environment selects it, so a project-wide answer would start an
+      // iteration that provisions a box and then fails vendor auth against a
+      // placeholder. Absent for a legacy (non-environment) run, which grants
+      // no secrets at all.
+      ...(environmentId ? { projectEnvironmentId: environmentId } : {}),
       ...(pinnedSkillSource ? { pinnedSkillSource } : {}),
       // Presence is meaningful (empty ⇒ "no skills", absent ⇒ live fetch), so
       // this checks for undefined rather than truthiness.

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -540,6 +540,17 @@ export type RunEvalSuiteOptions = {
       }>;
     };
   };
+  /**
+   * The PROJECT ENVIRONMENT this run launched from — a `projectEnvironments`
+   * doc id. Deliberately NOT inside `config.environment`, which is the servers
+   * snapshot, and deliberately not `computerEnvironmentId`, which is a sandbox
+   * IMAGE; the three are unrelated despite the shared word.
+   *
+   * The GRANT BOUNDARY for the run's project secrets, and therefore what a
+   * HARNESS iteration's BROKERED external-account credential check must be
+   * scoped to. Absent for a legacy (non-environment) run, which grants none.
+   */
+  projectEnvironmentId?: string;
   modelApiKeys?: Record<string, string>;
   orgModelConfig?: ResolvedOrgModelConfig;
   orgModelConfigTarget?: ResolveOrgModelConfigTarget;
@@ -1642,6 +1653,19 @@ type RunIterationBaseParams = {
    * its environment. Absent on quick-run paths that pre-resolve servers.
    */
   environment?: RunEvalSuiteOptions["config"]["environment"];
+  /**
+   * The PROJECT ENVIRONMENT this run launched from — a `projectEnvironments`
+   * doc id, and NOT to be confused with either neighbour: `environment` above
+   * is the servers snapshot, and `computerEnvironmentId` is a sandbox IMAGE.
+   *
+   * Carried for the HARNESS path only, where it is the grant boundary for the
+   * run's project secrets: an external-account credential delivered by a
+   * BROKERED secret is only composed onto this iteration's box when THIS
+   * environment selects it, so the check has to be scoped to it.
+   *
+   * Absent on a legacy (non-environment) suite run, which grants no secrets.
+   */
+  projectEnvironmentId?: string;
   /** Run caller's Convex bearer — used to provision/release the reproducible
    * eval sandbox when the suite pins a computerEnvironment. */
   convexAuthToken: string;
@@ -2030,6 +2054,9 @@ const executeTestCase = async (params: {
    * receives its servers pre-resolved via `selectedServers`.
    */
   environment?: RunEvalSuiteOptions["config"]["environment"];
+  /** The run's PROJECT ENVIRONMENT id (see RunEvalSuiteOptions) — the grant
+   *  boundary a harness iteration's brokered credential check is scoped to. */
+  projectEnvironmentId?: string;
   /** Pinned skill delivery for this run (see RunEvalSuiteOptions.pinnedSkillSource). */
   pinnedSkillSource?: EvalPinnedSkillSource;
   /** The run's frozen skills in harness shape (see
@@ -2073,6 +2100,7 @@ const executeTestCase = async (params: {
     setupAudit,
     suiteHostConfig,
     environment,
+    projectEnvironmentId,
     pinnedSkillSource,
     pinnedHarnessSkills,
     tasks,
@@ -2300,6 +2328,9 @@ const executeTestCase = async (params: {
         setupAudit,
         suiteHostConfig,
         environment,
+        // A `projectEnvironments` doc id, not the servers snapshot above and
+        // not a sandbox image — see `RunIterationBaseParams`.
+        ...(projectEnvironmentId ? { projectEnvironmentId } : {}),
         pinnedSkillSource,
         pinnedHarnessSkills,
         // The run's Tasks seam. Hosted-only: it exists so the HARNESS turn can
@@ -2362,6 +2393,9 @@ const executeTestCase = async (params: {
         setupAudit,
         suiteHostConfig,
         environment,
+        // A `projectEnvironments` doc id, not the servers snapshot above and
+        // not a sandbox image — see `RunIterationBaseParams`.
+        ...(projectEnvironmentId ? { projectEnvironmentId } : {}),
         pinnedSkillSource,
         pinnedHarnessSkills,
         // The run's Tasks seam. Hosted-only: it exists so the HARNESS turn can
@@ -2467,6 +2501,7 @@ export const runEvalSuiteWithAiSdk = async ({
   suiteInjectOpenAiCompat,
   hostExecutionPolicy,
   suiteHostConfig,
+  projectEnvironmentId,
   pinnedSkillSource,
   pinnedHarnessSkills,
   toolPolicy,
@@ -2697,6 +2732,9 @@ export const runEvalSuiteWithAiSdk = async ({
         ...(resolvedSetupAudit ? { setupAudit: resolvedSetupAudit } : {}),
         suiteHostConfig,
         environment: config.environment,
+        // The run's PROJECT ENVIRONMENT id — unrelated to `config.environment`
+        // above (a servers snapshot) despite the shared word.
+        ...(projectEnvironmentId ? { projectEnvironmentId } : {}),
         ...(toolPolicy
           ? {
               toolPolicy,
@@ -4136,6 +4174,7 @@ const runHostedIterationWithBrowser = async (
     // iteration eval-sandbox provisioning + the bash tool (hosted parity with
     // the local runner).
     environment,
+    projectEnvironmentId,
     pinnedSkillSource,
     pinnedHarnessSkills,
     tasks,
@@ -4752,6 +4791,13 @@ const runHostedIterationWithBrowser = async (
     ...(tasks !== undefined ? { tasks } : {}),
     ...(builtInTarget && "projectId" in builtInTarget
       ? { projectId: builtInTarget.projectId }
+      : {}),
+    // The run's PROJECT ENVIRONMENT — the grant boundary the harness path
+    // scopes its BROKERED external-account credential check to. Harness-gated
+    // like the rest of this cluster; the emulated path resolves no such
+    // credential and would only carry an unused field.
+    ...(resolvedExecution.harness && projectEnvironmentId
+      ? { environmentId: projectEnvironmentId }
       : {}),
     logSuffix: emit ? " (stream)" : "",
     extractToolCalls: (messages) =>

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -551,6 +551,15 @@ export type RunEvalSuiteOptions = {
    * scoped to. Absent for a legacy (non-environment) run, which grants none.
    */
   projectEnvironmentId?: string;
+  /**
+   * Why {@link projectEnvironmentId} is absent on a run that HAS an
+   * environment. Set ONLY by the replay path: a replay run inherits the source
+   * run's `configSnapshot.environmentRef` on the backend, so its boxes really
+   * may carry a brokered transform, but no public read projects that ref back
+   * out. Copy only — the harness refuses either way, and this just keeps the
+   * refusal from blaming an environment selection the reader never made.
+   */
+  projectEnvironmentUnresolvedReason?: string;
   modelApiKeys?: Record<string, string>;
   orgModelConfig?: ResolvedOrgModelConfig;
   orgModelConfigTarget?: ResolveOrgModelConfigTarget;
@@ -1666,6 +1675,15 @@ type RunIterationBaseParams = {
    * Absent on a legacy (non-environment) suite run, which grants no secrets.
    */
   projectEnvironmentId?: string;
+  /**
+   * Why {@link projectEnvironmentId} is absent on a run that HAS an
+   * environment. Set ONLY by the replay path: a replay run inherits the source
+   * run's `configSnapshot.environmentRef` on the backend, so its boxes really
+   * may carry a brokered transform, but no public read projects that ref back
+   * out. Copy only — the harness refuses either way, and this just keeps the
+   * refusal from blaming an environment selection the reader never made.
+   */
+  projectEnvironmentUnresolvedReason?: string;
   /** Run caller's Convex bearer — used to provision/release the reproducible
    * eval sandbox when the suite pins a computerEnvironment. */
   convexAuthToken: string;
@@ -2057,6 +2075,8 @@ const executeTestCase = async (params: {
   /** The run's PROJECT ENVIRONMENT id (see RunEvalSuiteOptions) — the grant
    *  boundary a harness iteration's brokered credential check is scoped to. */
   projectEnvironmentId?: string;
+  /** See {@link RunEvalSuiteOptions.projectEnvironmentUnresolvedReason}. */
+  projectEnvironmentUnresolvedReason?: string;
   /** Pinned skill delivery for this run (see RunEvalSuiteOptions.pinnedSkillSource). */
   pinnedSkillSource?: EvalPinnedSkillSource;
   /** The run's frozen skills in harness shape (see
@@ -2101,6 +2121,7 @@ const executeTestCase = async (params: {
     suiteHostConfig,
     environment,
     projectEnvironmentId,
+    projectEnvironmentUnresolvedReason,
     pinnedSkillSource,
     pinnedHarnessSkills,
     tasks,
@@ -2331,6 +2352,9 @@ const executeTestCase = async (params: {
         // A `projectEnvironments` doc id, not the servers snapshot above and
         // not a sandbox image — see `RunIterationBaseParams`.
         ...(projectEnvironmentId ? { projectEnvironmentId } : {}),
+        ...(projectEnvironmentUnresolvedReason
+          ? { projectEnvironmentUnresolvedReason }
+          : {}),
         pinnedSkillSource,
         pinnedHarnessSkills,
         // The run's Tasks seam. Hosted-only: it exists so the HARNESS turn can
@@ -2396,6 +2420,9 @@ const executeTestCase = async (params: {
         // A `projectEnvironments` doc id, not the servers snapshot above and
         // not a sandbox image — see `RunIterationBaseParams`.
         ...(projectEnvironmentId ? { projectEnvironmentId } : {}),
+        ...(projectEnvironmentUnresolvedReason
+          ? { projectEnvironmentUnresolvedReason }
+          : {}),
         pinnedSkillSource,
         pinnedHarnessSkills,
         // The run's Tasks seam. Hosted-only: it exists so the HARNESS turn can
@@ -2502,6 +2529,7 @@ export const runEvalSuiteWithAiSdk = async ({
   hostExecutionPolicy,
   suiteHostConfig,
   projectEnvironmentId,
+  projectEnvironmentUnresolvedReason,
   pinnedSkillSource,
   pinnedHarnessSkills,
   toolPolicy,
@@ -2735,6 +2763,9 @@ export const runEvalSuiteWithAiSdk = async ({
         // The run's PROJECT ENVIRONMENT id — unrelated to `config.environment`
         // above (a servers snapshot) despite the shared word.
         ...(projectEnvironmentId ? { projectEnvironmentId } : {}),
+        ...(projectEnvironmentUnresolvedReason
+          ? { projectEnvironmentUnresolvedReason }
+          : {}),
         ...(toolPolicy
           ? {
               toolPolicy,
@@ -4175,6 +4206,7 @@ const runHostedIterationWithBrowser = async (
     // the local runner).
     environment,
     projectEnvironmentId,
+    projectEnvironmentUnresolvedReason,
     pinnedSkillSource,
     pinnedHarnessSkills,
     tasks,
@@ -4798,6 +4830,13 @@ const runHostedIterationWithBrowser = async (
     // credential and would only carry an unused field.
     ...(resolvedExecution.harness && projectEnvironmentId
       ? { environmentId: projectEnvironmentId }
+      : {}),
+    // Replay only: the run HAS an environment and this process cannot name it.
+    // Keeps the refusal honest instead of blaming a selection.
+    ...(resolvedExecution.harness &&
+    !projectEnvironmentId &&
+    projectEnvironmentUnresolvedReason
+      ? { environmentUnresolvedReason: projectEnvironmentUnresolvedReason }
       : {}),
     logSuffix: emit ? " (stream)" : "",
     extractToolCalls: (messages) =>

--- a/mcpjam-inspector/server/services/evals/__tests__/drive-hosted-eval-turn.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/drive-hosted-eval-turn.test.ts
@@ -190,6 +190,28 @@ describe("harness execution options reach the engine", () => {
     expect(options.environmentId).toBe("env-1");
   });
 
+  it("forwards the replay path's UNRESOLVED reason when there is no id", async () => {
+    const options = await engineOptionsFor({
+      ...HARNESS_OPTIONS,
+      environmentUnresolvedReason: "replaying a run does not carry it.",
+    } as unknown as Partial<DriveHostedEvalTurnParams>);
+    expect(options.environmentUnresolvedReason).toBe(
+      "replaying a run does not carry it.",
+    );
+  });
+
+  it("drops the unresolved reason when the environment id IS known", async () => {
+    // The id answers the question; carrying an excuse alongside it could only
+    // weaken a refusal that has real evidence behind it.
+    const options = await engineOptionsFor({
+      ...HARNESS_OPTIONS,
+      environmentId: "env-1",
+      environmentUnresolvedReason: "should be ignored",
+    } as unknown as Partial<DriveHostedEvalTurnParams>);
+    expect(options.environmentId).toBe("env-1");
+    expect(options.environmentUnresolvedReason).toBeUndefined();
+  });
+
   it("leaves the environment id off an EMULATED turn", async () => {
     const options = await engineOptionsFor({
       environmentId: "env-1",

--- a/mcpjam-inspector/server/services/evals/__tests__/drive-hosted-eval-turn.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/drive-hosted-eval-turn.test.ts
@@ -178,6 +178,25 @@ describe("harness execution options reach the engine", () => {
     expect(options.harness).toBe("claude-code");
   });
 
+  it("forwards the run's PROJECT ENVIRONMENT as the secret grant boundary", async () => {
+    // What a harness iteration scopes its BROKERED external-account credential
+    // check to. Without it the check is project-wide, and a bound secret this
+    // run's environment does not grant reads as available — the iteration then
+    // provisions a box whose egress carries no transform and fails vendor auth.
+    const options = await engineOptionsFor({
+      ...HARNESS_OPTIONS,
+      environmentId: "env-1",
+    } as unknown as Partial<DriveHostedEvalTurnParams>);
+    expect(options.environmentId).toBe("env-1");
+  });
+
+  it("leaves the environment id off an EMULATED turn", async () => {
+    const options = await engineOptionsFor({
+      environmentId: "env-1",
+    } as unknown as Partial<DriveHostedEvalTurnParams>);
+    expect(options.environmentId).toBeUndefined();
+  });
+
   it("forwards a PRESENT-BUT-EMPTY pinnedHarnessSkills — the A/B arm", async () => {
     // The one harness field gated on `!== undefined` rather than truthiness,
     // and deliberately so: an empty array is how `skillsOverride: "exclude"`

--- a/mcpjam-inspector/server/services/evals/__tests__/replay-suite-run-environment.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/replay-suite-run-environment.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * What a REPLAY tells the runner about its Project Environment — and why the
+ * honest answer is neither an id nor silence.
+ *
+ * A replay run genuinely HAS an environment: `startTestSuiteRun` copies the
+ * source run's `configSnapshot.environmentRef` forward verbatim, and
+ * `resolveGrantForSandbox` follows that id, so the replay's boxes really can
+ * carry a brokered secret's egress transform. But nothing projects that ref
+ * back out — not the run-start return (it carries `configSnapshot.environment`,
+ * the servers snapshot, and no `environmentRef`), not `getRunReplayMetadata`,
+ * not the sandbox reservation — so this process cannot name it.
+ *
+ * Staying silent would make the harness read the absence as "no environment,
+ * therefore nothing granted" and tell the reader to fix a selection they never
+ * made. These cases pin the alternative: an explicit reason, and no invented id.
+ */
+
+const runEvalSuiteWithAiSdkMock = vi.fn(async () => undefined);
+vi.mock("../../evals-runner.js", () => ({
+  runEvalSuiteWithAiSdk: (...args: unknown[]) =>
+    runEvalSuiteWithAiSdkMock(...(args as [])),
+}));
+
+const startSuiteRunWithRecorderMock = vi.fn(async () => ({
+  runId: "replay-run-1",
+  recorder: { id: "recorder" },
+  config: { tests: [], environment: { servers: ["srv"] } },
+  hostConfig: { harness: "harness:cursor" },
+  gradingEngine: undefined,
+}));
+vi.mock("../recorder.js", () => ({
+  startSuiteRunWithRecorder: (...args: unknown[]) =>
+    startSuiteRunWithRecorderMock(...(args as [])),
+}));
+
+vi.mock("../route-helpers.js", () => ({
+  buildReplayManager: vi.fn(() => ({
+    disconnectAllServers: vi.fn(async () => {}),
+  })),
+  captureToolSnapshotForEvalAuthoring: vi.fn(async () => ({
+    toolSnapshot: {},
+    toolSnapshotDebug: {},
+  })),
+  connectReplayManagerServers: vi.fn(async () => {}),
+  fetchReplayConfig: vi.fn(async () => ({
+    servers: [{ serverId: "srv", url: "https://example.test" }],
+  })),
+  requireConvexHttpUrl: vi.fn(() => "https://convex.test"),
+  storeReplayConfig: vi.fn(async () => {}),
+}));
+
+vi.mock("../compat-runtime.js", () => ({
+  loadSuiteHostConfig: vi.fn(async () => ({ harness: "harness:cursor" })),
+}));
+
+vi.mock("@mcpjam/sdk/host-config/internal", () => ({
+  resolveOpenAiCompatForHostConfig: vi.fn(() => false),
+}));
+
+vi.mock("../replay-tool-policy.js", () => ({
+  recoverToolPolicyFromSourceRun: vi.fn(async () => undefined),
+}));
+
+vi.mock("../grading-mode.js", () => ({
+  resolveFrozenRunGradingMode: vi.fn(() => undefined),
+}));
+
+vi.mock("../../../utils/org-model-config.js", () => ({
+  resolveOrgModelConfig: vi.fn(async () => undefined),
+}));
+
+import { prepareSuiteReplayFromRun } from "../replay-suite-run.js";
+
+/** A source run that WAS environment-backed, replayed by an ordinary caller. */
+function convexClient() {
+  return {
+    query: vi.fn(async () => ({
+      suiteId: "suite-1",
+      projectId: "project-1",
+      hasServerReplayConfig: true,
+      environment: { servers: ["srv"] },
+    })),
+  } as never;
+}
+
+beforeEach(() => {
+  runEvalSuiteWithAiSdkMock.mockClear();
+});
+
+describe("prepareSuiteReplayFromRun — the environment it cannot name", () => {
+  it("hands the runner a REASON instead of silence, and never an invented id", async () => {
+    const prepared = await prepareSuiteReplayFromRun({
+      convexClient: convexClient(),
+      convexAuthToken: "token",
+      sourceRunId: "source-run-1",
+    });
+    await prepared.execute();
+
+    expect(runEvalSuiteWithAiSdkMock).toHaveBeenCalledTimes(1);
+    const options = runEvalSuiteWithAiSdkMock.mock.calls[0]![0] as unknown as {
+      projectEnvironmentId?: string;
+      projectEnvironmentUnresolvedReason?: string;
+    };
+
+    // Guessing an id would be the worse failure of the two: it would let the
+    // harness check a selection belonging to some OTHER environment and start
+    // a turn on the strength of it.
+    expect(options.projectEnvironmentId).toBeUndefined();
+
+    // Non-vacuous: a real, non-empty explanation naming replay — this is the
+    // whole payload, so an empty or missing string is a broken thread.
+    expect(typeof options.projectEnvironmentUnresolvedReason).toBe("string");
+    expect(options.projectEnvironmentUnresolvedReason!.length).toBeGreaterThan(
+      20,
+    );
+    expect(options.projectEnvironmentUnresolvedReason).toMatch(/replay/i);
+    expect(options.projectEnvironmentUnresolvedReason).toMatch(
+      /Project Environment/,
+    );
+  });
+});

--- a/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
+++ b/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
@@ -181,6 +181,13 @@ export interface DriveHostedEvalTurnParams {
    */
   environmentId?: string;
   /**
+   * Why `environmentId` is absent on a run that HAS an environment — set by the
+   * REPLAY path, which inherits the source run's `environmentRef` on the
+   * backend but cannot read it back out. Copy only; see the option's docblock
+   * on `MCPJamHandlerOptions`.
+   */
+  environmentUnresolvedReason?: string;
+  /**
    * THIS iteration's disposable box, handed to the harness.
    *
    * The SAME box the tool resolver already exposes as `bash` — one box per
@@ -623,6 +630,12 @@ export async function driveHostedEvalTurn(
             // external-account credential check is scoped to.
             ...(params.environmentId
               ? { environmentId: params.environmentId }
+              : {}),
+            ...(!params.environmentId && params.environmentUnresolvedReason
+              ? {
+                  environmentUnresolvedReason:
+                    params.environmentUnresolvedReason,
+                }
               : {}),
             // THIS iteration's box, so the harness runs on it instead of
             // reserving the acting member's personal computer.

--- a/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
+++ b/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
@@ -167,6 +167,20 @@ export interface DriveHostedEvalTurnParams {
    *  so a harness turn there fails fast with a clear projectId error). */
   projectId?: string;
   /**
+   * The Project Environment this run launched from — the GRANT BOUNDARY for its
+   * project secrets, and the same id `resolveGrantForSandbox` derives for this
+   * iteration's box from the run's `configSnapshot.environmentRef`.
+   *
+   * Forwarded (harness turns only) so an EXTERNAL-ACCOUNT credential delivered
+   * by a BROKERED secret is checked against what THIS environment selects. A
+   * project-wide check would report a bound-but-unselected secret available and
+   * start an iteration whose box carries no egress transform — it would
+   * provision, then fail vendor auth against a placeholder.
+   *
+   * Absent for a legacy (non-environment) suite run, which grants no secrets.
+   */
+  environmentId?: string;
+  /**
    * THIS iteration's disposable box, handed to the harness.
    *
    * The SAME box the tool resolver already exposes as `bash` — one box per
@@ -605,6 +619,11 @@ export async function driveHostedEvalTurn(
             // (authHeader already rides authContext.token). Harness-gated so
             // emulated evals stay byte-identical.
             ...(params.projectId ? { projectId: params.projectId } : {}),
+            // The run's environment — the grant boundary the brokered
+            // external-account credential check is scoped to.
+            ...(params.environmentId
+              ? { environmentId: params.environmentId }
+              : {}),
             // THIS iteration's box, so the harness runs on it instead of
             // reserving the acting member's personal computer.
             ...(params.harnessSandboxBinding

--- a/mcpjam-inspector/server/services/evals/replay-suite-run.ts
+++ b/mcpjam-inspector/server/services/evals/replay-suite-run.ts
@@ -204,6 +204,27 @@ export async function prepareSuiteReplayFromRun(
           // it replays. An absent stamp is the backend's `off`, not an absent
           // opinion; see the same translation in `routes/shared/evals.ts`.
           gradingMode: resolveFrozenRunGradingMode(runGradingEngine),
+          // NO `projectEnvironmentId`, and that absence is not the usual one.
+          //
+          // A replay run DOES have a Project Environment: `startTestSuiteRun`
+          // copies the source run's `configSnapshot.environmentRef` forward
+          // verbatim on a snapshot replay (and re-resolves one under
+          // `useCurrentSuiteConfig`), and `resolveGrantForSandbox` follows that
+          // id — so this run's boxes may genuinely carry a brokered secret's
+          // egress transform. This process just cannot NAME it: the run-start
+          // mutation's return projects `configSnapshot.environment` (the
+          // servers snapshot) but not `environmentRef`, and neither
+          // `getRunReplayMetadata` nor the sandbox reservation projects it
+          // either. Closing that needs a backend read this repo cannot add.
+          //
+          // So say what is true instead of letting the harness infer "no
+          // environment, therefore nothing granted" and tell the reader to fix
+          // a selection they never made. This changes no decision — an
+          // environment we cannot name is one whose grant we cannot verify, and
+          // an external-account harness is refused either way — only the copy.
+          projectEnvironmentUnresolvedReason:
+            "replaying a run does not carry the original run's Project " +
+            "Environment through to the runner.",
           ...(replayToolPolicy ? { toolPolicy: replayToolPolicy } : {}),
         });
       },

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
@@ -153,6 +153,10 @@ describe("swarm single-host runner — attempt ordering", () => {
       "anthropic/claude-haiku-4.5"
     );
     expect(adapter.runtime.scenarioId).toBeUndefined();
+    // A legacy host target pins no environment, so there is no grant boundary
+    // to forward — and inventing one would let a harness turn believe a
+    // brokered credential is granted when nothing composed it onto the box.
+    expect(adapter.runtime.environmentId).toBeUndefined();
     expect(adapter.persist).toMatchObject({
       sourceType: "swarm",
       origin: "swarm",
@@ -881,6 +885,27 @@ describe("swarm fan-out runner — environment targets (Project Environments)", 
       .map((c) => c[2] as any)
       .filter((a) => a.status !== "running");
     expect(terminals.every((a) => typeof a.targetId === "string")).toBe(true);
+  });
+
+  it("forwards each target's environment id as the session's secret GRANT BOUNDARY", async () => {
+    // What a harness turn scopes its BROKERED external-account credential check
+    // to. It has to be the TARGET's own environment: two targets sharing one
+    // host can grant different secrets, and `resolveGrantForSandbox` derives
+    // exactly this id for the attempt's box from the run snapshot.
+    fetchPinnedSkillMock.mockResolvedValue(pinnedArtifact("hash-1"));
+
+    await startJourneyRun(
+      baseOpts({ hosts: [ENV_TARGET_A, ENV_TARGET_B], sessionsPerTarget: 1 })
+    );
+
+    const bySession = new Map(
+      runSyntheticHostSessionMock.mock.calls.map((c) => [
+        (c[0] as any).chatSessionId,
+        (c[0] as any).runtime.environmentId,
+      ])
+    );
+    expect(bySession.get("synth_run-1_env_envA_0")).toBe("envA");
+    expect(bySession.get("synth_run-1_env_envB_0")).toBe("envB");
   });
 
   it("delivers pinned skill BODIES to the session runtime (authoritative array), and an empty pin set as []", async () => {

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -320,6 +320,19 @@ export interface SyntheticHostRuntime {
    * prepareChatV2's pinned branch, which throws on harness).
    */
   pinnedSkills?: PinnedSkillArtifact[];
+  /**
+   * The Project Environment this target runs (`environmentRef.environmentId` on
+   * the pinned execution spec). Absent for a legacy host target, which has no
+   * environment and therefore no secret grant at all.
+   *
+   * Threaded for the harness path's EXTERNAL-ACCOUNT credential check: brokered
+   * project secrets are composed onto a box from its environment's
+   * `secretSelection`, so this is what separates "the run's environment grants
+   * this credential" from "some environment in the project does". Without it a
+   * bound-but-unselected secret reads as available and the attempt provisions a
+   * box that then fails vendor auth against a placeholder.
+   */
+  environmentId?: string;
 }
 
 /** Attribution tags stamped onto every transcript persist for this session. */
@@ -427,6 +440,7 @@ export async function runSyntheticHostSession(
     harnessSandboxBinding,
     accessVersion,
     scenarioId,
+    environmentId,
   } = runtime;
 
   // FAIL CLOSED before anything is built (B-isolation F4). `runHarnessTurn`
@@ -979,6 +993,13 @@ export async function runSyntheticHostSession(
         // when a harness is selected — the emulated engine's shell binds through
         // `resolveHostTools` above instead.
         ...(harness && harnessSandboxBinding ? { harnessSandboxBinding } : {}),
+        // The target's Project Environment — the GRANT BOUNDARY the harness
+        // turn checks a BROKERED external-account credential against. Harness
+        // only: the emulated engine resolves no such credential, and this
+        // runner delivers no materialized secrets on either path (see the
+        // `runtimeSecrets` contract on `MCPJamHandlerOptions`), so brokered
+        // delivery is the only one a swarm attempt can use.
+        ...(harness && environmentId ? { environmentId } : {}),
         // Server-executed built-ins (`web_search`, …) for the HARNESS turn.
         // The emulated engine already receives them merged into `tools` via
         // prepareChatV2's `allTools`; the harness reads them off this separate
@@ -1539,6 +1560,7 @@ export async function drainAssistantTurn(
     harnessMcpProxy,
     pinnedHarnessSkills,
     harnessSandboxBinding,
+    environmentId,
     builtInTools: harnessBuiltInTools,
     extraBodyFields,
     hooks,
@@ -1744,6 +1766,10 @@ export async function drainAssistantTurn(
     // Ephemeral harness box (B-isolation phase 6) — present ⇒ the harness turn
     // runs on it instead of reserving the acting member's personal computer.
     ...(harnessSandboxBinding ? { harnessSandboxBinding } : {}),
+    // The turn's Project Environment — the grant boundary the harness path
+    // checks a BROKERED external-account credential against. Inert for the
+    // emulated engine, which resolves no such credential.
+    ...(environmentId ? { environmentId } : {}),
     // Server-executed built-ins for the harness path (see the drain's option).
     ...(harnessBuiltInTools ? { builtInTools: harnessBuiltInTools } : {}),
     ...(args.requireToolApproval !== undefined

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -1011,6 +1011,16 @@ async function runJourneyFanOut(
               // legacy live-pool). The shared core routes them to prepareChatV2
               // (`skillsSource`) or the harness pinned path — never a live query.
               ...(pinnedSkills !== undefined ? { pinnedSkills } : {}),
+              // The target's Project Environment — the GRANT BOUNDARY for its
+              // project secrets, and the same id `resolveGrantForSandbox`
+              // derives for this attempt's box from the run snapshot. Threaded
+              // so a harness turn's BROKERED external-account credential is
+              // checked against what THIS environment selects rather than
+              // against the whole project. Absent for a legacy host target,
+              // which has no environment and so no grant.
+              ...(target.environmentRef?.environmentId
+                ? { environmentId: target.environmentRef.environmentId }
+                : {}),
               // Swarm authorizes via project membership — no scenario access
               // version, no scenario id.
             },

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -282,6 +282,19 @@ export interface RunAssistantTurnOptions {
   runtimeSkillsOverride?: MCPJamHandlerOptions["runtimeSkillsOverride"];
 
   /**
+   * The Project Environment this turn resolved — the GRANT BOUNDARY for project
+   * secrets. Pass-through to `runHarnessTurn`, which needs it to answer whether
+   * a BROKERED credential is actually granted to this run's box: the backend
+   * composes a box's egress transform from the environment's `secretSelection`,
+   * so a project-wide answer would report a secret the box never receives.
+   *
+   * An id, never a resolved spec carrying values — see the option's docblock on
+   * `MCPJamHandlerOptions`. Absent ⇒ no grant, which is a normal state and not
+   * a failure.
+   */
+  environmentId?: MCPJamHandlerOptions["environmentId"];
+
+  /**
    * Override the Convex endpoint path. Stage 1 keeps this wired so
    * `handleHostedOrgChatModel` (org BYOK delegation chain) keeps
    * working — `runAssistantTurn` is the same engine, and the org BYOK
@@ -501,6 +514,11 @@ function buildHandlerOptions(
     ...(opts.runtimeSkillsOverride !== undefined
       ? { runtimeSkillsOverride: opts.runtimeSkillsOverride }
       : {}),
+    // The turn's grant boundary for project secrets. Harness-relevant: the
+    // external-account credential check asks whether a BROKERED secret is
+    // selected into THIS environment, and an absent id means "no grant" rather
+    // than "ask the project".
+    ...(opts.environmentId ? { environmentId: opts.environmentId } : {}),
     ...(opts.requireToolApproval !== undefined
       ? { requireToolApproval: opts.requireToolApproval }
       : {}),

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -295,6 +295,12 @@ export interface RunAssistantTurnOptions {
   environmentId?: MCPJamHandlerOptions["environmentId"];
 
   /**
+   * Why `environmentId` is absent on a run that HAS one (eval replay). Copy
+   * only — see the option's docblock on `MCPJamHandlerOptions`.
+   */
+  environmentUnresolvedReason?: MCPJamHandlerOptions["environmentUnresolvedReason"];
+
+  /**
    * Override the Convex endpoint path. Stage 1 keeps this wired so
    * `handleHostedOrgChatModel` (org BYOK delegation chain) keeps
    * working — `runAssistantTurn` is the same engine, and the org BYOK
@@ -519,6 +525,9 @@ function buildHandlerOptions(
     // selected into THIS environment, and an absent id means "no grant" rather
     // than "ask the project".
     ...(opts.environmentId ? { environmentId: opts.environmentId } : {}),
+    ...(opts.environmentUnresolvedReason
+      ? { environmentUnresolvedReason: opts.environmentUnresolvedReason }
+      : {}),
     ...(opts.requireToolApproval !== undefined
       ? { requireToolApproval: opts.requireToolApproval }
       : {}),

--- a/mcpjam-inspector/server/utils/computers/convex-secrets-client.ts
+++ b/mcpjam-inspector/server/utils/computers/convex-secrets-client.ts
@@ -66,6 +66,18 @@ const FN = {
    * comment on `markSecretsDelivered`.
    */
   markDelivered: "projectSecretsNode:markSecretsDelivered",
+  /**
+   * DELIVERY METADATA for every secret in a project the caller can see — names
+   * and binding shape, never a value (the backend view type has no `value`
+   * field at all).
+   *
+   * Read by the harness turn to answer ONE question a value-returning call
+   * cannot: does a BROKERED secret exist for the credential an
+   * external-account harness needs? Brokered values never enter this process,
+   * so the only way to distinguish "the project brokers this credential" from
+   * "the project has not configured it at all" is to ask about the row.
+   */
+  listMetadata: "projectSecrets:listSecrets",
 } as const;
 
 function stripBearer(token: string): string {
@@ -120,4 +132,46 @@ export async function convexMarkSecretsDelivered(
   args: { projectId: string; environmentId: string },
 ): Promise<{ marked: number }> {
   return await makeClient(bearer).action(FN.markDelivered as any, args);
+}
+
+/**
+ * One project secret's DELIVERY METADATA. A hand-mirrored subset of the
+ * backend's `projectSecrets:toSecretView`, carrying only what a delivery
+ * decision needs.
+ *
+ * There is deliberately no `value` here, and there is nothing to add one from:
+ * `listSecrets` is a metadata query whose return type has never had one.
+ */
+export interface ProjectSecretBinding {
+  /** The env-var name. This IS the secret's identity. */
+  name: string;
+  delivery: "brokered" | "materialized";
+  /** Brokered rows only — the hosts the egress proxy injects the header on. */
+  brokerHosts?: string[];
+  /** Brokered rows only — lowercased at write time by the backend. */
+  brokerHeader?: string;
+  /** Brokered rows only — `{}` is where the plaintext is substituted. */
+  brokerTemplate?: string;
+}
+
+/**
+ * List the project's secret bindings (metadata only).
+ *
+ * Throws on any failure, like its sibling above; the caller decides what a
+ * failure means. For the harness credential path it means "we could not
+ * establish that this credential is brokered", which is refused rather than
+ * assumed either way.
+ *
+ * PROJECT-SCOPED, not environment-scoped, because that is the only shape the
+ * backend exposes today. See `external-account-credentials.ts` for what that
+ * costs and why it is still the fail-closed direction.
+ */
+export async function convexListProjectSecretBindings(
+  bearer: string,
+  args: { projectId: string },
+): Promise<ProjectSecretBinding[]> {
+  const rows = (await makeClient(bearer).query(FN.listMetadata as any, {
+    projectId: args.projectId,
+  })) as ProjectSecretBinding[] | null;
+  return rows ?? [];
 }

--- a/mcpjam-inspector/server/utils/computers/convex-secrets-client.ts
+++ b/mcpjam-inspector/server/utils/computers/convex-secrets-client.ts
@@ -78,6 +78,23 @@ const FN = {
    * "the project has not configured it at all" is to ask about the row.
    */
   listMetadata: "projectSecrets:listSecrets",
+  /**
+   * The ENVIRONMENT's own secret SELECTION — which of the project's secret rows
+   * a run launched from this environment is actually granted.
+   *
+   * Read alongside `listMetadata` because project scope is not grant scope. The
+   * environment is the grant boundary (`projectEnvironments` →
+   * `secretSelection.secretIds`), and `projectSecretsEgress` composes a box's
+   * egress transform from exactly that selection — so a brokered row that
+   * exists in the project but is NOT selected here is never delivered to the
+   * box, and must never be reported as available.
+   *
+   * Returns ids the CALLER may see: the backend filters the selection through
+   * `visibleSecretIdsFor`, so another member's personal secret is absent here
+   * exactly as it is absent from `listSecrets`. That is the same rule
+   * `listBrokeredSecretsForBox` re-checks live against the session owner.
+   */
+  environment: "projectEnvironments:getEnvironment",
 } as const;
 
 function stripBearer(token: string): string {
@@ -143,6 +160,13 @@ export async function convexMarkSecretsDelivered(
  * `listSecrets` is a metadata query whose return type has never had one.
  */
 export interface ProjectSecretBinding {
+  /**
+   * The row id. Not the secret's identity — the NAME is — but it is what an
+   * environment's `secretSelection` names, so it is the only way to ask whether
+   * THIS run's environment actually grants THIS row. Always present:
+   * `toSecretView` has returned it since the view existed.
+   */
+  secretId: string;
   /** The env-var name. This IS the secret's identity. */
   name: string;
   delivery: "brokered" | "materialized";
@@ -162,9 +186,9 @@ export interface ProjectSecretBinding {
  * establish that this credential is brokered", which is refused rather than
  * assumed either way.
  *
- * PROJECT-SCOPED, not environment-scoped, because that is the only shape the
- * backend exposes today. See `external-account-credentials.ts` for what that
- * costs and why it is still the fail-closed direction.
+ * PROJECT-SCOPED. That is the only shape the backend exposes, and it is NOT the
+ * grant boundary — pair it with {@link convexGetEnvironmentSecretSelection} to
+ * narrow it to the rows a run launched from a given environment receives.
  */
 export async function convexListProjectSecretBindings(
   bearer: string,
@@ -174,4 +198,27 @@ export async function convexListProjectSecretBindings(
     projectId: args.projectId,
   })) as ProjectSecretBinding[] | null;
   return rows ?? [];
+}
+
+/**
+ * The secret row ids ONE environment grants — the caller-visible subset of its
+ * `secretSelection`.
+ *
+ * An empty array is a real answer and the fail-closed default: an environment
+ * with no selection grants NO secrets, which is exactly what the schema says
+ * ("absent ⇒ NO secrets … the reason there is no 'all project secrets' mode").
+ *
+ * Throws on any failure, like its siblings; the caller decides what a failure
+ * means. For the harness credential path it means "we could not establish that
+ * this credential is granted", which is refused rather than assumed either way.
+ */
+export async function convexGetEnvironmentSecretSelection(
+  bearer: string,
+  args: { projectId: string; environmentId: string },
+): Promise<string[]> {
+  const environment = (await makeClient(bearer).query(FN.environment as any, {
+    projectId: args.projectId,
+    environmentId: args.environmentId,
+  })) as { secretSelection?: { secretIds?: string[] } } | null;
+  return environment?.secretSelection?.secretIds ?? [];
 }

--- a/mcpjam-inspector/server/utils/computers/convex-secrets-client.ts
+++ b/mcpjam-inspector/server/utils/computers/convex-secrets-client.ts
@@ -89,10 +89,24 @@ const FN = {
    * exists in the project but is NOT selected here is never delivered to the
    * box, and must never be reported as available.
    *
-   * Returns ids the CALLER may see: the backend filters the selection through
-   * `visibleSecretIdsFor`, so another member's personal secret is absent here
-   * exactly as it is absent from `listSecrets`. That is the same rule
-   * `listBrokeredSecretsForBox` re-checks live against the session owner.
+   * WHAT KEEPS THIS READ CONFIDENTIAL, precisely — because the obvious answer
+   * is the weaker one.
+   *
+   * The Convex query DOES filter the selection per viewer today
+   * (`toView(row, await visibleSecretIdsFor(...))`), so another member's
+   * personal secret id is absent here just as the row is absent from
+   * `listSecrets`. But that filter is NOT what this module's safety rests on,
+   * and writing it down as though it were invites exactly the wrong repair if
+   * it ever changes.
+   *
+   * The load-bearing guarantee is the OTHER read. Candidate rows come from
+   * `listMetadata`, which is visibility-filtered at the row level, and the
+   * selection is consulted only to ADMIT one of those candidates
+   * (`selectedIds.has(row.secretId)`). A selection id with no matching
+   * candidate is inert: it can never name a row the caller could not already
+   * see, so an unfiltered selection would leak nothing and change no decision.
+   * Intersect in that direction and the filter above is a second lock, not the
+   * lock.
    */
   environment: "projectEnvironments:getEnvironment",
 } as const;
@@ -211,6 +225,23 @@ export async function convexListProjectSecretBindings(
  * Throws on any failure, like its siblings; the caller decides what a failure
  * means. For the harness credential path it means "we could not establish that
  * this credential is granted", which is refused rather than assumed either way.
+ *
+ * A MISSING OR CROSS-PROJECT ENVIRONMENT IS A THROW, NOT AN EMPTY ANSWER, and
+ * the distinction is worth stating because the shapes look alike from here.
+ * `getEnvironment` resolves the row through `loadEnvironment`, which calls
+ * `fail('NOT_FOUND', …)` — a thrown `ConvexError` — for both a row that does
+ * not exist and one belonging to another project; its declared return type is
+ * `EnvironmentView`, never `EnvironmentView | null`. (An unparseable id does
+ * not even reach the handler: `v.id('projectEnvironments')` rejects it first.)
+ * So there is no null result to flatten, and the only thing `?? []` covers is
+ * the one genuinely empty answer: an environment that exists and selects
+ * NOTHING, which grants nothing and is the schema's own fail-closed default.
+ *
+ * Both throws therefore land in the caller's "could not establish" arm rather
+ * than in "the environment grants nothing" — which is the fail-closed side, and
+ * the reason the caller logs the underlying message: a NOT_FOUND here is a
+ * wiring bug (environments are archived, never hard-deleted), and it should be
+ * diagnosable as one instead of reported as a missing secret.
  */
 export async function convexGetEnvironmentSecretSelection(
   bearer: string,
@@ -219,6 +250,6 @@ export async function convexGetEnvironmentSecretSelection(
   const environment = (await makeClient(bearer).query(FN.environment as any, {
     projectId: args.projectId,
     environmentId: args.environmentId,
-  })) as { secretSelection?: { secretIds?: string[] } } | null;
+  })) as { secretSelection?: { secretIds?: string[] } };
   return environment?.secretSelection?.secretIds ?? [];
 }

--- a/mcpjam-inspector/server/utils/harness/__tests__/external-account-credentials.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/external-account-credentials.test.ts
@@ -154,6 +154,39 @@ describe("fetchBrokeredCredentialNames", () => {
     expect(clientState.selectionCalls).toBe(0);
   });
 
+  it("carries a caller's UNRESOLVED reason through, without changing the answer", async () => {
+    // Eval replay: the run has an environment, this process cannot name it.
+    // The availability answer is identical to any other unnamed environment —
+    // refused — but the reason rides along so the copy can be honest.
+    clientState.rows = [brokeredRow()];
+    const result = await fetchBrokeredCredentialNames(
+      ask({
+        environmentId: undefined,
+        environmentUnresolvedReason: "replaying a run does not carry it.",
+      }),
+    );
+    expect(result?.available.size).toBe(0);
+    expect(result?.unselected.has("CURSOR_API_KEY")).toBe(true);
+    expect(result?.environmentMissing).toBe(true);
+    expect(result?.environmentUnresolvedReason).toBe(
+      "replaying a run does not carry it.",
+    );
+    expect(clientState.selectionCalls).toBe(0);
+  });
+
+  it("ignores an unresolved reason when the environment IS known", async () => {
+    // Defensive: a caller that sets both must not have its selection check
+    // downgraded into an excuse.
+    clientState.rows = [brokeredRow()];
+    clientState.selection = ["secret-something-else"];
+    const result = await fetchBrokeredCredentialNames(
+      ask({ environmentUnresolvedReason: "should be ignored" }),
+    );
+    expect(result?.environmentMissing).toBe(false);
+    expect(result?.environmentUnresolvedReason).toBeUndefined();
+    expect(result?.unselected.has("CURSOR_API_KEY")).toBe(true);
+  });
+
   it("skips the environment read when the project brokers nothing", async () => {
     // A project with no brokered row for this credential gets the same "add it"
     // refusal it always got — one query, not two.
@@ -378,6 +411,34 @@ describe("planExternalAccountCredentials", () => {
     }
     expect(message).toMatch(/no Project Environment/i);
     expect(message).toMatch(/grant boundary/i);
+  });
+
+  it("blames the PATH, not the user, when the environment could not be named", () => {
+    // The replay refusal. The reader's secret and selection may both be
+    // perfect, so the copy must not tell them to change either — and must not
+    // claim the run has no environment, because it does.
+    let message = "";
+    try {
+      planExternalAccountCredentials({
+        ...base,
+        secretEnv: undefined,
+        brokeredAvailable: new Set(),
+        unselected: new Set(["CURSOR_API_KEY"]),
+        environmentMissing: true,
+        environmentUnresolvedReason:
+          "replaying a run does not carry the original run's Project " +
+          "Environment through to the runner.",
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain("CURSOR_API_KEY");
+    expect(message).toContain("replaying a run");
+    // NOT the remediation for a selection the reader never made…
+    expect(message).not.toMatch(/does not select it/i);
+    expect(message).not.toMatch(/no Project Environment/i);
+    // …and it says plainly that the secret is fine.
+    expect(message).toMatch(/nothing about the secret itself needs to change/i);
   });
 
   it("prefers the MISBOUND complaint over the unselected one", () => {

--- a/mcpjam-inspector/server/utils/harness/__tests__/external-account-credentials.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/external-account-credentials.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The two-delivery credential decision for an EXTERNAL-ACCOUNT harness.
+ *
+ * The failure this module exists to prevent is not "the turn errors" — it is a
+ * turn that STARTS with a credential that will never arrive, because the box
+ * carries a placeholder and no transform was ever installed to replace it. Every
+ * case below is one way that could happen.
+ */
+
+const clientState = vi.hoisted(() => ({
+  rows: [] as Record<string, unknown>[],
+  error: null as Error | null,
+  calls: 0,
+}));
+
+vi.mock("../../computers/convex-secrets-client.js", () => ({
+  convexListProjectSecretBindings: vi.fn(async () => {
+    clientState.calls += 1;
+    if (clientState.error) throw clientState.error;
+    return clientState.rows;
+  }),
+  // Imported by `runtime-secrets.ts`, which this module's import graph does not
+  // reach — declared so the factory is a complete stand-in for the module.
+  convexListSecretsForRuntimeExecution: vi.fn(async () => []),
+  convexMarkSecretsDelivered: vi.fn(async () => ({ marked: 0 })),
+}));
+
+import {
+  EXTERNAL_ACCOUNT_BROKERED_PLACEHOLDER,
+  fetchBrokeredCredentialNames,
+  planExternalAccountCredentials,
+} from "../external-account-credentials";
+
+const CURSOR_BINDING = {
+  hosts: ["api2.cursor.sh"] as [string, ...string[]],
+  header: "authorization",
+  template: "Bearer {}",
+};
+const REQUIRED = { CURSOR_API_KEY: CURSOR_BINDING };
+
+function brokeredRow(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "CURSOR_API_KEY",
+    delivery: "brokered",
+    brokerHosts: ["api2.cursor.sh"],
+    brokerHeader: "authorization",
+    brokerTemplate: "Bearer {}",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  clientState.rows = [];
+  clientState.error = null;
+  clientState.calls = 0;
+});
+
+describe("fetchBrokeredCredentialNames", () => {
+  it("reports a correctly bound brokered secret on an ephemeral box", async () => {
+    clientState.rows = [brokeredRow()];
+    const result = await fetchBrokeredCredentialNames({
+      bearer: "Bearer t",
+      projectId: "project-1",
+      boxKind: "sandbox",
+      required: REQUIRED,
+    });
+    expect(result?.available.has("CURSOR_API_KEY")).toBe(true);
+    expect(result?.misboundHosts).toEqual({});
+  });
+
+  it("answers 'none' for a PERSISTENT computer without asking anything", async () => {
+    // `projectSecretsEgress.listBrokeredSecretsForBox` returns `[]` for any box
+    // with no `sandboxRowId` — persistent computers receive no brokered secrets
+    // in v1 — so this is a known answer, not an unknown one. Reading the
+    // project's secrets would have said "yes" and started a turn whose
+    // credential the box never receives.
+    clientState.rows = [brokeredRow()];
+    const result = await fetchBrokeredCredentialNames({
+      bearer: "Bearer t",
+      projectId: "project-1",
+      boxKind: "computer",
+      required: REQUIRED,
+    });
+    expect(result?.available.size).toBe(0);
+    expect(clientState.calls).toBe(0);
+  });
+
+  it("returns null — not 'none' — when the metadata read fails", async () => {
+    clientState.error = new Error("convex unavailable");
+    const result = await fetchBrokeredCredentialNames({
+      bearer: "Bearer t",
+      projectId: "project-1",
+      boxKind: "sandbox",
+      required: REQUIRED,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when there is no bearer to ask with", async () => {
+    const result = await fetchBrokeredCredentialNames({
+      projectId: "project-1",
+      boxKind: "sandbox",
+      required: REQUIRED,
+    });
+    expect(result).toBeNull();
+    expect(clientState.calls).toBe(0);
+  });
+
+  it("ignores a MATERIALIZED row with the same name", async () => {
+    clientState.rows = [{ name: "CURSOR_API_KEY", delivery: "materialized" }];
+    const result = await fetchBrokeredCredentialNames({
+      bearer: "Bearer t",
+      projectId: "project-1",
+      boxKind: "sandbox",
+      required: REQUIRED,
+    });
+    expect(result?.available.size).toBe(0);
+  });
+
+  it("records a row bound to the WRONG host as misbound, not available", async () => {
+    // The one misconfiguration that would otherwise reach the vendor as a
+    // placeholder and come back as an unexplained 401.
+    clientState.rows = [brokeredRow({ brokerHosts: ["api.example.com"] })];
+    const result = await fetchBrokeredCredentialNames({
+      bearer: "Bearer t",
+      projectId: "project-1",
+      boxKind: "sandbox",
+      required: REQUIRED,
+    });
+    expect(result?.available.size).toBe(0);
+    expect(result?.misboundHosts).toEqual({
+      CURSOR_API_KEY: ["api.example.com"],
+    });
+  });
+
+  it("rejects a row bound to the wrong HEADER", async () => {
+    clientState.rows = [brokeredRow({ brokerHeader: "x-api-key" })];
+    const result = await fetchBrokeredCredentialNames({
+      bearer: "Bearer t",
+      projectId: "project-1",
+      boxKind: "sandbox",
+      required: REQUIRED,
+    });
+    expect(result?.available.size).toBe(0);
+  });
+
+  it("rejects a template with no substitution point", async () => {
+    // Without `{}` the backend injects a constant header and the plaintext is
+    // never delivered at all.
+    clientState.rows = [brokeredRow({ brokerTemplate: "Bearer" })];
+    const result = await fetchBrokeredCredentialNames({
+      bearer: "Bearer t",
+      projectId: "project-1",
+      boxKind: "sandbox",
+      required: REQUIRED,
+    });
+    expect(result?.available.size).toBe(0);
+  });
+
+  it("accepts a template whose surrounding text differs", async () => {
+    // The vendor, not MCPJam, decides what its own header may look like.
+    clientState.rows = [brokeredRow({ brokerTemplate: "bearer {}" })];
+    const result = await fetchBrokeredCredentialNames({
+      bearer: "Bearer t",
+      projectId: "project-1",
+      boxKind: "sandbox",
+      required: REQUIRED,
+    });
+    expect(result?.available.has("CURSOR_API_KEY")).toBe(true);
+  });
+
+  it("lets a correctly bound row supersede a misbound sibling", async () => {
+    clientState.rows = [
+      brokeredRow({ brokerHosts: ["api.example.com"] }),
+      brokeredRow(),
+    ];
+    const result = await fetchBrokeredCredentialNames({
+      bearer: "Bearer t",
+      projectId: "project-1",
+      boxKind: "sandbox",
+      required: REQUIRED,
+    });
+    expect(result?.available.has("CURSOR_API_KEY")).toBe(true);
+    expect(result?.misboundHosts).toEqual({});
+  });
+});
+
+describe("planExternalAccountCredentials", () => {
+  const base = {
+    harnessDisplayName: "Cursor CLI",
+    required: ["CURSOR_API_KEY"],
+    brokerBinding: REQUIRED,
+  };
+
+  it("uses the MATERIALIZED value when the project has one", () => {
+    const plan = planExternalAccountCredentials({
+      ...base,
+      secretEnv: { CURSOR_API_KEY: "key_live_abc" },
+      brokeredAvailable: new Set(),
+    });
+    expect(plan.auth).toEqual({ CURSOR_API_KEY: "key_live_abc" });
+    expect(plan.materializedNames).toEqual(["CURSOR_API_KEY"]);
+    expect(plan.brokeredNames).toEqual([]);
+  });
+
+  it("hands the adapter a PLACEHOLDER on the brokered path", () => {
+    const plan = planExternalAccountCredentials({
+      ...base,
+      secretEnv: undefined,
+      brokeredAvailable: new Set(["CURSOR_API_KEY"]),
+    });
+    // The real key never enters this process: the backend injects it into the
+    // box's egress transform, which overwrites the header outside the VM.
+    expect(plan.auth).toEqual({
+      CURSOR_API_KEY: EXTERNAL_ACCOUNT_BROKERED_PLACEHOLDER,
+    });
+    expect(plan.brokeredNames).toEqual(["CURSOR_API_KEY"]);
+    // Nothing to stamp: this process delivered nothing.
+    expect(plan.materializedNames).toEqual([]);
+  });
+
+  it("prefers MATERIALIZED when both deliveries are configured", () => {
+    // A materialized value is the one this process can prove reached the box.
+    const plan = planExternalAccountCredentials({
+      ...base,
+      secretEnv: { CURSOR_API_KEY: "key_live_abc" },
+      brokeredAvailable: new Set(["CURSOR_API_KEY"]),
+    });
+    expect(plan.auth.CURSOR_API_KEY).toBe("key_live_abc");
+    expect(plan.brokeredNames).toEqual([]);
+  });
+
+  it("refuses when NEITHER delivery is present, naming both", () => {
+    expect(() =>
+      planExternalAccountCredentials({
+        ...base,
+        secretEnv: undefined,
+        brokeredAvailable: new Set(),
+      }),
+    ).toThrow(/CURSOR_API_KEY/);
+    let message = "";
+    try {
+      planExternalAccountCredentials({
+        ...base,
+        secretEnv: undefined,
+        brokeredAvailable: new Set(),
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toMatch(/brokered/i);
+    expect(message).toMatch(/materialized/i);
+    expect(message).toMatch(/Project Settings/);
+    expect(message).toContain("Cursor CLI");
+  });
+
+  it("refuses on an UNESTABLISHED brokered answer exactly like an absence", () => {
+    // `null` is the third state of the tri-state: a metadata read that failed.
+    // Guessing "yes" here starts a turn whose credential silently never comes.
+    expect(() =>
+      planExternalAccountCredentials({
+        ...base,
+        secretEnv: undefined,
+        brokeredAvailable: null,
+      }),
+    ).toThrow(/CURSOR_API_KEY/);
+  });
+
+  it("names the wrong hosts when a brokered row exists but is misbound", () => {
+    let message = "";
+    try {
+      planExternalAccountCredentials({
+        ...base,
+        secretEnv: undefined,
+        brokeredAvailable: new Set(),
+        misboundHosts: { CURSOR_API_KEY: ["api.example.com"] },
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    // "Missing" would send the reader to create a second secret they already
+    // have; the fix is a re-bind.
+    expect(message).toContain("api.example.com");
+    expect(message).toContain("api2.cursor.sh");
+    expect(message).toMatch(/Re-bind/i);
+  });
+
+  it("refuses a name the adapter cannot broker at all, without a broker hint", () => {
+    let message = "";
+    try {
+      planExternalAccountCredentials({
+        harnessDisplayName: "Cursor CLI",
+        required: ["OTHER_KEY"],
+        brokerBinding: REQUIRED,
+        secretEnv: undefined,
+        brokeredAvailable: new Set(["OTHER_KEY"]),
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    // Availability alone must not satisfy a name the runtime does not
+    // authenticate with by header — there is nothing to inject it into.
+    expect(message).toContain("OTHER_KEY");
+    expect(message).not.toMatch(/api2\.cursor\.sh/);
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/__tests__/external-account-credentials.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/external-account-credentials.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
  * The two-delivery credential decision for an EXTERNAL-ACCOUNT harness.
@@ -13,6 +13,10 @@ const clientState = vi.hoisted(() => ({
   rows: [] as Record<string, unknown>[],
   error: null as Error | null,
   calls: 0,
+  /** What the run's ENVIRONMENT selects — the grant boundary. */
+  selection: [] as string[],
+  selectionError: null as Error | null,
+  selectionCalls: 0,
 }));
 
 vi.mock("../../computers/convex-secrets-client.js", () => ({
@@ -20,6 +24,11 @@ vi.mock("../../computers/convex-secrets-client.js", () => ({
     clientState.calls += 1;
     if (clientState.error) throw clientState.error;
     return clientState.rows;
+  }),
+  convexGetEnvironmentSecretSelection: vi.fn(async () => {
+    clientState.selectionCalls += 1;
+    if (clientState.selectionError) throw clientState.selectionError;
+    return clientState.selection;
   }),
   // Imported by `runtime-secrets.ts`, which this module's import graph does not
   // reach — declared so the factory is a complete stand-in for the module.
@@ -40,8 +49,11 @@ const CURSOR_BINDING = {
 };
 const REQUIRED = { CURSOR_API_KEY: CURSOR_BINDING };
 
+const SELECTED_ID = "secret-cursor";
+
 function brokeredRow(overrides: Record<string, unknown> = {}) {
   return {
+    secretId: SELECTED_ID,
     name: "CURSOR_API_KEY",
     delivery: "brokered",
     brokerHosts: ["api2.cursor.sh"],
@@ -51,21 +63,39 @@ function brokeredRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
+type BrokeredAsk = Parameters<typeof fetchBrokeredCredentialNames>[0];
+
+/** The default ask: an ephemeral box, on an environment that DOES grant the
+ *  row `brokeredRow()` produces. Every case that changes one of those states
+ *  overrides it explicitly. */
+function ask(overrides: Partial<BrokeredAsk> = {}): BrokeredAsk {
+  return {
+    bearer: "Bearer t",
+    projectId: "project-1",
+    environmentId: "env-1",
+    boxKind: "sandbox",
+    required: REQUIRED,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  clientState.selection = [SELECTED_ID];
+});
+
 afterEach(() => {
   clientState.rows = [];
   clientState.error = null;
   clientState.calls = 0;
+  clientState.selection = [];
+  clientState.selectionError = null;
+  clientState.selectionCalls = 0;
 });
 
 describe("fetchBrokeredCredentialNames", () => {
   it("reports a correctly bound brokered secret on an ephemeral box", async () => {
     clientState.rows = [brokeredRow()];
-    const result = await fetchBrokeredCredentialNames({
-      bearer: "Bearer t",
-      projectId: "project-1",
-      boxKind: "sandbox",
-      required: REQUIRED,
-    });
+    const result = await fetchBrokeredCredentialNames(ask());
     expect(result?.available.has("CURSOR_API_KEY")).toBe(true);
     expect(result?.misboundHosts).toEqual({});
   });
@@ -77,30 +107,83 @@ describe("fetchBrokeredCredentialNames", () => {
     // project's secrets would have said "yes" and started a turn whose
     // credential the box never receives.
     clientState.rows = [brokeredRow()];
-    const result = await fetchBrokeredCredentialNames({
-      bearer: "Bearer t",
-      projectId: "project-1",
-      boxKind: "computer",
-      required: REQUIRED,
-    });
+    const result = await fetchBrokeredCredentialNames(
+      ask({ boxKind: "computer" }),
+    );
     expect(result?.available.size).toBe(0);
     expect(clientState.calls).toBe(0);
   });
 
+  it("does NOT report a correctly bound row the ENVIRONMENT does not select", async () => {
+    // THE bug this scoping exists to close. The project holds a brokered
+    // CURSOR_API_KEY, bound to exactly the right host/header/template — but the
+    // environment this run launched from does not grant it, so
+    // `listBrokeredSecretsForBox` composes NOTHING onto the box. Reporting it
+    // available starts a turn that provisions a sandbox and then authenticates
+    // with the placeholder.
+    clientState.rows = [brokeredRow()];
+    clientState.selection = ["secret-something-else"];
+    const result = await fetchBrokeredCredentialNames(ask());
+    expect(result?.available.size).toBe(0);
+    expect(result?.unselected.has("CURSOR_API_KEY")).toBe(true);
+    // Not a binding problem — the binding is perfect. Saying "misbound" would
+    // send the reader to re-bind a correct row.
+    expect(result?.misboundHosts).toEqual({});
+    expect(result?.environmentMissing).toBe(false);
+  });
+
+  it("does NOT report anything when the environment selects nothing at all", async () => {
+    clientState.rows = [brokeredRow()];
+    clientState.selection = [];
+    const result = await fetchBrokeredCredentialNames(ask());
+    expect(result?.available.size).toBe(0);
+    expect(result?.unselected.has("CURSOR_API_KEY")).toBe(true);
+  });
+
+  it("treats an ABSENT environment as no grant, and says which", async () => {
+    // The backend agrees: `resolveGrantForSandbox` answers NO_GRANT whenever it
+    // cannot resolve an environment for the box, so nothing is composed.
+    clientState.rows = [brokeredRow()];
+    const result = await fetchBrokeredCredentialNames(
+      ask({ environmentId: undefined }),
+    );
+    expect(result?.available.size).toBe(0);
+    expect(result?.unselected.has("CURSOR_API_KEY")).toBe(true);
+    expect(result?.environmentMissing).toBe(true);
+    // Nothing to scope against, so nothing to ask.
+    expect(clientState.selectionCalls).toBe(0);
+  });
+
+  it("skips the environment read when the project brokers nothing", async () => {
+    // A project with no brokered row for this credential gets the same "add it"
+    // refusal it always got — one query, not two.
+    clientState.rows = [
+      { secretId: "s1", name: "OTHER", delivery: "brokered" },
+    ];
+    const result = await fetchBrokeredCredentialNames(ask());
+    expect(result?.available.size).toBe(0);
+    expect(clientState.selectionCalls).toBe(0);
+  });
+
+  it("returns null — not 'none' — when the ENVIRONMENT read fails", async () => {
+    // Same tri-state rule as the bindings read: an unestablished grant is
+    // refused, never guessed in either direction.
+    clientState.rows = [brokeredRow()];
+    clientState.selectionError = new Error("convex unavailable");
+    const result = await fetchBrokeredCredentialNames(ask());
+    expect(result).toBeNull();
+  });
+
   it("returns null — not 'none' — when the metadata read fails", async () => {
     clientState.error = new Error("convex unavailable");
-    const result = await fetchBrokeredCredentialNames({
-      bearer: "Bearer t",
-      projectId: "project-1",
-      boxKind: "sandbox",
-      required: REQUIRED,
-    });
+    const result = await fetchBrokeredCredentialNames(ask());
     expect(result).toBeNull();
   });
 
   it("returns null when there is no bearer to ask with", async () => {
     const result = await fetchBrokeredCredentialNames({
       projectId: "project-1",
+      environmentId: "env-1",
       boxKind: "sandbox",
       required: REQUIRED,
     });
@@ -110,12 +193,7 @@ describe("fetchBrokeredCredentialNames", () => {
 
   it("ignores a MATERIALIZED row with the same name", async () => {
     clientState.rows = [{ name: "CURSOR_API_KEY", delivery: "materialized" }];
-    const result = await fetchBrokeredCredentialNames({
-      bearer: "Bearer t",
-      projectId: "project-1",
-      boxKind: "sandbox",
-      required: REQUIRED,
-    });
+    const result = await fetchBrokeredCredentialNames(ask());
     expect(result?.available.size).toBe(0);
   });
 
@@ -123,12 +201,7 @@ describe("fetchBrokeredCredentialNames", () => {
     // The one misconfiguration that would otherwise reach the vendor as a
     // placeholder and come back as an unexplained 401.
     clientState.rows = [brokeredRow({ brokerHosts: ["api.example.com"] })];
-    const result = await fetchBrokeredCredentialNames({
-      bearer: "Bearer t",
-      projectId: "project-1",
-      boxKind: "sandbox",
-      required: REQUIRED,
-    });
+    const result = await fetchBrokeredCredentialNames(ask());
     expect(result?.available.size).toBe(0);
     expect(result?.misboundHosts).toEqual({
       CURSOR_API_KEY: ["api.example.com"],
@@ -137,12 +210,7 @@ describe("fetchBrokeredCredentialNames", () => {
 
   it("rejects a row bound to the wrong HEADER", async () => {
     clientState.rows = [brokeredRow({ brokerHeader: "x-api-key" })];
-    const result = await fetchBrokeredCredentialNames({
-      bearer: "Bearer t",
-      projectId: "project-1",
-      boxKind: "sandbox",
-      required: REQUIRED,
-    });
+    const result = await fetchBrokeredCredentialNames(ask());
     expect(result?.available.size).toBe(0);
   });
 
@@ -150,38 +218,27 @@ describe("fetchBrokeredCredentialNames", () => {
     // Without `{}` the backend injects a constant header and the plaintext is
     // never delivered at all.
     clientState.rows = [brokeredRow({ brokerTemplate: "Bearer" })];
-    const result = await fetchBrokeredCredentialNames({
-      bearer: "Bearer t",
-      projectId: "project-1",
-      boxKind: "sandbox",
-      required: REQUIRED,
-    });
+    const result = await fetchBrokeredCredentialNames(ask());
     expect(result?.available.size).toBe(0);
   });
 
   it("accepts a template whose surrounding text differs", async () => {
     // The vendor, not MCPJam, decides what its own header may look like.
     clientState.rows = [brokeredRow({ brokerTemplate: "bearer {}" })];
-    const result = await fetchBrokeredCredentialNames({
-      bearer: "Bearer t",
-      projectId: "project-1",
-      boxKind: "sandbox",
-      required: REQUIRED,
-    });
+    const result = await fetchBrokeredCredentialNames(ask());
     expect(result?.available.has("CURSOR_API_KEY")).toBe(true);
   });
 
   it("lets a correctly bound row supersede a misbound sibling", async () => {
     clientState.rows = [
-      brokeredRow({ brokerHosts: ["api.example.com"] }),
+      brokeredRow({
+        secretId: "secret-wrong",
+        brokerHosts: ["api.example.com"],
+      }),
       brokeredRow(),
     ];
-    const result = await fetchBrokeredCredentialNames({
-      bearer: "Bearer t",
-      projectId: "project-1",
-      boxKind: "sandbox",
-      required: REQUIRED,
-    });
+    clientState.selection = ["secret-wrong", SELECTED_ID];
+    const result = await fetchBrokeredCredentialNames(ask());
     expect(result?.available.has("CURSOR_API_KEY")).toBe(true);
     expect(result?.misboundHosts).toEqual({});
   });
@@ -284,6 +341,60 @@ describe("planExternalAccountCredentials", () => {
     // have; the fix is a re-bind.
     expect(message).toContain("api.example.com");
     expect(message).toContain("api2.cursor.sh");
+    expect(message).toMatch(/Re-bind/i);
+  });
+
+  it("names the SELECTION as the fix when the row exists but is not granted", () => {
+    // "Add a CURSOR_API_KEY" would be wrong twice over: the secret exists, and
+    // the reader would create a duplicate instead of granting the one they have.
+    let message = "";
+    try {
+      planExternalAccountCredentials({
+        ...base,
+        secretEnv: undefined,
+        brokeredAvailable: new Set(),
+        unselected: new Set(["CURSOR_API_KEY"]),
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain("CURSOR_API_KEY");
+    expect(message).toMatch(/does not select it/i);
+    expect(message).not.toMatch(/Project Settings . Secrets/);
+  });
+
+  it("says there is NO environment when that is why nothing is granted", () => {
+    let message = "";
+    try {
+      planExternalAccountCredentials({
+        ...base,
+        secretEnv: undefined,
+        brokeredAvailable: new Set(),
+        unselected: new Set(["CURSOR_API_KEY"]),
+        environmentMissing: true,
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toMatch(/no Project Environment/i);
+    expect(message).toMatch(/grant boundary/i);
+  });
+
+  it("prefers the MISBOUND complaint over the unselected one", () => {
+    // A granted row with the wrong binding is the sharper problem: re-binding
+    // is the fix, and the selection is already correct.
+    let message = "";
+    try {
+      planExternalAccountCredentials({
+        ...base,
+        secretEnv: undefined,
+        brokeredAvailable: new Set(),
+        misboundHosts: { CURSOR_API_KEY: ["api.example.com"] },
+        unselected: new Set(["CURSOR_API_KEY"]),
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
     expect(message).toMatch(/Re-bind/i);
   });
 

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-external-account.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-external-account.test.ts
@@ -538,6 +538,54 @@ describe("runHarnessTurn — external-account BROKERED credential", () => {
     expect(registryState.createHarness).not.toHaveBeenCalled();
   });
 
+  it("blames the REPLAY path, not the reader, when it cannot name the environment", async () => {
+    // A replay run inherits the source run's environmentRef on the backend, so
+    // its box may really carry the transform — this process just cannot read
+    // that ref back. Still refused (an unverifiable grant is not a grant), but
+    // the copy must not send the reader to change a correct configuration.
+    secretsClientState.rows = [BROKERED_CURSOR_ROW];
+    const onEngineError = vi.fn();
+    await runHarnessTurn(
+      baseOptions({
+        runtimeSecrets: undefined,
+        environmentId: undefined,
+        environmentUnresolvedReason:
+          "replaying a run does not carry the original run's Project " +
+          "Environment through to the runner.",
+        harnessSandboxBinding: EPHEMERAL_BINDING,
+        onEngineError,
+      }) as never,
+      "none",
+    );
+    expect(onEngineError).toHaveBeenCalledTimes(1);
+    const err = onEngineError.mock.calls[0]![0] as { message: string };
+    expect(err.message).toContain("replaying a run");
+    expect(err.message).not.toMatch(/no Project Environment/i);
+    expect(err.message).not.toMatch(/does not select it/i);
+    expect(registryState.createHarness).not.toHaveBeenCalled();
+    expect(reserveHarnessBox).not.toHaveBeenCalled();
+  });
+
+  it("ignores a stale unresolved reason once the environment IS known", async () => {
+    // Belt and braces: a caller that sets both must not turn a real
+    // selection failure into "MCPJam could not tell".
+    secretsClientState.rows = [BROKERED_CURSOR_ROW];
+    secretsClientState.selection = ["secret-something-else"];
+    const onEngineError = vi.fn();
+    await runHarnessTurn(
+      baseOptions({
+        runtimeSecrets: undefined,
+        environmentUnresolvedReason: "should be ignored",
+        harnessSandboxBinding: EPHEMERAL_BINDING,
+        onEngineError,
+      }) as never,
+      "none",
+    );
+    const err = onEngineError.mock.calls[0]![0] as { message: string };
+    expect(err.message).toMatch(/does not select it/i);
+    expect(err.message).not.toContain("should be ignored");
+  });
+
   it("refuses when the brokered row is bound to the wrong host", async () => {
     secretsClientState.rows = [
       { ...BROKERED_CURSOR_ROW, brokerHosts: ["api.example.com"] },

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-external-account.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-external-account.test.ts
@@ -104,10 +104,16 @@ vi.mock("../registry.js", () => ({
  */
 const secretsClientState = vi.hoisted(() => ({
   rows: [] as Record<string, unknown>[],
+  /** What the run's ENVIRONMENT grants — the boundary the brokered check is
+   *  scoped to. Defaults (in `beforeEach`) to granting the Cursor row. */
+  selection: [] as string[],
 }));
 
 vi.mock("../../computers/convex-secrets-client.js", () => ({
   convexListProjectSecretBindings: vi.fn(async () => secretsClientState.rows),
+  convexGetEnvironmentSecretSelection: vi.fn(
+    async () => secretsClientState.selection,
+  ),
   convexListSecretsForRuntimeExecution: vi.fn(async () => []),
   convexMarkSecretsDelivered: vi.fn(async () => ({ marked: 0 })),
 }));
@@ -220,6 +226,11 @@ function baseOptions(overrides: Record<string, unknown> = {}) {
     requireToolApproval: false,
     sourceType: "eval",
     harness: "cursor",
+    // The run's Project Environment — the GRANT BOUNDARY. Every hosted surface
+    // that can run a Cursor host threads one (chat via `web-chat-turn`, swarm
+    // via the pinned target's `environmentRef`, eval via the run's
+    // `configSnapshot.environmentRef`), so the default here matches them.
+    environmentId: "env-1",
     runtimeSecrets: [CURSOR_KEY, OTHER_SECRET],
     ...overrides,
   };
@@ -229,6 +240,7 @@ beforeEach(() => {
   harnessState.finalText = "done";
   providerState.lastArgs = undefined;
   secretsClientState.rows = [];
+  secretsClientState.selection = [CURSOR_SECRET_ROW_ID];
   vi.stubGlobal(
     "fetch",
     vi.fn(async () => new Response("{}", { status: 200 })),
@@ -381,7 +393,10 @@ const EPHEMERAL_BINDING = {
   workdir: "/home/user/work",
 };
 
+const CURSOR_SECRET_ROW_ID = "secret-cursor";
+
 const BROKERED_CURSOR_ROW = {
+  secretId: CURSOR_SECRET_ROW_ID,
   name: "CURSOR_API_KEY",
   delivery: "brokered",
   brokerHosts: ["api2.cursor.sh"],
@@ -477,6 +492,49 @@ describe("runHarnessTurn — external-account BROKERED credential", () => {
       "none",
     );
     expect(onEngineError).toHaveBeenCalledTimes(1);
+    expect(registryState.createHarness).not.toHaveBeenCalled();
+  });
+
+  it("refuses a correctly bound row the run's ENVIRONMENT does not select", async () => {
+    // The turn-level proof for the scoping fix. The project holds a brokered
+    // CURSOR_API_KEY bound exactly right, but this run's environment does not
+    // grant it, so `listBrokeredSecretsForBox` composes nothing onto the box.
+    // Before scoping, this STARTED the turn and failed vendor auth after the
+    // box was provisioned; now nothing is provisioned at all.
+    secretsClientState.rows = [BROKERED_CURSOR_ROW];
+    secretsClientState.selection = ["secret-something-else"];
+    const onEngineError = vi.fn();
+    await runHarnessTurn(
+      baseOptions({
+        runtimeSecrets: undefined,
+        harnessSandboxBinding: EPHEMERAL_BINDING,
+        onEngineError,
+      }) as never,
+      "none",
+    );
+    expect(onEngineError).toHaveBeenCalledTimes(1);
+    const err = onEngineError.mock.calls[0]![0] as { message: string };
+    expect(err.message).toContain("CURSOR_API_KEY");
+    expect(err.message).toMatch(/does not select it/i);
+    expect(registryState.createHarness).not.toHaveBeenCalled();
+    expect(reserveHarnessBox).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the turn resolved no environment at all", async () => {
+    secretsClientState.rows = [BROKERED_CURSOR_ROW];
+    const onEngineError = vi.fn();
+    await runHarnessTurn(
+      baseOptions({
+        runtimeSecrets: undefined,
+        environmentId: undefined,
+        harnessSandboxBinding: EPHEMERAL_BINDING,
+        onEngineError,
+      }) as never,
+      "none",
+    );
+    expect(onEngineError).toHaveBeenCalledTimes(1);
+    const err = onEngineError.mock.calls[0]![0] as { message: string };
+    expect(err.message).toMatch(/no Project Environment/i);
     expect(registryState.createHarness).not.toHaveBeenCalled();
   });
 

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-external-account.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-external-account.test.ts
@@ -80,6 +80,13 @@ vi.mock("../registry.js", () => ({
     requiresComputer: true,
     modelAccess: "external-account",
     externalAccountCredentialEnv: ["CURSOR_API_KEY"],
+    externalAccountBrokerBinding: {
+      CURSOR_API_KEY: {
+        hosts: ["api2.cursor.sh"],
+        header: "authorization",
+        template: "Bearer {}",
+      },
+    },
     mcpDelivery: "native",
     mcpNativeDelivery: "session-config",
     // Never consulted on this path — declared so a regression that starts
@@ -88,6 +95,21 @@ vi.mock("../registry.js", () => ({
     createHarness: registryState.createHarness,
     parseToolName: vi.fn((toolName: string) => ({ toolName })),
   })),
+}));
+
+/**
+ * The BROKERED delivery lookup. Metadata only — there is no function here that
+ * could return a brokered value, because there is none in the real client
+ * either: a brokered plaintext never enters this process.
+ */
+const secretsClientState = vi.hoisted(() => ({
+  rows: [] as Record<string, unknown>[],
+}));
+
+vi.mock("../../computers/convex-secrets-client.js", () => ({
+  convexListProjectSecretBindings: vi.fn(async () => secretsClientState.rows),
+  convexListSecretsForRuntimeExecution: vi.fn(async () => []),
+  convexMarkSecretsDelivered: vi.fn(async () => ({ marked: 0 })),
 }));
 
 vi.mock("../resolve-sandbox.js", () => ({
@@ -206,6 +228,7 @@ function baseOptions(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   harnessState.finalText = "done";
   providerState.lastArgs = undefined;
+  secretsClientState.rows = [];
   vi.stubGlobal(
     "fetch",
     vi.fn(async () => new Response("{}", { status: 200 })),
@@ -339,5 +362,156 @@ describe("runHarnessTurn — external-account credential path", () => {
     const onEngineError = vi.fn();
     await runHarnessTurn(baseOptions({ onEngineError }) as never, "none");
     expect(onEngineError).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The BROKERED arm. The turn accepts a credential it never sees: the backend
+ * composes the project secret into the box's E2B egress transform, and the box
+ * carries a placeholder the proxy overwrites on the way out of the VM.
+ *
+ * This is the delivery hosted evals and swarms accept — they refuse an
+ * environment that selects MATERIALIZED secrets outright (`evalSandboxes.ts`,
+ * `journeyRuns.ts`), so before this arm existed a Cursor host could not run on
+ * those surfaces in any configuration at all.
+ */
+const EPHEMERAL_BINDING = {
+  sandboxRowId: "sbxrow_1",
+  sandboxId: "e2b_ephemeral_1",
+  workdir: "/home/user/work",
+};
+
+const BROKERED_CURSOR_ROW = {
+  name: "CURSOR_API_KEY",
+  delivery: "brokered",
+  brokerHosts: ["api2.cursor.sh"],
+  brokerHeader: "authorization",
+  brokerTemplate: "Bearer {}",
+};
+
+describe("runHarnessTurn — external-account BROKERED credential", () => {
+  it("runs with no materialized secret, handing the adapter a placeholder", async () => {
+    secretsClientState.rows = [BROKERED_CURSOR_ROW];
+    const onEngineError = vi.fn();
+    await runHarnessTurn(
+      baseOptions({
+        runtimeSecrets: undefined,
+        harnessSandboxBinding: EPHEMERAL_BINDING,
+        onEngineError,
+      }) as never,
+      "none",
+    );
+
+    expect(onEngineError).not.toHaveBeenCalled();
+    const args = registryState.createHarness.mock.calls[0]![0] as unknown as {
+      auth: Record<string, string>;
+    };
+    // The REAL key is not here and cannot be: nothing in this process ever
+    // fetched it. What the CLI sends is overwritten outside the VM.
+    expect(args.auth.CURSOR_API_KEY).toBe("mcpjam-brokered-credential");
+    expect(args.auth.CURSOR_API_KEY).not.toContain("key_live");
+    // Still no lease — external-account means MCPJam brokers no MODEL access.
+    expect(startHarnessModelBroker).not.toHaveBeenCalled();
+  });
+
+  it("does NOT stamp delivery for a brokered credential", async () => {
+    // `lastDeliveredAt` answers "did anything receive this from us". On this arm
+    // the answer is no: the backend delivered it into the egress transform.
+    secretsClientState.rows = [BROKERED_CURSOR_ROW];
+    const onSecretEnvDelivered = vi.fn();
+    await runHarnessTurn(
+      baseOptions({
+        runtimeSecrets: undefined,
+        harnessSandboxBinding: EPHEMERAL_BINDING,
+        onSecretEnvDelivered,
+      }) as never,
+      "none",
+    );
+    expect(onSecretEnvDelivered).not.toHaveBeenCalled();
+  });
+
+  it("still stamps delivery when the credential is MATERIALIZED", async () => {
+    secretsClientState.rows = [BROKERED_CURSOR_ROW];
+    const onSecretEnvDelivered = vi.fn();
+    await runHarnessTurn(
+      baseOptions({
+        runtimeSecrets: [CURSOR_KEY],
+        harnessSandboxBinding: EPHEMERAL_BINDING,
+        onSecretEnvDelivered,
+      }) as never,
+      "none",
+    );
+    expect(onSecretEnvDelivered).toHaveBeenCalled();
+    const args = registryState.createHarness.mock.calls[0]![0] as unknown as {
+      auth: Record<string, string>;
+    };
+    // Materialized WINS when both are configured: it is the delivery this
+    // process can prove reached the box.
+    expect(args.auth.CURSOR_API_KEY).toBe(CURSOR_KEY.value);
+  });
+
+  it("keeps the placeholder out of the box's session env bag", async () => {
+    secretsClientState.rows = [BROKERED_CURSOR_ROW];
+    await runHarnessTurn(
+      baseOptions({
+        runtimeSecrets: [OTHER_SECRET],
+        harnessSandboxBinding: EPHEMERAL_BINDING,
+      }) as never,
+      "none",
+    );
+    const sessionEnv = providerState.lastArgs?.sessionEnv as
+      | Record<string, string>
+      | undefined;
+    expect(sessionEnv).not.toHaveProperty("CURSOR_API_KEY");
+    expect(sessionEnv).toHaveProperty("STRIPE_API_KEY", OTHER_SECRET.value);
+  });
+
+  it("refuses a brokered-only credential on a PERSISTENT computer", async () => {
+    // `listBrokeredSecretsForBox` answers `[]` for any box with no sandbox row,
+    // so this box will never carry the transform — starting it would send a
+    // placeholder to the vendor.
+    secretsClientState.rows = [BROKERED_CURSOR_ROW];
+    const onEngineError = vi.fn();
+    await runHarnessTurn(
+      baseOptions({ runtimeSecrets: undefined, onEngineError }) as never,
+      "none",
+    );
+    expect(onEngineError).toHaveBeenCalledTimes(1);
+    expect(registryState.createHarness).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the brokered row is bound to the wrong host", async () => {
+    secretsClientState.rows = [
+      { ...BROKERED_CURSOR_ROW, brokerHosts: ["api.example.com"] },
+    ];
+    const onEngineError = vi.fn();
+    await runHarnessTurn(
+      baseOptions({
+        runtimeSecrets: undefined,
+        harnessSandboxBinding: EPHEMERAL_BINDING,
+        onEngineError,
+      }) as never,
+      "none",
+    );
+    expect(onEngineError).toHaveBeenCalledTimes(1);
+    const err = onEngineError.mock.calls[0]![0] as { message: string };
+    expect(err.message).toContain("api2.cursor.sh");
+    expect(registryState.createHarness).not.toHaveBeenCalled();
+  });
+
+  it("names BOTH deliveries when neither is configured", async () => {
+    const onEngineError = vi.fn();
+    await runHarnessTurn(
+      baseOptions({
+        runtimeSecrets: undefined,
+        harnessSandboxBinding: EPHEMERAL_BINDING,
+        onEngineError,
+      }) as never,
+      "none",
+    );
+    const err = onEngineError.mock.calls[0]![0] as { message: string };
+    expect(err.message).toContain("CURSOR_API_KEY");
+    expect(err.message).toMatch(/brokered/i);
+    expect(err.message).toMatch(/materialized/i);
   });
 });

--- a/mcpjam-inspector/server/utils/harness/e2b-sandbox-provider.ts
+++ b/mcpjam-inspector/server/utils/harness/e2b-sandbox-provider.ts
@@ -478,6 +478,47 @@ export function createE2BHarnessSandboxProvider(
       },
       // setNetworkPolicy omitted — E2B sets egress at create time; the
       // optional-call contract treats a missing impl as a no-op.
+      //
+      // `setRequestTransformations` / `addRequestTransformations` are omitted
+      // DELIBERATELY, and the cost of the omission is one console warning per
+      // Cursor turn: "The sandbox implementation does not support configuring
+      // request transformations, so credential brokering does not work.
+      // Falling back to less secure credential forwarding."
+      // (`@ai-sdk/harness`'s `warnCredentialBrokeringUnavailable`.) Three
+      // independent reasons, any one of which would be enough:
+      //
+      //  1. IT WOULD PUT THE REAL KEY IN THIS PROCESS. The framework hook is
+      //     called with the credential in `transform.headers` — its model is
+      //     "the HOST holds the key, the box gets a placeholder". MCPJam's
+      //     brokered project secrets are strictly stronger: the plaintext stays
+      //     behind KMS in the backend and is composed into the box's egress
+      //     policy there, so it never reaches the inspector at all. Wiring the
+      //     hook would be a regression dressed as a hardening.
+      //
+      //  2. E2B CANNOT EXPRESS THE MATCH. `HarnessV1RequestTransformation`
+      //     matches on host + path + method + header VALUE; E2B's network API
+      //     (`SandboxNetworkConfig.rules`) is keyed by DOMAIN alone and injects
+      //     unconditionally. Implementing the hook would mean silently widening
+      //     "this one exchange request carrying this exact placeholder" into
+      //     "every request to this host", which is not the rule the adapter
+      //     asked for.
+      //
+      //  3. THE WRITE IS REPLACE, AND WE DO NOT OWN THE BASELINE.
+      //     `PUT /sandboxes/{id}/network` replaces the whole rule set, and the
+      //     box's policy is composed by the CONTROL PLANE from its egress
+      //     baseline, its brokered project secrets, and (mid-turn) the model
+      //     lease header — see `composeBoxPolicy` and the
+      //     `hasActiveBrokerLease` precondition in mcpjam-backend. A write from
+      //     here holding only the adapter's rule would strip all of that
+      //     IRREVERSIBLY: the lease value exists only inside the transform and
+      //     cannot be read back, so the in-flight run would 401 for the rest of
+      //     its life. An ADDITIVE implementation is what the contract asks for
+      //     and is not something this side can build without a backend endpoint
+      //     that merges into the composed policy.
+      //
+      // The brokered credential path (`external-account-credentials.ts`) gets
+      // the same outcome the hook was for — real key outside the VM, placeholder
+      // inside — through the control plane instead.
 
       restricted: () => session, // same resource, narrower static type
     };

--- a/mcpjam-inspector/server/utils/harness/external-account-credentials.ts
+++ b/mcpjam-inspector/server/utils/harness/external-account-credentials.ts
@@ -1,0 +1,372 @@
+/**
+ * The credential an EXTERNAL-ACCOUNT harness authenticates with, and the two
+ * ways a project can supply it.
+ *
+ * A harness with `modelAccess: 'external-account'` (Cursor CLI) authenticates
+ * on the CUSTOMER's own account with the runtime vendor. MCPJam mints no model
+ * lease, so the only credential in play is the customer's — and a project can
+ * hand it over in either of the two deliveries the secrets system already
+ * supports:
+ *
+ *   MATERIALIZED — the plaintext is resolved by this process and handed to the
+ *     adapter as its auth environment. The original behaviour, unchanged.
+ *
+ *   BROKERED (preferred) — the plaintext never enters this process OR the box.
+ *     The backend composes the secret into the box's E2B egress transform,
+ *     which overwrites the credential header on the way out of the VM; the box
+ *     carries a placeholder so the CLI has something to send.
+ *
+ * ## Why brokered had to exist
+ *
+ * Hosted evals and swarms REFUSE an environment that selects a materialized
+ * secret — `convex/evalSandboxes.ts` (`materialized_secrets_unsupported`) and
+ * `convex/journeyRuns.ts` (`ENV_MATERIALIZED_SECRETS_UNSUPPORTED`) — because
+ * only the CHAT path resolves and injects materialized values, so on a
+ * runner-claimed attempt they would be silently ABSENT and the run would score
+ * a healthy connector as broken. Both refusals say in as many words that
+ * brokered secrets are fine there.
+ *
+ * With materialized as the only accepted delivery, `harness: "cursor"` could
+ * therefore not run in a hosted eval or swarm AT ALL: configure the secret the
+ * turn demands and the run is refused at sandbox reservation; leave it out and
+ * the turn is refused for a missing credential. This module is the way out of
+ * that vice.
+ *
+ * ## The placeholder contract, and where it is enforced
+ *
+ * There is no value-matching contract, and it matters that this is stated
+ * rather than assumed. `composeBoxPolicy` in
+ * `mcpjam-backend/convex/lib/harnessBrokerEgress.ts` builds
+ * `transform[host][header] = <template with {} substituted>`, which
+ * `convex/lib/computerProviders/e2b.ts` serialises as
+ * `rules[host] = [{ transform: { headers } }]`. That injection is HOST-SCOPED
+ * and UNCONDITIONAL: the proxy overwrites the header regardless of what the
+ * box put in it. So the in-box value only has to be present — never guessable,
+ * never correct — which is exactly what makes a fixed, obviously-fake
+ * placeholder the right thing to send.
+ *
+ * (This is deliberately NOT the `@ai-sdk/harness` credential-brokering shape,
+ * which matches on the outgoing header VALUE and therefore needs a random
+ * per-session placeholder. That mechanism keeps the real key in the HOST
+ * PROCESS; MCPJam's keeps it in the backend, behind KMS, which is strictly
+ * stronger. See `e2b-sandbox-provider.ts` for why the two cannot be combined.)
+ *
+ * ## Fail-closed, in both directions
+ *
+ * Availability is a TRI-STATE and the third state is not "no". A metadata read
+ * that fails answers `null` — "we could not establish that this credential is
+ * brokered" — and a null is refused exactly like an absence. Guessing "yes"
+ * would start a turn whose credential silently never arrives; guessing "no"
+ * from a blip would refuse a correctly configured project. Refusing on
+ * `null` is the same answer the turn gave before brokering existed, so a
+ * degraded read is a non-regression rather than a new failure.
+ */
+import {
+  convexListProjectSecretBindings,
+  type ProjectSecretBinding,
+} from "../computers/convex-secrets-client.js";
+import { logger } from "../logger.js";
+import type { HarnessExternalAccountBrokerBinding } from "./registry.js";
+
+/** Placeholder credential value handed to the in-sandbox CLI when an
+ *  EXTERNAL-ACCOUNT credential is delivered by a BROKERED project secret.
+ *
+ *  The real key never enters this process or the box: the backend composes the
+ *  secret into the box's E2B egress transform, which OVERWRITES the credential
+ *  header on the way out of the VM (`convex/lib/harnessBrokerEgress.ts` →
+ *  `rules[host] = [{ transform: { headers } }]`). That injection is
+ *  host-scoped and unconditional — it does not match on the outgoing value —
+ *  so this placeholder only has to be PRESENT, never guessable, and never
+ *  correct.
+ *
+ *  Deliberately a fixed, obviously-fake string rather than a random token:
+ *  a random one would look like a credential in a log or a `ps` line, and
+ *  there is nothing for it to be unguessable against. Same reasoning, and the
+ *  same shape, as `BROKER_DUMMY_CREDENTIAL` in `registry.ts` — which the
+ *  brokered MODEL path has handed the CLI since COMP-23.
+ *
+ *  Lives here rather than beside that one on purpose: this value is meaningful
+ *  only to the delivery decision below, and the registry is mocked wholesale by
+ *  the turn tests, so importing it from there would make a constant depend on a
+ *  test double.
+ *
+ *  If the transform is NOT installed (a misconfigured binding, a box the
+ *  backend does not compose secrets onto), this value reaches the vendor and
+ *  is rejected as an invalid key — a loud 401 from the runtime, never a
+ *  silently unauthenticated turn. */
+export const EXTERNAL_ACCOUNT_BROKERED_PLACEHOLDER =
+  "mcpjam-brokered-credential";
+
+/** What a turn should hand the adapter, and what each name cost to get there. */
+export type ExternalAccountCredentialPlan = {
+  /** The adapter's auth environment: real values for materialized names,
+   *  placeholders for brokered ones. */
+  auth: Record<string, string>;
+  /** Names satisfied by a MATERIALIZED secret. These are the ones the turn
+   *  removes from the box's session env bag, and the only ones a delivery
+   *  stamp may be recorded for — a brokered secret is delivered by the
+   *  backend, and stamping it here would credit a delivery this process did
+   *  not make. */
+  materializedNames: string[];
+  /** Names satisfied by a BROKERED secret. Present for logging and for the
+   *  tests that pin which arm ran; nothing downstream branches on it. */
+  brokeredNames: string[];
+};
+
+/** Why a name could not be satisfied — one arm per thing a user can fix. */
+type UnsatisfiedName =
+  /** Neither delivery is configured, or we could not establish that one is. */
+  | { name: string; reason: "absent" }
+  /** A brokered row exists but its binding cannot deliver this credential. */
+  | { name: string; reason: "misbound"; hosts: string[] };
+
+/**
+ * Does a brokered row's binding actually deliver this credential?
+ *
+ * Checked rather than trusted because a brokered secret with the right NAME and
+ * the wrong HOST is the one misconfiguration that would otherwise reach the
+ * vendor as a placeholder and come back as an unexplained 401. The row is
+ * canonicalized at write time (hosts lowercased, header lowercased), so this is
+ * an exact comparison on both sides and not a normalization pass.
+ *
+ * The TEMPLATE is required to contain `{}` — that is where the backend
+ * substitutes the plaintext — but its surrounding text is NOT compared. A
+ * runtime that accepts `Bearer <key>` and a project that stored `bearer {}`
+ * would be a false refusal, and the vendor, not MCPJam, is the authority on
+ * what its own header may look like.
+ */
+function bindingDelivers(
+  row: ProjectSecretBinding,
+  required: HarnessExternalAccountBrokerBinding,
+): boolean {
+  if (!row.brokerHosts?.length || !row.brokerHeader || !row.brokerTemplate) {
+    return false;
+  }
+  if (row.brokerHeader.toLowerCase() !== required.header.toLowerCase()) {
+    return false;
+  }
+  if (!row.brokerTemplate.includes("{}")) return false;
+  const hosts = new Set(row.brokerHosts.map((host) => host.toLowerCase()));
+  return required.hosts.every((host) => hosts.has(host.toLowerCase()));
+}
+
+/**
+ * The brokered credentials this box will actually be carrying, by name.
+ *
+ * `null` means "could not establish", NOT "none" — see the file header.
+ *
+ * ## Two narrowings that are not optimizations
+ *
+ * EPHEMERAL BOXES ONLY. `projectSecretsEgress.resolveBoxSecretGrant` returns
+ * `NO_GRANT` for anything without a `sandboxRowId`, and
+ * `listBrokeredSecretsForBox` returns `[]`: "PERSISTENT COMPUTERS receive no
+ * secrets in v1, and that is a decision rather than a gap". So a chat turn on a
+ * project computer has no brokered transform on its box no matter what the
+ * project has configured, and answering anything but "none" for it would be a
+ * turn that authenticates with a placeholder.
+ *
+ * PROJECT SCOPE, NOT ENVIRONMENT SCOPE, and this is the honest limitation of
+ * doing it from here. The exact question — "which brokered secrets is THIS box
+ * carrying" — is `projectSecretsEgress:listBrokeredSecretsForBox`, keyed on the
+ * sandbox row, but it is an `internalQuery` with no public counterpart, and
+ * `runHarnessTurn` is not even handed an `environmentId` to ask the
+ * environment-scoped version with. The reachable read is
+ * `projectSecrets:listSecrets`, which is project-scoped metadata.
+ *
+ * What that costs, precisely: a project that holds a correctly-bound brokered
+ * `CURSOR_API_KEY` which is NOT selected into the run's environment is allowed
+ * to start, and the runtime then fails its vendor auth. That is a legible
+ * misconfiguration with a legible failure, and it is strictly better than the
+ * alternative it replaces (the turn could not run at all). It is also the one
+ * thing a names-only public query keyed on the box would fix outright — see the
+ * note in `docs/inspector/claude-code-host.mdx`.
+ */
+export type BrokeredCredentialAvailability = {
+  /** Names whose brokered row exists AND binds what the runtime needs. */
+  available: Set<string>;
+  /** Names whose brokered row exists but binds the wrong hosts/header — kept
+   *  so the refusal can say WHICH hosts it found instead of "missing". */
+  misboundHosts: Record<string, string[]>;
+};
+
+export async function fetchBrokeredCredentialNames(args: {
+  bearer?: string;
+  projectId?: string;
+  /** Which box the turn runs on. Only `sandbox` (an ephemeral `evalSandboxes`
+   *  row) can carry brokered secret transforms. */
+  boxKind: "sandbox" | "computer";
+  /** The credential names worth asking about, with the binding each needs. */
+  required: Readonly<Record<string, HarnessExternalAccountBrokerBinding>>;
+}): Promise<BrokeredCredentialAvailability | null> {
+  const empty: BrokeredCredentialAvailability = {
+    available: new Set(),
+    misboundHosts: {},
+  };
+  if (Object.keys(args.required).length === 0) return empty;
+  // Not a failure: this box provably carries no brokered transform, so "none"
+  // is the correct answer rather than an unknown.
+  if (args.boxKind !== "sandbox") return empty;
+  if (!args.bearer || !args.projectId) return null;
+  let rows: ProjectSecretBinding[];
+  try {
+    rows = await convexListProjectSecretBindings(args.bearer, {
+      projectId: args.projectId,
+    });
+  } catch (error) {
+    logger.warn(
+      "[external-account-credentials] brokered secret lookup failed; " +
+        "treating the credential as unestablished",
+      { error: error instanceof Error ? error.message : String(error) },
+    );
+    return null;
+  }
+  const available = new Set<string>();
+  const misboundHosts: Record<string, string[]> = {};
+  for (const row of rows) {
+    if (row.delivery !== "brokered") continue;
+    const required = args.required[row.name];
+    if (!required) continue;
+    if (bindingDelivers(row, required)) {
+      available.add(row.name);
+      // A correctly bound row supersedes a sibling that is not: the credential
+      // WILL be delivered, so a stale "misbound" note must not turn into a
+      // refusal for a project that is configured correctly.
+      delete misboundHosts[row.name];
+      continue;
+    }
+    if (!available.has(row.name)) {
+      misboundHosts[row.name] = row.brokerHosts ?? [];
+    }
+  }
+  return { available, misboundHosts };
+}
+
+/**
+ * The hosts a brokered row for this credential must bind, as configured on the
+ * adapter — quoted back in a refusal so the fix is the message.
+ */
+function requiredBindingSummary(
+  binding: HarnessExternalAccountBrokerBinding,
+): string {
+  return `${binding.hosts.join(", ")} with header "${
+    binding.header
+  }" and template "${binding.template}"`;
+}
+
+/**
+ * Decide, per credential name, which delivery satisfies it — or refuse.
+ *
+ * PURE: the reads happen above, so the decision can be tested without a
+ * Convex double, and one call site cannot resolve a different answer from the
+ * one it acts on.
+ *
+ * MATERIALIZED WINS when both are present. Not an arbitrary tiebreak: a
+ * materialized value is the one this process can prove reached the box (the
+ * env bag is built from it), and preferring the placeholder there would take a
+ * working chat turn on a persistent computer and break it on the strength of a
+ * row that box never receives.
+ */
+export function planExternalAccountCredentials(args: {
+  /** For the refusal copy. */
+  harnessDisplayName: string;
+  required: readonly string[];
+  /** The materialized project secrets this turn resolved, if any. */
+  secretEnv: Readonly<Record<string, string>> | undefined;
+  /** The adapter's brokered binding declaration, if it has one. */
+  brokerBinding:
+    | Readonly<Record<string, HarnessExternalAccountBrokerBinding>>
+    | undefined;
+  /** Names the box is carrying by brokered egress. `null` = could not tell,
+   *  which is refused exactly like an absence. */
+  brokeredAvailable: ReadonlySet<string> | null;
+  /** Brokered rows that exist and match by NAME but not by BINDING — used only
+   *  to sharpen the refusal. */
+  misboundHosts?: Readonly<Record<string, string[]>>;
+}): ExternalAccountCredentialPlan {
+  const auth: Record<string, string> = {};
+  const materializedNames: string[] = [];
+  const brokeredNames: string[] = [];
+  const unsatisfied: UnsatisfiedName[] = [];
+
+  for (const name of args.required) {
+    const materialized = args.secretEnv?.[name];
+    if (materialized) {
+      auth[name] = materialized;
+      materializedNames.push(name);
+      continue;
+    }
+    if (args.brokerBinding?.[name] && args.brokeredAvailable?.has(name)) {
+      auth[name] = EXTERNAL_ACCOUNT_BROKERED_PLACEHOLDER;
+      brokeredNames.push(name);
+      continue;
+    }
+    const hosts = args.misboundHosts?.[name];
+    unsatisfied.push(
+      hosts && hosts.length > 0
+        ? { name, reason: "misbound", hosts }
+        : { name, reason: "absent" },
+    );
+  }
+
+  if (unsatisfied.length > 0) {
+    throw new Error(
+      externalAccountCredentialRefusal({
+        harnessDisplayName: args.harnessDisplayName,
+        unsatisfied,
+        brokerBinding: args.brokerBinding,
+      }),
+    );
+  }
+  return { auth, materializedNames, brokeredNames };
+}
+
+/**
+ * Preflight-shaped refusal copy: names the variable, BOTH deliveries, and where
+ * to set it, so the reader can act on it without opening a runbook.
+ *
+ * Naming both is the point of this change. The old copy said "requires a
+ * CURSOR_API_KEY project secret", which is true and useless in a hosted eval:
+ * the reader adds a materialized one and the RUN is then refused at sandbox
+ * reservation for selecting a materialized secret, with no hint that the fix
+ * was to have added a brokered one in the first place.
+ */
+function externalAccountCredentialRefusal(args: {
+  harnessDisplayName: string;
+  unsatisfied: readonly UnsatisfiedName[];
+  brokerBinding:
+    | Readonly<Record<string, HarnessExternalAccountBrokerBinding>>
+    | undefined;
+}): string {
+  const misbound = args.unsatisfied.filter(
+    (entry): entry is Extract<UnsatisfiedName, { reason: "misbound" }> =>
+      entry.reason === "misbound",
+  );
+  if (misbound.length > 0) {
+    const entry = misbound[0]!;
+    const binding = args.brokerBinding?.[entry.name];
+    return (
+      `The ${args.harnessDisplayName} harness found a brokered ` +
+      `${entry.name} project secret, but it is bound to ` +
+      `${entry.hosts.join(", ")} — the runtime authenticates against ` +
+      `${binding ? requiredBindingSummary(binding) : "a different host"}. ` +
+      `Re-bind the secret under Project Settings → Secrets, or switch it to ` +
+      `materialized delivery.`
+    );
+  }
+  const names = args.unsatisfied.map((entry) => entry.name);
+  const one = names.length === 1;
+  const brokerable = names.filter((name) => args.brokerBinding?.[name]);
+  const brokeredHint =
+    brokerable.length > 0
+      ? ` Use BROKERED delivery (bound to ` +
+        `${requiredBindingSummary(args.brokerBinding![brokerable[0]!]!)}) if ` +
+        `this environment is used by hosted evals or swarms — those refuse ` +
+        `materialized secrets outright.`
+      : "";
+  return (
+    `The ${args.harnessDisplayName} harness requires ${one ? "a " : ""}` +
+    `${names.join(", ")} project ${one ? "secret" : "secrets"} in this ` +
+    `environment, delivered either brokered or materialized — add ` +
+    `${one ? "it" : "them"} under Project Settings → Secrets.${brokeredHint}`
+  );
+}

--- a/mcpjam-inspector/server/utils/harness/external-account-credentials.ts
+++ b/mcpjam-inspector/server/utils/harness/external-account-credentials.ts
@@ -125,8 +125,18 @@ type UnsatisfiedName =
    * not grant it — either because the environment does not select it, or
    * because the turn resolved no environment at all. Distinct from `absent`
    * because the fix is a selection, not a new secret.
+   *
+   * `unresolvedReason`, when present, means something else again: the run HAS
+   * an environment and this process could not learn WHICH. That is MCPJam's
+   * limitation, not a misconfiguration, and the copy must not send the reader
+   * to fix a selection they never made.
    */
-  | { name: string; reason: "unselected"; environmentMissing: boolean };
+  | {
+      name: string;
+      reason: "unselected";
+      environmentMissing: boolean;
+      unresolvedReason?: string;
+    };
 
 /**
  * Does a brokered row's binding actually deliver this credential?
@@ -213,6 +223,10 @@ export type BrokeredCredentialAvailability = {
    *  Sharpens the `unselected` copy — "there is no environment" and "the
    *  environment does not select it" are different fixes. */
   environmentMissing: boolean;
+  /** Set when the caller KNOWS the run has an environment but could not supply
+   *  its id (see `fetchBrokeredCredentialNames`). Sharpens the copy a third
+   *  way: nothing the reader configured is wrong. */
+  environmentUnresolvedReason?: string;
 };
 
 export async function fetchBrokeredCredentialNames(args: {
@@ -225,6 +239,20 @@ export async function fetchBrokeredCredentialNames(args: {
    * with `environmentMissing`, never as an available credential.
    */
   environmentId?: string;
+  /**
+   * Why `environmentId` is absent, when the caller knows the run HAS one and
+   * simply cannot reach it. Purely for the refusal copy — availability is
+   * decided identically either way, because an environment we cannot name is
+   * an environment whose selection we cannot check.
+   *
+   * The one caller today is EVAL REPLAY. A replay run inherits the source run's
+   * `configSnapshot.environmentRef` verbatim (`testSuites.ts`, and
+   * `resolveGrantForSandbox` follows that id), so the box really may carry the
+   * transform — but no public read projects that ref back out, so this process
+   * cannot confirm it. Refusing is still right; blaming the user's environment
+   * selection would not be.
+   */
+  environmentUnresolvedReason?: string;
   /** Which box the turn runs on. Only `sandbox` (an ephemeral `evalSandboxes`
    *  row) can carry brokered secret transforms. */
   boxKind: "sandbox" | "computer";
@@ -314,7 +342,15 @@ export async function fetchBrokeredCredentialNames(args: {
   // A row that is granted but misbound is the sharper complaint: it says the
   // binding is wrong rather than that the secret is not granted.
   for (const name of Object.keys(misboundHosts)) unselected.delete(name);
-  return { available, misboundHosts, unselected, environmentMissing };
+  return {
+    available,
+    misboundHosts,
+    unselected,
+    environmentMissing,
+    ...(environmentMissing && args.environmentUnresolvedReason
+      ? { environmentUnresolvedReason: args.environmentUnresolvedReason }
+      : {}),
+  };
 }
 
 /**
@@ -363,6 +399,8 @@ export function planExternalAccountCredentials(args: {
   unselected?: ReadonlySet<string>;
   /** True when the turn resolved no Project Environment at all. */
   environmentMissing?: boolean;
+  /** Why the environment could not be named, when the run has one. */
+  environmentUnresolvedReason?: string;
 }): ExternalAccountCredentialPlan {
   const auth: Record<string, string> = {};
   const materializedNames: string[] = [];
@@ -391,6 +429,9 @@ export function planExternalAccountCredentials(args: {
         name,
         reason: "unselected",
         environmentMissing: args.environmentMissing === true,
+        ...(args.environmentUnresolvedReason
+          ? { unresolvedReason: args.environmentUnresolvedReason }
+          : {}),
       });
       continue;
     }
@@ -454,6 +495,21 @@ function externalAccountCredentialRefusal(args: {
   );
   if (unselected.length > 0) {
     const entry = unselected[0]!;
+    // NOT the user's misconfiguration. The run has an environment and may well
+    // grant this credential; MCPJam cannot see which environment it is, so it
+    // cannot promise the box will carry the transform. Say that, and do not
+    // send the reader to edit a selection that may already be correct.
+    if (entry.unresolvedReason) {
+      return (
+        `The ${args.harnessDisplayName} harness needs a brokered ` +
+        `${entry.name}, and MCPJam cannot confirm this run will receive one: ` +
+        `${entry.unresolvedReason} Brokered secrets are granted per Project ` +
+        `Environment, so without knowing this run's environment the ` +
+        `credential cannot be verified before the sandbox starts. Launch the ` +
+        `suite directly instead — nothing about the secret itself needs to ` +
+        `change.`
+      );
+    }
     return entry.environmentMissing
       ? `The ${args.harnessDisplayName} harness found a brokered ` +
           `${entry.name} project secret, but this run resolved no Project ` +

--- a/mcpjam-inspector/server/utils/harness/external-account-credentials.ts
+++ b/mcpjam-inspector/server/utils/harness/external-account-credentials.ts
@@ -62,6 +62,7 @@
  * degraded read is a non-regression rather than a new failure.
  */
 import {
+  convexGetEnvironmentSecretSelection,
   convexListProjectSecretBindings,
   type ProjectSecretBinding,
 } from "../computers/convex-secrets-client.js";
@@ -118,7 +119,14 @@ type UnsatisfiedName =
   /** Neither delivery is configured, or we could not establish that one is. */
   | { name: string; reason: "absent" }
   /** A brokered row exists but its binding cannot deliver this credential. */
-  | { name: string; reason: "misbound"; hosts: string[] };
+  | { name: string; reason: "misbound"; hosts: string[] }
+  /**
+   * A brokered row exists and binds correctly, but this run's ENVIRONMENT does
+   * not grant it — either because the environment does not select it, or
+   * because the turn resolved no environment at all. Distinct from `absent`
+   * because the fix is a selection, not a new secret.
+   */
+  | { name: string; reason: "unselected"; environmentMissing: boolean };
 
 /**
  * Does a brokered row's binding actually deliver this credential?
@@ -165,33 +173,58 @@ function bindingDelivers(
  * project has configured, and answering anything but "none" for it would be a
  * turn that authenticates with a placeholder.
  *
- * PROJECT SCOPE, NOT ENVIRONMENT SCOPE, and this is the honest limitation of
- * doing it from here. The exact question — "which brokered secrets is THIS box
- * carrying" — is `projectSecretsEgress:listBrokeredSecretsForBox`, keyed on the
- * sandbox row, but it is an `internalQuery` with no public counterpart, and
- * `runHarnessTurn` is not even handed an `environmentId` to ask the
- * environment-scoped version with. The reachable read is
- * `projectSecrets:listSecrets`, which is project-scoped metadata.
+ * ENVIRONMENT SCOPE, NOT PROJECT SCOPE. The environment is the GRANT BOUNDARY,
+ * and this is the whole reason the second read exists. The authoritative
+ * question — "which brokered secrets is THIS box carrying" — is
+ * `projectSecretsEgress:listBrokeredSecretsForBox`, an `internalQuery` with no
+ * public counterpart, but its body is reproducible from two public reads: it
+ * resolves the box's grant to an `environmentId`, takes that environment's
+ * `secretSelection.secretIds`, and keeps the brokered rows among them that
+ * carry a complete binding. `projectSecrets:listSecrets` supplies the rows and
+ * their bindings; `projectEnvironments:getEnvironment` supplies the selection.
  *
- * What that costs, precisely: a project that holds a correctly-bound brokered
- * `CURSOR_API_KEY` which is NOT selected into the run's environment is allowed
- * to start, and the runtime then fails its vendor auth. That is a legible
- * misconfiguration with a legible failure, and it is strictly better than the
- * alternative it replaces (the turn could not run at all). It is also the one
- * thing a names-only public query keyed on the box would fix outright — see the
- * note in `docs/inspector/claude-code-host.mdx`.
+ * A project-wide answer would be WRONG, not merely imprecise: a correctly bound
+ * brokered `CURSOR_API_KEY` that the run's environment does not select is never
+ * composed into the box's egress transform, so reporting it available starts a
+ * turn that provisions a box and then fails vendor auth with a placeholder.
+ * Refusing before provisioning, naming the selection as the fix, is the point.
+ *
+ * The ONE rule this pair cannot reproduce is `isSecretDeliverable`'s live
+ * personal-secret check against the session owner — and it does not have to.
+ * Both reads run on the END USER's own bearer, and the backend filters both
+ * through `canSeeSecret` / `visibleSecretIdsFor`, so a personal secret owned by
+ * someone else is already absent from what we see. The residue is a turn whose
+ * session owner is not the bearer's user, which the harness path does not
+ * produce.
  */
 export type BrokeredCredentialAvailability = {
-  /** Names whose brokered row exists AND binds what the runtime needs. */
+  /** Names whose brokered row exists, binds what the runtime needs, AND is
+   *  selected into this run's environment. */
   available: Set<string>;
-  /** Names whose brokered row exists but binds the wrong hosts/header — kept
-   *  so the refusal can say WHICH hosts it found instead of "missing". */
+  /** Names whose brokered row exists and IS granted but binds the wrong
+   *  hosts/header — kept so the refusal can say WHICH hosts it found instead of
+   *  "missing". */
   misboundHosts: Record<string, string[]>;
+  /** Names whose brokered row exists and binds correctly but is NOT selected
+   *  into this run's environment. The fix is a selection, not a new secret, so
+   *  the refusal has to be able to say which. */
+  unselected: Set<string>;
+  /** This turn resolved NO Project Environment, so nothing is granted at all.
+   *  Sharpens the `unselected` copy — "there is no environment" and "the
+   *  environment does not select it" are different fixes. */
+  environmentMissing: boolean;
 };
 
 export async function fetchBrokeredCredentialNames(args: {
   bearer?: string;
   projectId?: string;
+  /**
+   * The Project Environment this turn resolved — the GRANT BOUNDARY. Absent ⇒
+   * the environment grants nothing (the backend's own rule: `resolveGrantForSandbox`
+   * answers `[]` when it cannot resolve one), which is reported as `unselected`
+   * with `environmentMissing`, never as an available credential.
+   */
+  environmentId?: string;
   /** Which box the turn runs on. Only `sandbox` (an ephemeral `evalSandboxes`
    *  row) can carry brokered secret transforms. */
   boxKind: "sandbox" | "computer";
@@ -201,6 +234,8 @@ export async function fetchBrokeredCredentialNames(args: {
   const empty: BrokeredCredentialAvailability = {
     available: new Set(),
     misboundHosts: {},
+    unselected: new Set(),
+    environmentMissing: false,
   };
   if (Object.keys(args.required).length === 0) return empty;
   // Not a failure: this box provably carries no brokered transform, so "none"
@@ -220,25 +255,66 @@ export async function fetchBrokeredCredentialNames(args: {
     );
     return null;
   }
-  const available = new Set<string>();
-  const misboundHosts: Record<string, string[]> = {};
-  for (const row of rows) {
-    if (row.delivery !== "brokered") continue;
-    const required = args.required[row.name];
-    if (!required) continue;
-    if (bindingDelivers(row, required)) {
-      available.add(row.name);
-      // A correctly bound row supersedes a sibling that is not: the credential
-      // WILL be delivered, so a stale "misbound" note must not turn into a
-      // refusal for a project that is configured correctly.
-      delete misboundHosts[row.name];
-      continue;
-    }
-    if (!available.has(row.name)) {
-      misboundHosts[row.name] = row.brokerHosts ?? [];
+  const candidates = rows.filter(
+    (row) => row.delivery === "brokered" && args.required[row.name],
+  );
+  // Nothing to scope: skip the environment read entirely rather than pay a
+  // round trip to narrow an empty set. A project with no brokered row for this
+  // credential gets the same "add it" refusal it got before, one query later.
+  if (candidates.length === 0) return empty;
+
+  // The GRANT BOUNDARY. An absent environment is not an unknown — it is the
+  // backend answering "no grant" — so it is recorded rather than refused as a
+  // read failure, and the copy says which of the two it was.
+  const environmentMissing = !args.environmentId;
+  let selectedIds: ReadonlySet<string> = new Set<string>();
+  if (args.environmentId) {
+    try {
+      selectedIds = new Set(
+        await convexGetEnvironmentSecretSelection(args.bearer, {
+          projectId: args.projectId,
+          environmentId: args.environmentId,
+        }),
+      );
+    } catch (error) {
+      logger.warn(
+        "[external-account-credentials] environment secret-selection lookup " +
+          "failed; treating the credential as unestablished",
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+      return null;
     }
   }
-  return { available, misboundHosts };
+
+  const available = new Set<string>();
+  const misboundHosts: Record<string, string[]> = {};
+  const unselected = new Set<string>();
+  for (const row of candidates) {
+    const required = args.required[row.name]!;
+    // SELECTION FIRST. An unselected row's binding is irrelevant — it is not
+    // composed onto the box either way — and reporting it as "misbound" would
+    // send the reader to re-bind a secret whose binding is fine.
+    if (!selectedIds.has(row.secretId)) {
+      unselected.add(row.name);
+      continue;
+    }
+    if (bindingDelivers(row, required)) {
+      available.add(row.name);
+      continue;
+    }
+    misboundHosts[row.name] = row.brokerHosts ?? [];
+  }
+  // A correctly bound, granted row supersedes every sibling that is not: the
+  // credential WILL be delivered, so a stale note about another row must not
+  // turn into a refusal for a project that is configured correctly.
+  for (const name of available) {
+    delete misboundHosts[name];
+    unselected.delete(name);
+  }
+  // A row that is granted but misbound is the sharper complaint: it says the
+  // binding is wrong rather than that the secret is not granted.
+  for (const name of Object.keys(misboundHosts)) unselected.delete(name);
+  return { available, misboundHosts, unselected, environmentMissing };
 }
 
 /**
@@ -282,6 +358,11 @@ export function planExternalAccountCredentials(args: {
   /** Brokered rows that exist and match by NAME but not by BINDING — used only
    *  to sharpen the refusal. */
   misboundHosts?: Readonly<Record<string, string[]>>;
+  /** Brokered rows that exist and bind correctly but this run's environment
+   *  does NOT grant — used only to sharpen the refusal. */
+  unselected?: ReadonlySet<string>;
+  /** True when the turn resolved no Project Environment at all. */
+  environmentMissing?: boolean;
 }): ExternalAccountCredentialPlan {
   const auth: Record<string, string> = {};
   const materializedNames: string[] = [];
@@ -301,11 +382,19 @@ export function planExternalAccountCredentials(args: {
       continue;
     }
     const hosts = args.misboundHosts?.[name];
-    unsatisfied.push(
-      hosts && hosts.length > 0
-        ? { name, reason: "misbound", hosts }
-        : { name, reason: "absent" },
-    );
+    if (hosts && hosts.length > 0) {
+      unsatisfied.push({ name, reason: "misbound", hosts });
+      continue;
+    }
+    if (args.unselected?.has(name)) {
+      unsatisfied.push({
+        name,
+        reason: "unselected",
+        environmentMissing: args.environmentMissing === true,
+      });
+      continue;
+    }
+    unsatisfied.push({ name, reason: "absent" });
   }
 
   if (unsatisfied.length > 0) {
@@ -352,6 +441,32 @@ function externalAccountCredentialRefusal(args: {
       `Re-bind the secret under Project Settings → Secrets, or switch it to ` +
       `materialized delivery.`
     );
+  }
+  // GRANTED-BUT-NOT-SELECTED, and the refusal that closes the gap this module
+  // used to have. The secret exists and is bound correctly; what is missing is
+  // the environment's grant. "Add a CURSOR_API_KEY" would send the reader to
+  // create a duplicate of the row they already have, and — worse — the previous
+  // behaviour was not to refuse at all: the turn started, provisioned a box with
+  // no transform on it, and failed vendor auth with a placeholder.
+  const unselected = args.unsatisfied.filter(
+    (entry): entry is Extract<UnsatisfiedName, { reason: "unselected" }> =>
+      entry.reason === "unselected",
+  );
+  if (unselected.length > 0) {
+    const entry = unselected[0]!;
+    return entry.environmentMissing
+      ? `The ${args.harnessDisplayName} harness found a brokered ` +
+          `${entry.name} project secret, but this run resolved no Project ` +
+          `Environment — an environment is the grant boundary for project ` +
+          `secrets, so nothing is delivered to the box. Run this host from a ` +
+          `Project Environment that selects ${entry.name}, or configure it ` +
+          `with materialized delivery.`
+      : `The ${args.harnessDisplayName} harness found a brokered ` +
+          `${entry.name} project secret, but the environment this run uses ` +
+          `does not select it — brokered secrets are delivered per ` +
+          `environment, so the box would carry only a placeholder. Select ` +
+          `${entry.name} into that environment's secrets, or configure it ` +
+          `with materialized delivery.`;
   }
   const names = args.unsatisfied.map((entry) => entry.name);
   const one = names.length === 1;

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -418,6 +418,7 @@ export type HarnessCreateArgs = {
 type BrokeredModelAccessArm = {
   modelAccess: "broker";
   externalAccountCredentialEnv?: never;
+  externalAccountBrokerBinding?: never;
 };
 
 /** External-account model access: the runtime authenticates with the
@@ -426,7 +427,7 @@ type ExternalAccountModelAccessArm = {
   modelAccess: "external-account";
   /**
    * The environment variable names this runtime needs from the project's
-   * MATERIALIZED secrets, e.g. `["CURSOR_API_KEY"]` (which is exactly what
+   * secrets, e.g. `["CURSOR_API_KEY"]` (which is exactly what
    * `@ai-sdk/harness-cursor` declares as its own `credentialEnv`).
    *
    * REQUIRED on this arm, and that is the point: an external-account harness
@@ -440,6 +441,42 @@ type ExternalAccountModelAccessArm = {
    * runs there) and passes them to the adapter as its auth environment.
    */
   externalAccountCredentialEnv: readonly [string, ...string[]];
+  /**
+   * How each credential above can be satisfied by a BROKERED project secret
+   * instead of a materialized one — the binding the row has to carry for the
+   * backend's egress transform to actually deliver it.
+   *
+   * Keyed by the same env-var name. A name with no entry here can only ever be
+   * satisfied materialized, which is the honest default: brokering works only
+   * when the runtime authenticates by putting the credential in a HEADER, on a
+   * host we can name up front.
+   *
+   * These values are not a guess. They are read off the adapter's own
+   * `credentialBrokering` declaration — the request it says carries the key —
+   * so a runtime that changes where it authenticates changes this too, rather
+   * than silently brokering nothing.
+   */
+  externalAccountBrokerBinding?: Readonly<
+    Record<string, HarnessExternalAccountBrokerBinding>
+  >;
+};
+
+/**
+ * The project-secret binding that makes one external-account credential
+ * deliverable by MCPJam's egress proxy rather than as a value in the box.
+ *
+ * Mirrors the backend's `projectSecrets` broker triple exactly
+ * (`brokerHosts` / `brokerHeader` / `brokerTemplate`), because that is what a
+ * user has to type into Project Settings → Secrets and what the refusal copy
+ * has to be able to quote back at them.
+ */
+export type HarnessExternalAccountBrokerBinding = {
+  /** Exact hostnames the credential header must be injected on. */
+  hosts: readonly [string, ...string[]];
+  /** HTTP header name, LOWERCASE — the backend canonicalizes rows that way. */
+  header: string;
+  /** Header value template; `{}` is where the plaintext is substituted. */
+  template: string;
 };
 
 /** NATIVE delivery, `sandbox-files` mechanism: MCPJam writes runtime config
@@ -1295,11 +1332,34 @@ const cursorAdapter: HarnessRuntimeAdapter = {
   // throws if anything asks it for one.
   modelAccess: "external-account",
   // The name the CLI itself reads — `@ai-sdk/harness-cursor` declares exactly
-  // this as its `credentialEnv`. Delivered as a MATERIALIZED PROJECT SECRET:
-  // one key per environment, set once by an admin under Project Settings →
-  // Secrets. Missing ⇒ the turn is refused up front with copy that says so,
-  // never defaulted.
+  // this as its `credentialEnv`. Delivered as a PROJECT SECRET: one key per
+  // environment, set once by an admin under Project Settings → Secrets.
+  // Missing ⇒ the turn is refused up front with copy that says so, never
+  // defaulted.
   externalAccountCredentialEnv: ["CURSOR_API_KEY"],
+  // …and it can be BROKERED, which is the preferred delivery and the only
+  // one hosted evals and swarms accept at all (they refuse an environment that
+  // selects materialized secrets — `evalSandboxes.ts`'s
+  // `materialized_secrets_unsupported`, `journeyRuns.ts`'s
+  // `ENV_MATERIALIZED_SECRETS_UNSUPPORTED` — because only the chat path
+  // resolves and injects a materialized value, so on a runner-claimed attempt
+  // it would be silently absent).
+  //
+  // The triple is READ OFF THE ADAPTER, not invented: `@ai-sdk/harness-cursor`
+  // declares its own `credentialBrokering` against
+  // `POST https://api2.cursor.sh/auth/exchange_user_api_key` carrying
+  // `Authorization: Bearer <CURSOR_API_KEY>`. MCPJam's egress transform is
+  // host-scoped rather than path-scoped, so brokering the host covers that
+  // exchange and any sibling call that authenticates the same way.
+  externalAccountBrokerBinding: {
+    CURSOR_API_KEY: {
+      hosts: ["api2.cursor.sh"],
+      // LOWERCASE: `validateBrokerBinding` canonicalizes stored rows that way,
+      // so this is what a saved secret compares equal to.
+      header: "authorization",
+      template: "Bearer {}",
+    },
+  },
   defaultPermissionMode: "allow-all",
   // The ACP bridge routes every tool call through `session/request_permission`
   // and emits `tool-approval-request` for anything it does not auto-approve,

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -114,6 +114,11 @@ import {
   externalAccountPlanWallError,
   isExternalAccountPlanWallTurn,
 } from "./external-account-plan-wall.js";
+import {
+  fetchBrokeredCredentialNames,
+  planExternalAccountCredentials,
+  type ExternalAccountCredentialPlan,
+} from "./external-account-credentials.js";
 import { materializeSkillFiles } from "./materialize-skill-files.js";
 import { materializePinnedSkillFiles } from "./pinned-harness-skills.js";
 import { selectHarnessSkillSource } from "./skill-delivery.js";
@@ -1264,71 +1269,98 @@ export async function runHarnessTurn(
         : undefined;
 
       // EXTERNAL-ACCOUNT CREDENTIAL. A harness that authenticates on the
-      // customer's own provider account takes its credential from the SAME
-      // materialized project secrets above — there is no broker lease to mint,
-      // so this is the only place the value can come from.
+      // customer's own provider account takes its credential from the project's
+      // secrets — there is no broker lease to mint, so this is the only place
+      // the value can come from.
+      //
+      // TWO DELIVERIES, and the second is what makes hosted evals and swarms
+      // possible at all:
+      //
+      //   MATERIALIZED — the plaintext is in `secretEnv` above and goes to the
+      //     adapter directly. Unchanged.
+      //   BROKERED — the plaintext never enters this process or the box. The
+      //     backend composes the secret into the box's E2B egress transform;
+      //     the adapter gets a PLACEHOLDER so the CLI has something to send,
+      //     and the proxy overwrites the header outside the VM.
+      //
+      // Eval and swarm runs REFUSE an environment that selects materialized
+      // secrets (`evalSandboxes.ts`, `journeyRuns.ts`) because only the chat
+      // path injects them — so before brokered delivery existed here, a Cursor
+      // host could not run on those surfaces in either configuration.
       //
       // Resolved HERE, before the sandbox provider is built, for two reasons:
-      // a missing secret must fail the turn before anything is provisioned,
-      // and the credential has to be REMOVED from the box's session env bag
-      // that the provider is about to be constructed with.
+      // an unsatisfiable credential must fail the turn before anything is
+      // provisioned, and a materialized credential has to be REMOVED from the
+      // box's session env bag that the provider is about to be constructed
+      // with.
       //
-      // What that removal does and does not buy: the key no longer rides on
-      // every `run`/`spawn` in the box, so an unrelated command the agent
-      // shells out to cannot read it out of its own environment. The Cursor
-      // process itself still receives it — it has to, that is how the CLI
-      // authenticates. Fully keeping it out of the VM needs the adapter's
-      // credential-brokering hook wired to E2B's egress transform, which is
-      // tracked separately.
+      // What that removal does and does not buy on the MATERIALIZED arm: the
+      // key no longer rides on every `run`/`spawn` in the box, so an unrelated
+      // command the agent shells out to cannot read it out of its own
+      // environment. The runtime process itself still receives it — it has to,
+      // that is how the CLI authenticates. The BROKERED arm has no such
+      // residue: the box never holds the value at any point.
       const externalAccountCredentialNames =
         harnessAdapter.modelAccess === "external-account"
           ? harnessAdapter.externalAccountCredentialEnv
           : undefined;
-      let externalAccountAuth: HarnessAuth | undefined;
+      let externalAccountPlan: ExternalAccountCredentialPlan | undefined;
       if (externalAccountCredentialNames) {
-        const missing = externalAccountCredentialNames.filter(
-          (name) => !secretEnv?.[name],
+        // Ask about brokered delivery ONLY for the names materialized delivery
+        // did not already satisfy. A project that materializes its key pays no
+        // round trip and cannot be refused by a secrets-service blip — the
+        // pre-existing behaviour, preserved exactly.
+        const brokerBinding = harnessAdapter.externalAccountBrokerBinding;
+        const unresolved = externalAccountCredentialNames.filter(
+          (name) => !secretEnv?.[name] && brokerBinding?.[name],
         );
-        if (missing.length > 0) {
-          // Preflight-shaped copy: names the variable and where to set it, so
-          // the reader can act on it without opening a runbook. NEVER defaulted
-          // or silently skipped — starting the CLI with no credential produces
-          // an opaque failure from inside the box instead.
-          //
-          // KNOWN LIMITATION, and this is where it surfaces: callers that do
-          // NOT wire secrets deliver none (see the note on `runtimeSecrets`
-          // above — that is the documented contract, not an oversight). The
-          // SYNTHETIC path (`sessionSimulation/runner.ts`, which drives
-          // scenario/swarm/eval turns through `runUnifiedAssistantTurn`) is one
-          // of them, so an external-account harness is refused there today even
-          // when the environment does hold the secret.
-          //
-          // Deliberately not fixed here. Wiring it means fetching the secrets
-          // AND building the scrubber in that runner — the pair is what keeps
-          // delivered values out of the persisted transcript — and doing so
-          // would also start delivering project secrets to the EXISTING
-          // harnesses' synthetic turns, which today receive none. That is a
-          // security-relevant behaviour change well outside this change's
-          // scope. The refusal above is the fail-closed, legible alternative.
-          const one = missing.length === 1;
-          throw new Error(
-            `The ${harnessAdapter.displayName} harness requires ` +
-              `${one ? "a " : ""}${missing.join(", ")} project ` +
-              `${one ? "secret" : "secrets"} in this environment — add ` +
-              `${one ? "it" : "them"} under Project Settings → Secrets.`,
-          );
-        }
-        externalAccountAuth = Object.fromEntries(
-          externalAccountCredentialNames.map((name) => [
-            name,
-            secretEnv![name] as string,
-          ]),
-        );
+        // The box kind is decided by the CALLER's binding (see step 3 below),
+        // and it is known here because `harnessSandboxBinding` arrives on the
+        // options. It matters: `projectSecretsEgress.listBrokeredSecretsForBox`
+        // answers `[]` for anything without a `sandboxRowId` — persistent
+        // computers receive no brokered secrets in v1 — so a chat turn on a
+        // project computer must never be told its credential is brokered.
+        const brokered =
+          unresolved.length > 0 && brokerBinding
+            ? await fetchBrokeredCredentialNames({
+                ...(authHeader ? { bearer: authHeader } : {}),
+                ...(projectId ? { projectId } : {}),
+                boxKind: harnessSandboxBinding ? "sandbox" : "computer",
+                required: Object.fromEntries(
+                  unresolved.map((name) => [name, brokerBinding[name]!]),
+                ),
+              })
+            : { available: new Set<string>(), misboundHosts: {} };
+        // THROWS on an unsatisfiable credential, with copy that names the
+        // variable, BOTH deliveries, and where to set them. Never defaulted or
+        // silently skipped — starting the CLI with no credential produces an
+        // opaque failure from inside the box instead.
+        //
+        // KNOWN LIMITATION on the MATERIALIZED arm, and this is where it
+        // surfaces: callers that do NOT wire secrets deliver none (see the note
+        // on `runtimeSecrets` above — that is the documented contract, not an
+        // oversight). The SYNTHETIC path (`sessionSimulation/runner.ts`, which
+        // drives scenario/swarm/eval turns through `runUnifiedAssistantTurn`)
+        // is one of them. Those are exactly the surfaces that refuse
+        // materialized secrets anyway, so the answer for them is brokered
+        // delivery rather than wiring materialized secrets into a runner that
+        // has no scrubber to pair them with.
+        externalAccountPlan = planExternalAccountCredentials({
+          harnessDisplayName: harnessAdapter.displayName,
+          required: externalAccountCredentialNames,
+          secretEnv,
+          brokerBinding,
+          brokeredAvailable: brokered ? brokered.available : null,
+          ...(brokered ? { misboundHosts: brokered.misboundHosts } : {}),
+        });
       }
+      const externalAccountAuth = externalAccountPlan?.auth;
       // What the BOX's session env carries: everything the project materialized
       // MINUS the credentials handed to the adapter directly (see above). An
       // empty result is treated exactly like "no secrets" by the provider
-      // construction below.
+      // construction below. Filtering the full REQUIRED list, not just the
+      // materialized arm: on the brokered arm the name is absent from
+      // `secretEnv` anyway, so this is a no-op there and cannot drift.
       const sessionSecretEnv = externalAccountCredentialNames
         ? Object.fromEntries(
             Object.entries(secretEnv ?? {}).filter(
@@ -2186,7 +2218,16 @@ export async function runHarnessTurn(
       // secret is this one the bag is empty and nothing would ever stamp,
       // making a live credential read as dormant to whoever is deciding whether
       // it is safe to delete.
-      if (externalAccountAuth) onSecretEnvDelivered?.();
+      // BROKERED names are excluded on purpose: the backend delivered them
+      // into the box's egress transform, this process never held the value,
+      // and `markSecretsDelivered` re-resolves the MATERIALIZED grant — so
+      // stamping here would credit a delivery neither side made.
+      if (
+        externalAccountPlan &&
+        externalAccountPlan.materializedNames.length > 0
+      ) {
+        onSecretEnvDelivered?.();
+      }
 
       // Re-write SKILL.md WITH preserved extra frontmatter (allowed-tools /
       // license / …) for skills that carry it. The adapter's `skills` param

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -597,6 +597,7 @@ export async function runHarnessTurn(
     runtimeSkillsOverride,
     effectiveCapabilities,
     environmentId,
+    environmentUnresolvedReason,
     runtimeSecrets: runtimeSecretsOverride,
     secretsUnavailable,
     onSecretEnvDelivered,
@@ -1335,6 +1336,12 @@ export async function runHarnessTurn(
                 ...(authHeader ? { bearer: authHeader } : {}),
                 ...(projectId ? { projectId } : {}),
                 ...(environmentId ? { environmentId } : {}),
+                // Copy only — an environment this process cannot name is one
+                // whose selection it cannot check, so the answer is the same
+                // either way and only the refusal wording changes.
+                ...(!environmentId && environmentUnresolvedReason
+                  ? { environmentUnresolvedReason }
+                  : {}),
                 boxKind: harnessSandboxBinding ? "sandbox" : "computer",
                 required: Object.fromEntries(
                   unresolved.map((name) => [name, brokerBinding[name]!]),
@@ -1371,6 +1378,12 @@ export async function runHarnessTurn(
                 misboundHosts: brokered.misboundHosts,
                 unselected: brokered.unselected,
                 environmentMissing: brokered.environmentMissing,
+                ...(brokered.environmentUnresolvedReason
+                  ? {
+                      environmentUnresolvedReason:
+                        brokered.environmentUnresolvedReason,
+                    }
+                  : {}),
               }
             : {}),
         });

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -596,6 +596,7 @@ export async function runHarnessTurn(
     pinnedHarnessSkills,
     runtimeSkillsOverride,
     effectiveCapabilities,
+    environmentId,
     runtimeSecrets: runtimeSecretsOverride,
     secretsUnavailable,
     onSecretEnvDelivered,
@@ -1320,17 +1321,31 @@ export async function runHarnessTurn(
         // answers `[]` for anything without a `sandboxRowId` — persistent
         // computers receive no brokered secrets in v1 — so a chat turn on a
         // project computer must never be told its credential is brokered.
+        //
+        // `environmentId` is the OTHER half of that question, and the reason it
+        // is threaded all the way down here rather than approximated: the
+        // backend composes a box's egress transform from the ENVIRONMENT's
+        // `secretSelection`, so a correctly bound brokered row the run's
+        // environment does not select is never delivered. Asking project-wide
+        // would report it available and start a turn that provisions a box and
+        // then fails vendor auth against a placeholder.
         const brokered =
           unresolved.length > 0 && brokerBinding
             ? await fetchBrokeredCredentialNames({
                 ...(authHeader ? { bearer: authHeader } : {}),
                 ...(projectId ? { projectId } : {}),
+                ...(environmentId ? { environmentId } : {}),
                 boxKind: harnessSandboxBinding ? "sandbox" : "computer",
                 required: Object.fromEntries(
                   unresolved.map((name) => [name, brokerBinding[name]!]),
                 ),
               })
-            : { available: new Set<string>(), misboundHosts: {} };
+            : {
+                available: new Set<string>(),
+                misboundHosts: {},
+                unselected: new Set<string>(),
+                environmentMissing: false,
+              };
         // THROWS on an unsatisfiable credential, with copy that names the
         // variable, BOTH deliveries, and where to set them. Never defaulted or
         // silently skipped — starting the CLI with no credential produces an
@@ -1351,7 +1366,13 @@ export async function runHarnessTurn(
           secretEnv,
           brokerBinding,
           brokeredAvailable: brokered ? brokered.available : null,
-          ...(brokered ? { misboundHosts: brokered.misboundHosts } : {}),
+          ...(brokered
+            ? {
+                misboundHosts: brokered.misboundHosts,
+                unselected: brokered.unselected,
+                environmentMissing: brokered.environmentMissing,
+              }
+            : {}),
         });
       }
       const externalAccountAuth = externalAccountPlan?.auth;

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -670,6 +670,22 @@ export interface MCPJamHandlerOptions {
    */
   environmentId?: string;
   /**
+   * Why {@link environmentId} is absent on a turn whose run DOES have one.
+   *
+   * Absent `environmentId` normally means "no environment, therefore no grant",
+   * and the harness refusal says exactly that. On EVAL REPLAY it would be a
+   * lie: the replay run inherits the source run's `configSnapshot.environmentRef`
+   * verbatim, so the box may genuinely carry a brokered transform — but no
+   * public backend read projects that ref back out, so this process cannot name
+   * the environment or check its selection.
+   *
+   * Set by such a caller to make the refusal honest. It changes no decision:
+   * an environment we cannot name is one whose grant we cannot verify, and the
+   * turn is refused either way. Only the copy differs, and only so a reader is
+   * not told to fix a selection that may already be correct.
+   */
+  environmentUnresolvedReason?: string;
+  /**
    * This turn's MATERIALIZED project secrets, already resolved by the caller.
    *
    * THE ONLY SOURCE. The harness turn does not fetch secrets for itself, and


### PR DESCRIPTION
## What

`harness: "cursor"` could not run on hosted evals or swarms **in any configuration**, and this unblocks it.

Cursor authenticates on the customer's own account (`modelAccess: "external-account"`), and `run-harness-turn.ts` pulled `CURSOR_API_KEY` only out of `secretEnv` — i.e. **materialized** project secrets. But hosted evals (`mcpjam-backend convex/evalSandboxes.ts:210`) and journey/swarm runs (`convex/journeyRuns.ts:785`) **refuse** any environment selecting a materialized secret, because only the chat path resolves and injects them. So: add the secret → the run dies at sandbox reservation with `ENV_MATERIALIZED_SECRETS_UNSUPPORTED`; omit it → the turn is refused for a missing credential. Both verified live on production.

Both refusals also say, in their own comments, that **brokered secrets are fine there** — the backend composes them into the box's egress policy and no driver participates. This PR takes that path.

## The in-box placeholder contract (verified, not invented)

There is **no value-matching contract** in the backend. `composeBoxPolicy` builds `transform[host][header] = <brokerTemplate with {} substituted>`, and `computerProviders/e2b.ts:328` serialises it as `rules[host] = [{ transform: { headers } }]`. E2B's schema keys rules by **domain alone** and replaces an existing header of the same name — so injection is host-scoped and unconditional, and the in-box value only has to be **present**. A fixed, obviously-fake placeholder is therefore correct, and a failed injection yields a vendor 401 rather than an unauthenticated turn. **No backend change was required.**

Two constraints found and encoded:
- `projectSecretsEgress.listBrokeredSecretsForBox` returns `[]` without a `sandboxRowId` ("PERSISTENT COMPUTERS receive no secrets in v1"), so brokered delivery is real only on **ephemeral** boxes — exactly the eval/journey/scenario case. Chat on a project Computer still needs materialized, and the refusal copy now names both options.
- Brokered secrets are composed at the ephemeral provision seam and re-composed on every lease install/clear.

## Changes

- **`server/utils/harness/external-account-credentials.ts`** (new) — placeholder constant, binding validator, tri-state availability fetch, and the pure `planExternalAccountCredentials` decision. Materialized wins when both exist; a `null` (read failure) refuses exactly like an absence, so a Convex blip can never silently downgrade a credential.
- **`registry.ts`** — new `externalAccountBrokerBinding` on the external-account arm; the Cursor adapter declares `api2.cursor.sh` / `authorization` / `Bearer {}`, read off `@ai-sdk/harness-cursor`'s own `credentialBrokering` declaration rather than guessed.
- **`run-harness-turn.ts`** — plans across both deliveries; the brokered lookup runs only for names materialized did not satisfy (existing path pays no extra round trip); the delivery stamp fires only for materialized names.
- **`convex-secrets-client.ts`** — `convexListProjectSecretBindings` over the existing `projectSecrets:listSecrets` (metadata only; that query exposes no value field).
- **`e2b-sandbox-provider.ts`** — documented, deliberate omission of the framework's request-transform hook (below).
- **Docs** — "Harness credentials on your own vendor account": brokered vs materialized, the exact binding to enter, the persistent-Computer caveat, and a KMS subsection (project secrets need `SECRETS_KMS_WRITE` + the `GCP_KMS_*` vars, so a deployment without KMS cannot store one at all).

## Why the request-transform hook is NOT implemented

Three independent reasons, now recorded in a comment at the seam:
1. The framework hook receives the **real key** in `transform.headers` — its model is "the host holds the key". MCPJam's brokered secrets keep it behind KMS in the backend; wiring it would move the key *into* this process.
2. `HarnessV1RequestTransformation` matches host + path + method + header **value**; E2B matches domain only. Implementing it would silently widen the rule.
3. `PUT /sandboxes/{id}/network` is **replace** semantics and the policy is composed by the control plane (baseline + brokered secrets + live lease). A write from the inspector would irreversibly strip a live lease — the hazard `hasActiveBrokerLease` exists to prevent.

Cost: one console warning per Cursor turn. The brokered path achieves the same outcome (real key outside the VM, placeholder inside) through the control plane.

## Known limitation + optional backend follow-up

Detection is **project-scoped**, not box-scoped: the precise question (`projectSecretsEgress:listBrokeredSecretsForBox`) is an `internalQuery`, and `runHarnessTurn` is not handed an `environmentId`. Cost: a project holding a correctly-bound brokered `CURSOR_API_KEY` that is *not selected into the run's environment* starts and then fails vendor auth. A names-only public query keyed on `sandboxRowId` would close this; one-file backend PR, not blocking.

## Tests

- New `__tests__/external-account-credentials.test.ts` — 17 tests: brokered selection, persistent-computer "none" without a read, `null` on read failure, misbound host/header/template, materialized supersede.
- Extended `run-harness-turn-external-account.test.ts` — 16 total, 7 new end-to-end brokered cases (placeholder reaches the adapter, no delivery stamp, materialized still stamps and wins, session env stays clean, persistent-computer refusal, wrong-host refusal, both-deliveries copy).
- Harness suite: **533 passed**. `plugin-delivery.test.ts` fails to collect on a missing generated `PluginShim.bundled.js` — pre-existing worktree build artifact, unrelated. `tsc` clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches external-account credential delivery and secret grant scoping across eval, swarm, and harness turn paths; mistakes could refuse valid runs or start turns without real credentials, but behavior is fail-closed with extensive tests.
> 
> **Overview**
> **Cursor CLI harness** can satisfy `CURSOR_API_KEY` via **brokered** project secrets (egress header injection + in-box placeholder), not only materialized env vars—so `harness: "cursor"` can run on **hosted evals and swarms**, which reject materialized secret selections.
> 
> A new **`external-account-credentials`** path plans auth: materialized still wins when both exist; brokered availability is checked against the run’s **Project Environment** secret selection (not project-wide), with fail-closed preflight errors for misbound hosts, unselected secrets, persistent computers, and missing grant boundaries. **`projectEnvironmentId` / `environmentId`** is threaded from eval, swarm, and chat harness turns; **eval replay** passes an explicit `environmentUnresolvedReason` instead of blaming the user’s selection.
> 
> The Cursor adapter gains **`externalAccountBrokerBinding`** (`api2.cursor.sh`, `Authorization`, `Bearer {}`); **`convex-secrets-client`** adds metadata + environment selection reads. **`run-harness-turn`** integrates planning and only stamps delivery for materialized names. Docs expand harness hosts to include Cursor credential delivery, KMS prerequisites, and failure-mode tables; **`e2b-sandbox-provider`** documents why framework request-transform hooks stay omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58226590dc3847c0bdfeb8bf9d78d94c07fb2ce2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`harness: "cursor"` could not run in hosted evals or swarms — those surfaces refuse environments that select materialized secrets, which was the only delivery the turn accepted. It now also accepts a brokered `CURSOR_API_KEY`: the backend injects the real key into the box's E2B egress transform and the box only carries a placeholder, so the plaintext never enters this process.

**Brokered delivery**
- The binding is read off `@ai-sdk/harness-cursor`'s own `credentialBrokering` declaration, not guessed: `api2.cursor.sh`, `Authorization`, `Bearer {}`.
- Materialized delivery is unchanged and still wins when both exist; it's the only delivery a persistent project Computer can receive.
- Fail-closed in both directions: a failed metadata read refuses exactly like an absence, and a brokered row bound to the wrong host is refused by name.
- Availability is scoped to the run's environment, not the project: a bound key that environment doesn't select is refused before provisioning, and a turn with no environment is refused for lacking a grant boundary.
- An eval replay inherits an environment it can't name, so its refusal says the grant can't be confirmed instead of telling the reader to fix a selection.
- The framework's request-transform hook stays unwired — each Cursor turn logs one console warning, with the three reasons recorded at the seam.
- Docs now cover the exact binding to enter and the KMS prerequisite for storing any project secret.

<sup>Written for commit 58226590dc3847c0bdfeb8bf9d78d94c07fb2ce2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

