### PR TITLE
docs: Claude Code approval works with MCP servers; fix the Codex refusal reason

### DIFF
--- a/docs/inspector/claude-code-host.mdx
+++ b/docs/inspector/claude-code-host.mdx
@@ -33,7 +33,7 @@ MCPJam supports two harness hosts that run a real agent runtime inside your proj
 |---|---|
 | Model | Honored — must be an MCPJam-provided Anthropic model. Bring-your-own-key models are not supported and fail closed. |
 | System prompt | Honored — passed to the runtime. |
-| Require tool approval | Honored — the toggle is enabled for Claude Code hosts. When on, side-effecting built-ins (Bash, Write, etc.) and MCP server tools pause the turn for your decision; read-only tools run freely. Approval cannot be combined with selected MCP servers — that combination is rejected at pre-flight. |
+| Require tool approval | Honored — the toggle is enabled for Claude Code hosts. When on, the turn pauses for your decision before each side-effecting tool call — the runtime's own write-class built-ins (Bash, Write, Edit, and the like) and the tools of any selected MCP server. Read-only tools run freely. Approval and selected MCP servers can be combined. |
 | Selected MCP servers | Honored — delivered via the session's MCP config through MCPJam's proxy. |
 | Skills | Honored — runtime skills are materialized into the sandbox. |
 | Temperature and other sampling controls | Not honored — the Claude Code runtime owns its own sampling. These controls are grayed out in the UI. |
@@ -89,8 +89,7 @@ None of these fall back to the emulated engine — a turn that says it ran the r
 | Condition | What you see |
 |---|---|
 | Enterprise-managed authorization policy on the host | Pre-flight error — the combination is rejected rather than silently bypassed. |
-| Require tool approval + selected MCP servers (Claude Code) | Pre-flight error — turn approval off or remove the MCP servers. |
-| Require tool approval + selected MCP servers (Codex) | Pre-flight error — Codex runs the host's MCP tools on MCPJam's server and cannot pause them for approval. Turn approval off or remove the MCP servers. |
+| Require tool approval on a Codex host | Pre-flight error — the Codex runtime doesn't pause for tool approval, so the turn is refused rather than run unapproved, whether or not any MCP server is selected. The toggle is disabled on Codex hosts; a host that carried approval in from another harness has to turn it off. |
 | Computer data plane not configured | Pre-flight error naming the data plane requirement. |
 | Model not supported by the selected harness | Pre-flight error asking you to pick an eligible model. |
 | Computer at daily start cap | Start-limit dialog with upgrade option. |

--- a/docs/inspector/claude-code-host.mdx
+++ b/docs/inspector/claude-code-host.mdx
@@ -89,7 +89,7 @@ None of these fall back to the emulated engine — a turn that says it ran the r
 | Condition | What you see |
 |---|---|
 | Enterprise-managed authorization policy on the host | Pre-flight error — the combination is rejected rather than silently bypassed. |
-| Require tool approval on a Codex host | Pre-flight error — the Codex runtime doesn't pause for tool approval, so the turn is refused rather than run unapproved, whether or not any MCP server is selected. The toggle is disabled on Codex hosts; a host that carried approval in from another harness has to turn it off. |
+| Require tool approval on a Codex host | Pre-flight error — the Codex runtime doesn't pause for tool approval, so the turn is refused rather than run unapproved, whether or not any MCP server is selected. The toggle is disabled on Codex hosts, so a host that carried approval in from another harness keeps the stored value: clear `requireToolApproval` through the API or CLI, or switch the host off Codex to reach the toggle again. |
 | Computer data plane not configured | Pre-flight error naming the data plane requirement. |
 | Model not supported by the selected harness | Pre-flight error asking you to pick an eligible model. |
 | Computer at daily start cap | Start-limit dialog with upgrade option. |


### PR DESCRIPTION
Three rows on `docs/inspector/claude-code-host.mdx` described tool-approval behavior `main` no longer has. Spotted while reviewing #4595, but they predate that branch, so they were deliberately left out of it.

## Claude Code: the combination is supported, not refused

