### PR TITLE
Say what the Evaluate run launched against, and show the grading pair

### DIFF
--- a/.changeset/evaluate-run-launch-context.md
+++ b/.changeset/evaluate-run-launch-context.md
@@ -1,0 +1,27 @@
+---
+"@mcpjam/inspector": patch
+---
+
+The Evaluate run header says what the run launched against, and the grading pair is always visible.
+
+**A host chip is not an environment.** The run header showed one chip reading
+"Claude" and nothing else: not the model, not the MCP servers, not the
+environment revision. `RunLaunchContext` replaces it with labelled facts —
+client or environment, model, servers, revision — so none of them can be read as
+leftover chrome, and the model is recovered from the run's iterations when the
+list projection omitted `effectiveModelId`. `RunContextChip`'s host branch gains
+the same model attribution it already gave the environment branch.
+
+**The verdict's own evidence was buried in the sentence.** Expected against
+observed lived inside `RunVerdictHero` as a comma-joined line that only rendered
+for a `brokeAt` verdict. It moves out into `RunGradingPeek` — an always-visible
+"Graded against" pair of lists, with every expected call that was never observed
+marked in place rather than left for the reader to diff by eye. The list itself
+is now `EvaluateToolList`, shared with the case body so one miss reads the same
+wherever it surfaces.
+
+**"Prompt to improve" and "Open failing trace" move to the page header.** They
+were inline actions on the hero, scrolling away with it. `EvaluateRunPage` lifts
+them into its header through context, and the hero drops its copies when the
+header has them. Case rows lead with the disclosure chevron instead of a dashed
+placeholder mark for cases that never had a verdict read.

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-context-chip.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-context-chip.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { RunContextChip } from "../run-context-chip";
-import { envRun } from "./run-context-fixtures";
+import { envRun, hostRun } from "./run-context-fixtures";
 
 vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
   useProjectEnvironmentsEnabled: () => true,
