### PR TITLE
Playground: a reopened conversation stops describing itself with your current settings

### DIFF
--- a/.changeset/playground-reopened-conversation-target.md
+++ b/.changeset/playground-reopened-conversation-target.md
@@ -54,9 +54,18 @@ and **every** way to start a turn refuses, not just the button:
 
 A gate that covered only the composer would have been theatre. The two prompt
 paths keep their text as a composer draft rather than dropping it, so accepting
-the target and sending is one more click, not a retype. The acknowledgement is
-per conversation and survives a reactive refresh of that same conversation; New
-Chat, a detach and a rewind branch drop it.
+the target and sending is one more click, not a retype.
+
+And the gate is never reachable from a surface that cannot lift it, which would
+be the worse failure — no send AND no way to allow one. The disclosure is built
+once and every surface consumes it: the docked, centered and compare composers
+through `ChatInput`; the desktop fullscreen overlay, which REPLACES those
+composers, through its own slot above its input; and a mobile/tablet widget full
+takeover, the one layout with no composer at all, as a notice pinned over the
+thread — a widget can still request a follow-up there.
+
+The acknowledgement is per conversation and survives a reactive refresh of that
+same conversation; New Chat, a detach and a rewind branch drop it.
 
 The disclosure is derived only on the two paths that EXPLICITLY open a
 conversation — the history rail and the `?conversation=` restore — and never

--- a/.changeset/playground-reopened-conversation-target.md
+++ b/.changeset/playground-reopened-conversation-target.md
@@ -1,0 +1,59 @@
+---
+"@mcpjam/inspector": patch
+---
+
+A reopened Playground conversation no longer describes itself with your current settings
+
+Opening `/playground?conversation=<id>` restored the transcript and then framed
+it with whatever the viewer happened to have selected. A conversation that had
+run on a Cursor CLI harness host, against an environment, with the deepwiki
+server attached, reopened showing an unrelated host chip, `Claude Sonnet 5`,
+**Environment · none**, and another server's tools. The natural conclusion —
+"this never ran on Cursor" — was wrong, and the more expensive one followed from
+it: a reply typed under those chips ran on the target they named, so asking the
+Cursor transcript "what harness are you" got a Claude answer.
+
+**The chips were never about the conversation.** The previewed host and
+environment live in per-project browser storage (`use-previewed-client-id`,
+`use-previewed-environment-id`), which restore does not touch — by design, since
+they are the viewer's working state. What was missing is that the composer said
+so nowhere.
+
+**What the session actually records**, and what it does not:
+
+- `modelId` and `resumeConfig.selectedServers` are persisted and were already
+  restored.
+- `resumeConfig.environmentId` is persisted **only** for Agent Playground
+  (`origin: "api"`) sessions, and the browser ignored it entirely.
+- The **host** and, for browser Playground turns, the **environment** are not
+  persisted at all. `chatSessions.hostId` is stamped only for scenario- and
+  swarm-sourced rows, which the direct-chat read never serves; the browser
+  turn's `resumeConfig` carries no target field. `chatSessionTurnTraces` does
+  hold `environmentAtTurn` and `hostConfigId` per turn, but neither is projected
+  into the read the Playground uses.
+
+So the composer now says which of those it is standing on. A reopened
+conversation that recorded no target gets **"As-run configuration unavailable"**
+naming the target a reply would actually use; one that pinned an environment
+different from the selected one is named outright. Nothing is inferred and no
+default is dressed up as history — absence is reported as absence.
+
+Continuing on a different target is legitimate, so this is a one-click
+acknowledgement rather than a refusal — but it has to be the user's act, which
+is the part that was missing. Until it is given, the composer's Send is disabled
+and both send paths refuse: the composer submit (Enter, starter chips, eval
+Quick Run) and widget-driven follow-ups, which bypass the button entirely and
+would otherwise be the first thing to run on the wrong target. The
+acknowledgement is per conversation and survives a reactive refresh of that same
+conversation; New Chat, a detach and a rewind branch drop it.
+
+The disclosure is derived only on the two paths that EXPLICITLY open a
+conversation — the history rail and the `?conversation=` restore — and never
+from the reactive Convex refresh, which also runs for the live chat once it
+adopts a session id. It is bound to the live session id, so a fork or reset
+retires it without a second clear path to keep in step.
+
+Restoring the recorded environment automatically is deliberately **not** part of
+this: selecting one changes the chat scope key, and the reset that follows wipes
+the very transcript being restored. Naming it is honest today; adopting it needs
+the restore to run after the scope settles.

--- a/.changeset/playground-reopened-conversation-target.md
+++ b/.changeset/playground-reopened-conversation-target.md
@@ -41,11 +41,22 @@ default is dressed up as history — absence is reported as absence.
 Continuing on a different target is legitimate, so this is a one-click
 acknowledgement rather than a refusal — but it has to be the user's act, which
 is the part that was missing. Until it is given, the composer's Send is disabled
-and both send paths refuse: the composer submit (Enter, starter chips, eval
-Quick Run) and widget-driven follow-ups, which bypass the button entirely and
-would otherwise be the first thing to run on the wrong target. The
-acknowledgement is per conversation and survives a reactive refresh of that same
-conversation; New Chat, a detach and a rewind branch drop it.
+and **every** way to start a turn refuses, not just the button:
+
+- the composer submit (Enter, the Send button, eval Quick Run);
+- widget-driven follow-ups, which bypass the composer entirely;
+- starter chips, which are a one-click send from the empty state;
+- "Ask agent to run" on a harness built-in tool, which the Tools rail requests
+  from a sibling subtree through a store;
+- editing a past message, which is a send **and** a fork — it would run the
+  edited turn on the ambient target and mint a branch recording that it did.
+  The edit action is shown disabled rather than failing on click.
+
+A gate that covered only the composer would have been theatre. The two prompt
+paths keep their text as a composer draft rather than dropping it, so accepting
+the target and sending is one more click, not a retype. The acknowledgement is
+per conversation and survives a reactive refresh of that same conversation; New
+Chat, a detach and a rewind branch drop it.
 
 The disclosure is derived only on the two paths that EXPLICITLY open a
 conversation — the history rail and the `?conversation=` restore — and never

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/FullscreenChatOverlay.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/FullscreenChatOverlay.test.tsx
@@ -664,4 +664,50 @@ describe("FullscreenChatOverlay", () => {
     );
     expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
   });
