### PR TITLE
cursor/auto is a sentinel, not a provider — and it is what a Cursor session records

### DIFF
--- a/.changeset/cursor-auto-sentinel-is-not-a-provider.md
+++ b/.changeset/cursor-auto-sentinel-is-not-a-provider.md
@@ -22,24 +22,51 @@ organization`, which reads as a setup mistake the customer could fix. They
 cannot; there is no `cursor` key to configure, and there never will be.
 
 The sentinel is now exempted from provider resolution at one chokepoint,
-`deriveOrgProviderKey`, so all three derivation sites (the web chat rail, the
-local desktop rail, and the synthetic/swarm classifier) refuse it with a sentence
-that says what is actually wrong instead of asking Convex a question about a
-model no provider serves. `resolveSyntheticModelSource` classifies it
-`external-account` — the label that already means "not charged to MCPJam, and no
-configured provider either" — and `resolveTurnRuntime` maps that to the hosted
-runtime shape carrying only the harness, never a `providerKey`. On the public
-sessions API, which has no harness at all, the refusal moved up to
+`deriveOrgProviderKey`. Both rails that derive a key from it — the web chat rail
+and the local desktop rail — now refuse the sentinel with a sentence that says
+what is actually wrong, instead of asking Convex a question about a model no
+provider serves.
+
+The synthetic/swarm classifier answers a different question and gets a different
+answer: `resolveSyntheticModelSource` does not refuse the sentinel, it
+CLASSIFIES it, returning `external-account` — the label that already means "not
+charged to MCPJam, and no configured provider either" — ahead of the key
+derivation, with no `orgRuntime` to reuse. That is what lets a session row carry
+honest attribution for a turn nobody billed.
+
+Classifying it is not the same as running it, and `resolveTurnRuntime` now says
+so out loud: it refuses an `external-account` turn outright rather than handing
+back a runnable runtime. Without a harness the sentinel is unrunnable by
+construction. WITH one it is unrunnable on that surface specifically — an
+external-account runtime authenticates with the customer's own vendor
+credential, `runHarnessTurn` takes that credential only from the caller's
+materialized project secrets, and `runUnifiedAssistantTurn` (the facade every
+caller of the resolver drives) has no `runtimeSecrets` seam at all. Returning a
+"hosted + harness" runtime there advertised a turn that then died inside the
+harness telling the user to add a `CURSOR_API_KEY` secret they may already have
+set. Both refusals land before the caller marks the turn as possibly-spent.
+
+On the public sessions API, which has no harness at all, the refusal moved up to
 `assertUnambiguousModelId`, ahead of the turn lease: the lease is what creates
 the `chatSessions` row, so failing after it left a session that had run on
 nothing.
+
+`resolveHostModelDefinition` also stops asking the org's model config about the
+sentinel. Only an enabled provider that LISTS an id can win there and none can
+list `cursor/auto`, so on a live external-account turn that call was pure
+latency (its lookup carries a 15 s timeout) plus a failure mode, between the
+request and the first token.
 
 The same registration gap made the local `/api/mcp/chat-v2` rail send every
 Cursor host down the org-BYOK branch, so the harness was never reached — the
 preflight would call the host ready and the turn would then fail on a
 configuration error. That rail now takes the external-account exemption the web
 rail already had, and tags the turn `modelSource: 'external-account'` rather than
-`'mcpjam'`, which is what keeps it out of the org's MCPJam spend limit.
+`'mcpjam'`, which is what keeps it out of the org's MCPJam spend limit. The same
+exemption reaches the bearer mint that branch depends on: it was keyed on "MCPJam
+provides this model", so an anonymous Cursor turn arrived at the branch with no
+bearer and answered 503 ("Unable to authenticate with MCPJam servers") before the
+harness ever started, on a host the preflight had just called ready.
 
 Separately, a successful Cursor turn persisted a session that named the wrong
 model, or none. The Playground picker cannot hold `cursor/auto` (it is not a
@@ -53,7 +80,21 @@ provider-key derivation and the harness model gates by design. The host's model
 is now authoritative for an external-account harness on every surface — the
 runtime ignores the body's model, so the sentinel is the only honest record — and
 the chat route validates the model's `id`, not just that a `model` object was
-sent.
+sent (a null, empty or whitespace-only id is a 400 before the engine runs and
+before anything is persisted).
+
+That authority is scoped to a host that actually carries the SENTINEL, because
+the justification is "the host's id is the one honest description of the turn"
+and only the sentinel is that. A host whose harness is external-account but whose
+model is an ordinary id describes nothing that runs either — Cursor ignores it
+and picks its own model — so promoting it over the body would swap one wrong
+model id for another. That host is now a refused configuration rather than a
+silently mis-attributed run: the shared harness gate (`checkHarnessRuntimeAvailable`
+and the dispatch predicate `harnessModelEligibleForRuntime`, which must agree)
+rejects an external-account host that pins a model, naming the id it found so its
+owner can reset it. Where the two model rules were skipped for external-account
+harnesses, this one replaces them — same principle, applied to the arm where the
+runtime does the choosing.
 
 Wherever a model label is rendered, the sentinel now reads "Cursor Auto" rather
 than the raw id, and the Playground shows it locked with the real reason ("this

--- a/.changeset/cursor-auto-sentinel-is-not-a-provider.md
+++ b/.changeset/cursor-auto-sentinel-is-not-a-provider.md
@@ -83,18 +83,39 @@ the chat route validates the model's `id`, not just that a `model` object was
 sent (a null, empty or whitespace-only id is a 400 before the engine runs and
 before anything is persisted).
 
-That authority is scoped to a host that actually carries the SENTINEL, because
-the justification is "the host's id is the one honest description of the turn"
-and only the sentinel is that. A host whose harness is external-account but whose
-model is an ordinary id describes nothing that runs either — Cursor ignores it
-and picks its own model — so promoting it over the body would swap one wrong
-model id for another. That host is now a refused configuration rather than a
-silently mis-attributed run: the shared harness gate (`checkHarnessRuntimeAvailable`
-and the dispatch predicate `harnessModelEligibleForRuntime`, which must agree)
-rejects an external-account host that pins a model, naming the id it found so its
-owner can reset it. Where the two model rules were skipped for external-account
-harnesses, this one replaces them — same principle, applied to the arm where the
-runtime does the choosing.
+A host whose harness is external-account but whose model is an ordinary id is now
+a refused configuration rather than a silently mis-attributed run. Cursor ignores
+whatever id such a host carries, so the turn would run Cursor Auto while the
+session row, the trace and the eval metadata all named that id as the model that
+ran. The shared harness gate refuses it, naming the id it found so its owner can
+reset it. Where the two model rules were skipped for external-account harnesses,
+this one replaces them — same principle, applied to the arm where the runtime
+does the choosing.
+
+Two details of that rule are what make it hold rather than look like it holds.
+
+It is asked of the HOST's configured model, passed to the gate as its own
+`hostModelId` input, and not of the model the turn resolved. Nothing consumes
+the turn's model on this arm, so validating it would let a caller satisfy the
+rule by POSTing `cursor/auto` at a host that pins an ordinary id — the same
+mis-configured host, admitted from the other side. For the same reason the
+host-wins promotion above is unconditional for an external-account harness
+rather than scoped to hosts that already carry the sentinel: narrowing it leaves
+the body's model standing on exactly the hosts that must be refused. (With no
+model pinned at all, the turn's own model is the only description of what the
+host runs, and is held to the rule instead.)
+
+And an ineligible model on this arm now THROWS at the dispatch instead of
+falling back to the emulated engine. `runAssistantTurn` reads a `false` from the
+shared eligibility helper as "run the emulated engine and surface a warning",
+which is right for a brokered harness — that engine runs the refused model
+itself, on org BYOK — and wrong here twice over: the emulated engine cannot run
+a sentinel at all, and the id a mis-configured host carries is one the runtime
+would have ignored. What the fallback produced was worse than the bug the rule
+was added for: a swarm or eval turn that completes, reports success, records
+`executionEngineLabel: harness:cursor`, and never ran Cursor — indistinguishable
+in the transcript from a real run. The interactive rails fail closed at the
+pre-flight; this is the same refusal for the paths that never call it.
 
 Wherever a model label is rendered, the sentinel now reads "Cursor Auto" rather
 than the raw id, and the Playground shows it locked with the real reason ("this

--- a/.changeset/cursor-auto-sentinel-is-not-a-provider.md
+++ b/.changeset/cursor-auto-sentinel-is-not-a-provider.md
@@ -117,6 +117,21 @@ was added for: a swarm or eval turn that completes, reports success, records
 in the transcript from a real run. The interactive rails fail closed at the
 pre-flight; this is the same refusal for the paths that never call it.
 
+Eval is where the host's model was NOT yet authoritative, and the two ends
+disagreed because of it. Admission reads the host's id, so it accepted a case
+whose own model was an ordinary one; execution then carried that case model to
+the dispatch, whose eligibility check saw a non-sentinel on an external-account
+harness and refused a run it had already admitted. A per-case model is normal
+and legitimate in evals — a suite names one per case and is then pointed at a
+host — so this hit ordinary Cursor suites. An eval case on an external-account
+host now runs the host's model, resolved once in `runTestCase` so the canonical
+id, the MCPJam-vs-BYOK split, the org-BYOK lookup, the engine's wire payload and
+what the iteration reports all agree. Promoted rather than refused at admission,
+because the model pickers cannot hold `cursor/auto` — refusing would make every
+Cursor eval suite unrunnable. A host whose model is an ordinary id still
+promotes nothing and is still refused: that is a broken configuration, not a
+case-level choice.
+
 Wherever a model label is rendered, the sentinel now reads "Cursor Auto" rather
 than the raw id, and the Playground shows it locked with the real reason ("this
 host's runtime chooses its own model on your own account") instead of the

--- a/.changeset/cursor-auto-sentinel-is-not-a-provider.md
+++ b/.changeset/cursor-auto-sentinel-is-not-a-provider.md
@@ -1,0 +1,63 @@
+---
+"@mcpjam/inspector": patch
+---
+
+A Cursor CLI host no longer asks for a model-provider key that cannot exist, and its sessions record the model they actually ran
+
+The `cursor-cli` host template seeds `modelId: "cursor/auto"` — a neutral
+sentinel, deliberately not a real provider model. The Cursor CLI has no provider
+routing: it authenticates with a `CURSOR_API_KEY`, every request transits
+Cursor's servers, and the adapter passes no model at all, so Cursor Auto picks
+one on the customer's own account. Seeding a concrete `anthropic/...` was
+rejected precisely because it would put a model id into traces and eval metadata
+that nothing ever ran.
+
+Registering `cursor` as a `ModelProvider` — which is what stops the sentinel
+falling through the bare-id rule and classifying as `ollama` — had a second
+effect nobody asked for: every path that resolves a model through provider
+configuration started treating it as a BYOK provider needing a configured org
+key. A turn sent as `model: "cursor/auto"` came back
+`provider_not_configured: cursor is not enabled for this project/workspace
+organization`, which reads as a setup mistake the customer could fix. They
+cannot; there is no `cursor` key to configure, and there never will be.
+
+The sentinel is now exempted from provider resolution at one chokepoint,
+`deriveOrgProviderKey`, so all three derivation sites (the web chat rail, the
+local desktop rail, and the synthetic/swarm classifier) refuse it with a sentence
+that says what is actually wrong instead of asking Convex a question about a
+model no provider serves. `resolveSyntheticModelSource` classifies it
+`external-account` — the label that already means "not charged to MCPJam, and no
+configured provider either" — and `resolveTurnRuntime` maps that to the hosted
+runtime shape carrying only the harness, never a `providerKey`. On the public
+sessions API, which has no harness at all, the refusal moved up to
+`assertUnambiguousModelId`, ahead of the turn lease: the lease is what creates
+the `chatSessions` row, so failing after it left a session that had run on
+nothing.
+
+The same registration gap made the local `/api/mcp/chat-v2` rail send every
+Cursor host down the org-BYOK branch, so the harness was never reached — the
+preflight would call the host ready and the turn would then fail on a
+configuration error. That rail now takes the external-account exemption the web
+rail already had, and tags the turn `modelSource: 'external-account'` rather than
+`'mcpjam'`, which is what keeps it out of the org's MCPJam spend limit.
+
+Separately, a successful Cursor turn persisted a session that named the wrong
+model, or none. The Playground picker cannot hold `cursor/auto` (it is not a
+selectable entry, so the host-reseed effect skips it), and the host-model
+override was gated on scenario turns only — so the browser sent whatever model
+was last selected and the server recorded it verbatim, attributing the turn to a
+model Cursor never touched. Where the body carried no usable id at all, the row
+was written blank and the session read as having run on nothing: the harness rail
+is the one live path with no downstream model-id check, since it skips both the
+provider-key derivation and the harness model gates by design. The host's model
+is now authoritative for an external-account harness on every surface — the
+runtime ignores the body's model, so the sentinel is the only honest record — and
+the chat route validates the model's `id`, not just that a `model` object was
+sent.
+
+Wherever a model label is rendered, the sentinel now reads "Cursor Auto" rather
+than the raw id, and the Playground shows it locked with the real reason ("this
+host's runtime chooses its own model on your own account") instead of the
+sign-in wall it inherited. The id itself is never rewritten: what traces and eval
+metadata record is still `cursor/auto`, because the whole point of the sentinel
+is that the model is unknown to MCPJam.

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
@@ -3,6 +3,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { useChatSession } from "../use-chat-session";
 import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 import { DEFAULT_SYSTEM_PROMPT } from "@/components/chat-v2/shared/chat-helpers";
+import { GUEST_LOCKED_MODEL_REASON } from "@/components/chat-v2/shared/available-models";
 
 const mockGetToolsMetadata = vi.fn();
 const mockCountTextTokens = vi.fn();
@@ -1187,6 +1188,78 @@ describe("useChatSession minimal mode parity", () => {
     });
     expect(result.current.isAuthReady).toBe(true);
     expect(result.current.disableForAuthentication).toBe(false);
+  });
+
+  /**
+   * A RUNTIME-CHOSEN SENTINEL is locked for a different reason than everything
+   * else the placeholder builder produces, and the copy has to say so.
+   *
+   * `cursor/auto` is never in `availableModels` — it is not a selectable entry
+   * — so a Cursor host's pinned model ALWAYS lands on this fallback. Rendering
+   * it the ordinary way got both halves wrong at once: the label showed a raw
+   * id naming a model nothing ran, under a sign-in wall that signing in would
+   * not lift.
+   */
+  it("renders a runtime-chosen sentinel as its display name, locked for the real reason", async () => {
+    mockModelState.availableModels = [baseModel, mcpJamModel];
+    mockModelState.selectedModelId = mcpJamModel.id;
+    mockConvexAuth.isAuthenticated = false;
+    mockGetAccessToken.mockResolvedValue(null);
+
+    const { result } = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+        minimalMode: true,
+        executionConfig: { systemPrompt: "Prompt", modelId: "cursor/auto" },
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedModel.id).toBe("cursor/auto");
+    });
+
+    expect(result.current.selectedModel).toMatchObject({
+      // The id is NEVER rewritten — it is what the trace and eval metadata
+      // record, and the point of the sentinel is that the model is unknown.
+      id: "cursor/auto",
+      name: "Cursor Auto",
+      disabled: true,
+      disabledReason:
+        "This host's runtime chooses its own model on your own account.",
+    });
+  });
+
+  it("keeps the ordinary sign-in copy for a non-sentinel locked model", async () => {
+    // The control: the sentinel branch is an exception, not a replacement. An
+    // ordinary pinned id absent from `availableModels` still gets the raw id as
+    // its label and the guest sign-in reason.
+    mockModelState.availableModels = [baseModel, mcpJamModel];
+    mockModelState.selectedModelId = mcpJamModel.id;
+    mockConvexAuth.isAuthenticated = false;
+    mockGetAccessToken.mockResolvedValue(null);
+
+    const { result } = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+        minimalMode: true,
+        executionConfig: {
+          systemPrompt: "Prompt",
+          modelId: "anthropic/claude-sonnet-4.5",
+        },
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedModel.id).toBe(
+        "anthropic/claude-sonnet-4.5"
+      );
+    });
+
+    expect(result.current.selectedModel).toMatchObject({
+      name: "anthropic/claude-sonnet-4.5",
+      disabled: true,
+      disabledReason: GUEST_LOCKED_MODEL_REASON,
+    });
   });
 
   // BACK2-628. `setSelectedModel` already refuses to write when a surface

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -70,7 +70,10 @@ import {
 } from "@/components/chat-v2/shared/available-models";
 import { useOutOfCredits } from "@/hooks/useCreditBalance";
 import { isMCPJamGuestAllowedModel } from "@/shared/types";
-import { providerForModelId } from "@/shared/model-provider";
+import {
+  providerForModelId,
+  runtimeChosenModelSentinelName,
+} from "@/shared/model-provider";
 import { useDetectedOllamaModels } from "@/hooks/use-detected-ollama-models";
 import { useHostedModelCatalog } from "@/hooks/use-hosted-model-catalog";
 import { DEFAULT_SYSTEM_PROMPT } from "@/components/chat-v2/shared/chat-helpers";
@@ -708,6 +711,24 @@ function inferModelProviderFromId(modelId: string): ModelProvider {
 }
 
 function createLockedInitialModel(modelId: string): ModelDefinition {
+  // A RUNTIME-CHOSEN SENTINEL is locked for a different reason than everything
+  // else this builds, and the copy has to say so. `cursor/auto` is not a model
+  // the picker is hiding behind a sign-in wall — it is the placeholder for a
+  // runtime that chooses its own model on the customer's own account. Showing
+  // the raw id under "Sign in to use MCPJam provided models" gets both halves
+  // wrong: the label names a model nothing ran, and the reason names a wall
+  // signing in would not lift.
+  const sentinelName = runtimeChosenModelSentinelName(modelId);
+  if (sentinelName) {
+    return {
+      id: modelId,
+      name: sentinelName,
+      provider: inferModelProviderFromId(modelId),
+      disabled: true,
+      disabledReason:
+        "This host's runtime chooses its own model on your own account.",
+    };
+  }
   return {
     id: modelId,
     name: modelId,

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.guest-skills.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.guest-skills.test.ts
@@ -93,9 +93,19 @@ vi.mock("../../../utils/host-runtime-config.js", () => ({
   fetchHostRuntimeConfig: fetchHostRuntimeConfigMock,
 }));
 
-vi.mock("../../../utils/harness/harness-availability.js", () => ({
-  checkHarnessRuntimeAvailable: checkHarnessRuntimeAvailableMock,
-}));
+// Only `checkHarnessRuntimeAvailable` is stubbed. Spreading `actual` is
+// load-bearing, not tidiness: a wholesale replacement makes every OTHER export
+// the route calls `undefined(...)` at runtime — a 500 that looks like a routing
+// bug rather than a missing mock entry.
+vi.mock("../../../utils/harness/harness-availability.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/harness/harness-availability.js")
+  >("../../../utils/harness/harness-availability.js");
+  return {
+    ...actual,
+    checkHarnessRuntimeAvailable: checkHarnessRuntimeAvailableMock,
+  };
+});
 
 vi.mock("../../../utils/built-in-tools/registry.js", () => ({
   resolveHostTools: resolveHostToolsMock,

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.harness.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.harness.test.ts
@@ -5,6 +5,7 @@ const {
   prepareChatV2Mock,
   handleMCPJamFreeChatModelMock,
   fetchHostRuntimeConfigMock,
+  getProductionGuestAuthHeaderMock,
   checkHarnessRuntimeAvailableMock,
   resolveHostToolsMock,
   validateAppToolEntriesMock,
@@ -20,6 +21,7 @@ const {
   prepareChatV2Mock: vi.fn(),
   handleMCPJamFreeChatModelMock: vi.fn(),
   fetchHostRuntimeConfigMock: vi.fn(),
+  getProductionGuestAuthHeaderMock: vi.fn(),
   checkHarnessRuntimeAvailableMock: vi.fn(),
   resolveHostToolsMock: vi.fn(() => ({})),
   validateAppToolEntriesMock: vi.fn(() => []),
@@ -76,6 +78,16 @@ vi.mock("../../../utils/host-runtime-config.js", () => ({
   fetchHostRuntimeConfig: fetchHostRuntimeConfigMock,
 }));
 
+vi.mock("../../../utils/guest-auth.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/guest-auth.js")
+  >("../../../utils/guest-auth.js");
+  return {
+    ...actual,
+    getProductionGuestAuthHeader: getProductionGuestAuthHeaderMock,
+  };
+});
+
 vi.mock("../../../utils/harness/harness-availability.js", () => ({
   checkHarnessRuntimeAvailable: checkHarnessRuntimeAvailableMock,
 }));
@@ -119,6 +131,7 @@ describe("POST /api/mcp/chat-v2 harness host routing", () => {
       },
     });
     checkHarnessRuntimeAvailableMock.mockReturnValue({ ok: true });
+    getProductionGuestAuthHeaderMock.mockResolvedValue("Bearer guest-minted");
     prepareChatV2Mock.mockResolvedValue({
       allTools: {},
       enhancedSystemPrompt: "system",
@@ -237,5 +250,78 @@ describe("POST /api/mcp/chat-v2 harness host routing", () => {
     // (sourced from the runtime config, never the tampered body).
     expect(resolveHostToolsMock).toHaveBeenCalled();
     expect(resolveHostToolsMock.mock.calls[0][0].computer).toBeUndefined();
+  });
+
+  /**
+   * An EXTERNAL-ACCOUNT harness host (Cursor) on the desktop rail.
+   *
+   * Its model is the `cursor/auto` sentinel, deliberately NOT an MCPJam-hosted
+   * model, so `isMcpJamProvidedModel` is false for it — and every "does this
+   * turn take the MCPJam free path?" decision on this route used to be that one
+   * boolean. Exempting only the DISPATCH left the bearer mint behind it,
+   * which turned an anonymous Cursor turn into a 503 on a host the preflight
+   * had just called ready.
+   */
+  describe("external-account harness host (cursor)", () => {
+    const cursorHost = {
+      ok: true,
+      config: {
+        hostId: "host-cursor",
+        modelId: "cursor/auto",
+        systemPrompt: "host system",
+        requireToolApproval: false,
+        selectedServerIds: ["server-id-1"],
+        harness: "cursor",
+      },
+    };
+
+    const postAnonymousCursorTurn = async () => {
+      fetchHostRuntimeConfigMock.mockResolvedValue(cursorHost);
+      const app = createApp();
+      return await app.request("/api/mcp/chat-v2", {
+        method: "POST",
+        // NO Authorization header — the desktop inspector's ordinary state.
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId: "project-1",
+          hostId: "host-cursor",
+          selectedServers: ["server-1"],
+          selectedServerIds: ["server-id-1"],
+          messages: [{ role: "user", content: "create empty.txt" }],
+          // What the picker holds on a Cursor host: an unrelated model, since
+          // the sentinel is not a selectable entry.
+          model: {
+            id: "anthropic/claude-haiku-4.5",
+            provider: "anthropic",
+            name: "Claude Haiku 4.5",
+          },
+        }),
+      });
+    };
+
+    it("mints the guest bearer for an anonymous turn instead of 503-ing", async () => {
+      const response = await postAnonymousCursorTurn();
+
+      expect(response.status).toBe(200);
+      expect(getProductionGuestAuthHeaderMock).toHaveBeenCalled();
+      const engineArgs = handleMCPJamFreeChatModelMock.mock.calls.at(-1)![0];
+      expect(engineArgs.authHeader).toBe("Bearer guest-minted");
+      // The harness ran, on the host's own sentinel — not the browser's pick.
+      expect(engineArgs.harness).toBe("cursor");
+      expect(engineArgs.modelId).toBe("cursor/auto");
+    });
+
+    it("surfaces the mint failure as the 503 it is, not as a silent BYOK fallthrough", async () => {
+      // The bearer is genuinely required by this branch (it persists the
+      // session and authenticates the box reservation), so a failed mint must
+      // still refuse — the fix is about WHICH turns get one, not about running
+      // without.
+      getProductionGuestAuthHeaderMock.mockResolvedValue(null);
+
+      const response = await postAnonymousCursorTurn();
+
+      expect(response.status).toBe(503);
+      expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.harness.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.harness.test.ts
@@ -88,9 +88,19 @@ vi.mock("../../../utils/guest-auth.js", async () => {
   };
 });
 
-vi.mock("../../../utils/harness/harness-availability.js", () => ({
-  checkHarnessRuntimeAvailable: checkHarnessRuntimeAvailableMock,
-}));
+// Only `checkHarnessRuntimeAvailable` is stubbed. Spreading `actual` is
+// load-bearing, not tidiness: a wholesale replacement makes every OTHER export
+// the route calls `undefined(...)` at runtime — a 500 that looks like a routing
+// bug rather than a missing mock entry.
+vi.mock("../../../utils/harness/harness-availability.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/harness/harness-availability.js")
+  >("../../../utils/harness/harness-availability.js");
+  return {
+    ...actual,
+    checkHarnessRuntimeAvailable: checkHarnessRuntimeAvailableMock,
+  };
+});
 
 vi.mock("../../../utils/built-in-tools/registry.js", () => ({
   resolveHostTools: resolveHostToolsMock,

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -24,6 +24,7 @@ import { WEBMCP_INSPECTOR_ENABLED } from "../../config";
 import { fetchScenarioRuntimeConfig } from "../../utils/scenario-runtime-config";
 import { fetchHostRuntimeConfig } from "../../utils/host-runtime-config.js";
 import { checkHarnessRuntimeAvailable } from "../../utils/harness/harness-availability.js";
+import { harnessUsesExternalAccount } from "../../utils/harness/registry.js";
 import {
   handleMCPJamFreeChatModel,
   warnIfChatAbortSignalMissing,
@@ -925,8 +926,17 @@ chatV2.post("/", async (c) => {
     // never the body model: org-only ids (Bedrock, custom:NAME, OpenRouter
     // selections with vendor-prefixed ids) would otherwise inherit the
     // body's provider and route to the wrong runtime.
+    //
+    // Host-wins for a scenario, and ALSO for an EXTERNAL-ACCOUNT harness on any
+    // surface — see the twin gate in `routes/web/chat-v2.ts`. The Cursor
+    // adapter passes no model, so the body's model overrides nothing and only
+    // the host's `cursor/auto` sentinel describes the turn; recording the
+    // browser's leftover pick would attribute the turn to a model that never
+    // ran.
     if (
-      isScenarioSession &&
+      (isScenarioSession ||
+        (resolvedExecution.harness &&
+          harnessUsesExternalAccount(resolvedExecution.harness))) &&
       hostRuntimeConfig &&
       model &&
       resolvedExecution.modelId &&
@@ -1004,6 +1014,24 @@ chatV2.post("/", async (c) => {
       modelDefinition.id &&
       isHostedCatalogModel(modelDefinition.id, modelDefinition.provider),
     );
+    // …OR an EXTERNAL-ACCOUNT harness, whose host carries a sentinel model
+    // (`cursor/auto`) that is deliberately not MCPJam-hosted. Same exemption
+    // `streamWebChatTurn` makes, for the same reason: without it a Cursor host
+    // on this rail passes the harness preflight above and then falls into the
+    // org-BYOK branch, which asks the org config for a `cursor` provider key
+    // that cannot exist — so the harness never runs and the user sees a
+    // configuration error for a host the product just called ready.
+    //
+    // Kept separate from `isMcpJamProvidedModel` rather than folded into it:
+    // that name means "MCPJam pays for this model", and an external-account
+    // turn is precisely the case where it does not. The two facts differ, so
+    // the values do too — `modelSource` below reads this one.
+    const isExternalAccountHarnessTurn = Boolean(
+      resolvedExecution.harness &&
+        harnessUsesExternalAccount(resolvedExecution.harness),
+    );
+    const usesMcpjamFreePath =
+      isMcpJamProvidedModel || isExternalAccountHarnessTurn;
     // Guests may use any hosted model — model curation for guests is gone;
     // the backend enforces spend caps (a soft postpaid guard), not an
     // allowlist. A guest MCPJam-model request still gets its bearer minted
@@ -1533,8 +1561,9 @@ chatV2.post("/", async (c) => {
         })
       : undefined;
 
-    // MCPJam-provided models: delegate to stream handler
-    if (isMcpJamProvidedModel && modelDefinition.id) {
+    // MCPJam-provided models — and external-account harness turns, which carry
+    // a sentinel model id instead of a hosted one — delegate to stream handler
+    if (usesMcpjamFreePath && modelDefinition.id) {
       if (!process.env.CONVEX_HTTP_URL) {
         return c.json(
           { error: "Server missing CONVEX_HTTP_URL configuration" },
@@ -1646,7 +1675,13 @@ chatV2.post("/", async (c) => {
               return await persistChatSessionToConvex({
                 chatSessionId,
                 modelId: String(modelDefinition.id),
-                modelSource: "mcpjam",
+                // `'external-account'` rather than `'mcpjam'` when the runtime
+                // pays on the customer's own vendor account: `'mcpjam'` is what
+                // makes a turn consume the org's MCPJam spend limit, and this
+                // turn spent none of it.
+                modelSource: isExternalAccountHarnessTurn
+                  ? "external-account"
+                  : "mcpjam",
                 sourceType: chatSessionSourceType,
                 origin: chatSessionOrigin,
                 ...(!isScenarioSession && body.rewind

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -25,7 +25,6 @@ import { fetchScenarioRuntimeConfig } from "../../utils/scenario-runtime-config"
 import { fetchHostRuntimeConfig } from "../../utils/host-runtime-config.js";
 import { checkHarnessRuntimeAvailable } from "../../utils/harness/harness-availability.js";
 import { harnessUsesExternalAccount } from "../../utils/harness/registry.js";
-import { isRuntimeChosenModelSentinel } from "@/shared/model-provider";
 import {
   handleMCPJamFreeChatModel,
   warnIfChatAbortSignalMissing,
@@ -935,15 +934,15 @@ chatV2.post("/", async (c) => {
     // browser's leftover pick would attribute the turn to a model that never
     // ran.
     //
-    // …and only when the host carries the SENTINEL, matching the web rail: a
-    // Cursor host holding an ordinary id describes nothing that runs either, so
-    // promoting it would swap one wrong id for another. That host is refused by
-    // the harness preflight below.
+    // Unconditional for such a harness, matching the web rail: narrowing it to
+    // a host that carries the sentinel would leave the BODY's model standing on
+    // a mis-configured host, and the body's model is what the harness pre-flight
+    // below would then validate — a caller could satisfy the rule by sending
+    // `cursor/auto` while the host held an ordinary id.
     if (
       (isScenarioSession ||
         (resolvedExecution.harness &&
-          harnessUsesExternalAccount(resolvedExecution.harness) &&
-          isRuntimeChosenModelSentinel(resolvedExecution.modelId))) &&
+          harnessUsesExternalAccount(resolvedExecution.harness))) &&
       hostRuntimeConfig &&
       model &&
       resolvedExecution.modelId &&
@@ -1144,6 +1143,13 @@ chatV2.post("/", async (c) => {
           id: String(modelDefinition.id),
           provider: modelDefinition.provider,
         },
+        // The HOST's own configured id, kept separate from the resolved model
+        // above. Only the external-account rule reads it, and only that rule
+        // should: it asks whether this HOST carries the runtime's sentinel, a
+        // question a request body must not be able to answer.
+        ...(resolvedExecution.modelId
+          ? { hostModelId: resolvedExecution.modelId }
+          : {}),
         // Fail closed rather than let a harness turn bypass the host's
         // enterprise-managed policy: the harness proxy token carries no
         // host, so that route can't enforce it (see the flag's docstring).

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -23,7 +23,10 @@ import { logger } from "../../utils/logger";
 import { WEBMCP_INSPECTOR_ENABLED } from "../../config";
 import { fetchScenarioRuntimeConfig } from "../../utils/scenario-runtime-config";
 import { fetchHostRuntimeConfig } from "../../utils/host-runtime-config.js";
-import { checkHarnessRuntimeAvailable } from "../../utils/harness/harness-availability.js";
+import {
+  checkHarnessRuntimeAvailable,
+  externalAccountHostModelRefusalReason,
+} from "../../utils/harness/harness-availability.js";
 import { harnessUsesExternalAccount } from "../../utils/harness/registry.js";
 import {
   handleMCPJamFreeChatModel,
@@ -934,11 +937,32 @@ chatV2.post("/", async (c) => {
     // browser's leftover pick would attribute the turn to a model that never
     // ran.
     //
-    // Unconditional for such a harness, matching the web rail: narrowing it to
-    // a host that carries the sentinel would leave the BODY's model standing on
-    // a mis-configured host, and the body's model is what the harness pre-flight
-    // below would then validate — a caller could satisfy the rule by sending
-    // `cursor/auto` while the host held an ordinary id.
+    // Unconditional for such a harness, matching the web rail: the refusal
+    // directly above has already established that this host carries the
+    // sentinel, so there is nothing left for a narrowing here to decide.
+    // FAIL FAST on a mis-configured external-account host, BEFORE the promotion
+    // below resolves anything. `resolveHostModelDefinition` asks the org's
+    // model config about an id it cannot possibly list, on a call carrying a
+    // 15 s timeout — and this host is going to be refused by the harness
+    // pre-flight further down regardless. Deciding it here keeps the same
+    // refusal (one shared sentence, one rule) and pays nothing for it.
+    //
+    // The pre-flight's own copy of the rule stays: it is the gate every surface
+    // shares, and this is a shortcut in front of it, not a replacement.
+    if (resolvedExecution.harness) {
+      const hostModelRefusal = externalAccountHostModelRefusalReason({
+        harnessId: resolvedExecution.harness,
+        modelId: resolvedExecution.modelId ?? String(model?.id ?? ""),
+      });
+      if (hostModelRefusal) {
+        return c.json(
+          {
+            error: `This host runs the ${resolvedExecution.harness} harness, which isn't available: ${hostModelRefusal}.`,
+          },
+          503,
+        );
+      }
+    }
     if (
       (isScenarioSession ||
         (resolvedExecution.harness &&

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -25,6 +25,7 @@ import { fetchScenarioRuntimeConfig } from "../../utils/scenario-runtime-config"
 import { fetchHostRuntimeConfig } from "../../utils/host-runtime-config.js";
 import { checkHarnessRuntimeAvailable } from "../../utils/harness/harness-availability.js";
 import { harnessUsesExternalAccount } from "../../utils/harness/registry.js";
+import { isRuntimeChosenModelSentinel } from "@/shared/model-provider";
 import {
   handleMCPJamFreeChatModel,
   warnIfChatAbortSignalMissing,
@@ -933,10 +934,16 @@ chatV2.post("/", async (c) => {
     // the host's `cursor/auto` sentinel describes the turn; recording the
     // browser's leftover pick would attribute the turn to a model that never
     // ran.
+    //
+    // …and only when the host carries the SENTINEL, matching the web rail: a
+    // Cursor host holding an ordinary id describes nothing that runs either, so
+    // promoting it would swap one wrong id for another. That host is refused by
+    // the harness preflight below.
     if (
       (isScenarioSession ||
         (resolvedExecution.harness &&
-          harnessUsesExternalAccount(resolvedExecution.harness))) &&
+          harnessUsesExternalAccount(resolvedExecution.harness) &&
+          isRuntimeChosenModelSentinel(resolvedExecution.modelId))) &&
       hostRuntimeConfig &&
       model &&
       resolvedExecution.modelId &&
@@ -1038,7 +1045,15 @@ chatV2.post("/", async (c) => {
     // lazily below (resolveMcpJamAuthHeader).
     let mcpJamAuthHeader = requestAuthHeader;
     const resolveMcpJamAuthHeader = async () => {
-      if (mcpJamAuthHeader || !isMcpJamProvidedModel) return mcpJamAuthHeader;
+      // Keyed on the FREE-PATH predicate, not on "MCPJam provides this model".
+      // An external-account harness turn takes the same branch below and needs
+      // the same bearer for everything that branch does with it — persisting
+      // the session, reserving the box, fetching runtime config. Gating the
+      // mint on `isMcpJamProvidedModel` left an anonymous Cursor turn holding
+      // `undefined` and 503-ing on "Unable to authenticate with MCPJam
+      // servers" before the harness ever started, on a host the preflight had
+      // just called ready.
+      if (mcpJamAuthHeader || !usesMcpjamFreePath) return mcpJamAuthHeader;
       try {
         mcpJamAuthHeader = (await getProductionGuestAuthHeader()) ?? undefined;
       } catch {
@@ -1051,7 +1066,7 @@ chatV2.post("/", async (c) => {
     // it before tool prep too, otherwise host-enabled built-ins are omitted
     // even though the later MCPJam model path can authenticate the turn.
     if (
-      isMcpJamProvidedModel &&
+      usesMcpjamFreePath &&
       !mcpJamAuthHeader &&
       process.env.CONVEX_HTTP_URL
     ) {

--- a/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
@@ -512,6 +512,23 @@ describe("assertUnambiguousModelId", () => {
       expect(() => assertUnambiguousModelId(id)).toThrow();
     }
   });
+
+  it("rejects a runtime-chosen sentinel, which is unambiguous and still unrunnable here", () => {
+    // `cursor/auto` has an explicit provider prefix, so the ambiguity rule
+    // above waves it through. It still names no model this route can run —
+    // there is no harness on this surface — and asking the org-provider config
+    // about it answered `provider_not_configured: cursor`, i.e. "configure a
+    // key" for a provider that has no keys.
+    //
+    // Rejecting HERE and not later is load-bearing: everything downstream runs
+    // after `claimTurnLease`, which CREATES the session row before the model is
+    // resolved. A turn that dies after the claim leaves a row whose `modelId`
+    // was never written — a session that reads as having run on nothing.
+    expect(() => assertUnambiguousModelId("cursor/auto")).toThrow(
+      /Cursor Auto/,
+    );
+    expect(() => assertUnambiguousModelId("  cursor/auto  ")).toThrow();
+  });
 });
 
 // ── Tool policy ─────────────────────────────────────────────────────────────

--- a/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
+++ b/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
@@ -53,7 +53,10 @@ import { z } from "zod";
 import type { ConvexHttpClient } from "convex/browser";
 import type { MCPClientManager } from "@mcpjam/sdk";
 import type { ModelMessage, ToolSet } from "ai";
-import { MODEL_ID_PREFIX_TO_PROVIDER } from "@/shared/model-provider";
+import {
+  MODEL_ID_PREFIX_TO_PROVIDER,
+  runtimeChosenModelSentinelName,
+} from "@/shared/model-provider";
 import { isBedrockModelId, type ModelProvider } from "@/shared/types";
 import { ErrorCode, WebRouteError, parseWithSchema } from "../web/errors.js";
 import { createManualHostedConnection } from "../web/auth.js";
@@ -245,6 +248,28 @@ function releaseTurnSlot(key: string): void {
  */
 function assertUnambiguousModelId(modelId: string): void {
   const id = modelId.trim();
+  // A RUNTIME-CHOSEN SENTINEL is unambiguous and still unrunnable HERE. This
+  // route has no harness — the runtime that would pick the model cannot be
+  // reached from it — so `cursor/auto` names nothing this surface can execute.
+  //
+  // Refused at this line, and not one line later, on purpose: everything below
+  // is downstream of `claimTurnLease`, which CREATES the `chatSessions` row
+  // (`newSession: { projectId }`) before the model is resolved. A turn that
+  // dies after the claim leaves a session row whose `modelId` was never
+  // written — blank in the sessions list, a session that looks like it ran on
+  // nothing. Failing before the claim means no row is minted at all.
+  //
+  // The sentinel is deliberately NOT rewritten into some real model: the whole
+  // point of it is that the model is unknown to MCPJam.
+  const sentinelName = runtimeChosenModelSentinelName(id);
+  if (sentinelName) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      `modelId "${modelId}" (${sentinelName}) is a placeholder for a runtime that chooses its own model on your own account, not a model this API can run. It only has meaning on a host whose harness provides that runtime. Send a real provider-prefixed model id instead.`,
+      { reason: "MODEL_NOT_RUNNABLE" },
+    );
+  }
   if (id.startsWith("custom:") || isBedrockModelId(id)) return;
   const slashIdx = id.indexOf("/");
   if (

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
@@ -93,9 +93,19 @@ vi.mock("../../../utils/scenario-runtime-config.js", async () => {
 // delivery kill switch, computers data plane) that a unit test process has
 // none of. Those gates are covered by harness-availability's own tests; here we
 // only care about which skill set reaches which engine.
-vi.mock("../../../utils/harness/harness-availability.js", () => ({
-  checkHarnessRuntimeAvailable: () => ({ ok: true }),
-}));
+// Only `checkHarnessRuntimeAvailable` is stubbed. Spreading `actual` is
+// load-bearing, not tidiness: a wholesale replacement makes every OTHER export
+// the route calls `undefined(...)` at runtime — a 500 that looks like a routing
+// bug rather than a missing mock entry.
+vi.mock("../../../utils/harness/harness-availability.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/harness/harness-availability.js")
+  >("../../../utils/harness/harness-availability.js");
+  return {
+    ...actual,
+    checkHarnessRuntimeAvailable: () => ({ ok: true }),
+  };
+});
 
 vi.mock("../apps.js", () => ({ default: new Hono() }));
 

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -1501,25 +1501,27 @@ describe("web routes — chat-v2 hosted mode", () => {
 
     /**
      * The mis-configured host — an external-account harness whose model is an
-     * ordinary id — reaches the SHARED harness pre-flight, which refuses it.
-     * That refusal is asserted against the real gate in
+     * ordinary id. It is refused, and refused EARLY: before the host model is
+     * resolved (a Convex org-model-config call carrying a 15 s timeout) and
+     * before the shared pre-flight it would fail anyway.
+     *
+     * The refusal itself is asserted against the real gate in
      * `harness/__tests__/harness-availability.test.ts`; the pre-flight is
-     * stubbed here, so what these two assert is the input it is handed. Getting
-     * that input wrong is how the rule gets bypassed.
+     * stubbed `{ ok: true }` here, which is what makes these two tests sharp —
+     * a 503 can only be the route's own early check, and a call to the stub is
+     * proof the early check did NOT fire.
      */
-    it("hands the pre-flight the HOST's model, promoted over the body's", async () => {
-      // The promotion is unconditional for an external-account harness — NOT
-      // narrowed to hosts that carry the sentinel. Narrowing it leaves the
-      // body's model standing on a mis-configured host, and the body's model is
-      // then what the gate sees.
-      fetchHostRuntimeConfigMock.mockResolvedValue({
-        ok: true,
-        config: {
-          selectedServerIds: ["server-1"],
-          modelId: "anthropic/claude-sonnet-4.5",
-          harness: "cursor",
-        },
-      });
+    const misconfiguredCursorHost = {
+      ok: true,
+      config: {
+        selectedServerIds: ["server-1"],
+        modelId: "anthropic/claude-sonnet-4.5",
+        harness: "cursor",
+      },
+    };
+
+    it("refuses a mis-configured host before resolving its model", async () => {
+      fetchHostRuntimeConfigMock.mockResolvedValue(misconfiguredCursorHost);
       const { app, token } = createWebTestApp();
 
       const response = await postJson(
@@ -1540,33 +1542,27 @@ describe("web routes — chat-v2 hosted mode", () => {
         token
       );
 
-      expect(response.status).toBe(200);
-      expect(checkHarnessRuntimeAvailableMock).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          model: expect.objectContaining({
-            id: "anthropic/claude-sonnet-4.5",
-          }),
-          hostModelId: "anthropic/claude-sonnet-4.5",
-        })
-      );
+      expect(response.status).toBe(503);
+      const body = (await response.json()) as { error?: { message?: string } };
+      expect(JSON.stringify(body)).toContain("chooses its own model");
+      // The id its owner has to fix, named in the refusal.
+      expect(JSON.stringify(body)).toContain("anthropic/claude-sonnet-4.5");
+      // EARLY: the pre-flight sits after the model resolution, so reaching it
+      // would mean the 15 s org-config call had already been paid for.
+      expect(checkHarnessRuntimeAvailableMock).not.toHaveBeenCalled();
+      expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+      expect(persistChatSessionToConvexMock).not.toHaveBeenCalled();
     });
 
     it("a body-supplied sentinel cannot stand in for the host's own model", async () => {
       // The bypass this closes: POST `cursor/auto` at a host that pins an
-      // ordinary id, and the gate — reading the turn's model — would see the
-      // sentinel and admit the turn. The host's id has to reach the gate as the
-      // host's id, both as the promoted model and under `hostModelId`.
-      fetchHostRuntimeConfigMock.mockResolvedValue({
-        ok: true,
-        config: {
-          selectedServerIds: ["server-1"],
-          modelId: "anthropic/claude-sonnet-4.5",
-          harness: "cursor",
-        },
-      });
+      // ordinary id. Every check on this rail has to read the HOST's id —
+      // nothing consumes the turn's model on an external-account harness, so a
+      // rule held to the body's model is a rule a caller can satisfy.
+      fetchHostRuntimeConfigMock.mockResolvedValue(misconfiguredCursorHost);
       const { app, token } = createWebTestApp();
 
-      await postJson(
+      const response = await postJson(
         app,
         "/api/web/chat-v2",
         {
@@ -1580,13 +1576,46 @@ describe("web routes — chat-v2 hosted mode", () => {
         token
       );
 
+      expect(response.status).toBe(503);
+      expect(JSON.stringify(await response.json())).toContain(
+        "anthropic/claude-sonnet-4.5"
+      );
+      expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+      expect(persistChatSessionToConvexMock).not.toHaveBeenCalled();
+    });
+
+    it("hands the pre-flight the sentinel host's id under `hostModelId`", async () => {
+      // The correctly configured host runs, and the gate is told which id is
+      // the HOST's — the input the external-account rule reads, and the one a
+      // request body must never be able to supply.
+      fetchHostRuntimeConfigMock.mockResolvedValue(cursorHost);
+      const { app, token } = createWebTestApp();
+
+      const response = await postJson(
+        app,
+        "/api/web/chat-v2",
+        {
+          projectId: "project-1",
+          selectedServerIds: ["server-1"],
+          hostId: "host-cursor",
+          chatSessionId: "chat-cursor-6",
+          messages: [{ role: "user", content: "preview request" }],
+          model: {
+            id: "anthropic/claude-haiku-4.5",
+            provider: "anthropic",
+            name: "Haiku",
+          },
+        },
+        token
+      );
+
+      expect(response.status).toBe(200);
       expect(checkHarnessRuntimeAvailableMock).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          hostModelId: "anthropic/claude-sonnet-4.5",
+          // Promoted: the host's model, not the body's.
+          model: expect.objectContaining({ id: "cursor/auto" }),
+          hostModelId: "cursor/auto",
         })
-      );
-      expect(checkHarnessRuntimeAvailableMock).not.toHaveBeenLastCalledWith(
-        expect.objectContaining({ hostModelId: "cursor/auto" })
       );
     });
   });

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 
 const {
+  checkHarnessRuntimeAvailableMock,
   prepareChatV2Mock,
   listCloudRuntimeSkillsMock,
   handleMCPJamFreeChatModelMock,
@@ -20,6 +21,7 @@ const {
   buildWidgetModelContextSystemPromptMock,
   WidgetModelContextValidationErrorMock,
 } = vi.hoisted(() => ({
+  checkHarnessRuntimeAvailableMock: vi.fn(() => ({ ok: true })),
   prepareChatV2Mock: vi.fn(),
   listCloudRuntimeSkillsMock: vi.fn(),
   handleMCPJamFreeChatModelMock: vi.fn(),
@@ -131,6 +133,21 @@ vi.mock("../../../utils/host-runtime-config.js", () => ({
   fetchHostRuntimeConfig: fetchHostRuntimeConfigMock,
 }));
 
+// Only the PREFLIGHT is stubbed, and only so a harness-typed host can reach the
+// dispatch in a unit test (the real gate needs a computers data plane). Every
+// other export stays real — `harnessModelEligibleForRuntime` in particular,
+// which is the shared eligibility answer the dispatch reads.
+vi.mock("../../../utils/harness/harness-availability.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/harness/harness-availability.js")
+  >("../../../utils/harness/harness-availability.js");
+  return {
+    ...actual,
+    checkHarnessRuntimeAvailable: (...args: unknown[]) =>
+      checkHarnessRuntimeAvailableMock(...(args as [])),
+  };
+});
+
 vi.mock("../../../utils/scenario-runtime-config.js", async () => {
   const actual = await vi.importActual<
     typeof import("../../../utils/scenario-runtime-config.js")
@@ -179,6 +196,7 @@ describe("web routes — chat-v2 hosted mode", () => {
     vi.clearAllMocks();
     process.env.CONVEX_HTTP_URL = "https://example.convex.site";
 
+    checkHarnessRuntimeAvailableMock.mockReturnValue({ ok: true });
     prepareChatV2Mock.mockResolvedValue({
       allTools: {},
       enhancedSystemPrompt: "system",
@@ -1311,6 +1329,159 @@ describe("web routes — chat-v2 hosted mode", () => {
       // `{ kind: "none" }` here would take those down with the project's.
       const args = prepareChatV2Mock.mock.calls.at(-1)![0];
       expect(args.skillsSource).toBeUndefined();
+    });
+  });
+
+  /**
+   * The Cursor CLI host seeds `modelId: "cursor/auto"` — a neutral sentinel.
+   * The adapter passes NO model (`toNativeModel: () => undefined`) and Cursor
+   * Auto picks one on the customer's own account, so the sentinel is the only
+   * honest thing a Cursor turn can record.
+   *
+   * It could not survive the round trip. The Playground picker cannot hold the
+   * sentinel (it is not in `availableModels`), so the browser sent whatever
+   * model was last selected, and the non-scenario host-model override refused
+   * to correct it — leaving the session row naming a model the turn never
+   * touched, or nothing at all.
+   */
+  describe("an external-account harness host records ITS OWN model", () => {
+    const cursorHost = {
+      ok: true,
+      config: {
+        selectedServerIds: ["server-1"],
+        modelId: "cursor/auto",
+        harness: "cursor",
+      },
+    };
+
+    it("persists the host's cursor/auto sentinel, not the browser's leftover pick", async () => {
+      fetchHostRuntimeConfigMock.mockResolvedValue(cursorHost);
+      const { app, token } = createWebTestApp();
+
+      const response = await postJson(
+        app,
+        "/api/web/chat-v2",
+        {
+          projectId: "project-1",
+          selectedServerIds: ["server-1"],
+          hostId: "host-cursor",
+          chatSessionId: "chat-cursor-1",
+          messages: [{ role: "user", content: "preview request" }],
+          // What the picker actually holds on a Cursor host: an unrelated
+          // model, because the sentinel is not a selectable entry.
+          model: {
+            id: "anthropic/claude-haiku-4.5",
+            provider: "anthropic",
+            name: "Haiku",
+          },
+        },
+        token
+      );
+
+      expect(response.status).toBe(200);
+      expect(persistChatSessionToConvexMock).toHaveBeenCalledTimes(1);
+      const persisted = persistChatSessionToConvexMock.mock.calls.at(-1)![0];
+      // The sentinel — never blank, and never the Haiku id that nothing ran.
+      expect(persisted.modelId).toBe("cursor/auto");
+      // And not billed to MCPJam: the turn ran on the customer's Cursor account.
+      expect(persisted.modelSource).toBe("external-account");
+      expect(persisted.hostConfig?.modelId).toBe("cursor/auto");
+    });
+
+    it("routes the turn to the harness instead of demanding an org `cursor` provider key", async () => {
+      fetchHostRuntimeConfigMock.mockResolvedValue(cursorHost);
+      const { app, token } = createWebTestApp();
+
+      const response = await postJson(
+        app,
+        "/api/web/chat-v2",
+        {
+          projectId: "project-1",
+          selectedServerIds: ["server-1"],
+          hostId: "host-cursor",
+          chatSessionId: "chat-cursor-2",
+          messages: [{ role: "user", content: "preview request" }],
+          model: {
+            id: "anthropic/claude-haiku-4.5",
+            provider: "anthropic",
+            name: "Haiku",
+          },
+        },
+        token
+      );
+
+      // `cursor/auto` is not an MCPJam-hosted model, so without the
+      // external-account exemption this turn takes the org-BYOK branch and
+      // asks Convex for a `cursor` provider key — which answers
+      // `provider_not_configured: cursor`.
+      expect(response.status).toBe(200);
+      expect(handleMCPJamFreeChatModelMock).toHaveBeenCalledTimes(1);
+      const engineArgs = handleMCPJamFreeChatModelMock.mock.calls.at(-1)![0];
+      expect(engineArgs.harness).toBe("cursor");
+      expect(engineArgs.modelId).toBe("cursor/auto");
+    });
+
+    it("leaves a NON-harness host's model to the body, as before", async () => {
+      // The exemption is scoped to external-account harnesses. A Playground
+      // preview of an ordinary host must keep letting the owner's in-session
+      // model choice win — that is the whole point of `override-wins`.
+      fetchHostRuntimeConfigMock.mockResolvedValue({
+        ok: true,
+        config: {
+          selectedServerIds: ["server-1"],
+          modelId: "openai/gpt-5-mini",
+        },
+      });
+      const { app, token } = createWebTestApp();
+
+      const response = await postJson(
+        app,
+        "/api/web/chat-v2",
+        {
+          projectId: "project-1",
+          selectedServerIds: ["server-1"],
+          hostId: "host-plain",
+          chatSessionId: "chat-plain-1",
+          messages: [{ role: "user", content: "preview request" }],
+          model: {
+            id: "anthropic/claude-haiku-4.5",
+            provider: "anthropic",
+            name: "Haiku",
+          },
+        },
+        token
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = persistChatSessionToConvexMock.mock.calls.at(-1)![0];
+      expect(persisted.modelId).toBe("anthropic/claude-haiku-4.5");
+    });
+
+    it("refuses a body whose model carries no id, rather than persisting a blank one", async () => {
+      // The harness rail is the one live path with no downstream model-id
+      // check (it skips both `deriveOrgProviderKey` and the harness model
+      // gates), so an id-less body used to run a whole turn and write
+      // `String(undefined)` / `""` into the session row.
+      fetchHostRuntimeConfigMock.mockResolvedValue(cursorHost);
+      const { app, token } = createWebTestApp();
+
+      const response = await postJson(
+        app,
+        "/api/web/chat-v2",
+        {
+          projectId: "project-1",
+          selectedServerIds: ["server-1"],
+          hostId: "host-cursor",
+          chatSessionId: "chat-cursor-3",
+          messages: [{ role: "user", content: "preview request" }],
+          model: { provider: "anthropic", name: "Haiku" },
+        },
+        token
+      );
+
+      expect(response.status).toBe(400);
+      expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+      expect(persistChatSessionToConvexMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -1457,12 +1457,71 @@ describe("web routes — chat-v2 hosted mode", () => {
       expect(persisted.modelId).toBe("anthropic/claude-haiku-4.5");
     });
 
-    it("refuses a body whose model carries no id, rather than persisting a blank one", async () => {
-      // The harness rail is the one live path with no downstream model-id
-      // check (it skips both `deriveOrgProviderKey` and the harness model
-      // gates), so an id-less body used to run a whole turn and write
-      // `String(undefined)` / `""` into the session row.
-      fetchHostRuntimeConfigMock.mockResolvedValue(cursorHost);
+    // Every shape a browser can actually put in `model.id`. `model` arrives
+    // through an unvalidated body cast (`hostedChatSchema` does not describe
+    // it), so `ModelDefinition.id` being REQUIRED in TypeScript says nothing
+    // about what was posted — and the harness rail is the one live path with no
+    // downstream model-id check (it skips both `deriveOrgProviderKey` and the
+    // harness model gates), so an unusable id used to run a whole turn and
+    // write `String(undefined)` / `""` into the session row.
+    //
+    // The assertion that matters is not the 400 but WHEN: before the engine and
+    // before any persist, so a rejected turn leaves no trace of a session that
+    // ran on nothing.
+    it.each([
+      ["missing", { provider: "anthropic", name: "Haiku" }],
+      ["null", { id: null, provider: "anthropic", name: "Haiku" }],
+      ["empty", { id: "", provider: "anthropic", name: "Haiku" }],
+      ["whitespace-only", { id: "   ", provider: "anthropic", name: "Haiku" }],
+    ])(
+      "refuses a body whose model id is %s, before running or persisting anything",
+      async (label, model) => {
+        fetchHostRuntimeConfigMock.mockResolvedValue(cursorHost);
+        const { app, token } = createWebTestApp();
+
+        const response = await postJson(
+          app,
+          "/api/web/chat-v2",
+          {
+            projectId: "project-1",
+            selectedServerIds: ["server-1"],
+            hostId: "host-cursor",
+            chatSessionId: `chat-cursor-invalid-${label}`,
+            messages: [{ role: "user", content: "preview request" }],
+            model,
+          },
+          token
+        );
+
+        expect(response.status).toBe(400);
+        expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+        expect(persistChatSessionToConvexMock).not.toHaveBeenCalled();
+      }
+    );
+
+    it("does not promote a host model that is NOT the sentinel", async () => {
+      // The host-wins exception is justified by one fact — the host's id is the
+      // only honest description of a Cursor turn — and that fact holds only for
+      // the sentinel. A Cursor host pinned to an ordinary id describes nothing
+      // that runs either (the adapter passes no model regardless), so promoting
+      // it would swap one wrong model id for another and call it a fix.
+      //
+      // Such a host is a broken configuration, and the SHARED harness preflight
+      // refuses it outright — that refusal is asserted directly, against the
+      // real gate, in `harness/__tests__/harness-availability.test.ts`
+      // ("refuses an external-account host that pins an ORDINARY model id");
+      // the preflight is stubbed here so this test can see the gate underneath
+      // it. What this asserts is that the gate hands the preflight the id it
+      // was actually given, rather than laundering the host's wrong one in
+      // first.
+      fetchHostRuntimeConfigMock.mockResolvedValue({
+        ok: true,
+        config: {
+          selectedServerIds: ["server-1"],
+          modelId: "anthropic/claude-sonnet-4.5",
+          harness: "cursor",
+        },
+      });
       const { app, token } = createWebTestApp();
 
       const response = await postJson(
@@ -1471,17 +1530,26 @@ describe("web routes — chat-v2 hosted mode", () => {
         {
           projectId: "project-1",
           selectedServerIds: ["server-1"],
-          hostId: "host-cursor",
-          chatSessionId: "chat-cursor-3",
+          hostId: "host-cursor-misconfigured",
+          chatSessionId: "chat-cursor-4",
           messages: [{ role: "user", content: "preview request" }],
-          model: { provider: "anthropic", name: "Haiku" },
+          model: {
+            id: "anthropic/claude-haiku-4.5",
+            provider: "anthropic",
+            name: "Haiku",
+          },
         },
         token
       );
 
-      expect(response.status).toBe(400);
-      expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
-      expect(persistChatSessionToConvexMock).not.toHaveBeenCalled();
+      expect(response.status).toBe(200);
+      expect(checkHarnessRuntimeAvailableMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          model: expect.objectContaining({ id: "anthropic/claude-haiku-4.5" }),
+        })
+      );
+      const persisted = persistChatSessionToConvexMock.mock.calls.at(-1)![0];
+      expect(persisted.modelId).toBe("anthropic/claude-haiku-4.5");
     });
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -1499,21 +1499,19 @@ describe("web routes — chat-v2 hosted mode", () => {
       }
     );
 
-    it("does not promote a host model that is NOT the sentinel", async () => {
-      // The host-wins exception is justified by one fact — the host's id is the
-      // only honest description of a Cursor turn — and that fact holds only for
-      // the sentinel. A Cursor host pinned to an ordinary id describes nothing
-      // that runs either (the adapter passes no model regardless), so promoting
-      // it would swap one wrong model id for another and call it a fix.
-      //
-      // Such a host is a broken configuration, and the SHARED harness preflight
-      // refuses it outright — that refusal is asserted directly, against the
-      // real gate, in `harness/__tests__/harness-availability.test.ts`
-      // ("refuses an external-account host that pins an ORDINARY model id");
-      // the preflight is stubbed here so this test can see the gate underneath
-      // it. What this asserts is that the gate hands the preflight the id it
-      // was actually given, rather than laundering the host's wrong one in
-      // first.
+    /**
+     * The mis-configured host — an external-account harness whose model is an
+     * ordinary id — reaches the SHARED harness pre-flight, which refuses it.
+     * That refusal is asserted against the real gate in
+     * `harness/__tests__/harness-availability.test.ts`; the pre-flight is
+     * stubbed here, so what these two assert is the input it is handed. Getting
+     * that input wrong is how the rule gets bypassed.
+     */
+    it("hands the pre-flight the HOST's model, promoted over the body's", async () => {
+      // The promotion is unconditional for an external-account harness — NOT
+      // narrowed to hosts that carry the sentinel. Narrowing it leaves the
+      // body's model standing on a mis-configured host, and the body's model is
+      // then what the gate sees.
       fetchHostRuntimeConfigMock.mockResolvedValue({
         ok: true,
         config: {
@@ -1545,11 +1543,51 @@ describe("web routes — chat-v2 hosted mode", () => {
       expect(response.status).toBe(200);
       expect(checkHarnessRuntimeAvailableMock).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          model: expect.objectContaining({ id: "anthropic/claude-haiku-4.5" }),
+          model: expect.objectContaining({
+            id: "anthropic/claude-sonnet-4.5",
+          }),
+          hostModelId: "anthropic/claude-sonnet-4.5",
         })
       );
-      const persisted = persistChatSessionToConvexMock.mock.calls.at(-1)![0];
-      expect(persisted.modelId).toBe("anthropic/claude-haiku-4.5");
+    });
+
+    it("a body-supplied sentinel cannot stand in for the host's own model", async () => {
+      // The bypass this closes: POST `cursor/auto` at a host that pins an
+      // ordinary id, and the gate — reading the turn's model — would see the
+      // sentinel and admit the turn. The host's id has to reach the gate as the
+      // host's id, both as the promoted model and under `hostModelId`.
+      fetchHostRuntimeConfigMock.mockResolvedValue({
+        ok: true,
+        config: {
+          selectedServerIds: ["server-1"],
+          modelId: "anthropic/claude-sonnet-4.5",
+          harness: "cursor",
+        },
+      });
+      const { app, token } = createWebTestApp();
+
+      await postJson(
+        app,
+        "/api/web/chat-v2",
+        {
+          projectId: "project-1",
+          selectedServerIds: ["server-1"],
+          hostId: "host-cursor-misconfigured",
+          chatSessionId: "chat-cursor-5",
+          messages: [{ role: "user", content: "preview request" }],
+          model: { id: "cursor/auto", provider: "cursor", name: "Cursor Auto" },
+        },
+        token
+      );
+
+      expect(checkHarnessRuntimeAvailableMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          hostModelId: "anthropic/claude-sonnet-4.5",
+        })
+      );
+      expect(checkHarnessRuntimeAvailableMock).not.toHaveBeenLastCalledWith(
+        expect.objectContaining({ hostModelId: "cursor/auto" })
+      );
     });
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.scenario-environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.scenario-environment.test.ts
@@ -92,9 +92,19 @@ vi.mock("../../../utils/scenario-runtime-config.js", async () => {
   };
 });
 
-vi.mock("../../../utils/harness/harness-availability.js", () => ({
-  checkHarnessRuntimeAvailable: () => ({ ok: true }),
-}));
+// Only `checkHarnessRuntimeAvailable` is stubbed. Spreading `actual` is
+// load-bearing, not tidiness: a wholesale replacement makes every OTHER export
+// the route calls `undefined(...)` at runtime — a 500 that looks like a routing
+// bug rather than a missing mock entry.
+vi.mock("../../../utils/harness/harness-availability.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/harness/harness-availability.js")
+  >("../../../utils/harness/harness-availability.js");
+  return {
+    ...actual,
+    checkHarnessRuntimeAvailable: () => ({ ok: true }),
+  };
+});
 
 vi.mock("../apps.js", () => ({ default: new Hono() }));
 

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.scenario-sandbox.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.scenario-sandbox.test.ts
@@ -139,9 +139,19 @@ vi.mock("../../../utils/built-in-tools/bash.js", async () => {
   return { ...actual, buildBashTool: buildBashToolMock };
 });
 
-vi.mock("../../../utils/harness/harness-availability.js", () => ({
-  checkHarnessRuntimeAvailable: () => ({ ok: true }),
-}));
+// Only `checkHarnessRuntimeAvailable` is stubbed. Spreading `actual` is
+// load-bearing, not tidiness: a wholesale replacement makes every OTHER export
+// the route calls `undefined(...)` at runtime — a 500 that looks like a routing
+// bug rather than a missing mock entry.
+vi.mock("../../../utils/harness/harness-availability.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/harness/harness-availability.js")
+  >("../../../utils/harness/harness-availability.js");
+  return {
+    ...actual,
+    checkHarnessRuntimeAvailable: () => ({ ok: true }),
+  };
+});
 
 vi.mock("../apps.js", () => ({ default: new Hono() }));
 

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -84,7 +84,10 @@ import {
 } from "../../utils/effective-auth.js";
 import { resolveXaaIssuer } from "../../services/xaa-mint.js";
 import { type ExecutionScope } from "../../utils/execution-scope.js";
-import { checkHarnessRuntimeAvailable } from "../../utils/harness/harness-availability.js";
+import {
+  checkHarnessRuntimeAvailable,
+  externalAccountHostModelRefusalReason,
+} from "../../utils/harness/harness-availability.js";
 import { harnessUsesExternalAccount } from "../../utils/harness/registry.js";
 import { harnessSupportsSkills } from "../../utils/harness/registry.js";
 import { normalizeExecutionTarget } from "@/shared/execution-target";
@@ -765,17 +768,37 @@ chatV2.post("/", async (c) => {
     // exists.
     //
     // UNCONDITIONAL for such a harness — deliberately NOT narrowed to a host
-    // that carries the sentinel. Narrowing it looks safer (why promote an id
-    // that is also wrong?) and is the opposite: it leaves the BODY's model
-    // standing on a mis-configured host, and the body's model is what the
-    // harness pre-flight below then validates. A caller could satisfy the
-    // sentinel rule by POSTing `cursor/auto` while the host itself carried an
-    // ordinary id. Promote first, always, and let the pre-flight refuse the
-    // host on what the host actually holds.
+    // that carries the sentinel. It does not need to be: by the time the
+    // promotion runs, the refusal directly below has already established that
+    // this host carries one. Narrowing it as well would only invite the reader
+    // to wonder which of the two decides, and would leave the BODY's model
+    // standing if the refusal were ever moved.
     const externalAccountHarnessTurn = Boolean(
       resolvedExecution.harness &&
         harnessUsesExternalAccount(resolvedExecution.harness),
     );
+    // FAIL FAST on a mis-configured external-account host, BEFORE the promotion
+    // below resolves anything. `resolveHostModelDefinition` asks the org's
+    // model config about an id it cannot possibly list, on a call carrying a
+    // 15 s timeout — and this host is going to be refused by the harness
+    // pre-flight further down regardless. Deciding it here keeps the same
+    // refusal (one shared sentence, one rule) and pays nothing for it.
+    //
+    // The pre-flight's own copy of the rule stays: it is the gate every surface
+    // shares, and this is a shortcut in front of it, not a replacement.
+    if (resolvedExecution.harness) {
+      const hostModelRefusal = externalAccountHostModelRefusalReason({
+        harnessId: resolvedExecution.harness,
+        modelId: resolvedExecution.modelId ?? String(modelDefinition.id),
+      });
+      if (hostModelRefusal) {
+        throw new WebRouteError(
+          503,
+          ErrorCode.INTERNAL_ERROR,
+          `This host runs the ${resolvedExecution.harness} harness, which isn't available: ${hostModelRefusal}.`,
+        );
+      }
+    }
     if (
       (isScenarioSession || externalAccountHarnessTurn) &&
       hostRuntimeConfig &&

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -87,7 +87,6 @@ import { type ExecutionScope } from "../../utils/execution-scope.js";
 import { checkHarnessRuntimeAvailable } from "../../utils/harness/harness-availability.js";
 import { harnessUsesExternalAccount } from "../../utils/harness/registry.js";
 import { harnessSupportsSkills } from "../../utils/harness/registry.js";
-import { isRuntimeChosenModelSentinel } from "@/shared/model-provider";
 import { normalizeExecutionTarget } from "@/shared/execution-target";
 import { createConvexClient } from "../../services/evals/route-helpers.js";
 import {
@@ -765,18 +764,17 @@ chatV2.post("/", async (c) => {
     // the turn never touched. Recording the sentinel is the whole reason it
     // exists.
     //
-    // Scoped to a host that actually carries the SENTINEL, not to every
-    // external-account harness. The justification above is "the host's id is
-    // the one honest description of the turn", and that is only true of the
-    // sentinel — a Cursor host holding an ordinary `anthropic/...` id describes
-    // nothing that runs, so promoting it over the body would swap one wrong
-    // model id for another. Such a host is a broken configuration and the
-    // harness preflight below refuses it outright; this gate simply declines to
-    // launder it first.
+    // UNCONDITIONAL for such a harness — deliberately NOT narrowed to a host
+    // that carries the sentinel. Narrowing it looks safer (why promote an id
+    // that is also wrong?) and is the opposite: it leaves the BODY's model
+    // standing on a mis-configured host, and the body's model is what the
+    // harness pre-flight below then validates. A caller could satisfy the
+    // sentinel rule by POSTing `cursor/auto` while the host itself carried an
+    // ordinary id. Promote first, always, and let the pre-flight refuse the
+    // host on what the host actually holds.
     const externalAccountHarnessTurn = Boolean(
       resolvedExecution.harness &&
-        harnessUsesExternalAccount(resolvedExecution.harness) &&
-        isRuntimeChosenModelSentinel(resolvedExecution.modelId),
+        harnessUsesExternalAccount(resolvedExecution.harness),
     );
     if (
       (isScenarioSession || externalAccountHarnessTurn) &&
@@ -843,6 +841,13 @@ chatV2.post("/", async (c) => {
           id: String(modelDefinition.id),
           provider: modelDefinition.provider,
         },
+        // The HOST's own configured id, kept separate from the resolved model
+        // above. Only the external-account rule reads it, and only that rule
+        // should: it asks whether this HOST carries the runtime's sentinel, a
+        // question a request body must not be able to answer.
+        ...(resolvedExecution.modelId
+          ? { hostModelId: resolvedExecution.modelId }
+          : {}),
         // Fail closed rather than let a harness turn bypass the host's
         // enterprise-managed policy: the harness proxy token carries no
         // host, so that route can't enforce it (see the flag's docstring).

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -87,6 +87,7 @@ import { type ExecutionScope } from "../../utils/execution-scope.js";
 import { checkHarnessRuntimeAvailable } from "../../utils/harness/harness-availability.js";
 import { harnessUsesExternalAccount } from "../../utils/harness/registry.js";
 import { harnessSupportsSkills } from "../../utils/harness/registry.js";
+import { isRuntimeChosenModelSentinel } from "@/shared/model-provider";
 import { normalizeExecutionTarget } from "@/shared/execution-target";
 import { createConvexClient } from "../../services/evals/route-helpers.js";
 import {
@@ -763,9 +764,19 @@ chatV2.post("/", async (c) => {
     // what the transcript, the trace and eval metadata then recorded — a model
     // the turn never touched. Recording the sentinel is the whole reason it
     // exists.
+    //
+    // Scoped to a host that actually carries the SENTINEL, not to every
+    // external-account harness. The justification above is "the host's id is
+    // the one honest description of the turn", and that is only true of the
+    // sentinel — a Cursor host holding an ordinary `anthropic/...` id describes
+    // nothing that runs, so promoting it over the body would swap one wrong
+    // model id for another. Such a host is a broken configuration and the
+    // harness preflight below refuses it outright; this gate simply declines to
+    // launder it first.
     const externalAccountHarnessTurn = Boolean(
       resolvedExecution.harness &&
-        harnessUsesExternalAccount(resolvedExecution.harness),
+        harnessUsesExternalAccount(resolvedExecution.harness) &&
+        isRuntimeChosenModelSentinel(resolvedExecution.modelId),
     );
     if (
       (isScenarioSession || externalAccountHarnessTurn) &&

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -85,6 +85,7 @@ import {
 import { resolveXaaIssuer } from "../../services/xaa-mint.js";
 import { type ExecutionScope } from "../../utils/execution-scope.js";
 import { checkHarnessRuntimeAvailable } from "../../utils/harness/harness-availability.js";
+import { harnessUsesExternalAccount } from "../../utils/harness/registry.js";
 import { harnessSupportsSkills } from "../../utils/harness/registry.js";
 import { normalizeExecutionTarget } from "@/shared/execution-target";
 import { createConvexClient } from "../../services/evals/route-helpers.js";
@@ -279,7 +280,19 @@ chatV2.post("/", async (c) => {
     }
 
     let modelDefinition = model;
-    if (!modelDefinition) {
+    // The ID, not just the object. `model` arrives through an unvalidated body
+    // cast (`hostedChatSchema` does not describe it), and `ModelDefinition.id`
+    // being REQUIRED in TypeScript says nothing about what a browser posted.
+    //
+    // An id-less body used to reach the persist as `String(undefined)` /
+    // `String("")` — a session row that names a model nothing ran, or names
+    // nothing at all and reads blank in the sessions list. It survived that far
+    // only on the harness rail: every other path eventually derives an org
+    // provider key and 400s, while an external-account harness turn skips both
+    // the provider derivation AND the harness model gates by design. So the one
+    // rail with no downstream id check is exactly the one that persisted a
+    // blank. Check it once, here, for all of them.
+    if (!modelDefinition || !String(modelDefinition.id ?? "").trim()) {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
@@ -734,8 +747,28 @@ chatV2.post("/", async (c) => {
     // never the body model: org-only ids (Bedrock, custom:NAME, OpenRouter
     // selections with vendor-prefixed ids) would otherwise inherit the
     // body's provider and route to the wrong runtime.
+    //
+    // Host-wins for a scenario (a share-link client must not re-route the
+    // session), and ALSO for an EXTERNAL-ACCOUNT harness on any surface —
+    // including a Playground preview, where the body normally wins.
+    //
+    // That exception is not a preference, it is honesty about what ran. The
+    // Cursor adapter passes NO model (`toNativeModel: () => undefined`); the
+    // runtime picks one on the customer's own account. So the body's model is
+    // not an override of anything — nothing consumes it — while the host's
+    // `cursor/auto` sentinel is the one value that describes the turn. The
+    // Playground picker cannot even hold that sentinel (it is not in
+    // `availableModels`, so the host-reseed effect skips it), which left the
+    // browser sending whatever unrelated model was last selected; that id is
+    // what the transcript, the trace and eval metadata then recorded — a model
+    // the turn never touched. Recording the sentinel is the whole reason it
+    // exists.
+    const externalAccountHarnessTurn = Boolean(
+      resolvedExecution.harness &&
+        harnessUsesExternalAccount(resolvedExecution.harness),
+    );
     if (
-      isScenarioSession &&
+      (isScenarioSession || externalAccountHarnessTurn) &&
       hostRuntimeConfig &&
       resolvedExecution.modelId &&
       resolvedExecution.modelId !== modelDefinition.id
@@ -753,6 +786,7 @@ chatV2.post("/", async (c) => {
           body: modelDefinition.id,
           host: hostModelId,
           provider: hostModel.provider,
+          externalAccountHarness: externalAccountHarnessTurn,
         },
       );
       modelDefinition = hostModel;

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -156,6 +156,7 @@ import {
 } from "./evals/tool-policy-gate.js";
 import type { BenchmarkWriteGuard } from "./evals/artifact-ledger.js";
 import { buildStageAuthoredCase } from "./evals/stage-inputs.js";
+import { resolveEvalCaseModelDefinition } from "./evals/harness-admission.js";
 import {
   createRunSetupObserver,
   type RunSetupObserver,
@@ -2189,7 +2190,22 @@ const executeTestCase = async (params: {
     return outcomes;
   }
 
-  const modelDefinition = buildModelDefinition(test);
+  // THE HOST'S MODEL WINS on an external-account harness, exactly as it does on
+  // the chat rails. Resolved here rather than at either iteration runner so
+  // everything downstream of this line agrees on one model: the canonical id
+  // below, the MCPJam-vs-BYOK split, the org-BYOK runtime lookup, the engine's
+  // wire payload and what the iteration reports as the model it ran.
+  //
+  // Without it, admission and execution disagreed. Admission reads the host's
+  // id and accepts a case whose own model is an ordinary one; execution then
+  // carried that case model to `runAssistantTurn`, whose eligibility check saw
+  // a non-sentinel on an external-account harness and refused a run it had
+  // already admitted. A per-case model is normal in evals, so that refusal hit
+  // legitimate Cursor suites.
+  const modelDefinition = resolveEvalCaseModelDefinition({
+    hostConfig: suiteHostConfig,
+    caseModel: buildModelDefinition(test),
+  });
   const resolvedModelId = getCanonicalModelId(
     String(modelDefinition.id),
     modelDefinition.provider

--- a/mcpjam-inspector/server/services/evals/__tests__/harness-admission.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/harness-admission.test.ts
@@ -7,7 +7,10 @@ import {
   executionEngineLabel,
   harnessOfHostConfig,
   hasSelectedMcpServersForAdmission,
+  resolveEvalCaseModelDefinition,
 } from "../harness-admission";
+import { harnessModelEligibleForRuntime } from "../../../utils/harness/harness-availability";
+import { getHarnessAdapter } from "../../../utils/harness/registry";
 
 /**
  * The gate that stops a harness-hosted eval run from silently executing on the
@@ -602,5 +605,116 @@ describe("checkEvalExecutionAdmission", () => {
     expect(verdict.reason).toContain("bash");
     expect(verdict.reason).not.toContain("web_search");
     expect(verdict.reason.match(/bash/g)).toHaveLength(2); // named twice in one sentence pair
+  });
+});
+
+/**
+ * ADMISSION AND EXECUTION HAVE TO AGREE, and on an external-account host they
+ * did not: admission reads the HOST's id (a per-case model cannot answer
+ * "does this host carry the runtime's sentinel?"), then execution carried the
+ * CASE's model to the dispatch, whose eligibility check saw a non-sentinel on
+ * an external-account harness and refused a run it had already admitted.
+ *
+ * A per-case model is normal and legitimate in evals — a suite names one per
+ * case and is then pointed at a host — so that refusal hit ordinary Cursor
+ * suites. The seam is closed by making the host's model authoritative in eval
+ * execution too, the way it already is on the chat rails.
+ */
+describe("external-account hosts: the host's model is what an eval case runs", () => {
+  const cursorHost = { harness: "cursor", modelId: "cursor/auto" };
+  const caseModel = {
+    id: "anthropic/claude-haiku-4.5",
+    name: "Haiku",
+    provider: "anthropic" as const,
+  };
+
+  it("promotes the host's sentinel over the case's own model", () => {
+    const resolved = resolveEvalCaseModelDefinition({
+      hostConfig: cursorHost,
+      caseModel,
+    });
+
+    expect(resolved.id).toBe("cursor/auto");
+    // Carries the curated label and the registered provider, not a re-derived
+    // guess — the same definition the swarm runner builds for a pinned target.
+    expect(resolved.name).toBe("Cursor Auto");
+    expect(resolved.provider).toBe("cursor");
+  });
+
+  it("admits that case AND leaves it dispatchable — the two ends now agree", () => {
+    // The end this test exists for. Admission accepting while the dispatch
+    // refuses is the disagreement; asserting only the first half is what let it
+    // through.
+    expect(
+      checkEvalHarnessAdmission({
+        hostConfig: cursorHost,
+        serverIds: ["s1"],
+        cases: [
+          {
+            title: "a",
+            model: caseModel.id,
+            provider: caseModel.provider,
+          },
+        ],
+      })
+    ).toEqual({ ok: true, harness: "cursor" });
+
+    const resolved = resolveEvalCaseModelDefinition({
+      hostConfig: cursorHost,
+      caseModel,
+    });
+    expect(
+      harnessModelEligibleForRuntime({
+        adapter: getHarnessAdapter("cursor"),
+        modelId: String(resolved.id),
+        provider: resolved.provider,
+      })
+    ).toBe(true);
+  });
+
+  it("leaves a BROKERED harness host's case model alone", () => {
+    // The promotion is keyed on `modelAccess`, not on "the host runs a CLI". A
+    // Claude Code suite's per-case model is the model that actually runs.
+    expect(
+      resolveEvalCaseModelDefinition({
+        hostConfig: { harness: "claude-code", modelId: "openai/gpt-5-mini" },
+        caseModel,
+      }).id
+    ).toBe(caseModel.id);
+  });
+
+  it("leaves a non-harness host's case model alone", () => {
+    expect(
+      resolveEvalCaseModelDefinition({
+        hostConfig: { hostStyle: "mcpjam", modelId: "openai/gpt-5-mini" },
+        caseModel,
+      }).id
+    ).toBe(caseModel.id);
+    expect(
+      resolveEvalCaseModelDefinition({ hostConfig: null, caseModel }).id
+    ).toBe(caseModel.id);
+  });
+
+  it("does NOT promote a mis-configured external-account host's ordinary id", () => {
+    // Promoting it would launder a broken configuration into the run record.
+    // Admission refuses this host on its own id instead.
+    const misconfigured = {
+      harness: "cursor",
+      modelId: "anthropic/claude-sonnet-4.5",
+    };
+    expect(
+      resolveEvalCaseModelDefinition({ hostConfig: misconfigured, caseModel })
+        .id
+    ).toBe(caseModel.id);
+
+    const verdict = checkEvalHarnessAdmission({
+      hostConfig: misconfigured,
+      serverIds: ["s1"],
+      cases: [{ title: "a", model: caseModel.id, provider: caseModel.provider }],
+    });
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      expect(verdict.reason).toContain("anthropic/claude-sonnet-4.5");
+    }
   });
 });

--- a/mcpjam-inspector/server/services/evals/harness-admission.ts
+++ b/mcpjam-inspector/server/services/evals/harness-admission.ts
@@ -241,6 +241,11 @@ export function checkEvalHarnessStaticAdmission(args: {
     // rules rather than fail on a model nobody named: `checkModelEligibility`
     // below owns that decision once the run's cases are known.
     model: { id: hostModelId ?? "" },
+    // The same id again, under the name the external-account rule reads. It is
+    // not redundant on the FULL check below, where `model` becomes a per-case
+    // model and this stays the host's — an external-account host must carry the
+    // sentinel whatever a case asks for.
+    ...(hostModelId ? { hostModelId } : {}),
     // Same tri-state read the swarm gate makes: `invalid` is treated exactly
     // like `on`, because a malformed enterprise policy must never be MORE
     // permissive than a valid one.
@@ -299,6 +304,12 @@ export function checkEvalHarnessAdmission(args: {
   const xaaEnterprisePolicyOn =
     readXaaEnterprisePolicy(hostConfig.mcpProfile).kind !== "off";
   const requireToolApproval = hostConfig.requireToolApproval === true;
+  // Read once for the external-account rule below. Absent ⇒ the host pinned no
+  // model, and the gate holds the case's own model to the rule instead.
+  const fullCheckHostModelId =
+    typeof hostConfig.modelId === "string" && hostConfig.modelId.trim()
+      ? hostConfig.modelId.trim()
+      : undefined;
 
   // Model-bearing cases only. A model-free case runs pinned tool calls with no
   // runtime at all, so gating it on model eligibility would refuse a suite for
@@ -328,6 +339,10 @@ export function checkEvalHarnessAdmission(args: {
           id: String(test.model),
           ...(test.provider ? { provider: test.provider } : {}),
         },
+        // The HOST's id, not the case's: the external-account rule is about
+        // this host carrying the runtime's sentinel, and a case model can no
+        // more answer that than a request body can.
+        ...(fullCheckHostModelId ? { hostModelId: fullCheckHostModelId } : {}),
         xaaEnterprisePolicyOn,
       });
       verdict = availability.ok

--- a/mcpjam-inspector/server/services/evals/harness-admission.ts
+++ b/mcpjam-inspector/server/services/evals/harness-admission.ts
@@ -42,6 +42,9 @@ import {
   type HarnessUnavailableKind,
 } from "../../utils/harness/harness-availability.js";
 import { getHarnessAdapter } from "../../utils/harness/registry.js";
+import { isRuntimeChosenModelSentinel } from "@/shared/model-provider";
+import { buildSyntheticModelDefinition } from "../../utils/org-model-config.js";
+import type { ModelDefinition } from "@/shared/types";
 
 /**
  * `ok` means the run may proceed. `harness` is present when a harness was
@@ -197,6 +200,48 @@ function harnessCannotObserveWidgetsReason(
  * refuse on the surface today — a caller inlining the `serverIds`-only half is
  * the bug this exists to prevent.
  */
+/**
+ * The model an eval case ACTUALLY runs on — the host's, whenever the host runs
+ * an external-account harness that carries a runtime-chosen sentinel.
+ *
+ * A per-case model is normal and legitimate in evals: a suite names a model per
+ * case and is then pointed at a host. On an external-account host that model is
+ * consumed by nothing — Cursor's adapter passes NO model and Cursor Auto picks
+ * one on the customer's account — so the case's id describes nothing that runs.
+ * Carrying it downstream is the same mis-attribution this change closes on the
+ * chat rails, and it made ADMISSION and EXECUTION disagree: admission reads the
+ * host's id and accepts, then the dispatch's eligibility check sees the case's
+ * id and refuses a run that was already admitted.
+ *
+ * Promoted rather than refused, deliberately. Refusing at admission would be
+ * self-consistent and would also make every Cursor eval suite unrunnable: the
+ * model pickers cannot hold `cursor/auto` (it is not a selectable entry), so no
+ * case can name it. The host's model is authoritative on every other surface
+ * for exactly this reason; eval is the last one that was not.
+ *
+ * Only a SENTINEL host promotes. A host whose harness is external-account but
+ * whose model is an ordinary id is a broken configuration, and the admission
+ * gate refuses it on the host's own id — promoting that id would launder it.
+ */
+export function resolveEvalCaseModelDefinition(args: {
+  hostConfig: Record<string, unknown> | null | undefined;
+  /** The model the CASE names, already built into a definition. */
+  caseModel: ModelDefinition;
+}): ModelDefinition {
+  const harness = harnessOfHostConfig(args.hostConfig);
+  if (!harness) return args.caseModel;
+  if (getHarnessAdapter(harness).modelAccess !== "external-account") {
+    return args.caseModel;
+  }
+  const hostConfig = args.hostConfig as Record<string, unknown>;
+  const hostModelId =
+    typeof hostConfig.modelId === "string" ? hostConfig.modelId.trim() : "";
+  if (!isRuntimeChosenModelSentinel(hostModelId)) return args.caseModel;
+  // The same builder the swarm runner uses, so the sentinel arrives with its
+  // curated label and its registered provider rather than a re-derived guess.
+  return buildSyntheticModelDefinition(hostModelId);
+}
+
 export function hasSelectedMcpServersForAdmission(args: {
   serverIds?: readonly string[];
   pluginServerIds?: readonly string[];

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -564,6 +564,11 @@ async function runJourneyFanOut(
                   id: String(modelDefinition.id),
                   provider: modelDefinition.provider,
                 },
+                // The same pinned id under the name the external-account rule
+                // reads. Identical to `model.id` here — a swarm target has no
+                // request body to override it — and passed explicitly so it
+                // STAYS identical if that ever stops being true.
+                hostModelId: modelId,
                 // TRI-STATE, read without throwing, and INVALID counts as ON —
                 // the same call `mcp/chat-v2.ts` makes. `xaaPolicyFromMcpProfile`
                 // (the web route's variant) THROWS a 409 on a malformed profile,

--- a/mcpjam-inspector/server/utils/__tests__/assistant-turn.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/assistant-turn.test.ts
@@ -98,6 +98,11 @@ vi.mock("../logger", () => ({
     error: vi.fn(),
     warn: vi.fn(),
     info: vi.fn(),
+    // Stubbed so the emulated-engine path is fully drivable from this suite:
+    // without it, a turn that reaches the engine dies on a missing mock method,
+    // and a test asserting "no engine ran" would pass for the wrong reason.
+    event: vi.fn(),
+    systemEvent: vi.fn(),
   },
 }));
 
@@ -336,5 +341,108 @@ describe("runAssistantTurn", () => {
     await lastExecution;
 
     expect(onConversationComplete).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * THE DISPATCH GATE, and the one place where "model ineligible" must not mean
+   * "run the emulated engine instead".
+   *
+   * `useHarness = harnessRequested && modelEligible` is a silent degrade by
+   * design: a brokered harness handed a model MCPJam does not host falls back
+   * to the emulated engine, which runs exactly that model on org BYOK. Sound
+   * there, and the opposite of sound for an external-account harness — the
+   * emulated engine cannot run a sentinel at all, so what the fallback produces
+   * is a swarm or eval turn that completes, reports success, and is recorded
+   * under `executionEngineLabel` = `harness:cursor` having never run Cursor.
+   *
+   * This is the path with no pre-flight: the interactive rails fail closed at
+   * `checkHarnessRuntimeAvailable`, but `sessionSimulation/runner.ts` drives
+   * turns straight through here.
+   */
+  describe("external-account harness dispatch", () => {
+    const turn = (modelDefinition: ModelDefinition, harness: string) =>
+      runAssistantTurn({
+        messages: [{ role: "user", content: "Hi." }] as any,
+        modelDefinition,
+        systemPrompt: "You are helpful",
+        tools: {},
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        authContext: { kind: "user_bearer", token: "Bearer test-token" },
+        sourceType: "swarm",
+        origin: "scenario",
+        approvalMode: "auto-deny",
+        streamSink: "none",
+        persistMode: "caller",
+        harness: harness as any,
+      });
+
+    it("REFUSES an ordinary model rather than falling back to the emulated engine", async () => {
+      global.fetch = vi.fn();
+
+      await expect(
+        turn(
+          {
+            id: "anthropic/claude-sonnet-4.5",
+            provider: "anthropic",
+            name: "Sonnet",
+          } as ModelDefinition,
+          "cursor"
+        )
+      ).rejects.toThrow(/chooses its own model on your own account/);
+
+      // The load-bearing half: no engine ran at all. A resolved turn here is a
+      // completed run that never touched Cursor.
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("still runs the sentinel through the harness gate without refusing", async () => {
+      // The control on the rule itself: a correctly configured host is eligible,
+      // so the dispatch does NOT throw here (it goes on to `runHarnessTurn`,
+      // which this suite does not drive).
+      const { harnessModelEligibleForRuntime } = await vi.importActual<
+        typeof import("../harness/harness-availability.js")
+      >("../harness/harness-availability.js");
+      const { getHarnessAdapter } = await vi.importActual<
+        typeof import("../harness/registry.js")
+      >("../harness/registry.js");
+
+      expect(
+        harnessModelEligibleForRuntime({
+          adapter: getHarnessAdapter("cursor"),
+          modelId: "cursor/auto",
+          provider: "cursor",
+        })
+      ).toBe(true);
+    });
+
+    it("leaves the BROKERED fallback alone — ineligible there still degrades", async () => {
+      // The exemption is keyed on `modelAccess`, and the warn-and-emulate path
+      // it does not touch is the one that keeps an eval batch running when a
+      // case names a BYOK model.
+      global.fetch = vi.fn().mockResolvedValue(
+        createSseResponse([
+          {
+            type: "finish",
+            finishReason: "stop",
+            totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          },
+        ])
+      );
+
+      const resolved = await turn(
+        {
+          id: "llama3",
+          provider: "ollama",
+          name: "Llama 3",
+        } as ModelDefinition,
+        "claude-code"
+      );
+      await lastExecution;
+
+      expect(resolved.messages).toBeDefined();
+      expect(global.fetch).toHaveBeenCalled();
+    });
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/assistant-turn.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/assistant-turn.test.ts
@@ -16,6 +16,10 @@ import type { ModelDefinition } from "@/shared/types";
 let lastExecution: Promise<void> | null = null;
 let writtenChunks: any[] = [];
 
+const { runHarnessTurnMock } = vi.hoisted(() => ({
+  runHarnessTurnMock: vi.fn(),
+}));
+
 const buildSsePayload = (events: any[]) =>
   `${events
     .map((event) => `data: ${JSON.stringify(event)}\n\n`)
@@ -91,6 +95,14 @@ vi.mock("../chat-helpers", async () => {
 
 vi.mock("../mcpjam-tool-helpers", () => ({
   serializeToolsForConvex: vi.fn(() => []),
+}));
+
+// The harness arm, stubbed so this suite can see WHICH engine the dispatch
+// chose. Without it a sentinel turn would try to reserve a real computer, and
+// the only assertion available would be about the emulated engine's fetch —
+// which cannot tell "ran the harness" from "refused".
+vi.mock("../harness/run-harness-turn.js", () => ({
+  runHarnessTurn: runHarnessTurnMock,
 }));
 
 vi.mock("../logger", () => ({
@@ -392,29 +404,37 @@ describe("runAssistantTurn", () => {
         )
       ).rejects.toThrow(/chooses its own model on your own account/);
 
-      // The load-bearing half: no engine ran at all. A resolved turn here is a
-      // completed run that never touched Cursor.
+      // The load-bearing half: NEITHER engine ran. A resolved turn here is a
+      // completed run that never touched Cursor — the emulated engine's only
+      // outbound sign is the `/stream` POST, and the harness arm is stubbed.
       expect(global.fetch).not.toHaveBeenCalled();
+      expect(runHarnessTurnMock).not.toHaveBeenCalled();
     });
 
-    it("still runs the sentinel through the harness gate without refusing", async () => {
-      // The control on the rule itself: a correctly configured host is eligible,
-      // so the dispatch does NOT throw here (it goes on to `runHarnessTurn`,
-      // which this suite does not drive).
-      const { harnessModelEligibleForRuntime } = await vi.importActual<
-        typeof import("../harness/harness-availability.js")
-      >("../harness/harness-availability.js");
-      const { getHarnessAdapter } = await vi.importActual<
-        typeof import("../harness/registry.js")
-      >("../harness/registry.js");
+    it("sends the SENTINEL to the harness — the rule refuses configurations, not Cursor", async () => {
+      // The control that makes the refusal above meaningful. A rule that
+      // refused every Cursor turn would also satisfy "no silent emulation", so
+      // the dispatch has to be observed CHOOSING the harness for a correctly
+      // configured host — not merely observed not throwing.
+      global.fetch = vi.fn();
+      runHarnessTurnMock.mockResolvedValue({
+        messageHistory: [],
+        aborted: false,
+      });
 
-      expect(
-        harnessModelEligibleForRuntime({
-          adapter: getHarnessAdapter("cursor"),
-          modelId: "cursor/auto",
+      await turn(
+        {
+          id: "cursor/auto",
           provider: "cursor",
-        })
-      ).toBe(true);
+          name: "Cursor Auto",
+        } as ModelDefinition,
+        "cursor"
+      );
+
+      expect(runHarnessTurnMock).toHaveBeenCalledTimes(1);
+      // …and the emulated engine, whose only outbound sign is the `/stream`
+      // POST, was never reached.
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it("leaves the BROKERED fallback alone — ineligible there still degrades", async () => {

--- a/mcpjam-inspector/server/utils/__tests__/org-model-config.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/org-model-config.test.ts
@@ -4,6 +4,7 @@ import {
   deriveOrgProviderKey,
   isLocalRuntimeEligible,
   isUnsafeHostedOutboundUrl,
+  resolveHostModelDefinition,
   resolveOrgModelConfig,
   resolveSyntheticModelSource,
 } from "../org-model-config";
@@ -238,5 +239,63 @@ describe("runtime-chosen sentinel (cursor/auto) vs org provider resolution", () 
     expect(definition.id).toBe("cursor/auto");
     expect(definition.name).toBe("Cursor Auto");
     expect(definition.provider).toBe("cursor");
+  });
+
+  it("lifts the host's sentinel WITHOUT the org-model-config round-trip", async () => {
+    // `resolveHostModelDefinition` sits between the request and the first token
+    // of a live turn, and its org lookup carries a 15 s timeout. Only an
+    // enabled org provider that LISTS the id can win there, and none can list
+    // `cursor/auto` — so on an external-account harness turn the call was pure
+    // latency plus a failure mode, on a turn that needs nothing from the org's
+    // model config.
+    process.env.CONVEX_HTTP_URL = "https://convex.example/";
+    process.env.INSPECTOR_SERVICE_TOKEN = "service-token";
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const definition = await resolveHostModelDefinition({
+      modelId: "cursor/auto",
+      // A project id is what ARMS the lookup — without one it is skipped for
+      // every id, so the assertion below would prove nothing.
+      projectId: "proj_1",
+      auth: { bearerToken: "user-a" },
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(definition).toMatchObject({
+      id: "cursor/auto",
+      name: "Cursor Auto",
+      provider: "cursor",
+    });
+  });
+
+  it("still asks the org config for an ordinary host model id", async () => {
+    // The bypass is the sentinel's, not every harness host's: a vendor-prefixed
+    // id really can belong to an org's OpenRouter selection, and that is the
+    // ambiguity the lookup exists to settle.
+    process.env.CONVEX_HTTP_URL = "https://convex.example/";
+    process.env.INSPECTOR_SERVICE_TOKEN = "service-token";
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        ok: true,
+        providers: [
+          {
+            providerKey: "openrouter",
+            enabled: true,
+            hasSecret: true,
+            secret: "sk-or",
+            selectedModels: ["anthropic/claude-sonnet-4.5"],
+          },
+        ],
+      }),
+    );
+
+    const definition = await resolveHostModelDefinition({
+      modelId: "anthropic/claude-sonnet-4.5",
+      projectId: "proj_sentinel_bypass_control",
+      auth: { bearerToken: "user-a" },
+    });
+
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(definition.provider).toBe("openrouter");
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/org-model-config.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/org-model-config.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  buildSyntheticModelDefinition,
+  deriveOrgProviderKey,
   isLocalRuntimeEligible,
   isUnsafeHostedOutboundUrl,
   resolveOrgModelConfig,
+  resolveSyntheticModelSource,
 } from "../org-model-config";
+import type { ModelDefinition } from "@/shared/types";
 
 const ORIGINAL_ENV = {
   CONVEX_HTTP_URL: process.env.CONVEX_HTTP_URL,
@@ -161,5 +165,78 @@ describe("isLocalRuntimeEligible", () => {
 
   it("returns true for custom providers because they can run locally", () => {
     expect(isLocalRuntimeEligible("custom:my-llm")).toBe(true);
+  });
+});
+
+/**
+ * The Cursor CLI host template seeds `cursor/auto` — a neutral sentinel, not a
+ * provider model. `cursor` is a registered `ModelProvider` so the id classifies
+ * honestly instead of falling through the bare-id rule to `ollama`, and that
+ * registration is exactly what made every provider-resolution path treat it as
+ * a BYOK provider needing a configured org key. On prod, a turn sent with
+ * `model: "cursor/auto"` came back
+ * `provider_not_configured: cursor is not enabled for this project/workspace
+ * organization` — a setup error for a key that cannot exist.
+ */
+const CURSOR_SENTINEL_MODEL: ModelDefinition = {
+  id: "cursor/auto",
+  name: "Cursor Auto",
+  provider: "cursor",
+};
+
+describe("runtime-chosen sentinel (cursor/auto) vs org provider resolution", () => {
+  it("refuses to derive an org provider key for the sentinel", () => {
+    const result = deriveOrgProviderKey(CURSOR_SENTINEL_MODEL);
+
+    // The load-bearing assertion is `ok: false`. `{ ok: true, key: "cursor" }`
+    // is what sent the turn to `/stream/org` and produced
+    // `provider_not_configured: cursor`.
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toContain("cursor/auto");
+    expect(result.error).toContain("Cursor Auto");
+  });
+
+  it("still derives keys for real providers and custom org providers", () => {
+    expect(
+      deriveOrgProviderKey({
+        id: "claude-3-5-sonnet-latest",
+        name: "Claude",
+        provider: "anthropic",
+      }),
+    ).toEqual({ ok: true, key: "anthropic" });
+    expect(
+      deriveOrgProviderKey({
+        id: "custom:my-llm:m1",
+        name: "m1",
+        provider: "custom",
+        customProviderName: "my-llm",
+      }),
+    ).toEqual({ ok: true, key: "custom:my-llm" });
+  });
+
+  it("classifies the sentinel as external-account without resolving any org provider", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const resolution = await resolveSyntheticModelSource({
+      modelDefinition: CURSOR_SENTINEL_MODEL,
+      projectId: "proj_1",
+      authHeader: "Bearer t",
+    });
+
+    expect(resolution.source).toBe("external-account");
+    // No org runtime to reuse, and — the point of the fix — no round-trip that
+    // could answer `provider_not_configured`.
+    expect(resolution.orgRuntime).toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("gives the sentinel its display name without rewriting the id", () => {
+    const definition = buildSyntheticModelDefinition("cursor/auto");
+
+    // The id is what traces and eval metadata record; only the label changes.
+    expect(definition.id).toBe("cursor/auto");
+    expect(definition.name).toBe("Cursor Auto");
+    expect(definition.provider).toBe("cursor");
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/resolve-turn-runtime.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/resolve-turn-runtime.test.ts
@@ -150,32 +150,37 @@ describe("resolveTurnRuntime — runtime shape", () => {
     });
   });
 
-  it("external account (cursor/auto sentinel) → hosted /stream carrying only the harness", async () => {
+  it("external account WITH a harness is refused here — this surface cannot deliver the credential", async () => {
     // The host's model id names no provider model, so there is no org provider
-    // to resolve and no MCPJam credential to spend. Before this arm the
-    // resolver fell through to cloud BYOK and shipped `providerKey: "cursor"`
-    // to `/stream/org`, which Convex answered with
-    // `provider_not_configured: cursor`.
+    // to resolve and no MCPJam credential to spend — and the resolver no longer
+    // ships `providerKey: "cursor"` to `/stream/org`, which Convex answered
+    // with `provider_not_configured: cursor`.
+    //
+    // But "not a provider question" is not the same as "runnable". An
+    // external-account runtime authenticates with the customer's own vendor
+    // credential, which `runHarnessTurn` takes ONLY from the caller's
+    // materialized project secrets — and `runUnifiedAssistantTurn`, the facade
+    // every caller of this resolver drives, has no `runtimeSecrets` seam at
+    // all. Handing back a runnable "hosted + harness" runtime advertised a turn
+    // that then died inside the harness telling the user to add a
+    // `CURSOR_API_KEY` secret they may already have set. Refuse instead, with
+    // the real reason, before the caller marks the turn as possibly-spent.
     resolveSyntheticModelSourceMock.mockResolvedValue({
       source: "external-account",
     });
 
-    const rt = await resolveTurnRuntime(
-      baseArgs({ modelDefinition: CURSOR_SENTINEL_MODEL, harness: "cursor" }),
-    );
-
-    expect(rt.modelSource).toBe("external-account");
-    expect(rt.runtime).toEqual({
-      kind: "hosted",
-      endpointPath: "/stream",
-      harness: "cursor",
-    });
-    // No providerKey anywhere in the body — that is the whole point.
-    expect(
-      (rt.runtime as { extraBodyFields?: Record<string, unknown> })
-        .extraBodyFields,
-    ).toBeUndefined();
-    await rt.finalizeUsage(successResult());
+    await expect(
+      resolveTurnRuntime(
+        baseArgs({ modelDefinition: CURSOR_SENTINEL_MODEL, harness: "cursor" }),
+      ),
+    ).rejects.toThrow(/cursor\/auto[\s\S]*your own account/);
+    // Not "add a secret" — the diagnosis names the surface, not the customer.
+    await expect(
+      resolveTurnRuntime(
+        baseArgs({ modelDefinition: CURSOR_SENTINEL_MODEL, harness: "cursor" }),
+      ),
+    ).rejects.toThrow(/cannot deliver that credential/);
+    // And no round-trip that could answer `provider_not_configured`.
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -188,9 +193,11 @@ describe("resolveTurnRuntime — runtime shape", () => {
       source: "external-account",
     });
 
+    // The OTHER refusal sentence: this one is about the sentinel itself, not
+    // about what this surface can deliver, so the two arms stay legible apart.
     await expect(
       resolveTurnRuntime(baseArgs({ modelDefinition: CURSOR_SENTINEL_MODEL })),
-    ).rejects.toThrow(/cursor\/auto/);
+    ).rejects.toThrow(/cursor\/auto[\s\S]*not a model MCPJam can run/);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/mcpjam-inspector/server/utils/__tests__/resolve-turn-runtime.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/resolve-turn-runtime.test.ts
@@ -57,6 +57,12 @@ const LOCAL_MODEL: ModelDefinition = {
   name: "Llama3 local",
   provider: "ollama",
 };
+/** The Cursor CLI host template's neutral sentinel — no provider serves it. */
+const CURSOR_SENTINEL_MODEL: ModelDefinition = {
+  id: "cursor/auto",
+  name: "Cursor Auto",
+  provider: "cursor",
+};
 
 const baseArgs = (overrides: Record<string, unknown> = {}) => ({
   modelDefinition: MCPJAM_MODEL,
@@ -142,6 +148,50 @@ describe("resolveTurnRuntime — runtime shape", () => {
       extraBodyFields: { foo: "bar" },
       harness: "claude-code",
     });
+  });
+
+  it("external account (cursor/auto sentinel) → hosted /stream carrying only the harness", async () => {
+    // The host's model id names no provider model, so there is no org provider
+    // to resolve and no MCPJam credential to spend. Before this arm the
+    // resolver fell through to cloud BYOK and shipped `providerKey: "cursor"`
+    // to `/stream/org`, which Convex answered with
+    // `provider_not_configured: cursor`.
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "external-account",
+    });
+
+    const rt = await resolveTurnRuntime(
+      baseArgs({ modelDefinition: CURSOR_SENTINEL_MODEL, harness: "cursor" }),
+    );
+
+    expect(rt.modelSource).toBe("external-account");
+    expect(rt.runtime).toEqual({
+      kind: "hosted",
+      endpointPath: "/stream",
+      harness: "cursor",
+    });
+    // No providerKey anywhere in the body — that is the whole point.
+    expect(
+      (rt.runtime as { extraBodyFields?: Record<string, unknown> })
+        .extraBodyFields,
+    ).toBeUndefined();
+    await rt.finalizeUsage(successResult());
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("external account without a harness is refused, not routed to a provider", async () => {
+    // A sentinel on a turn with no harness selected cannot run at all. Saying
+    // so here — before the caller marks the turn as possibly-spent — is what
+    // replaces `provider_not_configured: cursor`, which read as "go configure
+    // a key" for a provider that has no keys.
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "external-account",
+    });
+
+    await expect(
+      resolveTurnRuntime(baseArgs({ modelDefinition: CURSOR_SENTINEL_MODEL })),
+    ).rejects.toThrow(/cursor\/auto/);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("cloud BYOK → hosted /stream/org with providerKey + serverIds (byte-parity body)", async () => {

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -39,7 +39,10 @@ import {
 import type { ChatOrigin, PersistedTurnTrace } from "./chat-ingestion.js";
 import { runHarnessTurn } from "./harness/run-harness-turn.js";
 import { getHarnessAdapter } from "./harness/registry.js";
-import { harnessModelEligibleForRuntime } from "./harness/harness-availability.js";
+import {
+  externalAccountHostModelRefusalReason,
+  harnessModelEligibleForRuntime,
+} from "./harness/harness-availability.js";
 import type { HarnessSessionCommitPayload } from "./harness/harness-session-state.js";
 import { logger } from "./logger.js";
 
@@ -629,10 +632,12 @@ export async function runAssistantTurn(
   // the EMULATED engine and reports the harness's name over it. That is a wrong
   // answer attributed to the wrong runtime, which is worse than a failure.
   //
-  // The helper also carries the external-account exemption: Cursor's host
-  // seeds a `cursor/auto` sentinel that is deliberately not an MCPJam-hosted
-  // model, so the hosted-model half would otherwise reject every Cursor turn
-  // here and silently fall back.
+  // The helper also carries the external-account arm: Cursor's host seeds a
+  // `cursor/auto` sentinel that is deliberately not an MCPJam-hosted model, so
+  // the hosted-model half would otherwise reject every Cursor turn here and
+  // silently fall back. On that arm the helper asks its own question instead —
+  // is this the sentinel? — and a `false` from it is NOT a fallback signal; see
+  // the throw below.
   const modelEligible = harnessAdapter
     ? harnessModelEligibleForRuntime({
         adapter: harnessAdapter,
@@ -642,6 +647,43 @@ export async function runAssistantTurn(
     : isHostedCatalogModel(harnessModelId, opts.modelDefinition.provider);
   const useHarness = harnessRequested && modelEligible;
   if (harnessRequested && !modelEligible) {
+    // AN EXTERNAL-ACCOUNT HARNESS HAS NO FALLBACK, so ineligibility here is a
+    // hard failure rather than a degrade. The warn-and-emulate below is sound
+    // only where the emulated engine is a real substitute — a brokered harness
+    // refused for "MCPJam does not host this model" leaves an engine that runs
+    // exactly that model, on org BYOK. Neither half of that holds here: the
+    // emulated engine cannot run a sentinel at all, and the id a mis-configured
+    // host carries is one the runtime would have ignored.
+    //
+    // What the fallback would produce is the failure this whole rule exists to
+    // stop, arriving through the fix for it: a swarm or eval turn on a
+    // mis-configured Cursor host runs the EMULATED engine, completes, and is
+    // recorded under `executionEngineLabel` = `harness:cursor`. A completed run
+    // that reports success and never ran Cursor is indistinguishable in the
+    // transcript from one that did — strictly worse than the mis-attributed
+    // model id, because there is no longer anything in the record that is
+    // wrong-looking. The interactive rails fail closed at
+    // `checkHarnessRuntimeAvailable`; this is the same refusal for the paths
+    // that never call it (`sessionSimulation/runner.ts` drives turns without a
+    // pre-flight, and only its swarm caller admits targets through one).
+    //
+    // Thrown, not returned: this is a wiring/configuration error, and every
+    // caller here already treats a thrown turn as a failed turn.
+    const externalAccountRefusal = harnessAdapter
+      ? externalAccountHostModelRefusalReason({
+          adapter: harnessAdapter,
+          modelId: harnessModelId,
+        })
+      : undefined;
+    if (externalAccountRefusal) {
+      // Wrapped in the SAME sentence the chat routes build around a pre-flight
+      // refusal, so a reader who meets this in a run log and one who meets it in
+      // a 503 are reading the same thing.
+      throw new Error(
+        `This host runs the ${opts.harness} harness, which isn't available: ` +
+          `${externalAccountRefusal}.`,
+      );
+    }
     logger.warn(
       "[assistant-turn] harness requested but model ineligible (not MCPJam-" +
         "provided, or unsupported by the runtime) — falling back to the emulated " +

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -671,7 +671,7 @@ export async function runAssistantTurn(
     // caller here already treats a thrown turn as a failed turn.
     const externalAccountRefusal = harnessAdapter
       ? externalAccountHostModelRefusalReason({
-          adapter: harnessAdapter,
+          harnessId: harnessAdapter.id,
           modelId: harnessModelId,
         })
       : undefined;

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
@@ -341,6 +341,70 @@ describe("checkHarnessRuntimeAvailable", () => {
       }
     });
 
+    it("holds the HOST's id to the rule, not the one the request supplied", () => {
+      // The mis-configured host, entered from the other side. Everything the
+      // external-account rule protects is a fact about the HOST — nothing
+      // consumes the turn's model on this arm — so a caller must not be able to
+      // satisfy it by sending the sentinel in the body while the host itself
+      // carries an ordinary id. Left reading `model.id`, this combination was
+      // ACCEPTED and Cursor ran under a host that pinned Sonnet.
+      setFullyAvailable();
+      const r = checkHarnessRuntimeAvailable(
+        args({
+          harnessId: "cursor" as HarnessId,
+          model: { id: "cursor/auto", provider: "cursor" },
+          hostModelId: "anthropic/claude-sonnet-4.5",
+        }),
+      );
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.kind).toBe("model-unsupported");
+        // The refusal names the HOST's id — the thing whose owner has to fix it.
+        expect(r.reason).toContain("anthropic/claude-sonnet-4.5");
+        expect(r.reason).not.toContain("cursor/auto");
+      }
+    });
+
+    it("accepts a host that pins the sentinel whatever the turn's model says", () => {
+      // The other direction of the same precedence: the host is what counts, so
+      // a stale body model on a correctly configured host is not the gate's
+      // problem (the routes promote the host's model over it anyway).
+      setFullyAvailable();
+      expect(
+        checkHarnessRuntimeAvailable(
+          args({
+            harnessId: "cursor" as HarnessId,
+            model: { id: "anthropic/claude-haiku-4.5", provider: "anthropic" },
+            hostModelId: "cursor/auto",
+          }),
+        ),
+      ).toEqual({ ok: true });
+    });
+
+    it("falls back to the turn's model when the host pinned none", () => {
+      // A host with a harness and no model at all pins nothing to validate, so
+      // the turn's own model is the only description of what it runs: a
+      // sentinel is a true one, an ordinary id is still refused.
+      setFullyAvailable();
+      expect(
+        checkHarnessRuntimeAvailable(
+          args({
+            harnessId: "cursor" as HarnessId,
+            model: { id: "cursor/auto", provider: "cursor" },
+          }),
+        ),
+      ).toEqual({ ok: true });
+
+      const ordinary = checkHarnessRuntimeAvailable(
+        args({
+          harnessId: "cursor" as HarnessId,
+          model: { id: "anthropic/claude-haiku-4.5", provider: "anthropic" },
+        }),
+      );
+      expect(ordinary.ok).toBe(false);
+      if (!ordinary.ok) expect(ordinary.kind).toBe("model-unsupported");
+    });
+
     it("does not exempt a BROKERED harness from the model gate", () => {
       // The exemption is keyed on `modelAccess`, not on "harness runs a CLI".
       setFullyAvailable();

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
@@ -315,6 +315,32 @@ describe("checkHarnessRuntimeAvailable", () => {
       ).toEqual({ ok: true });
     });
 
+    it("refuses an external-account host that pins an ORDINARY model id", () => {
+      // The exemption is not "no model rule applies", it is "a different one
+      // does": the host must carry the runtime's sentinel. Cursor ignores
+      // whatever id the host holds and picks its own model, so a host pinned to
+      // `anthropic/claude-sonnet-4.5` would run Cursor Auto while the session
+      // row, the trace and the eval metadata all named Sonnet as the model that
+      // ran — the exact mis-attribution this whole change exists to stop, just
+      // arriving from the host side instead of the browser's.
+      setFullyAvailable();
+      const r = checkHarnessRuntimeAvailable(
+        args({
+          harnessId: "cursor" as HarnessId,
+          model: {
+            id: "anthropic/claude-sonnet-4.5",
+            provider: "anthropic",
+          },
+        }),
+      );
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.kind).toBe("model-unsupported");
+        // Names the id it found, so the owner can see what to reset.
+        expect(r.reason).toContain("anthropic/claude-sonnet-4.5");
+      }
+    });
+
     it("does not exempt a BROKERED harness from the model gate", () => {
       // The exemption is keyed on `modelAccess`, not on "harness runs a CLI".
       setFullyAvailable();
@@ -386,6 +412,19 @@ describe("harnessModelEligibleForRuntime", () => {
         provider: "cursor",
       }),
     ).toBe(true);
+  });
+
+  it("refuses an ordinary model id on an EXTERNAL-ACCOUNT harness", () => {
+    // The dispatch half of the rule above. Left `true`, this is what let a
+    // mis-configured Cursor host run the real runtime and report an unrelated
+    // model id as the one that ran.
+    expect(
+      harnessModelEligibleForRuntime({
+        adapter: getHarnessAdapter("cursor"),
+        modelId: "anthropic/claude-sonnet-4.5",
+        provider: "anthropic",
+      }),
+    ).toBe(false);
   });
 
   it("still refuses a non-hosted model for a BROKERED harness", () => {

--- a/mcpjam-inspector/server/utils/harness/harness-availability.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-availability.ts
@@ -80,7 +80,7 @@ export function harnessModelEligibleForRuntime(args: {
   if (args.adapter.modelAccess === "external-account") {
     return (
       externalAccountHostModelRefusalReason({
-        adapter: args.adapter,
+        harnessId: args.adapter.id,
         modelId: args.modelId,
       }) === undefined
     );
@@ -116,14 +116,17 @@ export function harnessModelEligibleForRuntime(args: {
  * {@link harnessToolApprovalRefusalReason} below.
  */
 export function externalAccountHostModelRefusalReason(args: {
-  adapter: HarnessRuntimeAdapter;
+  /** Taken by ID so a caller holding only the host's `harness` can ask too —
+   *  the chat routes decide this BEFORE they have resolved any adapter. */
+  harnessId: HarnessId;
   /** The model id to hold to the rule. See the note above on which one. */
   modelId: string;
 }): string | undefined {
-  if (args.adapter.modelAccess !== "external-account") return undefined;
+  const adapter = getHarnessAdapter(args.harnessId);
+  if (adapter.modelAccess !== "external-account") return undefined;
   if (isRuntimeChosenModelSentinel(args.modelId)) return undefined;
   return (
-    `the ${args.adapter.displayName} harness chooses its own model on your ` +
+    `the ${adapter.displayName} harness chooses its own model on your ` +
     `own account, so this host cannot pin one — it carries ` +
     `"${args.modelId}", which the runtime would ignore while the session ` +
     `recorded it as the model that ran. Reset this host's model, or pick a ` +
@@ -362,7 +365,7 @@ export function checkHarnessRuntimeAvailable(args: {
   // so validating it would let a request satisfy the rule by sending
   // `cursor/auto` in the body while the host carried an ordinary id.
   const externalAccountRefusal = externalAccountHostModelRefusalReason({
-    adapter,
+    harnessId: args.harnessId,
     modelId: args.hostModelId ?? args.model.id,
   });
   if (externalAccountRefusal) {

--- a/mcpjam-inspector/server/utils/harness/harness-availability.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-availability.ts
@@ -18,6 +18,7 @@
  */
 import { isComputersDataPlaneConfigured } from "../computers/control-plane-client.js";
 import { getCanonicalModelId } from "@/shared/types";
+import { isRuntimeChosenModelSentinel } from "@/shared/model-provider";
 import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
 import { harnessBrokerDeliveryEnabled } from "./harness-flags.js";
 import {
@@ -52,6 +53,12 @@ import {
  *  - "the runtime can run this model" — guards the silent substitution where a
  *    runtime falls back to its own default. An external-account adapter passes
  *    NO model at all, so there is nothing to substitute and nothing to check.
+ *
+ * What replaces them is ONE condition of its own: the host's model must BE the
+ * sentinel. An external-account host carrying an ordinary id is not a leniency
+ * case, it is the same wrong answer from the other direction — the runtime
+ * ignores the id and picks its own model while the session, the trace and the
+ * eval metadata all record the id as the model that ran.
  */
 export function harnessModelEligibleForRuntime(args: {
   adapter: HarnessRuntimeAdapter;
@@ -60,7 +67,9 @@ export function harnessModelEligibleForRuntime(args: {
   /** REQUIRED for a bare id to canonicalize; see the note on the preflight. */
   provider?: string;
 }): boolean {
-  if (args.adapter.modelAccess === "external-account") return true;
+  if (args.adapter.modelAccess === "external-account") {
+    return isRuntimeChosenModelSentinel(args.modelId);
+  }
   if (!isHostedCatalogModel(args.modelId, args.provider)) return false;
   return args.adapter.supportsModel(
     getCanonicalModelId(args.modelId, args.provider),
@@ -259,11 +268,35 @@ export function checkHarnessRuntimeAvailable(args: {
   // account, so "is this an MCPJam-hosted model?" and "can the runtime run it?"
   // are questions about a value nothing consumes. Answering them would refuse
   // every Cursor host — its own catalog model is the `cursor/auto` sentinel,
-  // which is deliberately not an MCPJam-hosted model.
+  // which is deliberately not an MCPJam-hosted model. They are replaced by one
+  // rule of their own, immediately below, rather than by nothing.
   const canonicalModelId = getCanonicalModelId(
     args.model.id,
     args.model.provider,
   );
+
+  // …and here is that replacement for an external-account host: its model must
+  // be the runtime's own sentinel. This is the same rule as the two below —
+  // "never report one runtime's answer under another model's name" — applied to
+  // the arm where the runtime, not MCPJam, picks. Cursor ignores whatever id the
+  // host carries, so a host holding `anthropic/claude-sonnet-4.5` would run
+  // Cursor Auto and then persist that id as the model that ran, into the
+  // session row, the trace and eval metadata alike. Refused rather than
+  // silently rewritten: the host configuration is wrong and only its owner can
+  // say what they meant by it.
+  if (!brokered && !isRuntimeChosenModelSentinel(args.model.id)) {
+    return {
+      ok: false,
+      kind: "model-unsupported",
+      reason:
+        `the ${name} harness chooses its own model on your own account, so ` +
+        `this host cannot pin one — it carries "${args.model.id}", which the ` +
+        "runtime would ignore while the session recorded it as the model " +
+        `that ran. Reset this host's model, or pick a harness that runs the ` +
+        "model you chose",
+    };
+  }
+
   if (brokered && !isHostedCatalogModel(args.model.id, args.model.provider)) {
     return {
       ok: false,

--- a/mcpjam-inspector/server/utils/harness/harness-availability.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-availability.ts
@@ -54,11 +54,21 @@ import {
  *    runtime falls back to its own default. An external-account adapter passes
  *    NO model at all, so there is nothing to substitute and nothing to check.
  *
- * What replaces them is ONE condition of its own: the host's model must BE the
+ * What replaces them is ONE condition of its own, {@link
+ * externalAccountHostModelRefusalReason}: the host's model must BE the
  * sentinel. An external-account host carrying an ordinary id is not a leniency
  * case, it is the same wrong answer from the other direction — the runtime
  * ignores the id and picks its own model while the session, the trace and the
  * eval metadata all record the id as the model that ran.
+ *
+ * A `false` here means DIFFERENT things for the two arms, and callers have to
+ * honour the difference. For a brokered harness it means "the emulated engine
+ * can run this instead" — a real fallback, since that engine honours org BYOK.
+ * For an external-account harness there is NO such fallback: the emulated
+ * engine cannot run a sentinel at all, and running the host's ordinary id under
+ * the runtime's name is precisely the mis-attribution this rule exists to stop.
+ * `assistant-turn` therefore THROWS on this arm instead of degrading; see the
+ * note at its dispatch.
  */
 export function harnessModelEligibleForRuntime(args: {
   adapter: HarnessRuntimeAdapter;
@@ -68,11 +78,56 @@ export function harnessModelEligibleForRuntime(args: {
   provider?: string;
 }): boolean {
   if (args.adapter.modelAccess === "external-account") {
-    return isRuntimeChosenModelSentinel(args.modelId);
+    return (
+      externalAccountHostModelRefusalReason({
+        adapter: args.adapter,
+        modelId: args.modelId,
+      }) === undefined
+    );
   }
   if (!isHostedCatalogModel(args.modelId, args.provider)) return false;
   return args.adapter.supportsModel(
     getCanonicalModelId(args.modelId, args.provider),
+  );
+}
+
+/**
+ * The model rule that applies to an EXTERNAL-ACCOUNT harness, as a value the
+ * pre-flight and the dispatch both read — returns the refusal copy, or
+ * `undefined` when the combination is sound.
+ *
+ * The rule: the model must be the runtime's own sentinel. Cursor's adapter
+ * passes NO model (`toNativeModel: () => undefined`) and Cursor Auto picks one
+ * on the customer's account, so a host carrying `anthropic/claude-sonnet-4.5`
+ * would run Cursor Auto while the session row, the trace and the eval metadata
+ * all named Sonnet as the model that ran. Refused rather than silently
+ * rewritten: the host configuration is wrong and only its owner can say what
+ * they meant by it.
+ *
+ * WHICH id to pass is the whole subtlety, and it is a HOST question, not a turn
+ * question — see `hostModelId` on the pre-flight. Nothing consumes the turn's
+ * model on this arm, so validating the model a REQUEST supplied lets a caller
+ * satisfy the rule by sending the sentinel in the body while the host itself
+ * carries an ordinary id.
+ *
+ * Shared rather than spelled out twice because the two readers act on it
+ * differently — one returns a typed refusal, the other throws — and two copies
+ * of a condition drift. Same reasoning as
+ * {@link harnessToolApprovalRefusalReason} below.
+ */
+export function externalAccountHostModelRefusalReason(args: {
+  adapter: HarnessRuntimeAdapter;
+  /** The model id to hold to the rule. See the note above on which one. */
+  modelId: string;
+}): string | undefined {
+  if (args.adapter.modelAccess !== "external-account") return undefined;
+  if (isRuntimeChosenModelSentinel(args.modelId)) return undefined;
+  return (
+    `the ${args.adapter.displayName} harness chooses its own model on your ` +
+    `own account, so this host cannot pin one — it carries ` +
+    `"${args.modelId}", which the runtime would ignore while the session ` +
+    `recorded it as the model that ran. Reset this host's model, or pick a ` +
+    "harness that runs the model you chose"
   );
 }
 
@@ -172,6 +227,26 @@ export function checkHarnessRuntimeAvailable(args: {
    * definition makes the two answers consistent by construction.
    */
   model: { id: string; provider?: string };
+  /**
+   * The host's CONFIGURED model id, before any body or per-case override.
+   *
+   * Read ONLY by the external-account rule, because that rule asks a question
+   * about the HOST rather than about the turn: does this host carry the
+   * runtime's sentinel? Every other rule here is about the model that will
+   * actually run, which is what `model` above is.
+   *
+   * The distinction is load-bearing on the interactive rails, where a request
+   * body supplies its own model. Holding the external-account rule to `model`
+   * let a caller satisfy it by POSTing `cursor/auto` while the host itself
+   * carried an ordinary id — the mis-configured host the rule exists to refuse,
+   * entered from the other side.
+   *
+   * ABSENT ⇒ the host pinned no model and `model.id` is held to the rule
+   * instead. That is the honest fallback, not a bypass: with nothing pinned,
+   * the turn's own model is the only thing this host can be said to run, so a
+   * sentinel body is a true description and an ordinary one is still refused.
+   */
+  hostModelId?: string;
   /**
    * Whether the host's enterprise-managed authorization policy is on. The
    * harness reaches MCP servers through the signed-proxy route
@@ -276,24 +351,25 @@ export function checkHarnessRuntimeAvailable(args: {
   );
 
   // …and here is that replacement for an external-account host: its model must
-  // be the runtime's own sentinel. This is the same rule as the two below —
+  // be the runtime's own sentinel. Same principle as the two rules below —
   // "never report one runtime's answer under another model's name" — applied to
-  // the arm where the runtime, not MCPJam, picks. Cursor ignores whatever id the
-  // host carries, so a host holding `anthropic/claude-sonnet-4.5` would run
-  // Cursor Auto and then persist that id as the model that ran, into the
-  // session row, the trace and eval metadata alike. Refused rather than
-  // silently rewritten: the host configuration is wrong and only its owner can
-  // say what they meant by it.
-  if (!brokered && !isRuntimeChosenModelSentinel(args.model.id)) {
+  // the arm where the runtime, not MCPJam, does the choosing. The condition
+  // itself lives in `externalAccountHostModelRefusalReason` because the
+  // DISPATCH has to reach the identical verdict, and act on it differently.
+  //
+  // Held to the HOST's configured id, falling back to the turn's model only
+  // when the host pinned none: nothing consumes the turn's model on this arm,
+  // so validating it would let a request satisfy the rule by sending
+  // `cursor/auto` in the body while the host carried an ordinary id.
+  const externalAccountRefusal = externalAccountHostModelRefusalReason({
+    adapter,
+    modelId: args.hostModelId ?? args.model.id,
+  });
+  if (externalAccountRefusal) {
     return {
       ok: false,
       kind: "model-unsupported",
-      reason:
-        `the ${name} harness chooses its own model on your own account, so ` +
-        `this host cannot pin one — it carries "${args.model.id}", which the ` +
-        "runtime would ignore while the session recorded it as the model " +
-        `that ran. Reset this host's model, or pick a harness that runs the ` +
-        "model you chose",
+      reason: externalAccountRefusal,
     };
   }
 

--- a/mcpjam-inspector/server/utils/org-model-config.ts
+++ b/mcpjam-inspector/server/utils/org-model-config.ts
@@ -875,7 +875,8 @@ export function matchOrgProviderForModelId(
  * id, that provider wins; catalog/shape inference is the fallback.
  *
  * `custom:`-prefixed and Bedrock-shaped ids skip the config fetch — their
- * shape is exact, and this path sits on a live chat turn.
+ * shape is exact, and this path sits on a live chat turn. So does a
+ * runtime-chosen sentinel, which no org provider can list.
  */
 export async function resolveHostModelDefinition(args: {
   modelId: string;
@@ -886,7 +887,15 @@ export async function resolveHostModelDefinition(args: {
 
   const shapeIsExact =
     modelId.startsWith("custom:") || isBedrockModelId(modelId);
-  if (!shapeIsExact && projectId) {
+  // A RUNTIME-CHOSEN SENTINEL skips the fetch for a different reason than the
+  // exact shapes above: not "we already know which provider serves it" but "no
+  // provider serves it at all". `matchOrgProviderForModelId` can only ever miss
+  // on `cursor/auto`, so the round-trip is pure cost — and not a cheap one on a
+  // live turn: `resolveOrgModelConfig` carries a 15 s timeout, and this call
+  // sits between the request and the first token of an external-account harness
+  // turn that needs nothing from the org's model config.
+  const skipOrgConfig = shapeIsExact || isRuntimeChosenModelSentinel(modelId);
+  if (!skipOrgConfig && projectId) {
     try {
       const config = await resolveOrgModelConfig({ projectId }, auth);
       const fromConfig = matchOrgProviderForModelId(config, modelId);

--- a/mcpjam-inspector/server/utils/org-model-config.ts
+++ b/mcpjam-inspector/server/utils/org-model-config.ts
@@ -5,7 +5,11 @@ import {
   isBedrockModelId,
   type ModelDefinition,
 } from "@/shared/types";
-import { classifyModelIdProvider } from "@/shared/model-provider";
+import {
+  classifyModelIdProvider,
+  isRuntimeChosenModelSentinel,
+  runtimeChosenModelSentinelName,
+} from "@/shared/model-provider";
 import { isHostedCatalogModel } from "../services/hosted-model-catalog.js";
 import type { OrgProviderResolvedConfig } from "@mcpjam/sdk/model-factory";
 import type { BaseUrls, CustomProviderConfig } from "./chat-helpers";
@@ -274,6 +278,28 @@ export type DeriveOrgProviderKeyResult =
 export function deriveOrgProviderKey(
   modelDefinition: ModelDefinition,
 ): DeriveOrgProviderKeyResult {
+  // A RUNTIME-CHOSEN SENTINEL has no provider key, and inventing one is the
+  // bug: `cursor` is a registered ModelProvider so `cursor/auto` classifies
+  // honestly, but nobody can configure a BYOK `cursor` key — the request goes
+  // to Convex and comes back `provider_not_configured: cursor is not enabled
+  // for this project/workspace organization`, which reads as a setup mistake
+  // the customer could fix. They cannot. Refuse HERE, where the caller still
+  // has the context to say what actually went wrong, rather than asking the
+  // org-provider config a question about a model no provider serves.
+  const sentinelName = runtimeChosenModelSentinelName(
+    String(modelDefinition.id),
+  );
+  if (sentinelName) {
+    return {
+      ok: false,
+      error:
+        `"${String(modelDefinition.id)}" (${sentinelName}) is a placeholder ` +
+        "for a runtime that chooses its own model on your own account — it " +
+        "names no model provider, so there is no key to configure for it. " +
+        "Run this turn on a host whose harness provides that runtime, or " +
+        "pick a real model.",
+    };
+  }
   if (modelDefinition.provider === "custom") {
     if (!modelDefinition.customProviderName) {
       return {
@@ -641,16 +667,29 @@ export async function resolveOrgProviderRuntimeForTarget(
 // makes per session.
 // ---------------------------------------------------------------------------
 
-/** Persisted attribution label on chatSessions / llmUsageRecord rows. */
-export type SyntheticModelSource = "mcpjam" | "byok" | "local_byok";
+/**
+ * Persisted attribution label on chatSessions / llmUsageRecord rows.
+ *
+ * `"external-account"` — the customer's own account with the RUNTIME vendor
+ * (Cursor), where MCPJam holds no model credential at all. Distinct from
+ * `"byok"` on purpose: both mean "MCPJam is not charged", but byok also asserts
+ * a configured model PROVIDER and its key, which an external-account turn does
+ * not have. Mirrors `PersistChatSessionOptions["modelSource"]`.
+ */
+export type SyntheticModelSource =
+  | "mcpjam"
+  | "byok"
+  | "local_byok"
+  | "external-account";
 
 /**
  * Result of {@link resolveSyntheticModelSource}.
  *
- * `orgRuntime` is present when `source !== "mcpjam"` so the synthetic
+ * `orgRuntime` is present when the source is a BYOK one, so the synthetic
  * dispatcher can reuse the resolved runtime (cloud providerKey OR local
  * `OrgProviderResolvedConfig`) for the actual handler call — no
- * duplicate `resolveOrgProviderRuntime` round-trip.
+ * duplicate `resolveOrgProviderRuntime` round-trip. Absent for `"mcpjam"` and
+ * for `"external-account"`, neither of which resolves an org provider.
  */
 export interface SyntheticModelResolution {
   source: SyntheticModelSource;
@@ -689,6 +728,14 @@ export async function resolveSyntheticModelSource(args: {
   const modelIdStr = String(args.modelDefinition.id);
   if (isHostedCatalogModel(modelIdStr)) {
     return { source: "mcpjam" };
+  }
+  // A runtime-chosen sentinel resolves NO org provider — see
+  // `deriveOrgProviderKey`. Answered before the key derivation below so the
+  // resolver returns an attribution ("nobody billed MCPJam, and there is no
+  // configured provider either") instead of throwing on a key it must not ask
+  // for. `orgRuntime` is deliberately absent: there is no runtime to reuse.
+  if (isRuntimeChosenModelSentinel(modelIdStr)) {
+    return { source: "external-account" };
   }
   const keyResult = deriveOrgProviderKey(args.modelDefinition);
   if (!keyResult.ok) {
@@ -762,7 +809,11 @@ export function buildSyntheticModelDefinition(
 
   return {
     id: modelId,
-    name: modelId,
+    // A runtime-chosen sentinel gets its curated label ("Cursor Auto"); every
+    // other unknown id keeps the raw string, which is all there is to show.
+    // The id itself is NEVER rewritten — it is what traces and eval metadata
+    // record, and the whole point of the sentinel is that it names no model.
+    name: runtimeChosenModelSentinelName(modelId) ?? modelId,
     provider: classification.provider,
     ...(classification.customProviderName !== undefined
       ? { customProviderName: classification.customProviderName }

--- a/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
+++ b/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
@@ -21,6 +21,9 @@
  *   - local BYOK → direct engine (model built via `buildOrgModelFromResolvedConfig`)
  *     and `finalizeUsage` posts `/stream/org/local-usage` with the identical
  *     body `runLocalOrgChatTurnHeadless`'s `postLocalUsage` emitted.
+ *   - external account → hosted `/stream` shape carrying only the harness. The
+ *     endpoint is never dialed (runHarnessTurn ignores it); this arm exists so a
+ *     runtime-chosen sentinel never asks the org-provider config a question.
  */
 
 import type { ToolSet } from "ai";
@@ -228,6 +231,44 @@ export async function resolveTurnRuntime(
       runtime,
       modelSource: "local_byok",
       finalizeUsage,
+      classifyFailure: classifyTurnFailure,
+    };
+  }
+
+  // --- Runtime-chosen sentinel → the harness, on the customer's own account ---
+  //
+  // The host's model id names no provider model (`cursor/auto`), so there is no
+  // org provider to resolve and no MCPJam credential to spend. The turn is only
+  // runnable at all because a harness was selected: `runAssistantTurn` sees
+  // `harness` on the hosted runtime and dispatches `runHarnessTurn`, which
+  // ignores `endpointPath`/`extraBodyFields` entirely and authenticates the
+  // runtime with the customer's own vendor credential.
+  //
+  // Without a harness the sentinel is unrunnable, and saying so here is the
+  // point: this is BEFORE the caller marks the turn as possibly-spent, so a
+  // v1 session turn that named `cursor/auto` releases its lease and gets a
+  // sentence that explains itself — where it previously reached Convex and came
+  // back `provider_not_configured: cursor`, i.e. "go configure a key" for a
+  // provider that has no keys.
+  if (resolution.source === "external-account") {
+    if (!args.harness) {
+      throw new Error(
+        `"${modelId}" is a placeholder for a runtime that chooses its own ` +
+          "model, not a model MCPJam can run. Send this turn to a host whose " +
+          "harness provides that runtime, or pick a real model.",
+      );
+    }
+    return {
+      runtime: {
+        kind: "hosted",
+        endpointPath: "/stream",
+        ...(args.extraBodyFields
+          ? { extraBodyFields: args.extraBodyFields }
+          : {}),
+        harness: args.harness,
+      },
+      modelSource: "external-account",
+      finalizeUsage: HOSTED_NOOP_FINALIZE,
       classifyFailure: classifyTurnFailure,
     };
   }

--- a/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
+++ b/mcpjam-inspector/server/utils/resolve-turn-runtime.ts
@@ -21,9 +21,12 @@
  *   - local BYOK → direct engine (model built via `buildOrgModelFromResolvedConfig`)
  *     and `finalizeUsage` posts `/stream/org/local-usage` with the identical
  *     body `runLocalOrgChatTurnHeadless`'s `postLocalUsage` emitted.
- *   - external account → hosted `/stream` shape carrying only the harness. The
- *     endpoint is never dialed (runHarnessTurn ignores it); this arm exists so a
- *     runtime-chosen sentinel never asks the org-provider config a question.
+ *   - external account → REFUSED. A runtime-chosen sentinel (`cursor/auto`)
+ *     never asks the org-provider config a question, and it never runs here
+ *     either: the runtime authenticates with the customer's own vendor
+ *     credential, which reaches `runHarnessTurn` only through the caller's
+ *     materialized project secrets — a seam `runUnifiedAssistantTurn` does not
+ *     have. See the branch for what wiring it would take.
  */
 
 import type { ToolSet } from "ai";
@@ -235,42 +238,52 @@ export async function resolveTurnRuntime(
     };
   }
 
-  // --- Runtime-chosen sentinel → the harness, on the customer's own account ---
+  // --- Runtime-chosen sentinel → REFUSED on this surface ---
   //
   // The host's model id names no provider model (`cursor/auto`), so there is no
-  // org provider to resolve and no MCPJam credential to spend. The turn is only
-  // runnable at all because a harness was selected: `runAssistantTurn` sees
-  // `harness` on the hosted runtime and dispatches `runHarnessTurn`, which
-  // ignores `endpointPath`/`extraBodyFields` entirely and authenticates the
-  // runtime with the customer's own vendor credential.
+  // org provider to resolve and no MCPJam credential to spend. That much is
+  // what `resolveSyntheticModelSource` already decided; what is left is whether
+  // this resolver's callers can actually RUN such a turn, and none of them can.
   //
-  // Without a harness the sentinel is unrunnable, and saying so here is the
-  // point: this is BEFORE the caller marks the turn as possibly-spent, so a
-  // v1 session turn that named `cursor/auto` releases its lease and gets a
+  // Both refusals happen BEFORE the caller marks the turn as possibly-spent, so
+  // a v1 session turn that named `cursor/auto` releases its lease and gets a
   // sentence that explains itself — where it previously reached Convex and came
   // back `provider_not_configured: cursor`, i.e. "go configure a key" for a
   // provider that has no keys.
+  //
+  // WITHOUT a harness the sentinel is unrunnable by construction: nothing else
+  // reaches the runtime that would choose the model.
+  //
+  // WITH a harness it is unrunnable HERE, and the difference matters enough to
+  // say separately. An external-account runtime authenticates with the
+  // customer's own vendor credential, and `runHarnessTurn` takes that credential
+  // from ONE place — the caller's materialized project secrets
+  // (`runtimeSecretsOverride`), because delivering a value into the box and
+  // scrubbing it out of the persisted transcript are two uses of one list and
+  // only the caller can wire the second. `runUnifiedAssistantTurn` — the facade
+  // every caller of this resolver drives — has no `runtimeSecrets` seam at all,
+  // so the credential cannot arrive. Returning a "hosted + harness" runtime here
+  // would advertise a turn that then dies inside `runHarnessTurn` telling the
+  // user to add a `CURSOR_API_KEY` secret they may well have already added — a
+  // wrong diagnosis for a turn this surface was never able to run.
+  //
+  // The fix is not a bigger error message: it is wiring the secrets fetch AND
+  // the transcript scrubber into the synthetic runner, which would also start
+  // delivering project secrets to the existing harnesses' synthetic turns
+  // (today they receive none). That is a security-relevant change with its own
+  // review; see the matching note in `run-harness-turn.ts`. Until then, refuse.
   if (resolution.source === "external-account") {
-    if (!args.harness) {
-      throw new Error(
-        `"${modelId}" is a placeholder for a runtime that chooses its own ` +
-          "model, not a model MCPJam can run. Send this turn to a host whose " +
-          "harness provides that runtime, or pick a real model.",
-      );
-    }
-    return {
-      runtime: {
-        kind: "hosted",
-        endpointPath: "/stream",
-        ...(args.extraBodyFields
-          ? { extraBodyFields: args.extraBodyFields }
-          : {}),
-        harness: args.harness,
-      },
-      modelSource: "external-account",
-      finalizeUsage: HOSTED_NOOP_FINALIZE,
-      classifyFailure: classifyTurnFailure,
-    };
+    throw new Error(
+      args.harness
+        ? `"${modelId}" is a placeholder for a runtime that reaches its model ` +
+            "on your own account with the runtime vendor, and this turn " +
+            "surface cannot deliver that credential — it has no path for the " +
+            "project secrets the runtime authenticates with. Run this host " +
+            "from chat, which materializes them."
+        : `"${modelId}" is a placeholder for a runtime that chooses its own ` +
+            "model, not a model MCPJam can run. Send this turn to a host " +
+            "whose harness provides that runtime, or pick a real model.",
+    );
   }
 
   // --- MCPJam-provided → hosted `/stream` ---

--- a/mcpjam-inspector/shared/__tests__/model-provider.test.ts
+++ b/mcpjam-inspector/shared/__tests__/model-provider.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   MODEL_ID_PREFIX_ALIASES,
   MODEL_ID_PREFIX_TO_PROVIDER,
+  RUNTIME_CHOSEN_MODEL_SENTINELS,
   classifyModelIdProvider,
+  isRuntimeChosenModelSentinel,
   providerForModelId,
+  runtimeChosenModelSentinelName,
 } from "../model-provider";
 import { MODEL_PROVIDER_FIXTURES } from "./model-provider-fixtures";
 
@@ -60,6 +63,57 @@ describe("prefix map", () => {
       MODEL_ID_PREFIX_TO_PROVIDER
     )) {
       expect(providerForModelId(`${prefix}/some-model`)).toBe(provider);
+    }
+  });
+});
+
+describe("runtime-chosen sentinels", () => {
+  it("recognizes cursor/auto and names it Cursor Auto", () => {
+    expect(isRuntimeChosenModelSentinel("cursor/auto")).toBe(true);
+    expect(runtimeChosenModelSentinelName("cursor/auto")).toBe("Cursor Auto");
+  });
+
+  it("still classifies the sentinel's provider honestly", () => {
+    // Being a sentinel does NOT make the id providerless to the classifier —
+    // `cursor` is a registered ModelProvider precisely so the id does not fall
+    // through the bare-id rule to `ollama`. The two answers are independent:
+    // one says who serves it, the other says "nobody, and that is the point".
+    expect(providerForModelId("cursor/auto")).toBe("cursor");
+  });
+
+  it("says no for ordinary models, other cursor ids, and non-strings", () => {
+    expect(isRuntimeChosenModelSentinel("anthropic/claude-haiku-4.5")).toBe(
+      false
+    );
+    // Only the exact sentinel — a hypothetical real `cursor/...` id is not one.
+    expect(isRuntimeChosenModelSentinel("cursor/gpt-5")).toBe(false);
+    expect(isRuntimeChosenModelSentinel("")).toBe(false);
+    expect(isRuntimeChosenModelSentinel(undefined)).toBe(false);
+    expect(isRuntimeChosenModelSentinel(null)).toBe(false);
+    expect(runtimeChosenModelSentinelName("anthropic/claude-haiku-4.5")).toBe(
+      undefined
+    );
+  });
+
+  it("tolerates surrounding whitespace, like the classifier does", () => {
+    expect(isRuntimeChosenModelSentinel("  cursor/auto  ")).toBe(true);
+    expect(runtimeChosenModelSentinelName(" cursor/auto")).toBe("Cursor Auto");
+  });
+
+  it("cannot be answered by Object.prototype keys", () => {
+    // The table is null-prototype; a bare index would return a FUNCTION here
+    // and read as a truthy display name.
+    expect(isRuntimeChosenModelSentinel("constructor")).toBe(false);
+    expect(runtimeChosenModelSentinelName("toString")).toBe(undefined);
+  });
+
+  it("gives every declared sentinel a non-empty display name", () => {
+    const entries = Object.entries(RUNTIME_CHOSEN_MODEL_SENTINELS);
+    expect(entries.length).toBeGreaterThan(0);
+    for (const [id, name] of entries) {
+      expect(name.trim().length).toBeGreaterThan(0);
+      expect(isRuntimeChosenModelSentinel(id)).toBe(true);
+      expect(runtimeChosenModelSentinelName(id)).toBe(name);
     }
   });
 });

--- a/mcpjam-inspector/shared/model-provider.ts
+++ b/mcpjam-inspector/shared/model-provider.ts
@@ -154,3 +154,65 @@ export function classifyModelIdProvider(
 export function providerForModelId(modelId: string): ModelProvider | null {
   return classifyModelIdProvider(modelId)?.provider ?? null;
 }
+
+/**
+ * RUNTIME-CHOSEN SENTINELS — model ids that name no provider model at all.
+ *
+ * A host whose harness reaches its model on the CUSTOMER'S OWN account with the
+ * runtime vendor (`modelAccess: "external-account"`) has no model for MCPJam to
+ * choose: the adapter passes none, and the runtime picks one on an account
+ * MCPJam cannot see. The host template still has to seed SOMETHING, so it seeds
+ * a sentinel — deliberately not a real provider model, because a concrete
+ * `anthropic/...` would put a model id into traces and eval metadata that
+ * nothing ever ran.
+ *
+ * The sentinel then has to survive every path that asks a model id a provider
+ * question, and there are two different right answers:
+ *
+ *   - PROVIDER RESOLUTION must EXEMPT it. `cursor` is a registered
+ *     {@link ModelProvider} — so the id classifies honestly instead of falling
+ *     through the bare-id rule to `ollama` — but it is NOT a provider anyone
+ *     configures a BYOK key for. Routing the sentinel into org-provider
+ *     resolution asks a customer to configure a key that cannot exist, and the
+ *     backend answers `provider_not_configured: cursor`.
+ *   - DISPLAY must RESOLVE it, to the label below rather than to the raw id.
+ *
+ * Canonical id → display name, on a null prototype so `"constructor"` and
+ * friends cannot answer the lookup. One table here, beside the classification
+ * rules, instead of `=== "cursor/auto"` scattered across server and client.
+ */
+export const RUNTIME_CHOSEN_MODEL_SENTINELS: Readonly<Record<string, string>> =
+  Object.assign(Object.create(null) as Record<string, string>, {
+    // The Cursor CLI harness. `cursor-agent` authenticates with a
+    // `CURSOR_API_KEY`, every request transits Cursor's servers, and Cursor
+    // Auto picks the model on that account.
+    "cursor/auto": "Cursor Auto",
+  });
+
+/**
+ * Is this id a runtime-chosen sentinel rather than a model some provider serves?
+ *
+ * Blank- and nullish-safe, and trim-tolerant like {@link classifyModelIdProvider}
+ * — a provider-resolution site often holds a value it has not validated yet.
+ */
+export function isRuntimeChosenModelSentinel(
+  modelId: string | undefined | null,
+): boolean {
+  if (typeof modelId !== "string") return false;
+  return Object.prototype.hasOwnProperty.call(
+    RUNTIME_CHOSEN_MODEL_SENTINELS,
+    modelId.trim(),
+  );
+}
+
+/**
+ * The display name for a runtime-chosen sentinel (e.g. `"Cursor Auto"`), or
+ * `undefined` for an ordinary model id. Use it wherever a model label is
+ * rendered so the raw sentinel never reaches a user-visible surface.
+ */
+export function runtimeChosenModelSentinelName(
+  modelId: string | undefined | null,
+): string | undefined {
+  if (typeof modelId !== "string") return undefined;
+  return RUNTIME_CHOSEN_MODEL_SENTINELS[modelId.trim()];
+}


### PR DESCRIPTION
## What

Two bugs that made a Cursor CLI session misrepresent itself — one of which **prevented Cursor hosts from reaching the harness at all on the desktop rail**.

The `cursor-cli` template seeds `modelId: "cursor/auto"`, a deliberate NEUTRAL SENTINEL: the Cursor CLI has no provider routing, the adapter passes no model, and Cursor Auto picks. Backend #1224 additionally registered `cursor` as a `ModelProviderName` so the sentinel would not classify as `ollama`. That registration had a consequence nobody traced.

## Root causes

**1 — `cursor/auto` demanded a BYOK provider key.** `deriveOrgProviderKey` (`server/utils/org-model-config.ts:274-287`) returns `{ok: true, key: provider}` for anything non-`custom`, so `cursor/auto` yielded `key: "cursor"`. Three call sites then hit the org config:
- `resolveSyntheticModelSource` → not local-eligible → `source: "byok"` → `resolve-turn-runtime.ts` built `/stream/org` with `providerKey: "cursor"` → Convex `provider_not_configured: cursor is not enabled for this project/workspace organization`. (This is what we hit live on the v1 sessions path.)
- `web-chat-turn.ts:1082` for non-harness turns.
- **`routes/mcp/chat-v2.ts:1732` — worse:** the gate was `isMcpJamProvidedModel && modelDefinition.id`, so **every Cursor host on the local desktop rail fell into org-BYOK and never reached the harness at all.**

**2 — the session recorded no model.** Two independent holes, both specific to the external-account harness:
- `routes/web/chat-v2.ts:737` gated the host-model override on `isScenarioSession`, so a Playground host-bound turn never adopted the host's `cursor/auto`. The client cannot supply it either — the picker reseed only adopts a host model that resolves in `availableModels`, and the sentinel never does — so the body's leftover pick was recorded verbatim.
- `routes/web/chat-v2.ts:282` guarded `!modelDefinition` (the object), never `.id`, and `model` arrives via an unvalidated body cast. The harness rail is the only live path with no downstream id check (it skips `deriveOrgProviderKey` *and* both harness model gates, which are exempt for `external-account`), so an id-less body ran a full turn and `""`/`undefined` reached ingestion, where `JSON.stringify` drops the key — hence `modelId: undefined` on the persisted row.

## Changes

- **`shared/model-provider.ts`** — `RUNTIME_CHOSEN_MODEL_SENTINELS` (null-prototype id → label) plus `isRuntimeChosenModelSentinel` / `runtimeChosenModelSentinelName`. One shared predicate beside the classification rules, usable by server and client, instead of scattered `=== "cursor/auto"` checks.
- **`org-model-config.ts`** — `deriveOrgProviderKey` refuses the sentinel at the single chokepoint covering all three call sites; `resolveSyntheticModelSource` returns `external-account` before any key derivation; `buildSyntheticModelDefinition` labels it **"Cursor Auto"** without rewriting the id.
- **`resolve-turn-runtime.ts`** — new `external-account` arm → hosted `/stream` carrying only the harness, `modelSource: "external-account"`, no `providerKey`; throws clearly when no harness is selected.
- **`routes/v1/chat-session-turn.ts`** — refuses the sentinel **before** `claimTurnLease`, which is what creates the `chatSessions` row; refusing after it is what leaves a modelless orphan.
- **`routes/mcp/chat-v2.ts`** — external-account exemption on the MCPJam-free branch (mirrors web-chat-turn) + host-model authority.
- **`routes/web/chat-v2.ts`** — host model is authoritative for an external-account harness on every surface, not just scenarios; ingress validates `model.id`, not just `model`.
- **`client/src/hooks/use-chat-session.ts`** — renders the sentinel as "Cursor Auto" with an honest lock reason instead of the raw id under a sign-in wall.

## Tests

199 passing across the touched files (5389 in the wider server+shared sweep, 2097 client). **Non-vacuity verified per file** by stashing only the production change:
- revert `web/chat-v2.ts` → 3 of 4 new route tests fail (`expected 'anthropic/claude-haiku-4.5' to be 'cursor/auto'` ×2; `expected 200 to be 400` for the id-less body — the unfixed code returns 200 and persists the blank).
- revert `org-model-config.ts` + `resolve-turn-runtime.ts` → 5 fail, incl. `expected 'byok' to be 'external-account'` — the exact route to `provider_not_configured`.
- revert `shared/model-provider.ts` → 5 fail; revert `chat-session-turn.ts` → the sentinel refusal fails.

A deliberately passing-both-ways case ("leaves a NON-harness host's model to the body, as before") keeps the exemption scoped.

## Found, not fixed (reported, not silently carried)

- **Orphan lease rows in general**: `claimTurnLease` creates the `chatSessions` row before the model resolves, so *any* turn dying between claim and ingest leaves a modelless row. The `cursor/auto` case is closed by refusing earlier; the general shape remains.
- `""` is indistinguishable from absent in the trace projection (`routes/v1/chat-sessions.ts:402`).
- `getDefaultModel` returns `availableModels[0]` against a declared `ModelDefinition` return type (documented as INSPECTOR-CLIENT-222).
- `String(model.id)` laundering turns an undefined id into the string `"undefined"` at three client sites.
- The Playground picker still shows a stale model on a Cursor host (the reseed skips the sentinel); the server no longer records it, and the Behavior tab already marks the selection unenforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model routing, spend attribution (`modelSource`), harness preflight, and eval dispatch across web, MCP, v1, and swarm paths—high behavioral surface area but heavily tested and fail-closed for misconfiguration.
> 
> **Overview**
> Fixes Cursor CLI hosts misrouting on `cursor/auto` and recording the wrong (or empty) model in sessions.
> 
> **Provider and runtime handling.** Introduces shared runtime-chosen sentinel helpers (`cursor/auto` → display **Cursor Auto**, id unchanged). `deriveOrgProviderKey` refuses the sentinel instead of yielding a `cursor` BYOK key; classification uses `external-account` without org lookup. `resolveTurnRuntime` rejects those turns on surfaces that cannot pass harness credentials (e.g. v1 API). The public sessions API rejects the sentinel **before** the turn lease creates a row.
> 
> **Chat rails (web + desktop MCP).** External-account harness turns follow the MCPJam-free/harness path (not org-BYOK), persist `modelSource: 'external-account'`, mint guest bearer for anonymous desktop Cursor turns, and treat the **host** model as authoritative over the browser picker. Ingress requires a non-empty `model.id`; misconfigured hosts (ordinary id on Cursor harness) fail early via `externalAccountHostModelRefusalReason` using `hostModelId`.
> 
> **Harness gates and dispatch.** External-account harnesses must pin the sentinel; `runAssistantTurn` throws instead of silently emulating. Eval execution promotes the host sentinel over per-case models so admission and dispatch agree.
> 
> **UI.** Playground shows **Cursor Auto** locked with copy that the host runtime picks the model on the user's account, not a sign-in wall.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24b7df94bdde4b61c36ac9ac1dff68a339fe75fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats `cursor/auto` as a sentinel rather than a provider model, so Cursor CLI turns no longer fail with `provider_not_configured` and sessions record the host's sentinel instead of a model that never ran.

**Bug Fixes**
- Adds a shared sentinel predicate that exempts `cursor/auto` from provider-key derivation and the org-model-config lookup, classifies it as `external-account`, and labels it "Cursor Auto" on the server and client.
- Web and local MCP rails route external-account harness turns to the harness without a provider key, tagged `external-account` so they don't consume MCPJam spend; anonymous local turns now get a guest bearer instead of 503-ing.
- Refuses `external-account` turns on surfaces that can't deliver the customer's credential: `resolveTurnRuntime` before the turn is marked spent, and the public sessions API before the turn lease creates the session row.
- Makes the host's sentinel authoritative over the browser's leftover model on every surface, including eval runs where admission and execution now agree, and rejects missing, null, or blank `model.id` before anything runs or persists.
- Rejects external-account hosts that pin an ordinary model id, holding the host's own configured id to the gate so a body-supplied sentinel can't bypass it; the check runs before the org-model-config lookup, and the dispatch throws instead of falling back to the emulated engine.

<sup>Written for commit 24b7df94bdde4b61c36ac9ac1dff68a339fe75fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

