### PR TITLE
sdk: register eval_iteration as a permalink resource type

### DIFF
--- a/.changeset/eval-iteration-permalink.md
+++ b/.changeset/eval-iteration-permalink.md
@@ -1,0 +1,26 @@
+---
+"@mcpjam/sdk": patch
+---
+
+`eval_iteration` is a platform permalink resource type
+
+An eval iteration is now addressable through the same registry as every other
+MCPJam resource: `buildAppPermalink({ type: "eval_iteration", … })` mints
+`/evals/suite/<suiteId>/runs/<runId>?iteration=<iterationId>&project=<projectId>`,
+labelled **View iteration**, and `isPlatformResourceType("eval_iteration")` is
+true. An iteration has no page of its own — the run detail reads `?iteration=`
+off its query string — so the route is the run's path with an id selector.
+
+That route needs two ancestors (the run, and the run's suite), which the
+single-`parent` ref could not express. `PlatformResourceRef.parent` is now a
+`PlatformResourceParentRef` that may carry its own `parent`, and route
+segments gained `":grandparent"` beside `":parent"`. The builder walks the
+chain against the table — the iteration entry says only "under `eval_run`";
+that a run lives under a suite is still stated once, on `eval_run` — and
+refuses a chain that is short or wrong at any level. Existing single-parent
+refs are unchanged in shape and mint identical URLs.
+
+`evalIterationRef(iterationId, runId, suiteId, projectId?)` is exported from
+`@mcpjam/sdk/platform` operations for the follow-up that wires a caller:
+`get_eval_iteration_trace` still declares no permalink, because its response
+names no suite to reach the run through.

--- a/mcpjam-inspector/client/src/lib/__tests__/permalink-routes.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/permalink-routes.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from "vitest";
 import {
   PLATFORM_PERMALINK_ROUTES,
   buildAppPermalink,
+  type PlatformResourceParentRef,
   type PlatformResourceType,
 } from "@mcpjam/sdk/platform";
 import { APP_ROUTES } from "../app-routes";
@@ -21,20 +22,46 @@ import {
   buildProjectPluginPath,
   buildProjectServerPath,
 } from "../app-navigation";
+import { parseEvalRouteFromUrl } from "../eval-route-url";
 
 const APP_ORIGIN = "https://app.mcpjam.com";
 const PROJECT = "v977phvmg9dttdemo";
 
+/**
+ * The parent chain a type's route declares, one placeholder id per level
+ * (`parent-id`, then `grandparent-id`), read off the table the way the SDK
+ * builder reads it.
+ */
+function parentChainFor(
+  type: PlatformResourceType,
+): PlatformResourceParentRef | undefined {
+  const labels = ["parent-id", "grandparent-id"];
+  const chain: PlatformResourceType[] = [];
+  let current = (PLATFORM_PERMALINK_ROUTES[type] as { parent?: string })
+    .parent as PlatformResourceType | undefined;
+  while (current) {
+    chain.push(current);
+    current = (PLATFORM_PERMALINK_ROUTES[current] as { parent?: string })
+      .parent as PlatformResourceType | undefined;
+  }
+  return chain.reduceRight<PlatformResourceParentRef | undefined>(
+    (parent, ancestorType, index) => ({
+      type: ancestorType,
+      id: labels[index] ?? `ancestor-${index + 1}`,
+      ...(parent ? { parent } : {}),
+    }),
+    undefined,
+  );
+}
+
 /** The app path one resource type mints, with ids that cannot collide. */
 function pathFor(type: PlatformResourceType): string {
-  const route = PLATFORM_PERMALINK_ROUTES[type] as { parent?: string };
+  const parent = parentChainFor(type);
   return buildAppPermalink(
     {
       type,
       id: "resource-id",
-      ...(route.parent
-        ? { parent: { type: route.parent as PlatformResourceType, id: "parent-id" } }
-        : {}),
+      ...(parent ? { parent } : {}),
       projectId: PROJECT,
     },
     { appOrigin: APP_ORIGIN },
@@ -100,6 +127,37 @@ describe("the SDK permalink registry ↔ the app route table", () => {
     for (const [type, appPath] of cases) {
       expect(new URL(pathFor(type), APP_ORIGIN).pathname, type).toBe(appPath);
     }
+  });
+
+  it("an eval iteration permalink parses as the run page with that iteration selected", () => {
+    // The SDK's `eval_iteration` route is the run's path plus `?iteration=`,
+    // because the run page is what reads that parameter. This is the test
+    // that proves the link WORKS rather than merely looking right: the app's
+    // own eval-route parser gets the minted path and must land on the run
+    // detail with the suite, the run and the iteration all recovered.
+    const permalink = buildAppPermalink(
+      {
+        type: "eval_iteration",
+        id: "it_1",
+        parent: {
+          type: "eval_run",
+          id: "run_1",
+          parent: { type: "eval_suite", id: "s_1" },
+        },
+        projectId: PROJECT,
+      },
+      { appOrigin: APP_ORIGIN },
+    );
+    const url = new URL(permalink.url);
+    expect(url.pathname).toBe("/evals/suite/s_1/runs/run_1");
+    expect(url.search).toBe(`?iteration=it_1&project=${PROJECT}`);
+    expect(parseEvalRouteFromUrl("/evals", url.pathname, url.search)).toEqual({
+      type: "run-detail",
+      suiteId: "s_1",
+      runId: "run_1",
+      iteration: "it_1",
+      testCaseId: undefined,
+    });
   });
 
   it("carries the project scope on every route but organizations", () => {

--- a/sdk/src/platform/__tests__/permalinks.test.ts
+++ b/sdk/src/platform/__tests__/permalinks.test.ts
@@ -13,9 +13,11 @@ import {
   runOperationWithPermalinks,
   withPermalinkEnvelope,
   type PlatformPermalink,
+  type PlatformResourceParentRef,
   type PlatformResourceRef,
   type PlatformResourceType,
 } from "../permalinks.js";
+import { evalIterationRef } from "../operations.js";
 
 const ORIGIN = DEFAULT_MCPJAM_APP_ORIGIN;
 const PROJECT = "v977phvmg9dttdemo";
@@ -25,6 +27,31 @@ function build(
   appOrigin = ORIGIN
 ): PlatformPermalink {
   return buildAppPermalink(resource, { appOrigin });
+}
+
+/**
+ * The parent chain a type's route declares, read off the table the same way
+ * the builder reads it, with one placeholder id per level (`p-1`, `p-2`, …).
+ */
+function parentChainFor(
+  type: PlatformResourceType
+): PlatformResourceParentRef | undefined {
+  const chain: PlatformResourceType[] = [];
+  let current = (PLATFORM_PERMALINK_ROUTES[type] as { parent?: string })
+    .parent as PlatformResourceType | undefined;
+  while (current) {
+    chain.push(current);
+    current = (PLATFORM_PERMALINK_ROUTES[current] as { parent?: string })
+      .parent as PlatformResourceType | undefined;
+  }
+  return chain.reduceRight<PlatformResourceParentRef | undefined>(
+    (parent, ancestorType, index) => ({
+      type: ancestorType,
+      id: `p-${index + 1}`,
+      ...(parent ? { parent } : {}),
+    }),
+    undefined
+  );
 }
 
 describe("route mappings", () => {
@@ -66,6 +93,48 @@ describe("route mappings", () => {
     ).toBe(`/evals/suite/s_1/runs/run_1?project=${PROJECT}`);
   });
 
+  it("selects an iteration on its run's page, two levels under the suite", () => {
+    // An iteration has no page of its own: the run detail reads
+    // `?iteration=` off the query string. So the link is the RUN's path
+    // exactly, plus the selector, plus the project — in that order.
+    const permalink = build({
+      type: "eval_iteration",
+      id: "it_1",
+      parent: {
+        type: "eval_run",
+        id: "run_1",
+        parent: { type: "eval_suite", id: "s_1" },
+      },
+      projectId: PROJECT,
+    });
+    expect(permalink.path).toBe(
+      `/evals/suite/s_1/runs/run_1?iteration=it_1&project=${PROJECT}`
+    );
+    expect(permalink.label).toBe("View iteration");
+    expect(permalink.resource).toEqual({ type: "eval_iteration", id: "it_1" });
+    expect(permalink.projectId).toBe(PROJECT);
+
+    const run = build({
+      type: "eval_run",
+      id: "run_1",
+      parent: { type: "eval_suite", id: "s_1" },
+      projectId: PROJECT,
+    });
+    expect(new URL(permalink.url).pathname).toBe(new URL(run.url).pathname);
+  });
+
+  it("the ref builder composes the same chain by hand", () => {
+    expect(build(evalIterationRef("it_1", "run_1", "s_1", PROJECT)).path).toBe(
+      `/evals/suite/s_1/runs/run_1?iteration=it_1&project=${PROJECT}`
+    );
+    // Without a project the ref carries none, and the builder refuses it the
+    // way it refuses every other project-scoped type.
+    expect(evalIterationRef("it_1", "run_1", "s_1").projectId).toBeUndefined();
+    expect(() => build(evalIterationRef("it_1", "run_1", "s_1"))).toThrow(
+      /needs a project id/
+    );
+  });
+
   it("sends a grouped launch to the suite's runs lens, not one member run", () => {
     // The non-obvious one: a group has an id of its own but no page of its
     // own, and linking to one member would hide a sibling's failure.
@@ -95,6 +164,10 @@ describe("route mappings", () => {
     // meaning.
     expect(isPlatformResourceType("swarm")).toBe(false);
     expect(isPlatformResourceType("journey_run")).toBe(true);
+  });
+
+  it("has a route for an eval iteration, reached through its run", () => {
+    expect(isPlatformResourceType("eval_iteration")).toBe(true);
   });
 
   it("has no route for a readiness run, which nothing can address", () => {
@@ -148,9 +221,18 @@ describe("query merging", () => {
   });
 
   it("coexists with a route's own id selector", () => {
-    for (const [type, key] of [["chat_session", "session"]] as const) {
-      const params = new URL(build({ type, id: "x", projectId: PROJECT }).url)
-        .searchParams;
+    for (const [type, key] of [
+      ["chat_session", "session"],
+      ["eval_iteration", "iteration"],
+    ] as const) {
+      const params = new URL(
+        build({
+          type,
+          id: "x",
+          ...(parentChainFor(type) ? { parent: parentChainFor(type) } : {}),
+          projectId: PROJECT,
+        }).url
+      ).searchParams;
       expect(params.get(key)).toBe("x");
       expect(params.get(PROJECT_DEEP_LINK_PARAM)).toBe(PROJECT);
       expect([...params.keys()].sort()).toEqual([key, "project"].sort());
@@ -229,6 +311,68 @@ describe("required scope and parents", () => {
     ).toThrow(/nests under eval_suite, not chat_session/);
   });
 
+  it("refuses an iteration whose chain is short, or wrong at either level", () => {
+    // Run given, suite missing: the second level is checked, not just the
+    // first — otherwise the URL would be `/evals/suite/undefined/…`.
+    expect(() =>
+      build({
+        type: "eval_iteration",
+        id: "it_1",
+        parent: { type: "eval_run", id: "run_1" },
+        projectId: PROJECT,
+      })
+    ).toThrow(/needs its eval_suite parent \(through eval_run\)/);
+    expect(() =>
+      build({ type: "eval_iteration", id: "it_1", projectId: PROJECT })
+    ).toThrow(/needs its eval_run parent;/);
+    expect(() =>
+      build({
+        type: "eval_iteration",
+        id: "it_1",
+        parent: { type: "eval_suite", id: "s_1" },
+        projectId: PROJECT,
+      })
+    ).toThrow(/nests under eval_run, not eval_suite/);
+    expect(() =>
+      build({
+        type: "eval_iteration",
+        id: "it_1",
+        parent: {
+          type: "eval_run",
+          id: "run_1",
+          parent: { type: "chat_session", id: "cs_1" },
+        },
+        projectId: PROJECT,
+      })
+    ).toThrow(/eval_run permalink nests under eval_suite, not chat_session/);
+    expect(() =>
+      build({
+        type: "eval_iteration",
+        id: "it_1",
+        parent: {
+          type: "eval_run",
+          id: "run_1",
+          parent: { type: "eval_suite", id: " " },
+        },
+        projectId: PROJECT,
+      })
+    ).toThrow(/non-empty eval_suite id/);
+  });
+
+  it("refuses a project-scoped iteration with no project, like every other type", () => {
+    expect(() =>
+      build({
+        type: "eval_iteration",
+        id: "it_1",
+        parent: {
+          type: "eval_run",
+          id: "run_1",
+          parent: { type: "eval_suite", id: "s_1" },
+        },
+      })
+    ).toThrow(/needs a project id/);
+  });
+
   it("refuses an empty id", () => {
     expect(() =>
       build({ type: "project_server", id: "  ", projectId: PROJECT })
@@ -268,14 +412,11 @@ describe("the route registry is the type list", () => {
         parent?: string;
         projectScoped?: boolean;
       };
+      const parent = parentChainFor(type);
       const permalink = build({
         type,
         id: "id-1",
-        ...(route.parent
-          ? {
-              parent: { type: route.parent as PlatformResourceType, id: "p-1" },
-            }
-          : {}),
+        ...(parent ? { parent } : {}),
         projectId: PROJECT,
       });
       const params = new URL(permalink.url).searchParams;
@@ -284,6 +425,69 @@ describe("the route registry is the type list", () => {
       );
       expect(permalink.label.length, type).toBeGreaterThan(0);
     }
+  });
+
+  it("every ancestor segment is backed by a declared parent at that depth", () => {
+    // `:grandparent` in a route whose parent has no parent would encode
+    // `undefined` into the path. Caught in the table, not by a recipient.
+    const depthOf = { ":parent": 1, ":grandparent": 2 } as const;
+    for (const type of Object.keys(
+      PLATFORM_PERMALINK_ROUTES
+    ) as PlatformResourceType[]) {
+      const route = PLATFORM_PERMALINK_ROUTES[type] as {
+        segments: readonly string[];
+      };
+      let depth = 0;
+      for (let p = parentChainFor(type); p; p = p.parent) depth += 1;
+      for (const segment of route.segments) {
+        const needed = depthOf[segment as keyof typeof depthOf];
+        if (needed === undefined) continue;
+        expect(depth, `${type} uses ${segment}`).toBeGreaterThanOrEqual(needed);
+      }
+    }
+  });
+
+  it("builds every pre-existing type's URL exactly as before the chain", () => {
+    // The chain walk replaced the single-parent branch. Pin the URL each
+    // pre-existing type minted under the old code, so a regression in parent
+    // handling shows up as a changed string, not as a subtly different path.
+    const expected: Record<
+      Exclude<PlatformResourceType, "eval_iteration">,
+      string
+    > = {
+      project: `/servers?project=${PROJECT}`,
+      project_server: `/servers/id-1?project=${PROJECT}`,
+      project_environment: `/environments/id-1?project=${PROJECT}`,
+      project_plugin: `/servers/plugins/id-1?project=${PROJECT}`,
+      host: `/hosts/id-1?project=${PROJECT}`,
+      eval_suite: `/evals/suite/id-1?project=${PROJECT}`,
+      eval_case: `/evals/suite/p-1/test/id-1?project=${PROJECT}`,
+      eval_run: `/evals/suite/p-1/runs/id-1?project=${PROJECT}`,
+      eval_run_group: `/evals/suite/p-1?view=runs&project=${PROJECT}`,
+      chat_session: `/sessions?session=id-1&project=${PROJECT}`,
+      conformance_run: `/conformance/runs/id-1?project=${PROJECT}`,
+      journey_run: `/swarms/id-1?project=${PROJECT}`,
+      user_testing_scenario: `/user-testing/id-1?project=${PROJECT}`,
+      organization: "/organizations/id-1",
+    };
+    for (const [type, path] of Object.entries(expected) as Array<
+      [PlatformResourceType, string]
+    >) {
+      const parent = parentChainFor(type);
+      expect(
+        build({
+          type,
+          id: "id-1",
+          ...(parent ? { parent } : {}),
+          projectId: PROJECT,
+        }).path,
+        type
+      ).toBe(path);
+    }
+    // And the table gained exactly the one type this pins nothing for.
+    expect(
+      Object.keys(PLATFORM_PERMALINK_ROUTES).filter((t) => !(t in expected))
+    ).toEqual(["eval_iteration"]);
   });
 });
 

--- a/sdk/src/platform/index.ts
+++ b/sdk/src/platform/index.ts
@@ -50,6 +50,7 @@ export {
   type PlatformPermalink,
   type PlatformPermalinkContext,
   type PlatformPermalinkPolicy,
+  type PlatformResourceParentRef,
   type PlatformResourceRef,
   type PlatformResourceType,
 } from "./permalinks.js";
@@ -307,6 +308,7 @@ export {
 } from "./show-servers.js";
 
 export {
+  evalIterationRef,
   buildImageOperation,
   callServerToolOperation,
   renderServerWidgetOperation,

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -847,6 +847,32 @@ function evalRunRef(
 }
 
 /**
+ * One iteration of an eval run, addressed through the run and the run's suite.
+ *
+ * Exported, unlike its siblings, because no catalog operation can compose it
+ * yet: the trace and iteration-list responses name the run but not the suite,
+ * and a ref needs both. The follow-up that stamps `suiteId` onto those DTOs
+ * is where this gets its first caller.
+ */
+export function evalIterationRef(
+  iterationId: string,
+  runId: string,
+  suiteId: string,
+  projectId?: string
+): PlatformResourceRef {
+  return {
+    type: "eval_iteration",
+    id: iterationId,
+    parent: {
+      type: "eval_run",
+      id: runId,
+      parent: { type: "eval_suite", id: suiteId },
+    },
+    ...(projectId ? { projectId } : {}),
+  };
+}
+
+/**
  * An eval case, addressed through its suite.
  *
  * Returns NOTHING when the suite is unknown rather than falling back to the
@@ -6342,7 +6368,7 @@ export const getEvalIterationTraceOperation: PlatformOperation<
   readOnly: true,
   permalink: noPermalink(
     "no-addressable-resource",
-    "A trace payload for one iteration; iterations have no route of their own, and the response names no suite to reach the run through."
+    "A trace payload for one iteration. `eval_iteration` is addressable (the run page plus `?iteration=`), but the response names no suite to reach the run through, and the ref needs both."
   ),
   inputSchema: evalIterationTraceInput,
   async execute(input, { client, signal, onScopeResolved }) {

--- a/sdk/src/platform/permalinks.ts
+++ b/sdk/src/platform/permalinks.ts
@@ -51,6 +51,25 @@ export const PROJECT_DEEP_LINK_PARAM = "project";
  */
 export const DEFAULT_MCPJAM_APP_ORIGIN = "https://app.mcpjam.com";
 
+/**
+ * One ancestor in a ref's parent chain.
+ *
+ * Recursive rather than a flat list: the table already says, once, that an
+ * eval run lives under its suite, so a ref for something under a RUN only
+ * has to say "here is the run, and here is the run's parent". The builder
+ * walks the chain against the table, so a link is refused when any level
+ * names the wrong type, not just the first.
+ */
+export interface PlatformResourceParentRef {
+  type: PlatformResourceType;
+  id: string;
+  /**
+   * The parent's own parent, required when the parent's route itself declares
+   * a `parent` — an iteration nests under its run, which nests under its suite.
+   */
+  parent?: PlatformResourceParentRef;
+}
+
 /** A reference to a resource, before it becomes a URL. */
 export interface PlatformResourceRef {
   type: PlatformResourceType;
@@ -65,9 +84,10 @@ export interface PlatformResourceRef {
    * The resource whose route this one nests under — an eval case and an
    * eval run are both addressed through their suite. Required for the types
    * that declare `parent`; supplying the wrong type is an error, not a
-   * silent fallback to the collection.
+   * silent fallback to the collection. Carries its own `parent` when the
+   * route nests two levels deep (an eval iteration: run, then suite).
    */
-  parent?: { type: PlatformResourceType; id: string };
+  parent?: PlatformResourceParentRef;
   /** Overrides the route's default label ("View run", "Open suite", …). */
   label?: string;
 }
@@ -156,9 +176,10 @@ interface PlatformPermalinkRoute {
   /** Default link text. Imperative, short enough for a chat line. */
   label: string;
   /**
-   * Path segments, with `":id"` standing for the resource's own id and
-   * `":parent"` for its parent's. Every segment is percent-encoded on the
-   * way out; none of them may be assembled by a caller.
+   * Path segments, with `":id"` standing for the resource's own id,
+   * `":parent"` for its parent's and `":grandparent"` for its parent's
+   * parent's. Every segment is percent-encoded on the way out; none of them
+   * may be assembled by a caller.
    */
   segments: readonly string[];
   /** Static query the route needs to land on the right view. */
@@ -169,7 +190,12 @@ interface PlatformPermalinkRoute {
    * `":id"` segment in practice, though nothing here forbids both.
    */
   idParam?: string;
-  /** The parent type a `":parent"` segment resolves against. */
+  /**
+   * The parent type a `":parent"` segment resolves against. When that type
+   * declares a `parent` of its own, `":grandparent"` resolves against it and
+   * the ref must carry the whole chain — the nesting is stated once, on the
+   * parent's entry, never restated here.
+   */
   parent?: string;
   /**
    * False only for resources that live above a project (organizations).
@@ -231,6 +257,20 @@ export const PLATFORM_PERMALINK_ROUTES = {
     label: "View run",
     segments: ["evals", "suite", ":parent", "runs", ":id"],
     parent: "eval_suite",
+  },
+  /**
+   * One iteration of a run, selected on the run's page.
+   *
+   * An iteration has no page of its own: the run detail reads `?iteration=`
+   * off its query string and opens that trial. So the route is the RUN's
+   * path with an id selector, and it nests two levels deep — the run is the
+   * parent, and the run's own entry above says the suite is the run's.
+   */
+  eval_iteration: {
+    label: "View iteration",
+    segments: ["evals", "suite", ":grandparent", "runs", ":parent"],
+    idParam: "iteration",
+    parent: "eval_run",
   },
   /**
    * A grouped launch (one suite fanned across several targets).
@@ -363,6 +403,18 @@ function normalizeAppOrigin(appOrigin: string): URL {
 }
 
 /**
+ * Which level of a ref's parent chain each ancestor segment reads.
+ *
+ * `:parent` is the immediate parent, `:grandparent` the one above it. The
+ * vocabulary stops there on purpose: nothing in the app nests deeper, and a
+ * third token would be adding a route shape no screen has.
+ */
+const ANCESTOR_SEGMENT_DEPTH: Readonly<Record<string, number>> = {
+  ":parent": 0,
+  ":grandparent": 1,
+};
+
+/**
  * Build one resource's permalink.
  *
  * Uses `URL`/`URLSearchParams` throughout rather than string concatenation:
@@ -394,32 +446,57 @@ export function buildAppPermalink(
   const origin = normalizeAppOrigin(options.appOrigin);
   const url = new URL(origin.toString());
 
-  let parentId: string | undefined;
-  if (route.parent) {
-    if (!resource.parent) {
+  // Walk the parent chain as far as the TABLE says it goes: the route names
+  // its parent type, that type's own entry names the next, and so on. Each
+  // level of the ref is checked against the level the table expects, so an
+  // iteration handed a run whose parent is a chat session fails here rather
+  // than minting `/evals/suite/<session id>/…`.
+  const ancestorIds: string[] = [];
+  let expectedType = route.parent;
+  let ancestor = resource.parent;
+  let through = resource.type;
+  while (expectedType) {
+    if (!ancestor) {
       throw new PlatformPermalinkError(
-        `A ${resource.type} permalink needs its ${route.parent} parent; without it the URL would address the wrong resource.`
+        `A ${resource.type} permalink needs its ${expectedType} parent${
+          through === resource.type ? "" : ` (through ${through})`
+        }; without it the URL would address the wrong resource.`
       );
     }
-    if (resource.parent.type !== route.parent) {
+    if (ancestor.type !== expectedType) {
       throw new PlatformPermalinkError(
-        `A ${resource.type} permalink nests under ${route.parent}, not ${resource.parent.type}.`
+        `A ${through} permalink nests under ${expectedType}, not ${ancestor.type}.`
       );
     }
-    parentId = resource.parent.id?.trim();
-    if (!parentId) {
+    const ancestorId = ancestor.id?.trim();
+    if (!ancestorId) {
       throw new PlatformPermalinkError(
-        `A ${resource.type} permalink needs a non-empty ${route.parent} id.`
+        `A ${resource.type} permalink needs a non-empty ${expectedType} id.`
       );
     }
+    ancestorIds.push(ancestorId);
+    through = ancestor.type;
+    expectedType = (
+      PLATFORM_PERMALINK_ROUTES[ancestor.type] as PlatformPermalinkRoute
+    ).parent;
+    ancestor = ancestor.parent;
   }
 
   // `URL.pathname =` would re-interpret `%2F` inside a value as a separator,
   // so each segment is encoded and joined here instead.
   const segments = route.segments.map((segment) => {
     if (segment === ":id") return encodeURIComponent(id);
-    if (segment === ":parent") return encodeURIComponent(parentId as string);
-    return segment;
+    const depth = ANCESTOR_SEGMENT_DEPTH[segment];
+    if (depth === undefined) return segment;
+    const ancestorId = ancestorIds[depth];
+    if (ancestorId === undefined) {
+      // A table mistake, not a caller's: the route names an ancestor deeper
+      // than its declared parent chain reaches.
+      throw new PlatformPermalinkError(
+        `Route for ${resource.type} uses "${segment}" but declares no ancestor at that depth.`
+      );
+    }
+    return encodeURIComponent(ancestorId);
   });
   url.pathname = `/${segments.join("/")}`;
 


### PR DESCRIPTION
Makes an eval iteration addressable through the same permalink envelope as every other MCPJam resource. Contract-only; no runtime behaviour changes.

## Why

`get_eval_iteration_trace` declares `noPermalink("no-addressable-resource", "…iterations have no route of their own…")`. Half of that is no longer true: the run page already parses `?iteration=` off its query string (`client/src/lib/eval-route-url.ts`, the `run-detail` branch), so an iteration **is** addressable — as the run's path with a selector. The other half still holds and is untouched here: the trace response carries no suite id, so that operation cannot derive its own link. Wiring it up needs `suiteId` on the trace DTO and is a separate follow-up.

## The design question, and what it cost

Existing entries support ONE `:parent`. An iteration nests two levels: the run is its parent, and the run's own entry already says the suite is the run's.

Chosen: a **recursive** `PlatformResourceParentRef`, with `":grandparent"` as a segment token. The nesting is stated once, on each entry, and the builder walks the chain against the table — so a link is refused when *any* level names the wrong type, not just the first.

Rejected: a flat ancestor array (restates on the iteration entry what `eval_run` already says, and drifts the day a run moves); and hoisting the suite id onto the ref as a plain field (works, but makes `eval_iteration` a special case the table cannot describe, which is exactly what the one-table rule exists to prevent).

`PlatformResourceType` stays inferred from `PLATFORM_PERMALINK_ROUTES`, so the new type cannot exist without its route.

## Verification

- `sdk/src/platform/__tests__/permalinks.test.ts`: 36 passing, including that every pre-existing resource type still builds the identical URL it did before (the guard against a regression in parent handling).
- `client/src/lib/__tests__/permalink-routes.test.ts`: the minted path is fed back through the app's own eval-route parser and must land on `run-detail` with the suite, run and iteration all recovered. This is the assertion that proves the link works rather than merely looks right.
- `npx tsc -p sdk --noEmit` clean. Changeset included.

**Worktree note for the reviewer:** the client test resolves `@mcpjam/sdk` through a `node_modules` symlink to the shared checkout, so it fails locally in a worktree against the *old* SDK. Re-run with the SDK aliased to this branch's `sdk/src` and all 5 pass; in CI the whole tree is one checkout and this does not arise.

## Relationship to the backend

`MCPJam/mcpjam-backend#1234` teaches the GitHub PR feedback comment to emit the same envelope. It mints its own URLs from `convex/lib/appUrls.ts` and does not import this package, so neither PR blocks the other — but the two URL shapes agree: `/evals/suite/<suiteId>/runs/<runId>?iteration=<id>&project=<pid>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4a8e118266121419d27a562c7983d82fd136d604. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`eval_iteration` was previously excluded from SDK permalink routes; it now produces the standard permalink envelope for the run detail page using `?iteration=`, so iterations can be linked directly without changing runtime behavior.

**New Features**

- Adds recursive `PlatformResourceParentRef` support so nested resources can resolve run and suite ancestors from the route registry.
- Exports `evalIterationRef(...)` from `@mcpjam/sdk/platform` for callers with iteration, run, and suite IDs.
- Validates every ancestor type and ID while preserving existing URLs for all current resource types.
- Keeps `get_eval_iteration_trace` without a permalink because its response still lacks the suite ID needed to build the chain.
- Adds SDK and client route coverage plus a patch changeset.

<sup>Written for commit 4a8e118266121419d27a562c7983d82fd136d604. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

