### PR TITLE
ci(release): skip the local-harness pack until its digests are committed

### DIFF
--- a/.github/workflows/local-harness-pack.yml
+++ b/.github/workflows/local-harness-pack.yml
@@ -131,7 +131,14 @@ jobs:
           expected="$(grep " ${archive}\$" "$RUNNER_TEMP/SHASUMS256.txt" | cut -d' ' -f1)"
           actual="$(sha256sum "$RUNNER_TEMP/node-runtime.${ext}" | cut -d' ' -f1)"
           if [ -z "$expected" ] || [ "$expected" != "$actual" ]; then
+            # Both values, because the message alone cannot tell an empty
+            # lookup (the SHASUMS line did not match) from a genuine byte
+            # mismatch, and the two have nothing in common as bugs. The
+            # win32-x64 leg failed here on the 2026-09-02 release with no way
+            # to say which it was.
             echo "nodejs.org archive checksum mismatch for ${archive}" >&2
+            echo "  expected: ${expected:-<no SHASUMS256.txt line matched>}" >&2
+            echo "  actual:   ${actual:-<sha256sum produced nothing>}" >&2
             exit 1
           fi
           echo "NODE_ARCHIVE=$RUNNER_TEMP/node-runtime.${ext}" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
       publish_cli: ${{ steps.plan.outputs.publish_cli }}
       publish_inspector: ${{ steps.plan.outputs.publish_inspector }}
       build_inspector_artifacts: ${{ steps.plan.outputs.build_inspector_artifacts }}
+      build_harness_pack: ${{ steps.plan.outputs.build_harness_pack }}
       inspector_version: ${{ steps.plan.outputs.inspector_version }}
       release_tag: ${{ steps.plan.outputs.release_tag }}
       scope: ${{ steps.plan.outputs.scope }}
@@ -233,6 +234,36 @@ jobs:
             );
           }
 
+          // Whether this release builds and publishes local-harness runtime
+          // packs, read from the digest table the Inspector build itself
+          // carries rather than from a dispatch input.
+          //
+          // `pack-digests.generated.ts` is written from a dispatched pack build
+          // and committed (docs/local-harness.md). Until that happens
+          // EXPECTED_PACK_VERSION is "", every `expectedPackFor` answers null,
+          // and the local harness is inert in the shipped build — so packs
+          // would be assets nothing can ask for, on a job whose enforcement
+          // step ("the committed digest table matches the packs this build
+          // produced") must fail by construction.
+          //
+          // Deriving it from the table means committing the digests IS the
+          // reintroduction: there is no second switch to remember, and no way
+          // to ship a build naming digests without building the packs they
+          // name — the failure direction this whole gate exists to prevent.
+          const packDigestsPath =
+            "mcpjam-inspector/server/utils/harness/local/pack-digests.generated.ts";
+          const packVersionMatch = fs
+            .readFileSync(packDigestsPath, "utf8")
+            .match(/EXPECTED_PACK_VERSION\s*=\s*"([^"]*)"/);
+          // A shape change there must update this script, not silently stop
+          // building the packs — a release that quietly skips them is exactly
+          // the state this file cannot detect on its own.
+          if (!packVersionMatch) {
+            throw new Error(
+              `Could not read EXPECTED_PACK_VERSION from ${packDigestsPath}.`
+            );
+          }
+
           const inspectorVersion =
             releases.get("@mcpjam/inspector")?.newVersion ?? "";
           const outputs = {
@@ -242,6 +273,9 @@ jobs:
             publish_cli: String(selected.cli),
             publish_inspector: String(selected.inspector),
             build_inspector_artifacts: String(selected.inspector),
+            build_harness_pack: String(
+              selected.inspector && packVersionMatch[1] !== ""
+            ),
             inspector_version: inspectorVersion,
             release_tag: inspectorVersion ? `v${inspectorVersion}` : "",
           };
@@ -290,10 +324,15 @@ jobs:
 
   # The local-harness runtime pack. Not a desktop artifact — it is downloaded
   # on demand by both distributions — but it is published on the same release,
-  # so it is built alongside them and gated the same way.
+  # so it is built alongside them.
+  #
+  # Gated more narrowly than they are, though: on `build_harness_pack` rather
+  # than `build_inspector_artifacts`, because a release whose Inspector carries
+  # no pack digests has no pack to publish. See preflight for why that is read
+  # from the committed table.
   build-local-harness-pack:
     needs: preflight
-    if: ${{ fromJSON(needs.preflight.outputs.build_inspector_artifacts) }}
+    if: ${{ fromJSON(needs.preflight.outputs.build_harness_pack) }}
     uses: ./.github/workflows/local-harness-pack.yml
     with:
       pack_version: ${{ needs.preflight.outputs.inspector_version }}
@@ -338,7 +377,13 @@ jobs:
           # A release whose packs did not build would ship an Inspector whose
           # manifest names digests for assets that are not there, and every
           # install would fail verification with nothing to point at.
-          if [ "${{ needs.build-local-harness-pack.result }}" != "success" ]; then
+          #
+          # `skipped` is a legitimate result here — the pack job runs only when
+          # the committed digest table names a pack — so this asks preflight
+          # what it decided rather than reading the raw job result, which would
+          # read a deliberate skip as a failure.
+          if [ "${{ needs.preflight.outputs.build_harness_pack }}" = "true" ] \
+            && [ "${{ needs.build-local-harness-pack.result }}" != "success" ]; then
             echo "Local harness runtime pack build failed." >&2
             exit 1
           fi