#4531 moved the Claude Code adapter to the permission mode under which the in-sandbox bridge gates MCP calls, and flipped `supportsMcpToolApproval` to `true`. `harnessToolApprovalRefusalReason` reads that flag on the native arm of the delivery split, so it returns `undefined` and the host is admitted — asserted directly by *"admits an approval host WITH selected MCP servers on Claude Code"* in `server/utils/harness/__tests__/harness-availability.test.ts`.

The follow-up docs pass (#4539) rewrote the front half of the capability row but left its trailing sentence, and never touched the failure-modes table. The page therefore contradicted both the code and itself.

- **Capability row** — drops "Approval cannot be combined with selected MCP servers", says plainly that the two work together, and describes what approval actually pauses on: the runtime's write-class built-ins and the tools of any selected MCP server, with read-only tools running free.
- **Failure-modes row** — deleted. The adapter declares all three approval capabilities, so Claude Code has no approval-related pre-flight refusal left to document.

## Codex: right refusal, wrong reason

The Codex row blamed host-executed MCP tools for a refusal Codex never produces that way. `supportsNativeToolApproval` is `false`, so the general approval refusal fires first and the MCP-specific message is unreachable for that harness — the test for Codex-with-servers asserts only that *some* refusal comes back, and the MCP message is exercised through a synthetic native adapter instead.

The refusal itself is real and still reachable, so the row is rewritten rather than dropped. It is pinned with **no** servers selected (*"refuses Codex under approval even with NO servers selected"*), and the combination can still be built: the older client-config editor renders an ungated approval switch, the stored value survives a harness switch, and the CLI/API can set `requireToolApproval=true` alongside `harness=codex`. The condition loses the MCP qualifier and the reason now matches what pre-flight returns. The Codex capability row (already accurate, and describing the default transport) is untouched.

## Notes

- Docs only — no code or test changes.
- No changeset: `docs/` sits outside every published package, matching the precedent docs-only commit.
- `docs/README.md` rules respected: no feature-flag keys, no internals (permission-mode names, bridge callbacks), and nothing gated is described or alluded to.

## Verification

- Only the three rows move; every table row still has exactly three pipes.
- `grep -rn "Approval cannot be combined\|approval off or remove the MCP servers" docs/` → no hits.
- `grep -n "app-server\|allow-reads\|allow-edits\|canUseTool\|codex-host-enabled\|cursor" docs/inspector/claude-code-host.mdx` → no hits.
- `npx vitest run server/utils/harness/__tests__/harness-availability.test.ts` → **36 passed**, including the four cases the new wording rests on: *"admits an approval host WITH selected MCP servers on Claude Code"*, *"allows Claude Code under approval once a server is attached"*, *"refuses Codex under approval even with NO servers selected"*, and *"still refuses a native harness that can't approve its MCP tools"*.
- Every claim was re-derived from the adapter declarations in `server/utils/harness/registry.ts`, the branch order in `harness-availability.ts`, and the assertions in that suite, rather than taken from the report that prompted the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112qxHVTKXhQ1aebBPGqkcz

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the Claude Code and Codex approval docs to match current harness behavior.

- Claude Code: approval can be combined with selected MCP servers, so the failure-mode row for that combination is removed.
- Codex: the refusal is now described as Codex not pausing for tool approval, and the row names how to clear a stored approval value: the API or CLI `requireToolApproval`, or switching the host off Codex.
- Docs-only change; no code or test changes.

<sup>Written for commit cb3aa66fb82fa765c484b56ef898de386e54c8b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to inspector host guidance; no runtime, API, or test changes.
> 
> **Overview**
> Updates **`docs/inspector/claude-code-host.mdx`** so host settings and failure modes match current harness pre-flight and capability flags.
> 
> **Claude Code — require tool approval:** The capability row no longer claims approval and selected MCP servers are mutually exclusive. It now states that approval pauses **write-class built-ins and any selected MCP server tools**, with read-only tools still running freely, and that **both settings can be used together**.
> 
> **Failure modes:** The pre-flight row that rejected **Claude Code with approval plus MCP servers** is **removed**, since that combination is admitted. The two Codex rows that blamed **approval + MCP servers** are **replaced** by one row for **require tool approval on any Codex host** (with or without servers), explaining Codex does not pause for approval and how to clear a stale `requireToolApproval` value when the UI toggle is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb3aa66fb82fa765c484b56ef898de386e54c8b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->