@@ -65,5 +65,18 @@ describe("RunContextChip model attribution", () => {
     renderChip({ modelLabel: "Gemini 2.5 Flash" });
     const label = screen.getByText("Gemini 2.5 Flash");
     expect(label).toHaveAttribute("title", "Gemini 2.5 Flash");
+  });
+
+  it("names the model next to a host chip, not only an environment chip", () => {
+    render(
+      <RunContextChip
+        run={hostRun("r-host", "host-1", {
+          effectiveModelId: "anthropic/claude-haiku-4.5",
+        })}
+        hostNamesById={new Map([["host-1", "Claude"]])}
+      />,
+    );
+    expect(screen.getByText("Claude")).toBeInTheDocument();
+    expect(screen.getByText("claude-haiku-4.5")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/export-traces-modal.tsx
+++ b/mcpjam-inspector/client/src/components/evals/export-traces-modal.tsx
@@ -130,8 +130,7 @@ export function ExportTracesModal({
         <DialogHeader>
           <DialogTitle>Export traces</DialogTitle>
           <DialogDescription>
-            Download as OTLP JSON (OpenInference + MCP Apps conventions) for
-            Arize Phoenix, Datadog, or any OTLP-compatible backend.
+            Download as OTLP JSON (OpenInference + MCP Apps conventions).
           </DialogDescription>
         </DialogHeader>
 

--- a/mcpjam-inspector/client/src/components/evals/run-context-chip.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-context-chip.tsx
@@ -131,7 +131,30 @@ export function RunContextChip({
   // screen (mislabelled as a host) with the flag off.
   const name = runHostLabel(run, hostNamesById) ?? fallbackName;
   if (!name) return null;
+  // Same model attribution as the environment branch: a host chip by itself
+  // only names the client, not which model actually ran.
   return (
-    <HostChip name={name} hostId={run.namedHostId} className={className} />
+    <span className="inline-flex min-w-0 items-center gap-1.5">
+      <HostChip name={name} hostId={run.namedHostId} className={className} />
+      {resolvedModelLabel ? (
+        <span
+          className={cn(
+            "truncate text-[11px]",
+            modelSource === "override"
+              ? "text-foreground"
+              : "text-muted-foreground",
+          )}
+          title={
+            modelSource === "client_default"
+              ? `Client default · ${resolvedModelLabel}`
+              : modelSource === "override"
+                ? `Override · ${resolvedModelLabel}`
+                : resolvedModelLabel
+          }
+        >
+          {resolvedModelLabel}
+        </span>
+      ) : null}
+    </span>
   );
 }

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -1324,6 +1324,7 @@ export function SuiteIterationsView({
                 <EvaluateRunPage
                   run={selectedRunDetails}
                   hostNamesById={hostNamesById}
+                  iterations={caseGroupsForSelectedRun}
                   otherRuns={runs.filter(
                     (candidate) =>
                       candidate._id !== selectedRunDetails._id &&

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/evaluate-run-content.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/evaluate-run-content.test.tsx
@@ -206,12 +206,21 @@ describe("EvaluateRunContent", () => {
     expect(screen.getByTestId("run-verdict-sentence")).toHaveTextContent(
       "Draw and share a diagram broke at Selection: an expected tool call was never made.",
     );
-    // The expected/observed pair is the thing the old page never showed. Scoped
-    // to the hero: the open case row repeats both names in its own evidence
-    // block, which is intended, so a document-wide query would be ambiguous.
-    const hero = screen.getByTestId("run-verdict-hero");
-    expect(within(hero).getByText("export_to_excalidraw")).toBeInTheDocument();
-    expect(within(hero).getByText("create_view")).toBeInTheDocument();
+    // The expected/observed pair is a peek under the sentence, not the
+    // counting caveats and not the hero. The open case row repeats both names
+    // in its own evidence block, which is intended, so queries are scoped.
+    const peek = screen.getByTestId("run-grading-peek");
+    expect(peek).toHaveTextContent("Graded against");
+    expect(within(peek).getByText("create_view")).toBeInTheDocument();
+    expect(
+      within(peek).getByText("never called").closest("li"),
+    ).toHaveTextContent("export_to_excalidraw never called");
+    expect(screen.getByTestId("run-verdict-hero")).not.toHaveTextContent(
+      "Expected",
+    );
+    expect(screen.getByTestId("run-verdict-caveats")).not.toHaveTextContent(
+      "export_to_excalidraw",
+    );
   });
 
   it("folds the counting caveats instead of leading with them", () => {
@@ -258,6 +267,7 @@ describe("EvaluateRunContent", () => {
       /\b(Failed|Inconclusive)\b/,
     );
     expect(screen.queryByTestId("run-verdict-caveats")).toBeNull();
+    expect(screen.queryByTestId("run-grading-peek")).toBeNull();
   });
 
   it("says nothing about a verdict when the read failed", () => {

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/evaluate-run-page.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/evaluate-run-page.test.tsx
@@ -53,6 +53,33 @@ describe("EvaluateRunPage", () => {
     expect(screen.getByTestId("evaluate-run-compare-open")).toBeEnabled();
   });
 
+  it("labels the MCP server this run used", () => {
+    render(
+      <EvaluateRunPage
+        run={makeRun({
+          _id: "n57cvtk9tsmnbj5tpcvnmdgkwn8dnjeq",
+          configSnapshot: {
+            tests: [],
+            environment: { servers: ["Excalidraw (App)"] },
+          },
+        })}
+        hostNamesById={hostNamesById}
+        otherRuns={[makeRun({ _id: "other-run" })]}
+        defaultCompareRunId="other-run"
+        onCompareWithRun={vi.fn()}
+      >
+        <div>run body</div>
+      </EvaluateRunPage>,
+    );
+
+    expect(screen.getByTestId("evaluate-run-launch-context")).toHaveTextContent(
+      "Server",
+    );
+    expect(screen.getByTestId("evaluate-run-servers")).toHaveTextContent(
+      "Excalidraw (App)",
+    );
+  });
+
   it("disables Compare when there is no other run", () => {
     render(
       <EvaluateRunPage

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/run-case-rows.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/run-case-rows.test.tsx
@@ -107,10 +107,14 @@ describe("RunCaseRows", () => {
 
     const legacy = screen.getByTestId("run-case-row-g2");
     expect(
-      within(legacy).getByLabelText("No verdict read for this case"),
-    ).toBeInTheDocument();
+      within(legacy).queryByLabelText("No verdict read for this case"),
+    ).toBeNull();
+    expect(within(legacy).queryByLabelText(/Case verdict/)).toBeNull();
     // And it says why, so the missing mark is an answer rather than a gap.
     expect(legacy).toHaveTextContent("counted in iterations");
+    expect(
+      within(legacy).getByRole("button", { name: /Draw a rectangle/ }),
+    ).toHaveAttribute("aria-expanded", "false");
   });
 
   it("hides the fraction for a case that ran once", () => {

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/run-grading-peek.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/run-grading-peek.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * The grading peek is the always-visible expected/observed pair. Empty input
+ * must not leave an empty "Graded against" box on a passed or unread run.
+ */
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { RunGradingPeek } from "../run-grading-peek";
+
+describe("RunGradingPeek", () => {
+  it("hides when there is nothing to compare", () => {
+    const { container } = render(
+      <RunGradingPeek expected={[]} observed={[]} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("marks the expected call that was never observed", () => {
+    render(
+      <RunGradingPeek
+        expected={["create_view", "export_to_excalidraw"]}
+        observed={["create_view"]}
+      />,
+    );
+
+    const peek = screen.getByTestId("run-grading-peek");
+    expect(peek).toHaveTextContent("Graded against");
+    expect(peek).toHaveTextContent("create_view");
+    expect(screen.getByText("never called").closest("li")).toHaveTextContent(
+      "export_to_excalidraw never called",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/run-launch-context.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/run-launch-context.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { RunLaunchContext, modelsFromRun } from "../run-launch-context";
+import type { EvalIteration, EvalSuiteRun } from "../../evals/types";
+
+vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
+  useProjectEnvironmentsEnabled: () => false,
+}));
+
+function makeRun(
+  overrides: Partial<EvalSuiteRun> & { _id: string },
+): EvalSuiteRun {
+  return {
+    suiteId: "suite-1",
+    createdBy: "u1",
+    runNumber: 1,
+    configRevision: "1",
+    configSnapshot: {
+      tests: [],
+      environment: { servers: ["Excalidraw (App)"] },
+    },
+    status: "completed",
+    result: "failed",
+    createdAt: 1,
+    completedAt: 2,
+    source: "ui",
+    namedHostId: "host-1",
+    ...overrides,
+  };
+}
+
+const hostNamesById = new Map<string, string | null>([["host-1", "Claude"]]);
+
+describe("RunLaunchContext", () => {
+  it("labels client, model from iterations, and server", () => {
+    const iterations = [
+      {
+        testCaseSnapshot: { model: "anthropic/claude-haiku-4.5" },
+      },
+    ] as EvalIteration[];
+
+    render(
+      <RunLaunchContext
+        run={makeRun({ _id: "run-1" })}
+        hostNamesById={hostNamesById}
+        iterations={iterations}
+      />,
+    );
+
+    const strip = screen.getByTestId("evaluate-run-launch-context");
+    expect(strip).toHaveTextContent("Client");
+    expect(strip).toHaveTextContent("Claude");
+    expect(strip).toHaveTextContent("Model");
+    expect(strip).toHaveTextContent("claude-haiku-4.5");
+    expect(strip).toHaveTextContent("Server");
+    expect(screen.getByTestId("evaluate-run-servers")).toHaveTextContent(
+      "Excalidraw (App)",
+    );
+  });
+
+  it("prefers the run's effectiveModelId over iteration snapshots", () => {
+    expect(
+      modelsFromRun(
+        makeRun({
+          _id: "run-1",
+          effectiveModelId: "anthropic/claude-sonnet-4-6",
+        }),
+        [
+          {
+            testCaseSnapshot: { model: "anthropic/claude-haiku-4.5" },
+          } as EvalIteration,
+        ],
+      ),
+    ).toEqual(["claude-sonnet-4-6"]);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evaluate/evaluate-run-content.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/evaluate-run-content.tsx
@@ -50,6 +50,7 @@ import { RunCaseRowBody } from "./run-case-row-body";
 import { RunCaseRows } from "./run-case-rows";
 import { RunStageStrip } from "./run-stage-strip";
 import { buildStageStrip } from "./run-stage-strip-model";
+import { RunGradingPeek } from "./run-grading-peek";
 import { RunVerdictCaveats } from "./run-verdict-caveats";
 import {
   buildEvaluateImprovePrompt,
@@ -58,6 +59,7 @@ import {
 import { remedyForDiagnostic } from "./stage-remedy";
 import { RunVerdictHero } from "./run-verdict-hero";
 import { buildRunVerdictHero } from "./run-verdict-hero-model";
+import { useEvaluateRunPageHeaderActions } from "./evaluate-run-page";
 
 export function EvaluateRunContent({
   projectId,
@@ -299,14 +301,28 @@ export function EvaluateRunContent({
   }, [improvePrompt]);
 
   const focusTarget = view.focus?.diagnostic;
-  const openFailingTrace =
-    onOpenIteration && focusTarget?.testCaseId
-      ? () =>
-          onOpenIteration({
-            testCaseId: focusTarget.testCaseId as string,
-            iterationId: focusTarget.iterationId,
-          })
-      : undefined;
+  const openFailingTrace = useCallback(() => {
+    if (!onOpenIteration || !focusTarget?.testCaseId) return;
+    onOpenIteration({
+      testCaseId: focusTarget.testCaseId,
+      iterationId: focusTarget.iterationId,
+    });
+  }, [onOpenIteration, focusTarget?.testCaseId, focusTarget?.iterationId]);
+
+  const canOpenFailingTrace = Boolean(
+    onOpenIteration && focusTarget?.testCaseId,
+  );
+
+  const inRunPageHeader = useEvaluateRunPageHeaderActions(
+    canOpenFailingTrace || improvePrompt
+      ? {
+          ...(improvePrompt ? { onImprove: copyImprovePrompt } : {}),
+          ...(canOpenFailingTrace
+            ? { onOpenFailingTrace: openFailingTrace }
+            : {}),
+        }
+      : null,
+  );
 
   return (
     <div
@@ -315,9 +331,11 @@ export function EvaluateRunContent({
     >
       <RunVerdictHero
         view={view}
-        {...(openFailingTrace ? { onOpenFailingTrace: openFailingTrace } : {})}
+        {...(!inRunPageHeader && canOpenFailingTrace
+          ? { onOpenFailingTrace: openFailingTrace }
+          : {})}
         actions={
-          improvePrompt ? (
+          !inRunPageHeader && improvePrompt ? (
             <Button
               type="button"
               size="sm"
@@ -343,7 +361,13 @@ export function EvaluateRunContent({
         </p>
       ) : null}
 
-      <div className="px-5 pb-4">
+      <div className="flex flex-col gap-3 px-5 pb-4">
+        {view.sentence.kind === "brokeAt" ? (
+          <RunGradingPeek
+            expected={view.sentence.expected}
+            observed={view.sentence.observed}
+          />
+        ) : null}
         <RunVerdictCaveats
           summary={detail.summary}
           shownDiagnostics={detail.diagnostics.length}

--- a/mcpjam-inspector/client/src/components/evaluate/evaluate-run-page.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/evaluate-run-page.tsx
@@ -6,8 +6,14 @@
  * other-run list. Compare is a picker ({@link EvaluateRunCompare}) that then
  * uses the existing `compareToRunId` route / RunDiffView.
  */
-import { useState, type ReactNode } from "react";
-import { GitCompareArrows } from "lucide-react";
+import {
+  createContext,
+  useContext,
+  useLayoutEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { ArrowUpRight, Copy, GitCompareArrows } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { cn } from "@/lib/utils";
 import {
@@ -15,9 +21,40 @@ import {
   evalSurfaceHeaderClass,
 } from "../evals/eval-surface-chrome";
 import { formatRunId } from "../evals/helpers";
-import { RunContextChip } from "../evals/run-context-chip";
-import type { EvalSuiteRun } from "../evals/types";
+import type { EvalIteration, EvalSuiteRun } from "../evals/types";
 import { EvaluateRunCompare } from "./evaluate-run-compare";
+import { RunLaunchContext } from "./run-launch-context";
+
+export type EvaluateRunPageHeaderActions = {
+  onImprove?: () => void;
+  onOpenFailingTrace?: () => void;
+};
+
+const HeaderActionsContext = createContext<
+  ((actions: EvaluateRunPageHeaderActions | null) => void) | null
+>(null);
+
+/** Lift Prompt-to-improve / Open-failing-trace into this page's header. */
+export function useEvaluateRunPageHeaderActions(
+  actions: EvaluateRunPageHeaderActions | null,
+) {
+  const setActions = useContext(HeaderActionsContext);
+  const onImprove = actions?.onImprove;
+  const onOpenFailingTrace = actions?.onOpenFailingTrace;
+  useLayoutEffect(() => {
+    if (!setActions) return;
+    setActions(
+      onImprove || onOpenFailingTrace
+        ? {
+            ...(onImprove ? { onImprove } : {}),
+            ...(onOpenFailingTrace ? { onOpenFailingTrace } : {}),
+          }
+        : null,
+    );
+    return () => setActions(null);
+  }, [setActions, onImprove, onOpenFailingTrace]);
+  return Boolean(setActions);
+}
 
 export function EvaluateRunPage({
   run,
@@ -26,6 +63,7 @@ export function EvaluateRunPage({
   defaultCompareRunId,
   onCompareWithRun,
   onExport,
+  iterations,
   children,
 }: {
   run: EvalSuiteRun;
@@ -34,84 +72,117 @@ export function EvaluateRunPage({
   defaultCompareRunId: string | null;
   onCompareWithRun: (baseRunId: string) => void;
   onExport?: () => void;
+  /** Used to recover the model when the list projection omitted effectiveModelId. */
+  iterations?: readonly EvalIteration[];
   children: ReactNode;
 }) {
   const [comparing, setComparing] = useState(false);
+  const [headerActions, setHeaderActions] =
+    useState<EvaluateRunPageHeaderActions | null>(null);
   const canCompare = otherRuns.length >= 1;
 
   return (
-    <section
-      className={cn(
-        evalSurfaceCardClass,
-        "flex min-h-0 flex-1 flex-col overflow-hidden bg-muted/35 dark:bg-muted/20",
-      )}
-      data-testid="evaluate-run-page"
-    >
-      <div
+    <HeaderActionsContext.Provider value={setHeaderActions}>
+      <section
         className={cn(
-          evalSurfaceHeaderClass,
-          "flex flex-wrap items-center justify-between gap-3 border-border/30 bg-transparent px-5 py-3.5",
+          evalSurfaceCardClass,
+          "flex min-h-0 flex-1 flex-col overflow-hidden bg-muted/35 dark:bg-muted/20",
         )}
+        data-testid="evaluate-run-page"
       >
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <h2 className="font-mono text-[15px] font-semibold tracking-tight text-foreground">
-            Run {formatRunId(run._id)}
-          </h2>
-          <RunOutcomeBadge run={run} />
-          <RunContextChip
+        <div
+          className={cn(
+            evalSurfaceHeaderClass,
+            "flex flex-col gap-2.5 border-border/30 bg-transparent px-5 py-3.5",
+          )}
+        >
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <h2 className="font-mono text-[15px] font-semibold tracking-tight text-foreground">
+                Run {formatRunId(run._id)}
+              </h2>
+              <RunOutcomeBadge run={run} />
+            </div>
+            <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+              {headerActions?.onImprove ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  className="h-8"
+                  onClick={headerActions.onImprove}
+                  data-testid="run-verdict-improve"
+                >
+                  <Copy className="h-4 w-4" />
+                  Prompt to improve
+                </Button>
+              ) : null}
+              {headerActions?.onOpenFailingTrace ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8"
+                  onClick={headerActions.onOpenFailingTrace}
+                  data-testid="run-verdict-open-trace"
+                >
+                  Open failing trace
+                  <ArrowUpRight className="h-3.5 w-3.5" />
+                </Button>
+              ) : null}
+              {onExport ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8"
+                  onClick={onExport}
+                >
+                  Export
+                </Button>
+              ) : null}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-8"
+                disabled={!canCompare}
+                title={
+                  canCompare ? "Compare two runs" : "Need at least two runs"
+                }
+                onClick={() => setComparing(true)}
+                data-testid="evaluate-run-compare-open"
+              >
+                <GitCompareArrows className="h-4 w-4" />
+                Compare runs
+              </Button>
+            </div>
+          </div>
+          <RunLaunchContext
             run={run}
             hostNamesById={hostNamesById}
-            className="gap-1 px-2 py-0.5 text-[11px] shadow-none"
+            iterations={iterations}
           />
         </div>
-        <div className="flex shrink-0 items-center gap-2">
-          {onExport ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-8"
-              onClick={onExport}
-            >
-              Export
-            </Button>
-          ) : null}
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="h-8"
-            disabled={!canCompare}
-            title={
-              canCompare ? "Compare two runs" : "Need at least two runs"
-            }
-            onClick={() => setComparing(true)}
-            data-testid="evaluate-run-compare-open"
-          >
-            <GitCompareArrows className="h-4 w-4" />
-            Compare runs
-          </Button>
-        </div>
-      </div>
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-card">
-        {comparing ? (
-          <EvaluateRunCompare
-            thisRun={run}
-            otherRuns={otherRuns}
-            defaultOtherRunId={defaultCompareRunId}
-            hostNamesById={hostNamesById}
-            onSelect={(baseRunId) => {
-              setComparing(false);
-              onCompareWithRun(baseRunId);
-            }}
-            onCancel={() => setComparing(false)}
-          />
-        ) : (
-          children
-        )}
-      </div>
-    </section>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-card">
+          {comparing ? (
+            <EvaluateRunCompare
+              thisRun={run}
+              otherRuns={otherRuns}
+              defaultOtherRunId={defaultCompareRunId}
+              hostNamesById={hostNamesById}
+              onSelect={(baseRunId) => {
+                setComparing(false);
+                onCompareWithRun(baseRunId);
+              }}
+              onCancel={() => setComparing(false)}
+            />
+          ) : (
+            children
+          )}
+        </div>
+      </section>
+    </HeaderActionsContext.Provider>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/evaluate/evaluate-tool-list.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/evaluate-tool-list.tsx
@@ -1,0 +1,52 @@
+/**
+ * Expected or observed tool names, with the misses called out in the observed
+ * column rather than left for the reader to diff by eye.
+ *
+ * Shared by the case body and the grading peek so one miss reads the same
+ * wherever it surfaces.
+ */
+export function EvaluateToolList({
+  label,
+  names,
+  missing = [],
+}: {
+  label: string;
+  names: string[];
+  /** Expected calls with no observed counterpart. ALL of them, not the first. */
+  missing?: readonly string[];
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="text-[10.5px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <ul className="mt-1.5 flex flex-col gap-1">
+        {names.length === 0 && missing.length === 0 ? (
+          <li className="text-[12.5px] text-muted-foreground">none recorded</li>
+        ) : (
+          names.map((name, index) => (
+            // Keyed by position, because a case may legitimately call the same
+            // tool twice and two list items cannot share a key.
+            <li
+              key={`${name}-${index}`}
+              className="font-mono text-[12.5px] text-foreground"
+            >
+              {name}
+            </li>
+          ))
+        )}
+        {missing.map((name, index) => (
+          <li
+            key={`missing-${name}-${index}`}
+            className="font-mono text-[12.5px] text-destructive"
+          >
+            {name}{" "}
+            {/* A real space, not just the margin: this text is read aloud and
+                copied, and "export_to_excalidrawnever called" is neither. */}
+            <span className="font-sans text-[11.5px]">never called</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evaluate/run-case-row-body.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/run-case-row-body.tsx
@@ -28,52 +28,7 @@ import type {
 } from "./evaluate-case-row-model";
 import { buildStageFixPrompt } from "./stage-fix-prompt";
 import { remedyForReason, type StageRemedy } from "./stage-remedy";
-
-function ToolList({
-  label,
-  names,
-  missing = [],
-}: {
-  label: string;
-  names: string[];
-  /** Expected calls with no observed counterpart. ALL of them, not the first. */
-  missing?: readonly string[];
-}) {
-  return (
-    <div className="min-w-0">
-      <div className="text-[10.5px] font-medium uppercase tracking-wide text-muted-foreground">
-        {label}
-      </div>
-      <ul className="mt-1.5 flex flex-col gap-1">
-        {names.length === 0 ? (
-          <li className="text-[12.5px] text-muted-foreground">none recorded</li>
-        ) : (
-          names.map((name, index) => (
-            // Keyed by position, because a case may legitimately call the same
-            // tool twice and two list items cannot share a key.
-            <li
-              key={`${name}-${index}`}
-              className="font-mono text-[12.5px] text-foreground"
-            >
-              {name}
-            </li>
-          ))
-        )}
-        {missing.map((name, index) => (
-          <li
-            key={`missing-${name}-${index}`}
-            className="font-mono text-[12.5px] text-destructive"
-          >
-            {name}{" "}
-            {/* A real space, not just the margin: this text is read aloud and
-                copied, and "export_to_excalidrawnever called" is neither. */}
-            <span className="font-sans text-[11.5px]">never called</span>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
+import { EvaluateToolList } from "./evaluate-tool-list";
 
 function groupHeading(group: CaseFailureGroup, count: number): string {
   const iterations = count === 1 ? "1 iteration" : `${count} iterations`;
@@ -147,8 +102,8 @@ function FailureGroup({
       </header>
 
       <div className="grid gap-4 px-3.5 py-3 sm:grid-cols-2">
-        <ToolList label="Expected" names={[...expectedNames]} />
-        <ToolList
+        <EvaluateToolList label="Expected" names={[...expectedNames]} />
+        <EvaluateToolList
           label="Observed"
           names={observedNames.filter((name) => !missingSet.has(name))}
           missing={missing}

--- a/mcpjam-inspector/client/src/components/evaluate/run-case-rows.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/run-case-rows.tsx
@@ -85,16 +85,7 @@ function Mark({ row }: { row: EvaluateCaseRow }) {
       </span>
     );
   }
-  // No verdict was read for this case. A dash is not a state word, so it
-  // cannot be mistaken for one.
-  return (
-    <span
-      className="inline-flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border border-dashed border-border text-[11px] text-muted-foreground"
-      aria-label="No verdict read for this case"
-    >
-      –
-    </span>
-  );
+  return null;
 }
 
 const CELL_CLASS: Record<CaseRowIterationCell["outcome"], string> = {
@@ -325,9 +316,19 @@ export function RunCaseRows({
               onClick={() => setOpenKey(open ? null : row.key)}
               className="flex w-full items-start gap-3 px-5 py-3 text-left hover:bg-muted/50"
             >
-              <span className="pt-0.5">
-                <Mark row={row} />
+              <span className="pt-0.5" aria-hidden="true">
+                <ChevronRight
+                  className={cn(
+                    "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+                    open && "rotate-90",
+                  )}
+                />
               </span>
+              {row.mark ? (
+                <span className="pt-0.5">
+                  <Mark row={row} />
+                </span>
+              ) : null}
               <span className="min-w-0 flex-1">
                 <span className="flex flex-wrap items-baseline gap-x-2">
                   <span className="text-[14px] font-semibold text-foreground">
@@ -366,12 +367,6 @@ export function RunCaseRows({
               <span className="hidden w-16 shrink-0 text-right text-[12.5px] tabular-nums text-muted-foreground sm:block">
                 {formatRunCaseLatencyMs(row.p50Ms)}
               </span>
-              <ChevronRight
-                className={cn(
-                  "mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-transform",
-                  open && "rotate-90",
-                )}
-              />
             </button>
             {open ? (
               <div

--- a/mcpjam-inspector/client/src/components/evaluate/run-grading-peek.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/run-grading-peek.tsx
@@ -1,0 +1,49 @@
+/**
+ * What the grader compared for the focused miss — always visible.
+ *
+ * Not the counting caveats: those answer how 2/3 was reached. This is the
+ * expected vs observed pair the sentence above already named, shown as lists
+ * so the miss does not have to be spotted in a comma-joined line.
+ */
+import { EvaluateToolList } from "./evaluate-tool-list";
+
+export function RunGradingPeek({
+  expected,
+  observed,
+}: {
+  expected: readonly string[];
+  observed: readonly string[];
+}) {
+  if (expected.length === 0 && observed.length === 0) return null;
+
+  // Matched by occurrence, so a case expecting two writes and observing one
+  // reports the second missing rather than neither.
+  const remaining = [...observed];
+  const missing: string[] = [];
+  for (const name of expected) {
+    const at = remaining.indexOf(name);
+    if (at === -1) missing.push(name);
+    else remaining.splice(at, 1);
+  }
+  const missingSet = new Set(missing);
+  const observedShown = observed.filter((name) => !missingSet.has(name));
+
+  return (
+    <section
+      className="rounded-lg border border-border/40 bg-muted/20 px-4 py-3"
+      data-testid="run-grading-peek"
+    >
+      <div className="text-[10.5px] font-medium uppercase tracking-wide text-muted-foreground">
+        Graded against
+      </div>
+      <div className="mt-2.5 grid gap-4 sm:grid-cols-2">
+        <EvaluateToolList label="Expected" names={[...expected]} />
+        <EvaluateToolList
+          label="Observed"
+          names={observedShown}
+          missing={missing}
+        />
+      </div>
+    </section>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evaluate/run-launch-context.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/run-launch-context.tsx
@@ -1,0 +1,118 @@
+/**
+ * What this run launched against — client or environment, model, servers.
+ *
+ * The header used to show only a host chip ("Claude"). A host is not an
+ * environment: the model lives on the run or its iterations, and the MCP
+ * servers live on the frozen config snapshot. Each fact is labelled so none
+ * of them can be mistaken for leftover chrome.
+ */
+import { compactModelLabel } from "@/components/chat-v2/shared/model-helpers";
+import { compactModelIdTail } from "@/lib/environment-label";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
+import { HostChip } from "@/components/hosts/host-chip";
+import {
+  runEnvironmentRef,
+  runHostLabel,
+  runRevisionLabel,
+} from "../evals/helpers";
+import { EnvironmentChip } from "../evals/run-context-chip";
+import type { EvalIteration, EvalSuiteRun } from "../evals/types";
+
+function Fact({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-w-0 items-baseline gap-1.5">
+      <dt className="shrink-0 text-[10.5px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="min-w-0 truncate text-[12.5px] text-foreground">
+        {children}
+      </dd>
+    </div>
+  );
+}
+
+export function modelsFromRun(
+  run: EvalSuiteRun,
+  iterations: readonly EvalIteration[] = [],
+): string[] {
+  if (run.effectiveModelId) {
+    return [compactModelIdTail(run.effectiveModelId)];
+  }
+  const models = new Set<string>();
+  for (const iteration of iterations) {
+    const raw = iteration.testCaseSnapshot?.model?.trim();
+    if (!raw) continue;
+    const labelled = compactModelLabel(raw);
+    models.add(compactModelIdTail(labelled || raw));
+  }
+  return [...models];
+}
+
+export function RunLaunchContext({
+  run,
+  hostNamesById,
+  iterations,
+}: {
+  run: EvalSuiteRun;
+  hostNamesById: Map<string, string | null>;
+  iterations?: readonly EvalIteration[];
+}) {
+  const projectEnvironmentsEnabled = useProjectEnvironmentsEnabled();
+  const environmentRef = projectEnvironmentsEnabled
+    ? runEnvironmentRef(run)
+    : null;
+  const client = runHostLabel(run, hostNamesById);
+  const models = modelsFromRun(run, iterations);
+  const servers = run.configSnapshot?.environment?.servers ?? [];
+
+  if (
+    !environmentRef &&
+    !client &&
+    models.length === 0 &&
+    servers.length === 0
+  ) {
+    return null;
+  }
+
+  return (
+    <dl
+      className="flex min-w-0 flex-wrap items-baseline gap-x-4 gap-y-1"
+      data-testid="evaluate-run-launch-context"
+    >
+      {environmentRef ? (
+        <Fact label="Environment">
+          <EnvironmentChip
+            name={environmentRef.name}
+            environmentId={environmentRef.environmentId}
+            revisionLabel={runRevisionLabel(run)}
+            className="border-0 bg-transparent px-0 py-0"
+          />
+        </Fact>
+      ) : client ? (
+        <Fact label="Client">
+          <HostChip
+            name={client}
+            hostId={run.namedHostId}
+            className="gap-1 px-0 py-0 text-[12.5px] shadow-none"
+          />
+        </Fact>
+      ) : null}
+      {models.length > 0 ? (
+        <Fact label={models.length === 1 ? "Model" : "Models"}>
+          {models.join(" · ")}
+        </Fact>
+      ) : null}
+      {servers.length > 0 ? (
+        <Fact label={servers.length === 1 ? "Server" : "Servers"}>
+          <span data-testid="evaluate-run-servers">{servers.join(" · ")}</span>
+        </Fact>
+      ) : null}
+    </dl>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evaluate/run-verdict-hero.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/run-verdict-hero.tsx
@@ -142,29 +142,6 @@ export function RunVerdictHero({
           </p>
         ) : null}
 
-        {view.sentence.kind === "brokeAt" &&
-        (view.sentence.expected.length > 0 ||
-          view.sentence.observed.length > 0) ? (
-          <dl className="mt-2.5 flex flex-wrap gap-x-6 gap-y-1 text-[12.5px]">
-            {view.sentence.expected.length > 0 ? (
-              <div className="flex gap-1.5">
-                <dt className="text-muted-foreground">Expected</dt>
-                <dd className="font-mono text-foreground">
-                  {view.sentence.expected.join(", ")}
-                </dd>
-              </div>
-            ) : null}
-            {view.sentence.observed.length > 0 ? (
-              <div className="flex gap-1.5">
-                <dt className="text-muted-foreground">Observed</dt>
-                <dd className="font-mono text-foreground">
-                  {view.sentence.observed.join(", ")}
-                </dd>
-              </div>
-            ) : null}
-          </dl>
-        ) : null}
-
         {actions || canOpenTrace ? (
           <div className="mt-4 flex flex-wrap items-center gap-2">
             {actions}


### PR DESCRIPTION
Follow-on to #4627. That PR squash-merged the committed half of the branch; this
slice was still uncommitted when it landed, so it never made the merge. Ported
onto current `main` — the one real reconciliation was `run-case-row-body.tsx`,
where `main` had renamed `stage-reason-recommendation` → `stage-remedy` and
widened `missing` from the first unobserved call to all of them. `main`'s
semantics win; the extracted list keeps them.

### A host chip is not an environment

The run header showed one chip reading "Claude" and nothing else — not the
model, not the MCP servers, not the environment revision. `RunLaunchContext`
replaces it with labelled facts (client or environment, model, servers,
revision), so none of them can be read as leftover chrome. The model is
recovered from the run's iterations when the list projection omitted
`effectiveModelId`. `RunContextChip`'s host branch gains the same model
attribution its environment branch already gave.

### The verdict's own evidence was buried in its sentence

Expected against observed lived inside `RunVerdictHero` as a comma-joined line
that only rendered for a `brokeAt` verdict. `RunGradingPeek` makes it an
always-visible "Graded against" pair of lists, with every expected call that was
never observed marked in place rather than left to be diffed by eye. The list is
now `EvaluateToolList`, shared with the case body — matched by occurrence, so a
case expecting two writes and observing one reports the second missing.

### The two actions stop scrolling away

"Prompt to improve" and "Open failing trace" were inline on the hero.
`EvaluateRunPage` lifts them into its header through context, and the hero drops
its copies when the header has them. Case rows lead with the disclosure chevron
instead of a dashed placeholder mark for cases that never had a verdict read.

### Verification

- `npx vitest run client/src/components/{evaluate,evals}/__tests__` — 168 files,
  1605 tests, all passing (includes 2 new test files).
- `npm run typecheck:client` — clean.
- Prettier: the 5 files still flagged were already failing on `main` at this
  commit; only lines this PR wrote were formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwMjvV9Heh9Tjiga1ZGev7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Evaluate UI-only changes with new components and tests; no auth, data, or API contract changes beyond copy in the export traces modal.
> 
> **Overview**
> The **Evaluate run page header** no longer relies on a lone host chip. **`RunLaunchContext`** replaces it with labelled **Client/Environment**, **Model** (from `effectiveModelId` or iteration snapshots), and **MCP server(s)** from the frozen config, so launch context reads as facts rather than chrome. **`RunContextChip`**’s host branch now shows the same model label the environment branch already had.
> 
> For **`brokeAt`** verdicts, expected vs observed tool calls move out of **`RunVerdictHero`** into **`RunGradingPeek`** — an always-visible **“Graded against”** pair of lists. Missing expected calls are marked **“never called”** via shared **`EvaluateToolList`** (also used in expanded case bodies) with occurrence-based matching.
> 
> **“Prompt to improve”** and **“Open failing trace”** are lifted into the **`EvaluateRunPage`** header through context; **`EvaluateRunContent`** registers them and drops duplicate buttons on the hero when the header owns them. Case rows lead with the disclosure chevron and omit the dashed “no verdict” placeholder when no per-case verdict was read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d39917fbb20a1ca54cbfdcbcc2aad330cb3991d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Evaluate run header and verdict evidence show the facts behind a run's result, so the header no longer reduces to a bare host chip and a `brokeAt` verdict no longer hides its evidence in a comma-joined sentence.

**Launch context**
- Replaces the single host chip with labelled client or environment, model, MCP servers, and revision facts.
- Recovers the model from iterations when `effectiveModelId` is missing; host chips get the same model attribution as environment chips.
- Passes iterations into `EvaluateRunPage` through a new `iterations` prop.

**Grading and actions**
- Moves expected/observed into an always-visible `RunGradingPeek` that marks every expected call never observed.
- Extracts `EvaluateToolList` from the case body so misses read the same in the peek and case rows.
- Moves "Prompt to improve" and "Open failing trace" from the hero into the page header so they don't scroll away.
- Leads case rows with the disclosure chevron instead of a dashed placeholder for unread verdicts.

<sup>Written for commit d39917fbb20a1ca54cbfdcbcc2aad330cb3991d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

