### PR TITLE
chore: add release changeset for inspector, CLI, and SDK

### DIFF
--- a/.changeset/releases-2026-09-02.md
+++ b/.changeset/releases-2026-09-02.md
@@ -1,0 +1,15 @@
+---
+"@mcpjam/inspector": patch
+"@mcpjam/cli": patch
+"@mcpjam/sdk": patch
+---
+
+Release @mcpjam/inspector, @mcpjam/cli, and @mcpjam/sdk.
+
+Cuts a version for the unreleased work that landed without a changeset of its own:
+
+- **Swarms** — a Findings tab that leads the run as the default landing tab with a persona-journey narrative, a live strip that no longer contradicts its own session count, and a running swarm that keeps its thread.
+- **Local Claude Code** — the real agent runs natively on the user's machine.
+- **Codex over app-server** — a transport that can actually pause a run.
+- **WebMCP viewport** — sharp at rest, honest geometry, and a stream that answers a slow link.
+- **Models** — brand logos for 11 catalog providers, with `spacexai` wired to xAI.


### PR DESCRIPTION
- Adds one changeset that bumps `@mcpjam/inspector`, `@mcpjam/cli`, and `@mcpjam/sdk` a patch version each.
- No code changes — this just tells the release job to cut new versions of those three packages.
- Covers the work that landed since the last release without a changeset: the Swarms Findings tab, live-strip count fix and running-swarm thread; Local Claude Code running natively; Codex over app-server; the WebMCP viewport; and brand logos for 11 model providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a release changeset that bumps `@mcpjam/inspector`, `@mcpjam/cli`, and `@mcpjam/sdk` to a new patch version. No code changes; this tells the release job to cut new versions for the unreleased work that landed since the last release.

**Included work**
- Swarms: new Findings tab, fixed live-strip count, and running swarms keep their thread.
- Local Claude Code now runs natively; Codex over app-server can pause a run.
- WebMCP viewport sharpens and streams more reliably on slow links.
- Brand logos for 11 model providers, with `spacexai` wired to xAI.

<sup>Written for commit 3b0364ba36ca848aa19670bd774d2e4d2eed6239. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