@@ -803,7 +848,7 @@ jobs:
       # Every platform's pack, its signed manifest, its signature and its
       # sha256 — this is where the installer downloads from.
       - name: Download local harness runtime packs
-        if: ${{ fromJSON(needs.preflight.outputs.build_inspector_artifacts) }}
+        if: ${{ fromJSON(needs.preflight.outputs.build_harness_pack) }}
         uses: actions/download-artifact@v4
         with:
           pattern: local-harness-pack-*

--- a/mcpjam-inspector/docs/local-harness.md
+++ b/mcpjam-inspector/docs/local-harness.md
@@ -325,6 +325,16 @@ refusing win32, and the leg keeps reporting — which is the point of running it
       not match what is committed. The table is committed rather than injected
       at build time so the digest a release trusts is reviewed in a diff —
       which is the property the whole verification chain rests on.
+
+      Committing that table is also what **turns the pack build on**:
+      `release.yml` reads `EXPECTED_PACK_VERSION` out of it and skips
+      `build-local-harness-pack` entirely while it is `""`. That is not a
+      convenience — a build carrying no digests refuses every network-sourced
+      pack anyway, so publishing packs alongside it would attach assets nothing
+      can ask for, and the enforcement step above would fail by construction.
+      There is deliberately no separate switch: a release cannot ship digests
+      without building the packs they name, and cannot build packs the shipped
+      build would not accept.
 - [ ] Conformance green on `ubuntu-latest` and `macos-latest`, and
       `lifecycleConformanceVersion` stamped from that run. Empty ⇒ every
       platform refuses, by design.


### PR DESCRIPTION
## Why

The 2026-09-02 release (run [33671459105](https://github.com/MCPJam/inspector/actions/runs/33671459105)) failed in `build-local-harness-pack` — the job #4604 wired into `release.yml`. Every leg red, `artifact-gate` with them, and `publish-packages` / `deploy-webapp` / `finalize` skipped behind it. `deploy-backend-prod` had already promoted, so the release stopped exactly between the two halves it exists to keep in order.

Three causes, none of them release regressions — all three are the launch checklist in `docs/local-harness.md` not having been done before the first release that runs the job:

| | |
|---|---|
| darwin-arm64, darwin-x64, linux-x64, linux-arm64 | `LOCAL_HARNESS_PACK_SIGNING_KEY` does not exist in the repo secrets. The checklist calls this "a hard blocker for release". |
| win32-x64 | Failed earlier, verifying the bundled Node download: `nodejs.org archive checksum mismatch for node-v24.20.0-win-x64.zip`. The `SHASUMS256.txt` lookup is correct (verified locally), so `sha256sum` computed something else. Windows-only, still undiagnosed. |
| would have failed anyway | `collect` checks the built packs against `pack-digests.generated.ts`, which is empty — `EXPECTED_PACK_VERSION = ""`, all records `{}`. |

## What this changes

The third row is the real shape of it. An Inspector build whose digest table is empty **expects no pack at all**: `expectedPackFor` answers `null` for every target, `PACK_SIGNING_KEYS` refuses every network-sourced pack, and the feature is inert behind its flag. Building packs for it publishes assets nothing can ask for, on a job whose enforcement step cannot pass by construction.

So the job is now gated on the table rather than on "is the inspector in scope":

- `preflight` reads `EXPECTED_PACK_VERSION` and emits `build_harness_pack`; empty ⇒ skip.
- `artifact-gate` asks preflight what it decided instead of reading a deliberate `skipped` as a failure.
- `finalize` downloads packs only when there are packs.

Derived from the committed table rather than a dispatch input, so **committing the digests is the reintroduction** — no second switch to forget, and no way to ship a build naming digests without building the packs they name, which is the failure direction the gate exists to prevent. The signing key and the win32 leg become prerequisites of that commit rather than of every release.

Also prints both hashes when the pack build's checksum step fails: the message could not distinguish an unmatched `SHASUMS256.txt` line from a genuine byte mismatch, which is why win32-x64 is still undiagnosed.

## Verification

Ran the extracted `plan` step against a synthetic changeset status:

- empty table (today's tree) → `build_harness_pack=false`, `build_inspector_artifacts=true`
- `EXPECTED_PACK_VERSION = "2.48.0"` → `build_harness_pack=true`
- constant renamed → throws rather than silently skipping the packs

Both workflows parse.

## Follow-ups (not this PR)

1. Generate the pack signing key, commit its public half, add `LOCAL_HARNESS_PACK_SIGNING_KEY`.
2. Diagnose win32-x64 with the new output.
3. Dispatch "Local harness runtime pack", commit the digest table — which turns this job back on by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qNR584viu78RCTK7obRVU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 877281134dca94ffc360b6771748905cf8078400. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, the release workflow built local-harness packs whenever Inspector artifacts were built, causing releases to fail while the committed digest table was empty. It now builds packs only when `EXPECTED_PACK_VERSION` names them, so committing the digests automatically re-enables the job without a second switch.

**Release workflow**

- Preflight fails if it cannot read `EXPECTED_PACK_VERSION` instead of silently skipping packs.
- Artifact gating accepts an intentional skipped pack job, and finalization downloads pack artifacts only when enabled.
- Node archive checksum failures now print both expected and actual hashes to distinguish a missing checksum entry from a byte mismatch.
- The local-harness checklist documents the digest commit as the re-enable step; signing-key and platform checks remain prerequisites.

<sup>Written for commit 877281134dca94ffc360b6771748905cf8078400. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