+
+  describe("notice slot", () => {
+    // The overlay REPLACES the docked composer, so anything that disables Send
+    // has to be able to state its case — and offer its way out — here. Without
+    // this slot a gate whose control lives in the docked composer leaves the
+    // user unable to send AND unable to un-disable sending.
+    it("renders the notice above the composer", () => {
+      renderWithProviders(
+        <FullscreenChatOverlay
+          {...defaultProps}
+          notice={<div data-testid="test-notice">Continue here?</div>}
+        />
+      );
+
+      const notice = screen.getByTestId("test-notice");
+      expect(notice).toBeInTheDocument();
+      // Interactive, not decoration: it sits inside the pinned, clickable
+      // shell rather than under the `pointer-events-none` backdrop.
+      expect(screen.getByTestId("fullscreen-composer-notice")).toContainElement(
+        notice,
+      );
+    });
+
+    it("keeps the notice visible when the thread is collapsed", () => {
+      // Collapsed is exactly the state in which the composer is all there is,
+      // so a notice that lived inside the message list would vanish.
+      renderWithProviders(
+        <FullscreenChatOverlay
+          {...defaultProps}
+          open={false}
+          messages={[createMessage()]}
+          notice={<div data-testid="test-notice">Continue here?</div>}
+        />
+      );
+
+      expect(screen.getByTestId("test-notice")).toBeInTheDocument();
+    });
+
+    it("renders nothing extra when there is no notice", () => {
+      renderWithProviders(<FullscreenChatOverlay {...defaultProps} />);
+
+      expect(
+        screen.queryByTestId("fullscreen-composer-notice"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -14,6 +14,7 @@ import type {
   DragEvent,
   FormEvent,
   KeyboardEvent,
+  ReactNode,
 } from "react";
 import { cn } from "@/lib/chat-utils";
 import { track } from "@/lib/analytics";
@@ -382,6 +383,17 @@ interface ChatInputProps {
    */
   environmentServersOverridden?: boolean;
   onResetEnvironmentServers?: () => void;
+  /**
+   * Banner rendered inside the composer, above everything else.
+   *
+   * Exists for statements the composer has to make ABOUT ITSELF — today, that
+   * a reopened conversation's as-run host/environment was never recorded, so
+   * these controls are the viewer's current selection rather than history (see
+   * `ConversationTargetNotice`). Rendered here rather than by each caller
+   * because there are six `<ChatInput>` sites and the notice must not be
+   * reachable from only some of them.
+   */
+  notice?: ReactNode;
 }
 
 export function ChatInput({
@@ -446,6 +458,7 @@ export function ChatInput({
   onEnvironmentServerToggle,
   environmentServersOverridden = false,
   onResetEnvironmentServers,
+  notice,
 }: ChatInputProps) {
   // The project LIBRARY half of the `/` picker: list/load skills from the
   // project's Convex source (Playground carries the id via `clientSelector`).
@@ -1422,6 +1435,8 @@ export function ChatInput({
               {DROP_OVERLAY_TEXT}
             </div>
           )}
+
+          {notice}
 
           <PromptsPopover
             anchor={caret}

--- a/mcpjam-inspector/client/src/components/chat-v2/fullscreen-chat-overlay.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/fullscreen-chat-overlay.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, KeyboardEvent, useEffect, useMemo, useRef } from "react";
+import type { ReactNode } from "react";
 import type { CSSProperties } from "react";
 
 import type { UIMessage } from "@ai-sdk/react";
@@ -598,6 +599,17 @@ type FullscreenChatOverlayProps = {
   isThinking: boolean;
   onStop?: () => void;
   onSend: () => void;
+  /**
+   * Rendered directly above the composer, inside the pinned (and therefore
+   * clickable) shell.
+   *
+   * This overlay REPLACES the docked composer — the caller stops rendering
+   * that one entirely while the overlay is up — so anything that gates Send
+   * has to be able to state its case, and offer its way out, here. Without
+   * this slot a gate whose control lives in the docked composer disables the
+   * only visible Send control and hides the only control that re-enables it.
+   */
+  notice?: ReactNode;
   /** Provider id from the active chat model — feeds the indicator's
    * fallback path for surfaces without a scenario host context. */
   modelProvider?: string | null;
@@ -615,6 +627,7 @@ export function FullscreenChatOverlay({
   isThinking,
   onStop,
   onSend,
+  notice,
   modelProvider,
 }: FullscreenChatOverlayProps) {
   const scenarioHostStyle = useScenarioHostStyle();
@@ -645,6 +658,17 @@ export function FullscreenChatOverlay({
             modelProvider={modelProvider}
             chatSessionId={chatSessionId}
           />
+          {/* Above the composer and OUTSIDE the collapsible message list, so
+              it stays visible when the thread is collapsed — the state in
+              which the composer is all there is. */}
+          {notice ? (
+            <div
+              data-testid="fullscreen-composer-notice"
+              className="mb-2 rounded-3xl border border-border/40 bg-background/95 px-2 py-2 shadow-2xl backdrop-blur-xl"
+            >
+              {notice}
+            </div>
+          ) : null}
           <Composer
             value={input}
             onChange={onInputChange}

--- a/mcpjam-inspector/client/src/components/playground/ConversationTargetNotice.tsx
+++ b/mcpjam-inspector/client/src/components/playground/ConversationTargetNotice.tsx
@@ -1,0 +1,107 @@
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { cn } from "@/lib/utils";
+import type { ConversationTargetDisclosure } from "@/lib/conversation-execution-target";
+
+/**
+ * Honest header for a REOPENED conversation whose composer does not describe
+ * it.
+ *
+ * The Playground's host, environment and tool controls are ambient per-project
+ * browser state, so a conversation opened by `?conversation=<id>` renders under
+ * the viewer's current selection. Left unlabelled that reads as a statement
+ * about the conversation, and a reply typed under it silently runs on a target
+ * the transcript never used.
+ *
+ * Two things are said here, and nothing is invented:
+ *
+ *   - `unrecorded` — the conversation stored no execution target, so we say so
+ *     rather than dressing the ambient selection up as history.
+ *   - `mismatch` — it DID store one and it is not the one selected, so we name
+ *     the recorded id and say a reply goes elsewhere.
+ *
+ * `onAcknowledge` is what un-gates the composer. Continuing on a different
+ * target is legitimate — that is why this is a one-click acknowledgement and
+ * not a refusal — but it has to be the user's deliberate act, which is exactly
+ * what "silently ran on the wrong host" was missing.
+ */
+export function ConversationTargetNotice({
+  disclosure,
+  composerHostName,
+  composerEnvironmentId,
+  onAcknowledge,
+  className,
+}: {
+  disclosure: ConversationTargetDisclosure;
+  /** Display name of the host a reply would run on, when one is resolved. */
+  composerHostName?: string | null;
+  /** Environment a reply would run on, when the composer is in environment mode. */
+  composerEnvironmentId?: string | null;
+  onAcknowledge: () => void;
+  className?: string;
+}) {
+  if (disclosure.kind === "none") return null;
+
+  const runsOn = composerEnvironmentId
+    ? `environment ${composerEnvironmentId}`
+    : composerHostName
+    ? composerHostName
+    : "your current selection";
+
+  return (
+    <div
+      className={cn(
+        "mx-2 mb-2 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-[11px] leading-relaxed text-amber-700 dark:text-amber-400",
+        className,
+      )}
+      role="status"
+      data-testid="conversation-target-notice"
+      data-disclosure={disclosure.kind}
+    >
+      <AlertTriangle className="mt-[2px] size-3.5 shrink-0" aria-hidden />
+      <div className="min-w-0 flex-1">
+        {disclosure.kind === "unrecorded" ? (
+          <p>
+            <span className="font-medium">
+              As-run configuration unavailable.
+            </span>{" "}
+            This conversation didn&apos;t record which host or environment it
+            ran on, so the controls below are your current selection — not this
+            chat&apos;s. A reply will run on {runsOn}.
+          </p>
+        ) : (
+          <p>
+            <span className="font-medium">
+              This conversation ran somewhere else.
+            </span>{" "}
+            It recorded{" "}
+            {disclosure.recorded.kind === "environment" ? (
+              <>
+                environment{" "}
+                <code className="font-mono">
+                  {disclosure.recorded.environmentId}
+                </code>
+              </>
+            ) : (
+              <>
+                host{" "}
+                <code className="font-mono">{disclosure.recorded.hostId}</code>
+              </>
+            )}
+            , which is not what is selected. A reply will run on {runsOn}.
+          </p>
+        )}
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-6 shrink-0 px-2 text-[11px] font-medium"
+        onClick={onAcknowledge}
+        data-testid="conversation-target-notice-acknowledge"
+      >
+        Continue here
+      </Button>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -134,6 +134,13 @@ import { usePlaygroundEnvironment } from "@/hooks/use-playground-environment";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import { useWebmcpInspectorStore } from "@/stores/webmcp-inspector-store";
 import { PlaygroundEnvironmentSection } from "@/components/playground/PlaygroundEnvironmentSection";
+import { ConversationTargetNotice } from "@/components/playground/ConversationTargetNotice";
+import {
+  describeConversationTargetDisclosure,
+  readConversationExecutionTarget,
+  type ComposerExecutionTarget,
+  type ConversationExecutionTarget,
+} from "@/lib/conversation-execution-target";
 import { useHarnessBuiltinTools } from "@/hooks/useHarnessBuiltinTools";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { useComputerAttachmentUpload } from "@/hooks/useComputerAttachmentUpload";
@@ -577,6 +584,25 @@ export function PlaygroundMain({
   // every send. Compare gates key off this flag so the layout only steps
   // aside for genuine replay.
   const [viewingHistoryReplay, setViewingHistoryReplay] = useState(false);
+  /**
+   * The execution target the OPEN persisted conversation actually recorded,
+   * kept beside the conversation it came from.
+   *
+   * The host and environment controls are ambient per-project browser state,
+   * so a restored conversation renders under the viewer's current selection.
+   * That is only a problem when it goes UNSAID — this is what lets the composer
+   * say it (see `ConversationTargetNotice`) and what gates a reply until the
+   * user has deliberately accepted the target it will actually run on.
+   *
+   * `acknowledged` is per conversation and survives a reactive refresh of the
+   * same one; it is dropped wholesale when the conversation is (New Chat,
+   * detach, a rewind branch) because the next one is a different question.
+   */
+  const [restoredConversation, setRestoredConversation] = useState<{
+    chatSessionId: string;
+    target: ConversationExecutionTarget;
+    acknowledged: boolean;
+  } | null>(null);
   const [loadingHistorySessionId, setLoadingHistorySessionId] = useState<
     string | null
   >(null);
@@ -606,6 +632,9 @@ export function PlaygroundMain({
   // `onReset` above it, which is why this is a ref rather than the callback.
   const clearConversationUrlRef = useRef<() => void>(() => {});
   const appliedHistoryContentSignatureRef = useRef<string | null>(null);
+  // Assigned during render from `needsConversationTargetAck` below; read by the
+  // send paths, which are declared above it.
+  const needsConversationTargetAckRef = useRef(false);
   const resumedThreadSendBaselineRef = useRef<{
     sessionId: string;
     version: number;
@@ -2216,6 +2245,10 @@ export function PlaygroundMain({
     setActiveHistorySessionId(null);
     setLoadedThreadOwnerUserId(null);
     setViewingHistoryReplay(false);
+    // No persisted conversation is open any more, so there is nothing left to
+    // disclose about one — and leaving the flag set would gate sends on a
+    // fresh chat the user just started.
+    setRestoredConversation(null);
   }, [invalidatePendingReactiveHistoryLoad]);
 
   const markHistorySessionRead = useCallback(async (sessionId: string) => {
@@ -2225,6 +2258,67 @@ export function PlaygroundMain({
       // Best-effort: unread state should not block chat usage.
     }
   }, []);
+
+  // ── As-run configuration honesty ──────────────────────────────────────────
+  //
+  // Scoped to the LIVE session id: the moment the chat forks or resets (New
+  // Chat, a rewind branch, the auth-bootstrap wipe) the ids diverge and the
+  // disclosure stands down on its own, without a second clear path to keep in
+  // step with `restoredConversation`.
+  const activeRestoredConversation =
+    restoredConversation && restoredConversation.chatSessionId === chatSessionId
+      ? restoredConversation
+      : null;
+  // Where a reply typed right now would actually run. Environment mode and
+  // host mode are mutually exclusive on the wire, so this is one statement.
+  const composerExecutionTarget: ComposerExecutionTarget =
+    isEnvironmentMode && playgroundEnvironment.environmentId
+      ? {
+          kind: "environment",
+          environmentId: playgroundEnvironment.environmentId,
+        }
+      : { kind: "host", hostId: previewedHostId ?? null };
+  const conversationTargetDisclosure = describeConversationTargetDisclosure({
+    recorded: activeRestoredConversation?.target ?? null,
+    composer: composerExecutionTarget,
+  });
+  const needsConversationTargetAck =
+    conversationTargetDisclosure.kind !== "none" &&
+    !(activeRestoredConversation?.acknowledged ?? false);
+  // Read at SEND time by callbacks defined above this line, so it has to be a
+  // ref rather than a dependency — the send paths must not be re-created (and
+  // re-armed) on every host or environment change.
+  needsConversationTargetAckRef.current = needsConversationTargetAck;
+  const acknowledgeConversationTarget = useCallback(() => {
+    setRestoredConversation((previous) =>
+      previous ? { ...previous, acknowledged: true } : previous,
+    );
+  }, []);
+
+  /**
+   * Record what an EXPLICITLY opened conversation says about where it ran.
+   *
+   * Called from the two open paths only — the rail click and the
+   * `?conversation=` restore — and deliberately NOT from `loadHistorySession`,
+   * which the reactive Convex refresh also drives for the LIVE chat once
+   * `refreshCurrentHistorySession` adopts its session id. Deriving there would
+   * make the composer disclose a mismatch against a conversation the user is
+   * sitting in and just sent on.
+   */
+  const adoptRestoredConversationTarget = useCallback(
+    (detail: ChatHistoryDetailSession) => {
+      setRestoredConversation((previous) => ({
+        chatSessionId: detail.chatSessionId,
+        target: readConversationExecutionTarget(detail),
+        // Reopening the SAME conversation keeps the acknowledgement; a
+        // different one is a different question.
+        acknowledged:
+          previous?.chatSessionId === detail.chatSessionId &&
+          previous.acknowledged,
+      }));
+    },
+    [],
+  );
 
   const restoreHistoryServerSelection = useCallback(
     (savedServerNames: string[] | undefined) => {
@@ -2648,6 +2742,7 @@ export function PlaygroundMain({
         restoreHistoryServerSelection(
           detail.session.resumeConfig?.selectedServers,
         );
+        adoptRestoredConversationTarget(detail.session);
       } catch (err) {
         if (historySelectionRequestIdRef.current === selectionRequestId) {
           setActiveHistorySessionId(null);
@@ -2662,6 +2757,7 @@ export function PlaygroundMain({
       }
     },
     [
+      adoptRestoredConversationTarget,
       clearComposerDraft,
       convexProjectId,
       ensureDiscardDraftConfirmed,
@@ -2706,6 +2802,7 @@ export function PlaygroundMain({
         restoreHistoryServerSelection(
           detail.session.resumeConfig?.selectedServers,
         );
+        adoptRestoredConversationTarget(detail.session);
         // `loadHistorySession` skips the model when the catalog hasn't loaded
         // yet; remember it so the effect below can apply it on arrival.
         pendingRestoredModelRef.current = detail.session.modelId
@@ -2745,7 +2842,12 @@ export function PlaygroundMain({
         }
       }
     },
-    [convexProjectId, loadHistorySession, restoreHistoryServerSelection],
+    [
+      adoptRestoredConversationTarget,
+      convexProjectId,
+      loadHistorySession,
+      restoreHistoryServerSelection,
+    ],
   );
 
   const { isRestoringConversation, clearConversation } =
@@ -3253,6 +3355,13 @@ export function PlaygroundMain({
   const handleSendFollowUp = useCallback(
     (text: string) => {
       void (async () => {
+        // Same gate as the composer, and for the same reason: a widget-driven
+        // follow-up on a reopened conversation would otherwise be the FIRST
+        // thing that runs on a target the transcript never used, with no user
+        // action in between to make that a choice.
+        if (needsConversationTargetAckRef.current) {
+          return;
+        }
         if (!(await ensureSelectedServerReadyForChat())) {
           return;
         }
@@ -3744,6 +3853,11 @@ export function PlaygroundMain({
     if (!composerHasContent || sendBlocked) {
       return false;
     }
+    // The composer is disabled in this state, so this is the belt to that
+    // brace: Enter-to-send, starter chips and eval Quick Run all land here.
+    if (needsConversationTargetAckRef.current) {
+      return false;
+    }
     if (!(await ensureSelectedServerReadyForChat())) {
       return false;
     }
@@ -4223,7 +4337,23 @@ export function PlaygroundMain({
       composer.submitGatedByServer ||
       isPreparingServerForSend ||
       // Same environment-transition gate as `sharedChatInputProps` above.
-      isEnvironmentTargetPending,
+      isEnvironmentTargetPending ||
+      // A reopened conversation whose composer does not describe it. The
+      // notice rendered directly above the input says why and carries the
+      // one-click way out.
+      needsConversationTargetAck,
+    notice: needsConversationTargetAck ? (
+      <ConversationTargetNotice
+        disclosure={conversationTargetDisclosure}
+        composerHostName={previewedHost?.name ?? null}
+        composerEnvironmentId={
+          composerExecutionTarget.kind === "environment"
+            ? composerExecutionTarget.environmentId
+            : null
+        }
+        onAcknowledge={acknowledgeConversationTarget}
+      />
+    ) : null,
     tokenUsage,
     selectedServers,
     mcpToolsTokenCount,

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -4312,6 +4312,31 @@ export function PlaygroundMain({
     !hasLiveTimelineContent &&
     !preludeTraceEnvelope?.spans?.length;
 
+  /**
+   * ONE construction site for the as-run disclosure, consumed by every surface
+   * that can be blocked by it.
+   *
+   * The gate must never be reachable from a surface that cannot lift it. The
+   * docked/centered/compare composers take it through `ChatInput`'s `notice`
+   * slot; the fullscreen overlay REPLACES those composers, so it takes the
+   * same element through its own slot; and a widget full takeover, which
+   * renders no composer at all, gets it pinned over the thread (see
+   * `showPinnedConversationTargetNotice`). Rendering it in only one of those
+   * places disables the visible Send and hides the button that re-enables it.
+   */
+  const conversationTargetNotice = needsConversationTargetAck ? (
+    <ConversationTargetNotice
+      disclosure={conversationTargetDisclosure}
+      composerHostName={previewedHost?.name ?? null}
+      composerEnvironmentId={
+        composerExecutionTarget.kind === "environment"
+          ? composerExecutionTarget.environmentId
+          : null
+      }
+      onAcknowledge={acknowledgeConversationTarget}
+    />
+  ) : null;
+
   // Shared chat input props
   const sharedChatInputProps = {
     value: composer.input,
@@ -4366,18 +4391,7 @@ export function PlaygroundMain({
       // notice rendered directly above the input says why and carries the
       // one-click way out.
       needsConversationTargetAck,
-    notice: needsConversationTargetAck ? (
-      <ConversationTargetNotice
-        disclosure={conversationTargetDisclosure}
-        composerHostName={previewedHost?.name ?? null}
-        composerEnvironmentId={
-          composerExecutionTarget.kind === "environment"
-            ? composerExecutionTarget.environmentId
-            : null
-        }
-        onAcknowledge={acknowledgeConversationTarget}
-      />
-    ) : null,
+    notice: conversationTargetNotice,
     tokenUsage,
     selectedServers,
     mcpToolsTokenCount,
@@ -4461,9 +4475,38 @@ export function PlaygroundMain({
     !shouldShowUpsell &&
     (showPostConnectGuide || !showFullscreenChatOverlay);
 
+  /**
+   * The one layout that renders NO composer: a mobile/tablet widget full
+   * takeover hides the footer input and forbids the overlay. A widget can
+   * still request a follow-up there, and the as-run gate refuses it — so
+   * without this the refusal is silent and there is nothing on screen that
+   * could lift it. Pin the disclosure over the thread instead.
+   *
+   * The two exclusions keep it from doubling up on a notice another surface
+   * is already rendering: the centered empty-state composer survives a full
+   * takeover (but only ACTUALLY renders on an empty thread, which is the
+   * condition that matters here), and the trace-diagnostics shell has its own
+   * composer with the device frame behind it set to `display: none`.
+   */
+  const showPinnedConversationTargetNotice =
+    !!conversationTargetNotice &&
+    isWidgetFullTakeover &&
+    !showLiveTraceDiagnostics &&
+    !(isThreadEmpty && showSingleModelEmptyStateComposer);
+
   // Thread content - single ChatInput that persists across empty/non-empty states
   const threadContent = (
     <div className="relative flex flex-col flex-1 min-h-0">
+      {showPinnedConversationTargetNotice ? (
+        <div
+          data-testid="pinned-conversation-target-notice"
+          className="pointer-events-auto absolute inset-x-0 top-0 z-30 px-2 pt-2"
+        >
+          <div className="rounded-md bg-background/95 shadow-lg backdrop-blur-md">
+            {conversationTargetNotice}
+          </div>
+        </div>
+      ) : null}
       {isThreadEmpty ? (
         // Empty state — centered (welcome + composer, or post-connect guide)
         <div
@@ -4743,10 +4786,12 @@ export function PlaygroundMain({
           onInputChange={composer.setInput}
           placeholder={placeholder}
           disabled={composerDisabled}
-          // The overlay has no room for the notice, so the honest thing it can
-          // do is show Send as unavailable — `performComposerSubmit` refuses
-          // this state anyway, and a live-looking button that does nothing is
-          // worse than a disabled one.
+          // The overlay replaces the docked composer, so it carries the
+          // disclosure — and its "Continue here" button — itself. Disabling
+          // Send without this would leave the user unable to send AND unable
+          // to acknowledge, which is a worse failure than the one the gate
+          // exists to prevent.
+          notice={conversationTargetNotice}
           canSend={
             !sendBlocked && composerHasContent && !needsConversationTargetAck
           }

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -4002,6 +4002,12 @@ export function PlaygroundMain({
   const handleEditUserMessage = useCallback(
     async (message: UIMessage, text: string) => {
       if (sendBlocked) return false;
+      // A rewind IS a send, and a costlier one: it mints a branch and runs the
+      // edited turn on the CURRENT target, so on a reopened conversation it
+      // would both execute somewhere the transcript never ran AND fork the
+      // thread to record it. `editDisabled` below carries the same condition
+      // so the affordance reads as unavailable rather than failing on click.
+      if (needsConversationTargetAckRef.current) return false;
       // Same fire-and-forget exposure as the rewind below, and it lands FIRST:
       // `ensureSelectedServerReadyForChat` wraps `ensureServersReady` in
       // try/FINALLY with no catch, so a rejected connect propagates straight
@@ -4161,7 +4167,16 @@ export function PlaygroundMain({
         prompt,
         location: isCompareMode ? "playground_compare" : "playground_single",
       });
-      if (composerDisabled || sendBlocked) {
+      // Same gate as the composer. A starter chip is a one-click SEND, so
+      // without this it is the shortest path to running a reopened
+      // conversation on a target its transcript never used. Preserved as a
+      // draft rather than dropped: the chip's text is the user's input, and
+      // it is waiting for them the moment they accept the target.
+      if (
+        composerDisabled ||
+        sendBlocked ||
+        needsConversationTargetAckRef.current
+      ) {
         composer.setInput(prompt);
         return;
       }
@@ -4222,7 +4237,16 @@ export function PlaygroundMain({
   // composer as a draft). No bespoke execution path — it's a normal turn.
   const submitAgentToolPrompt = useCallback(
     async (text: string) => {
-      if (composerDisabled || sendBlocked) {
+      // Same gate as the composer, and this path is the one the user never
+      // typed into: the rail requests the send from a sibling subtree, so a
+      // disabled Send button is no protection at all. Left in the composer as
+      // a draft, which is exactly what this handler already does for every
+      // other not-ready state.
+      if (
+        composerDisabled ||
+        sendBlocked ||
+        needsConversationTargetAckRef.current
+      ) {
         composer.setInput(text);
         return;
       }
@@ -4646,7 +4670,7 @@ export function PlaygroundMain({
                     ? undefined
                     : handleEditUserMessage
                 }
-                editDisabled={sendBlocked}
+                editDisabled={sendBlocked || needsConversationTargetAck}
                 renderUserMessageActions={
                   chatSessionId && convexProjectId
                     ? (message) => {
@@ -4719,7 +4743,13 @@ export function PlaygroundMain({
           onInputChange={composer.setInput}
           placeholder={placeholder}
           disabled={composerDisabled}
-          canSend={!sendBlocked && composerHasContent}
+          // The overlay has no room for the notice, so the honest thing it can
+          // do is show Send as unavailable — `performComposerSubmit` refuses
+          // this state anyway, and a live-looking button that does nothing is
+          // worse than a disabled one.
+          canSend={
+            !sendBlocked && composerHasContent && !needsConversationTargetAck
+          }
           isThinking={isStreamingActive}
           onStop={stopActiveChat}
           // Same submit path as the docked composer. Its own copy dropped

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -340,6 +340,7 @@ vi.mock("@/components/chat-v2/thread", () => ({
     onEditUserMessage,
     editDisabled,
     sendFollowUpMessage,
+    onFullscreenChange,
   }: {
     messages: any[];
     isLoading: boolean;
@@ -349,6 +350,9 @@ vi.mock("@/components/chat-v2/thread", () => ({
     // Widget-driven follow-ups bypass the composer, so tests need the handler
     // itself — a rendered button could never stand in for that path.
     sendFollowUpMessage?: (text: string) => void;
+    // A widget going fullscreen is what swaps the docked composer for the
+    // pinned overlay; only the widget can report it, so tests drive it here.
+    onFullscreenChange?: (fullscreen: boolean) => void;
   }) =>
     (() => {
       mockThread({
@@ -358,6 +362,7 @@ vi.mock("@/components/chat-v2/thread", () => ({
         onEditUserMessage,
         editDisabled,
         sendFollowUpMessage,
+        onFullscreenChange,
       });
       return (
         <div data-testid="thread">
@@ -561,11 +566,38 @@ vi.mock(
   })
 );
 
-// Mock FullscreenChatOverlay
+// Mock FullscreenChatOverlay. It renders the `notice` slot and a
+// canSend-driven Send button because the overlay REPLACES the docked
+// composer — a stub that dropped either would hide exactly the dead end
+// these tests exist to catch.
 vi.mock("@/components/chat-v2/fullscreen-chat-overlay", () => ({
-  FullscreenChatOverlay: (props: { loadingIndicatorVariant?: string }) => {
+  FullscreenChatOverlay: (props: {
+    loadingIndicatorVariant?: string;
+    notice?: React.ReactNode;
+    input?: string;
+    onInputChange?: (value: string) => void;
+    canSend?: boolean;
+    onSend?: () => void;
+  }) => {
     mockFullscreenChatOverlay(props);
-    return <div data-testid="fullscreen-overlay">Fullscreen Overlay</div>;
+    return (
+      <div data-testid="fullscreen-overlay">
+        {props.notice}
+        <input
+          data-testid="fullscreen-overlay-input"
+          value={props.input ?? ""}
+          onChange={(e) => props.onInputChange?.(e.target.value)}
+        />
+        <button
+          type="button"
+          data-testid="fullscreen-overlay-send"
+          disabled={!props.canSend}
+          onClick={() => props.onSend?.()}
+        >
+          Send
+        </button>
+      </div>
+    );
   },
 }));
 
@@ -3119,11 +3151,13 @@ describe("PlaygroundMain", () => {
      * is what binds the disclosure to the thread on screen.
      */
     const openRestoredConversation = async (
-      resumeConfig: Record<string, unknown>
+      resumeConfig: Record<string, unknown>,
+      extraProps: Record<string, unknown> = {}
     ) => {
       arriveAtRestoredConversation(resumeConfig);
-      const { rerender } = render(
-        <PlaygroundMain {...defaultProps} syncConversationToUrl />
+      const props = { ...defaultProps, ...extraProps };
+      const { rerender: rerenderRaw } = render(
+        <PlaygroundMain {...props} syncConversationToUrl />
       );
       await waitFor(() => {
         expect(mockGetChatHistoryDetail).toHaveBeenCalledWith(
@@ -3131,8 +3165,13 @@ describe("PlaygroundMain", () => {
         );
       });
       mockUseChatSession.chatSessionId = RESTORED_SESSION_ID;
+      // Keeps the caller's props on every re-render, so a test that entered
+      // via `displayMode: "fullscreen"` does not silently fall back to the
+      // docked composer on the next flush.
+      const rerender = () =>
+        rerenderRaw(<PlaygroundMain {...props} syncConversationToUrl />);
       await act(async () => {
-        rerender(<PlaygroundMain {...defaultProps} syncConversationToUrl />);
+        rerender();
       });
       return { rerender };
     };
@@ -3148,6 +3187,9 @@ describe("PlaygroundMain", () => {
       window.history.replaceState({}, "", "/");
       invalidateChatHistoryPrefetch();
       useAgentToolPromptBridge.setState({ pending: null });
+      // Module-level store, not reset by the global `beforeEach`; the overlay
+      // tests below change it and every other test assumes the default.
+      mockUIPlaygroundStore.deviceType = "mobile";
     });
 
     it("says nothing about a live chat the user started here", () => {
@@ -3211,7 +3253,7 @@ describe("PlaygroundMain", () => {
         { id: "m1", role: "user", parts: [{ type: "text", text: "hi" }] },
       ] as any;
       await act(async () => {
-        rerender(<PlaygroundMain {...defaultProps} syncConversationToUrl />);
+        rerender();
       });
 
       const sendFollowUpMessage =
@@ -3298,7 +3340,7 @@ describe("PlaygroundMain", () => {
         { id: "1", role: "user", parts: [{ type: "text", text: "hi" }] },
       ] as any;
       await act(async () => {
-        rerender(<PlaygroundMain {...defaultProps} syncConversationToUrl />);
+        rerender();
       });
       await screen.findByTestId("conversation-target-notice");
 
@@ -3315,6 +3357,157 @@ describe("PlaygroundMain", () => {
       });
 
       expect(mockUseChatSession.rewindToMessage).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The gate must never be reachable from a surface that cannot lift it.
+     * Disabling Send while the only "Continue here" button lives in a composer
+     * the layout has hidden is a worse failure than the one the gate prevents:
+     * it has no exit.
+     */
+    describe("surfaces that replace the docked composer", () => {
+      /**
+       * `displayMode` reaches the component through the host-context draft,
+       * not the prop: `extractEffectiveHostDisplayMode` always resolves to a
+       * concrete mode (defaulting to "inline"), so the prop's `??` fallback
+       * never fires. Every layout below is entered through the store.
+       */
+      const setHostDisplayMode = (mode: string) => {
+        useHostContextStore.setState({
+          draftHostContext: { displayMode: mode },
+        });
+      };
+
+      /** Widget fullscreen on a desktop-ish frame swaps in the pinned overlay. */
+      const enterFullscreenOverlay = async (
+        rerender: () => void,
+      ): Promise<void> => {
+        mockUseChatSession.messages = [
+          { id: "m1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        ] as any;
+        await act(async () => {
+          rerender();
+        });
+        const onFullscreenChange =
+          mockThread.mock.calls.at(-1)?.[0].onFullscreenChange;
+        expect(onFullscreenChange).toBeDefined();
+        await act(async () => {
+          onFullscreenChange(true);
+        });
+      };
+
+      it("moves the acknowledgement into the fullscreen overlay instead of stranding it in the hidden composer", async () => {
+        mockUIPlaygroundStore.deviceType = "fill";
+        setHostDisplayMode("fullscreen");
+        const { rerender } = await openRestoredConversation({
+          selectedServers: ["deepwiki"],
+        });
+        await screen.findByTestId("conversation-target-notice");
+
+        await enterFullscreenOverlay(rerender);
+
+        // The docked composer really is gone — this is what made it a dead end.
+        expect(screen.getByTestId("fullscreen-overlay")).toBeInTheDocument();
+        expect(screen.queryByTestId("chat-input")).not.toBeInTheDocument();
+
+        // ...and the notice moved with it, rather than disappearing.
+        const notice = screen.getByTestId("conversation-target-notice");
+        expect(screen.getByTestId("fullscreen-overlay")).toContainElement(
+          notice,
+        );
+        expect(screen.getByTestId("fullscreen-overlay-send")).toBeDisabled();
+      });
+
+      it("sends from the overlay once its own acknowledgement is used", async () => {
+        // The "gate opens" direction: the overlay is a decision point, not a
+        // trap. Without a reachable control this test cannot even be written.
+        mockUIPlaygroundStore.deviceType = "fill";
+        setHostDisplayMode("fullscreen");
+        const { rerender } = await openRestoredConversation({
+          selectedServers: ["deepwiki"],
+        });
+        await screen.findByTestId("conversation-target-notice");
+        await enterFullscreenOverlay(rerender);
+
+        fireEvent.click(
+          screen.getByTestId("conversation-target-notice-acknowledge"),
+        );
+        await waitFor(() => {
+          expect(
+            screen.queryByTestId("conversation-target-notice"),
+          ).not.toBeInTheDocument();
+        });
+
+        fireEvent.change(screen.getByTestId("fullscreen-overlay-input"), {
+          target: { value: "continue here" },
+        });
+        await waitFor(() => {
+          expect(
+            screen.getByTestId("fullscreen-overlay-send"),
+          ).not.toBeDisabled();
+        });
+        fireEvent.click(screen.getByTestId("fullscreen-overlay-send"));
+
+        await waitFor(() => {
+          expect(mockUseChatSession.sendMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ text: "continue here" }),
+          );
+        });
+      });
+
+      it("pins the acknowledgement over a widget full takeover, which renders no composer at all", async () => {
+        // Mobile/tablet fullscreen hides the footer composer AND forbids the
+        // overlay, yet a widget can still request a follow-up — which the gate
+        // refuses. Nothing on screen would lift it without this.
+        mockUIPlaygroundStore.deviceType = "mobile";
+        setHostDisplayMode("fullscreen");
+        const { rerender } = await openRestoredConversation({
+          selectedServers: ["deepwiki"],
+        });
+        mockUseChatSession.messages = [
+          { id: "m1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        ] as any;
+        await act(async () => {
+          rerender();
+        });
+
+        expect(screen.queryByTestId("chat-input")).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId("fullscreen-overlay"),
+        ).not.toBeInTheDocument();
+
+        const pinned = await screen.findByTestId(
+          "pinned-conversation-target-notice",
+        );
+        expect(pinned).toContainElement(
+          screen.getByTestId("conversation-target-notice"),
+        );
+
+        // A widget follow-up is refused until it is used, and goes through after.
+        const sendFollowUpMessage =
+          mockThread.mock.calls.at(-1)?.[0].sendFollowUpMessage;
+        await act(async () => {
+          sendFollowUpMessage("follow up from a widget");
+        });
+        expect(mockUseChatSession.sendMessage).not.toHaveBeenCalled();
+
+        fireEvent.click(
+          screen.getByTestId("conversation-target-notice-acknowledge"),
+        );
+        await waitFor(() => {
+          expect(
+            screen.queryByTestId("pinned-conversation-target-notice"),
+          ).not.toBeInTheDocument();
+        });
+        await act(async () => {
+          sendFollowUpMessage("follow up from a widget");
+        });
+        await waitFor(() => {
+          expect(mockUseChatSession.sendMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ text: "follow up from a widget" }),
+          );
+        });
+      });
     });
 
     it("names the environment a conversation pinned when the composer points elsewhere", async () => {

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -14,6 +14,7 @@ import { useHostContextStore } from "@/stores/client-context-store";
 import { usePlaygroundChatHistoryBridgeStore } from "@/components/playground/playground-chat-history-bridge";
 import { saveSelectedModelId } from "@/lib/selected-model-storage";
 import { invalidateChatHistoryPrefetch } from "@/components/chat-v2/history/chat-history-prefetch";
+import { useAgentToolPromptBridge } from "@/stores/agent-tool-prompt-bridge";
 
 vi.mock("framer-motion", async (importOriginal) => {
   const actual = await importOriginal<typeof import("framer-motion")>();
@@ -3138,11 +3139,15 @@ describe("PlaygroundMain", () => {
 
     beforeEach(() => {
       invalidateChatHistoryPrefetch();
+      // The bridge is a module-level store; a request left pending by one test
+      // would fire on the next one's first render.
+      useAgentToolPromptBridge.setState({ pending: null });
     });
 
     afterEach(() => {
       window.history.replaceState({}, "", "/");
       invalidateChatHistoryPrefetch();
+      useAgentToolPromptBridge.setState({ pending: null });
     });
 
     it("says nothing about a live chat the user started here", () => {
@@ -3217,6 +3222,99 @@ describe("PlaygroundMain", () => {
       });
 
       expect(mockUseChatSession.sendMessage).not.toHaveBeenCalled();
+    });
+
+    // Every remaining way to start a turn. A gate that only covers the
+    // composer is theatre: each of these reaches `sendMessage`,
+    // `queueBroadcastRequest` or `rewindToMessage` without the composer's
+    // Send button ever being pressed.
+    it("holds a starter chip to the same gate, and keeps its prompt as a draft", async () => {
+      // A chip is a one-click SEND from the empty state — the shortest path of
+      // all to running a reopened conversation on the wrong target.
+      await openRestoredConversation({ selectedServers: ["deepwiki"] });
+      await screen.findByTestId("conversation-target-notice");
+
+      fireEvent.click(screen.getByRole("button", { name: "Starter chip" }));
+      await act(async () => {});
+
+      expect(mockUseChatSession.sendMessage).not.toHaveBeenCalled();
+      // Refused, not discarded: the text is waiting in the composer.
+      expect(screen.getByTestId("chat-input-field")).toHaveValue(
+        "Starter chip prompt",
+      );
+    });
+
+    it("lets the starter chip through once the target is accepted", async () => {
+      // The other half of the gate: it has to open, or the disclosure is a
+      // dead end rather than a decision.
+      await openRestoredConversation({ selectedServers: ["deepwiki"] });
+      await screen.findByTestId("conversation-target-notice");
+
+      fireEvent.click(
+        screen.getByTestId("conversation-target-notice-acknowledge"),
+      );
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("conversation-target-notice"),
+        ).not.toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Starter chip" }));
+
+      await waitFor(() => {
+        expect(mockUseChatSession.sendMessage).toHaveBeenCalledWith(
+          expect.objectContaining({ text: "Starter chip prompt" }),
+        );
+      });
+    });
+
+    it("holds an 'Ask agent to run' prompt to the same gate, and keeps it as a draft", async () => {
+      // The Tools rail requests this send from a sibling subtree through the
+      // bridge store, so a disabled Send button is no protection at all.
+      await openRestoredConversation({ selectedServers: ["deepwiki"] });
+      await screen.findByTestId("conversation-target-notice");
+
+      await act(async () => {
+        useAgentToolPromptBridge
+          .getState()
+          .requestRun("Run read_file on /etc/hosts");
+      });
+      await act(async () => {});
+
+      expect(mockUseChatSession.sendMessage).not.toHaveBeenCalled();
+      expect(screen.getByTestId("chat-input-field")).toHaveValue(
+        "Run read_file on /etc/hosts",
+      );
+    });
+
+    it("will not rewind a reopened conversation, and shows the edit action as unavailable", async () => {
+      // A rewind is a send AND a fork: it would run the edited turn on the
+      // ambient target and mint a branch recording that it did.
+      mockConvexAuthState.isAuthenticated = true;
+      const { rerender } = await openRestoredConversation({
+        selectedServers: ["deepwiki"],
+      });
+      mockUseChatSession.messages = [
+        { id: "1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      ] as any;
+      await act(async () => {
+        rerender(<PlaygroundMain {...defaultProps} syncConversationToUrl />);
+      });
+      await screen.findByTestId("conversation-target-notice");
+
+      // Disabled, not merely inert: the affordance says so before it is used.
+      expect(screen.getByTestId("edit-first-message")).toBeDisabled();
+
+      // And the handler refuses even when invoked directly, which is what the
+      // real `UserMessageRow` does fire-and-forget from its editor.
+      const onEditUserMessage =
+        mockThread.mock.calls.at(-1)?.[0].onEditUserMessage;
+      expect(onEditUserMessage).toBeDefined();
+      await act(async () => {
+        await onEditUserMessage(mockUseChatSession.messages[0], "edited");
+      });
+
+      expect(mockUseChatSession.rewindToMessage).not.toHaveBeenCalled();
     });
 
     it("names the environment a conversation pinned when the composer points elsewhere", async () => {

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -338,12 +338,16 @@ vi.mock("@/components/chat-v2/thread", () => ({
     loadingIndicatorVariant,
     onEditUserMessage,
     editDisabled,
+    sendFollowUpMessage,
   }: {
     messages: any[];
     isLoading: boolean;
     loadingIndicatorVariant?: string;
     onEditUserMessage?: (message: any, text: string) => void;
     editDisabled?: boolean;
+    // Widget-driven follow-ups bypass the composer, so tests need the handler
+    // itself — a rendered button could never stand in for that path.
+    sendFollowUpMessage?: (text: string) => void;
   }) =>
     (() => {
       mockThread({
@@ -352,6 +356,7 @@ vi.mock("@/components/chat-v2/thread", () => ({
         loadingIndicatorVariant,
         onEditUserMessage,
         editDisabled,
+        sendFollowUpMessage,
       });
       return (
         <div data-testid="thread">
@@ -393,6 +398,7 @@ vi.mock("@/components/chat-v2/chat-input", () => ({
     onChangeSkillResults?: (results: unknown[]) => void;
     skillResults?: unknown[];
     onModelSelectorOpenChange?: (open: boolean) => void;
+    notice?: React.ReactNode;
   }) => {
     // Captures the FULL props object (not just the fields this stub renders)
     // so tests can reach into props the rendered markup below never surfaces
@@ -412,6 +418,7 @@ vi.mock("@/components/chat-v2/chat-input", () => ({
       clientSelector,
       onChangeSkillResults,
       skillResults,
+      notice,
     } = props;
     return (
       <form
@@ -424,6 +431,7 @@ vi.mock("@/components/chat-v2/chat-input", () => ({
           onSubmit(e);
         }}
       >
+        {notice}
         <input
           data-testid="chat-input-field"
           value={value}
@@ -938,6 +946,14 @@ describe("PlaygroundMain", () => {
         const bridge = usePlaygroundChatHistoryBridgeStore.getState().bridge;
         await Promise.resolve(bridge?.onSelectThread(session));
       });
+
+      // A rail-opened conversation records no host or environment, so the
+      // composer discloses that and holds the first reply until the user
+      // accepts the target it will actually run on. Accept it here — this test
+      // is about the pre-send SYNC, not about the target disclosure.
+      fireEvent.click(
+        screen.getByTestId("conversation-target-notice-acknowledge")
+      );
 
       // Control: with the sync healthy the send goes through, so the assertions
       // below are about the failure and not about a submit path that never runs.
@@ -3055,6 +3071,162 @@ describe("PlaygroundMain", () => {
         rerender(<PlaygroundMain {...defaultProps} syncConversationToUrl />);
       });
       expect(mockUseChatSession.setSelectedModel).not.toHaveBeenCalled();
+    });
+  });
+  /**
+   * A reopened conversation renders under the viewer's AMBIENT host and
+   * environment — those live in per-project browser storage, not on the
+   * session — so the composer describes the viewer, not the chat. Left
+   * unlabelled that reads as history, and the reply goes to whatever is
+   * selected: a Cursor-harness transcript answering as Claude.
+   */
+  describe("as-run execution target", () => {
+    const RESTORED_SESSION_ID = "restored-target-session";
+
+    const arriveAtRestoredConversation = (
+      resumeConfig: Record<string, unknown>
+    ) => {
+      window.history.replaceState(
+        {},
+        "",
+        `/playground?conversation=${RESTORED_SESSION_ID}`
+      );
+      mockGetChatHistoryDetail.mockResolvedValue({
+        ok: true,
+        session: {
+          _id: "history-restored-target",
+          chatSessionId: RESTORED_SESSION_ID,
+          firstMessagePreview: "what harness are you",
+          status: "active" as const,
+          directVisibility: "private" as const,
+          version: 3,
+          createdAt: 1,
+          updatedAt: 1,
+          lastActivityAt: 1,
+          isPinned: false,
+          manualUnread: false,
+          isUnread: false,
+          messagesBlobUrl: "https://storage.test/blob",
+          resumeConfig,
+        },
+        widgetSnapshots: [],
+      });
+    };
+
+    /**
+     * Open the conversation and let the chat hook adopt its session id, which
+     * is what binds the disclosure to the thread on screen.
+     */
+    const openRestoredConversation = async (
+      resumeConfig: Record<string, unknown>
+    ) => {
+      arriveAtRestoredConversation(resumeConfig);
+      const { rerender } = render(
+        <PlaygroundMain {...defaultProps} syncConversationToUrl />
+      );
+      await waitFor(() => {
+        expect(mockGetChatHistoryDetail).toHaveBeenCalledWith(
+          expect.objectContaining({ chatSessionId: RESTORED_SESSION_ID })
+        );
+      });
+      mockUseChatSession.chatSessionId = RESTORED_SESSION_ID;
+      await act(async () => {
+        rerender(<PlaygroundMain {...defaultProps} syncConversationToUrl />);
+      });
+      return { rerender };
+    };
+
+    beforeEach(() => {
+      invalidateChatHistoryPrefetch();
+    });
+
+    afterEach(() => {
+      window.history.replaceState({}, "", "/");
+      invalidateChatHistoryPrefetch();
+    });
+
+    it("says nothing about a live chat the user started here", () => {
+      render(<PlaygroundMain {...defaultProps} syncConversationToUrl />);
+
+      expect(
+        screen.queryByTestId("conversation-target-notice")
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("chat-submit-button")).not.toBeDisabled();
+    });
+
+    it("discloses that a reopened conversation recorded no target, instead of passing the current selection off as history", async () => {
+      // The shape every `origin: "playground"` row has: prompt/servers, no
+      // host and no environment anywhere on the session.
+      await openRestoredConversation({ selectedServers: ["deepwiki"] });
+
+      const notice = await screen.findByTestId("conversation-target-notice");
+      expect(notice).toHaveAttribute("data-disclosure", "unrecorded");
+      expect(notice.textContent).toContain("As-run configuration unavailable");
+    });
+
+    it("blocks the reply until the user accepts the target it will actually run on", async () => {
+      await openRestoredConversation({ selectedServers: ["deepwiki"] });
+
+      await screen.findByTestId("conversation-target-notice");
+      expect(screen.getByTestId("chat-submit-button")).toBeDisabled();
+
+      fireEvent.click(
+        screen.getByTestId("conversation-target-notice-acknowledge")
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("conversation-target-notice")
+        ).not.toBeInTheDocument();
+      });
+      expect(screen.getByTestId("chat-submit-button")).not.toBeDisabled();
+    });
+
+    it("refuses the send outright, not just the button, while the target is unaccepted", async () => {
+      await openRestoredConversation({ selectedServers: ["deepwiki"] });
+      await screen.findByTestId("conversation-target-notice");
+
+      fireEvent.change(screen.getByTestId("chat-input-field"), {
+        target: { value: "what harness are you" },
+      });
+      fireEvent.submit(screen.getByTestId("chat-input"));
+
+      await act(async () => {});
+      expect(mockUseChatSession.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("holds a widget-driven follow-up to the same gate", async () => {
+      // A widget follow-up bypasses the composer entirely, so a disabled Send
+      // button is no protection: it would be the first thing to run on a
+      // target the transcript never used.
+      const { rerender } = await openRestoredConversation({
+        selectedServers: ["deepwiki"],
+      });
+      mockUseChatSession.messages = [
+        { id: "m1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      ] as any;
+      await act(async () => {
+        rerender(<PlaygroundMain {...defaultProps} syncConversationToUrl />);
+      });
+
+      const sendFollowUpMessage =
+        mockThread.mock.calls.at(-1)?.[0].sendFollowUpMessage;
+      expect(sendFollowUpMessage).toBeDefined();
+      await act(async () => {
+        sendFollowUpMessage("follow up from a widget");
+      });
+
+      expect(mockUseChatSession.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("names the environment a conversation pinned when the composer points elsewhere", async () => {
+      // `resumeConfig.environmentId` is the one execution target that IS
+      // persisted (Agent Playground turns pin it), and the browser ignored it.
+      await openRestoredConversation({ environmentId: "env_recorded" });
+
+      const notice = await screen.findByTestId("conversation-target-notice");
+      expect(notice).toHaveAttribute("data-disclosure", "mismatch");
+      expect(notice.textContent).toContain("env_recorded");
     });
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/conversation-execution-target.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/conversation-execution-target.test.ts
@@ -129,6 +129,23 @@ describe("describeConversationTargetDisclosure", () => {
     });
   });
 
+  it("reports a mismatch when a recorded host is opened with no host selected", () => {
+    // `hostId: null` is the composer's shape when the host picker is empty —
+    // on a cold load, or after the previewed host was deleted. "Nothing
+    // selected" is not the recorded host, so this is a mismatch, not `none`:
+    // treating it as agreement would silently drop the gate exactly where the
+    // composer says the least about where a reply would run.
+    expect(
+      describeConversationTargetDisclosure({
+        recorded: { kind: "host", hostId: "cursor-host" },
+        composer: { kind: "host", hostId: null },
+      }),
+    ).toEqual({
+      kind: "mismatch",
+      recorded: { kind: "host", hostId: "cursor-host" },
+    });
+  });
+
   it("reports a mismatch when the previewed host is not the recorded one", () => {
     expect(
       describeConversationTargetDisclosure({

--- a/mcpjam-inspector/client/src/lib/__tests__/conversation-execution-target.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/conversation-execution-target.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  describeConversationTargetDisclosure,
+  readConversationExecutionTarget,
+} from "../conversation-execution-target";
+
+describe("readConversationExecutionTarget", () => {
+  it("reads the environment a session pinned", () => {
+    expect(
+      readConversationExecutionTarget({
+        resumeConfig: { environmentId: "env_1" },
+      }),
+    ).toEqual({ kind: "environment", environmentId: "env_1" });
+  });
+
+  it("reads a stamped host when there is no environment pin", () => {
+    expect(readConversationExecutionTarget({ hostId: "host_1" })).toEqual({
+      kind: "host",
+      hostId: "host_1",
+    });
+  });
+
+  it("prefers the environment when a row somehow carries both", () => {
+    // An environment IS the execution statement on the wire; a host id beside
+    // it is the environment's resolved host, not a second target.
+    expect(
+      readConversationExecutionTarget({
+        hostId: "host_1",
+        resumeConfig: { environmentId: "env_1" },
+      }),
+    ).toEqual({ kind: "environment", environmentId: "env_1" });
+  });
+
+  it("reports UNRECORDED for a browser Playground session, which pins neither", () => {
+    // This is the shape of every `origin: "playground"` row: `resumeConfig`
+    // carries prompt/temperature/servers and no target field at all.
+    expect(
+      readConversationExecutionTarget({
+        resumeConfig: { environmentId: undefined },
+      }),
+    ).toEqual({ kind: "unrecorded" });
+    expect(readConversationExecutionTarget({})).toEqual({
+      kind: "unrecorded",
+    });
+    expect(readConversationExecutionTarget(null)).toEqual({
+      kind: "unrecorded",
+    });
+  });
+
+  it("treats a blank id as absent rather than as a target that cannot resolve", () => {
+    expect(
+      readConversationExecutionTarget({
+        hostId: "   ",
+        resumeConfig: { environmentId: "" },
+      }),
+    ).toEqual({ kind: "unrecorded" });
+  });
+});
+
+describe("describeConversationTargetDisclosure", () => {
+  it("says nothing when no persisted conversation is open", () => {
+    expect(
+      describeConversationTargetDisclosure({
+        recorded: null,
+        composer: { kind: "host", hostId: "host_1" },
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("says nothing when the composer is on the environment the conversation ran", () => {
+    expect(
+      describeConversationTargetDisclosure({
+        recorded: { kind: "environment", environmentId: "env_1" },
+        composer: { kind: "environment", environmentId: "env_1" },
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("says nothing when the composer is on the host the conversation ran", () => {
+    expect(
+      describeConversationTargetDisclosure({
+        recorded: { kind: "host", hostId: "host_1" },
+        composer: { kind: "host", hostId: "host_1" },
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("reports UNRECORDED rather than letting the ambient selection read as history", () => {
+    expect(
+      describeConversationTargetDisclosure({
+        recorded: { kind: "unrecorded" },
+        composer: { kind: "host", hostId: "cli-box-host" },
+      }),
+    ).toEqual({ kind: "unrecorded" });
+  });
+
+  it("still reports UNRECORDED when nothing is selected either", () => {
+    // "No host selected" is not evidence that the conversation had none.
+    expect(
+      describeConversationTargetDisclosure({
+        recorded: { kind: "unrecorded" },
+        composer: { kind: "host", hostId: null },
+      }),
+    ).toEqual({ kind: "unrecorded" });
+  });
+
+  it("reports a mismatch when the composer points at a different environment", () => {
+    expect(
+      describeConversationTargetDisclosure({
+        recorded: { kind: "environment", environmentId: "env_recorded" },
+        composer: { kind: "environment", environmentId: "env_other" },
+      }),
+    ).toEqual({
+      kind: "mismatch",
+      recorded: { kind: "environment", environmentId: "env_recorded" },
+    });
+  });
+
+  it("reports a mismatch when an environment conversation is opened in host mode", () => {
+    expect(
+      describeConversationTargetDisclosure({
+        recorded: { kind: "environment", environmentId: "env_recorded" },
+        composer: { kind: "host", hostId: "host_1" },
+      }),
+    ).toEqual({
+      kind: "mismatch",
+      recorded: { kind: "environment", environmentId: "env_recorded" },
+    });
+  });
+
+  it("reports a mismatch when the previewed host is not the recorded one", () => {
+    expect(
+      describeConversationTargetDisclosure({
+        recorded: { kind: "host", hostId: "cursor-host" },
+        composer: { kind: "host", hostId: "cli-box-host" },
+      }),
+    ).toEqual({
+      kind: "mismatch",
+      recorded: { kind: "host", hostId: "cursor-host" },
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/web/chat-history-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/chat-history-api.ts
@@ -57,12 +57,33 @@ export interface ResumeConfig {
   modelVisibleMcpToolResults?: ModelVisibleMcpToolResults;
   mcpToolResultImageRendering?: McpToolResultImageRenderingPolicy;
   selectedServers?: string[];
+  /**
+   * The environment this session is PINNED to, written only by the Agent
+   * Playground turn route (`origin: "api"`) and first-write-wins at the ingest
+   * boundary. Browser Playground turns persist no target field at all, so
+   * absence here does NOT mean "ran without an environment" — see
+   * `lib/conversation-execution-target.ts`.
+   */
+  environmentId?: string;
 }
 
+/**
+ * The `/direct-chat/detail` proxy returns the whole `chatSessions` document
+ * spread into `session`, so this interface is a hand-mirror of the fields we
+ * consume — narrower than what arrives. Adding a field here is a read, not a
+ * contract change.
+ */
 export interface ChatHistoryDetailSession extends ChatHistorySession {
   messagesBlobUrl: string | null;
   usedServerIds?: string[];
   resumeConfig?: ResumeConfig;
+  /**
+   * Host attribution stamped at ingest. Present for scenario- and swarm-sourced
+   * rows; the direct-chat read only ever serves `sourceType: "direct"` rows,
+   * which are not stamped today, so treat absence as "unrecorded" rather than
+   * "no host".
+   */
+  hostId?: string;
 }
 
 export interface ChatHistoryWidgetSnapshot {

--- a/mcpjam-inspector/client/src/lib/conversation-execution-target.ts
+++ b/mcpjam-inspector/client/src/lib/conversation-execution-target.ts
@@ -1,0 +1,128 @@
+/**
+ * What a persisted conversation says about the target it ACTUALLY ran on, and
+ * whether the composer currently describes that target or something else.
+ *
+ * ## Why this exists
+ *
+ * Opening `/playground?conversation=<id>` restores the transcript but not the
+ * configuration: the previewed host and the previewed environment are ambient,
+ * per-project browser state (`use-previewed-client-id`,
+ * `use-previewed-environment-id`), so a reopened conversation renders under
+ * whatever the viewer last had selected. The chips read as a statement about
+ * the conversation — "this ran on cli-box-host, Claude Sonnet 5, no
+ * environment" — when they are only a statement about the viewer. A reply typed
+ * there then runs on that ambient target, which is how a Cursor-harness
+ * transcript ends up answering a follow-up as Claude.
+ *
+ * ## What is actually recoverable
+ *
+ * The direct-chat detail read returns the whole `chatSessions` document, so
+ * anything on the row reaches the browser. Of the execution facts:
+ *
+ *   - `modelId` — recorded, and already restored by `loadHistorySession`.
+ *   - `resumeConfig.selectedServers` — recorded, already restored.
+ *   - `resumeConfig.environmentId` — recorded ONLY for `origin: "api"`
+ *     sessions (the Agent Playground turn route pins it; see
+ *     `server/routes/v1/chat-session-turn.ts`). Browser Playground turns write
+ *     a `resumeConfig` that has no target field at all
+ *     (`server/utils/web-chat-turn.ts`).
+ *   - `hostId` — stamped at ingest only for scenario- and swarm-sourced
+ *     sessions, and those are never served by the direct-chat read. Declared
+ *     here anyway so the moment the backend starts stamping it for direct
+ *     chats this module reports it instead of "unrecorded".
+ *
+ * So for the overwhelming majority of Playground conversations the as-run
+ * target is genuinely NOT PERSISTED. This module's job is to keep that fact
+ * distinguishable from "ran on the thing you see", never to invent a value.
+ */
+
+/** The execution target a conversation recorded, if it recorded one. */
+export type ConversationExecutionTarget =
+  | { kind: "environment"; environmentId: string }
+  | { kind: "host"; hostId: string }
+  /** Nothing on the row identifies where this conversation ran. */
+  | { kind: "unrecorded" };
+
+/** The target the composer is currently pointed at. */
+export type ComposerExecutionTarget =
+  | { kind: "environment"; environmentId: string }
+  | { kind: "host"; hostId: string | null };
+
+/**
+ * The narrow slice of the session DTO this derivation reads. Structural on
+ * purpose: the caller passes `ChatHistoryDetailSession`, and a test passes a
+ * literal, without either having to import the other.
+ */
+export interface ConversationExecutionTargetSource {
+  hostId?: string;
+  resumeConfig?: { environmentId?: string };
+}
+
+function nonEmpty(value: string | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Read the recorded target off a persisted session.
+ *
+ * Environment wins over host when both are somehow present: an environment IS
+ * the execution statement on the wire (`normalizeExecutionTarget` refuses a
+ * body carrying both pointers), and a host id sitting beside it would be the
+ * environment's resolved host, not an independent target.
+ */
+export function readConversationExecutionTarget(
+  session: ConversationExecutionTargetSource | null | undefined,
+): ConversationExecutionTarget {
+  const environmentId = nonEmpty(session?.resumeConfig?.environmentId);
+  if (environmentId) return { kind: "environment", environmentId };
+  const hostId = nonEmpty(session?.hostId);
+  if (hostId) return { kind: "host", hostId };
+  return { kind: "unrecorded" };
+}
+
+/**
+ * What the UI owes the user about the open conversation.
+ *
+ *   `none`       — the composer describes this conversation. Say nothing.
+ *   `unrecorded` — the conversation never recorded a target, so the composer
+ *                  cannot be describing it. The controls are the viewer's
+ *                  current selection and must be labelled as such.
+ *   `mismatch`   — the conversation DID record a target and it is not the one
+ *                  selected. A reply would run somewhere else.
+ */
+export type ConversationTargetDisclosure =
+  | { kind: "none" }
+  | { kind: "unrecorded" }
+  | {
+      kind: "mismatch";
+      recorded: Extract<
+        ConversationExecutionTarget,
+        { kind: "environment" } | { kind: "host" }
+      >;
+    };
+
+/**
+ * Compare the conversation's recorded target against the composer's.
+ *
+ * `recorded: null` means "no persisted conversation is open" — a live chat the
+ * user started here, where the composer is the target by construction.
+ */
+export function describeConversationTargetDisclosure(input: {
+  recorded: ConversationExecutionTarget | null;
+  composer: ComposerExecutionTarget;
+}): ConversationTargetDisclosure {
+  const { recorded, composer } = input;
+  if (!recorded) return { kind: "none" };
+  if (recorded.kind === "unrecorded") return { kind: "unrecorded" };
+  if (recorded.kind === "environment") {
+    return composer.kind === "environment" &&
+      composer.environmentId === recorded.environmentId
+      ? { kind: "none" }
+      : { kind: "mismatch", recorded };
+  }
+  return composer.kind === "host" && composer.hostId === recorded.hostId
+    ? { kind: "none" }
+    : { kind: "mismatch", recorded };
+}


### PR DESCRIPTION
## What

Opening a persisted Playground conversation showed the composer with the viewer's **current** host / model / environment / server selections rather than the ones the conversation actually ran under — so a Cursor-harness conversation displayed `cli-box-host` + `Claude Sonnet 5` + `Environment · none`, and a follow-up typed there silently ran on that unrelated target. That is how a real Cursor transcript got mistaken for a Claude one during testing tonight.

## What the client actually had

- **Already restored:** `session.modelId` (`PlaygroundMain.tsx:2340`) and `resumeConfig.selectedServers` (`:2287`).
- **On the wire but silently dropped:** `resumeConfig.environmentId` — persisted by `chat-session-turn.ts:1228`, kept first-write-wins by the backend allowlist, and spread into `/direct-chat/detail`. The client's hand-mirrored `ResumeConfig` type never declared it, so nothing read it. (Only `origin: "api"` sessions write it.)
- **Not persisted at all:** the **host**. `chatSessions.hostId` exists but ingest stamps it only for scenario/swarm rows, and `getDirectSession` only serves `direct` rows. Browser Playground turns build `resumeConfig` from 7 fields, none of them a target. What was displayed instead came from per-project `localStorage` (`use-previewed-client-id.ts`, `use-previewed-environment-id.ts`), which restore never touched. The `data-harness-session` part that would have proven "Cursor" is `transient: true` and never persisted.

## Changes

- **`client/src/lib/conversation-execution-target.ts`** (new, pure) — `readConversationExecutionTarget` → `environment` / `host` / `unrecorded`, and `describeConversationTargetDisclosure` comparing it to the composer's live target → `none` / `unrecorded` / `mismatch`. Environment wins over host (mutually exclusive on the wire); blank ids are absence, not a target.
- **`chat-history-api.ts`** — declares `ResumeConfig.environmentId` and `ChatHistoryDetailSession.hostId`, documented as hand-mirrors.
- **`ConversationTargetNotice.tsx`** (new) — composer banner naming the target a reply *will* use: "as-run configuration unavailable" when unrecorded, or the recorded environment/host on a mismatch. One "Continue here" acknowledgement.
- **`chat-input.tsx`** — one `notice?: ReactNode` slot (six call sites, one insertion point).
- **`PlaygroundMain.tsx`** — `restoredConversation` set only on the two paths that *explicitly* open a conversation (rail click, `?conversation=`), deliberately **not** in `loadHistorySession`, which the reactive Convex refresh also drives and would have gated a chat the user just sent. Scoped to the live `chatSessionId` so a fork/reset retires it. Until acknowledged: `submitDisabled` plus hard refusals in `performComposerSubmit` (Enter, starter chips, eval Quick Run) and `handleSendFollowUp` (widget follow-ups bypass the button entirely).

**Deliberately not done — auto-adopting a recorded environment.** `selectEnvironment` changes `hostedTargetKey`, and the scope-change branch in `use-chat-session.ts:4546` does `setMessages([])` + a new session id — it would wipe the transcript being restored. Adopting needs restore to run after the scope settles.

## Reviewer decision: how strict should this be?

The acknowledgement gate applies to **every** reopened conversation, because none of them record a target today — one extra click on a common path. It is also the only part that actually prevents the reported harm (a reply silently running elsewhere). Dropping `needsConversationTargetAck` from `submitDisabled` and the two send guards makes it disclosure-only; that is a three-line change if you prefer less friction.

A companion PR persists the target for new turns, which makes both the notice and the gate rare rather than universal.

## Tests

- `conversation-execution-target.test.ts` — 13 tests (derivation incl. the browser-Playground shape, blank ids, match and all mismatch cases).
- `PlaygroundMain.test.tsx` new `as-run execution target` block — 6 tests: silent on a live chat; unrecorded disclosure on reopen; send blocked then unblocked; submit refused at the handler not just the button; widget follow-up held to the same gate; recorded environment named on mismatch.
- One existing test now acknowledges before sending — intentional behavior change, commented in place.
- **Results:** ui-playground + chat-v2 + the new lib test → 82 files, 1193 tests passing. `typecheck:client` clean. One unrelated pre-existing failure in `scenario-chat-transcript.test.ts` (untouched file). The two new source files are prettier-clean; the modified files already failed `prettier --check` on main and untouched lines were left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all Playground send paths and reopen flows; wrong gating or disclosure scope could block legitimate sends or still allow silent target mismatches.
> 
> **Overview**
> Reopened Playground chats no longer look like they ran under your **current** host/environment chips. The PR adds honest disclosure when the persisted session’s execution target is **unrecorded** or **doesn’t match** what the composer shows, and blocks the first reply until you click **Continue here**.
> 
> **New behavior:** `conversation-execution-target` reads `resumeConfig.environmentId` and `hostId` from history detail and compares them to the live composer target. `ConversationTargetNotice` explains what a reply would actually run on. `PlaygroundMain` tracks this only when you explicitly open a conversation (history rail or `?conversation=`), not on reactive refresh; acknowledgement is per session and clears on new chat or fork.
> 
> **Send gating** covers every turn entry point—not just Send—including widget follow-ups, starter chips, harness “Ask agent to run”, and message edit/rewind (edit stays disabled). `ChatInput` and `FullscreenChatOverlay` get a shared `notice` slot; widget full takeover pins the same banner when there is no composer.
> 
> **Types:** `chat-history-api` documents `environmentId` and `hostId` on the detail DTO. Auto-switching to a recorded environment is intentionally out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff47ec5c8b8bc2ffdb794738a05acd878c514ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reopened Playground conversations showing your current host/environment selections instead of the target the conversation actually ran under, so a follow-up no longer silently runs on an unrelated host.

- Adds a banner that names the recorded environment or host when it doesn't match your selection, or says "As-run configuration unavailable" when the conversation recorded no target. It's rendered on every surface that can block a send: the docked/centered/compare composers, the fullscreen overlay, and a mobile/tablet widget takeover, which renders no composer at all.
- Blocks the first reply until you acknowledge the target it will run on; every send path is gated — composer submit, widget-driven follow-ups, starter chips, "Ask agent to run" from the Tools rail, and editing a past message.
- Reads `resumeConfig.environmentId` (persisted but previously ignored) and `hostId` (stamped only for scenario/swarm rows) from the session detail.
- Derives the disclosure only on the two explicit open paths (history rail, `?conversation=`), never on the reactive refresh, and scopes it to the live session id so a fork or reset retires it.

<sup>Written for commit ff47ec5c8b8bc2ffdb794738a05acd878c514ccf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

