### PR TITLE
fix(ci): hash the bundled Node download from stdin, not by filename

### DIFF
--- a/.github/workflows/local-harness-pack.yml
+++ b/.github/workflows/local-harness-pack.yml
@@ -129,7 +129,13 @@ jobs:
           curl -fsSL "https://nodejs.org/dist/v${BUNDLED_NODE_VERSION}/SHASUMS256.txt" \
             -o "$RUNNER_TEMP/SHASUMS256.txt"
           expected="$(grep " ${archive}\$" "$RUNNER_TEMP/SHASUMS256.txt" | cut -d' ' -f1)"
-          actual="$(sha256sum "$RUNNER_TEMP/node-runtime.${ext}" | cut -d' ' -f1)"
+          # Hashed from STDIN rather than by filename. GNU coreutils escapes a
+          # filename containing a backslash, and signals that it escaped one
+          # with a leading `\` on the line — so on Windows, where RUNNER_TEMP
+          # is `D:\a\_temp`, this read back as `\6cac9ff…` and could never
+          # equal the SHASUMS256.txt hash however correct the download was.
+          # Redirecting makes the name `-`, which has nothing to escape.
+          actual="$(sha256sum < "$RUNNER_TEMP/node-runtime.${ext}" | cut -d' ' -f1)"
           if [ -z "$expected" ] || [ "$expected" != "$actual" ]; then
             # Both values, because the message alone cannot tell an empty
             # lookup (the SHASUMS line did not match) from a genuine byte


### PR DESCRIPTION
## Root cause

The `win32-x64` pack leg has never got past verifying the Node runtime it bundles. It failed in the release run and again in the diagnostic dispatch ([33675607446](https://github.com/MCPJam/inspector/actions/runs/33675607446)) — but with both hashes printed it turns out not to be a download problem at all:

```
expected: 6cac9ffbca8f6a47091e4b5c772e0606049c3871cb67d900c0cedde630e545ba
actual:  \6cac9ffbca8f6a47091e4b5c772e0606049c3871cb67d900c0cedde630e545ba
```

Same 64 hex digits. One leading backslash.

GNU coreutils escapes a filename containing a backslash or a newline, and signals that it escaped something by prefixing the **line** with `\`. So `cut -d' ' -f1` takes the marker along with the hash. `$RUNNER_TEMP` is `D:\a\_temp` on Windows and a backslash-free POSIX path everywhere else — which is the whole of why exactly one leg in five failed, and why it looked like a corrupt download.

## Fix

Hash from stdin. The filename becomes `-`, which has nothing to escape.

Reproduces and fixes identically under macOS `shasum`, so this is the output format rather than one implementation's quirk:

```
$ printf 'x' > 'back\slash.bin'
by filename: \2d711642b726b04401627ca9fbac32f5c8530fb1903cc4db02258717921a4881
from stdin:   2d711642b726b04401627ca9fbac32f5c8530fb1903cc4db02258717921a4881
```

This is the only checksum call site of its kind in the repo — `build-local-harness-pack.mjs` hashes through `node:crypto`.

## Context

Diagnostic dispatch results at `pack_version=3.3.5`: `linux-x64` and `linux-arm64` built, verified and uploaded packs; darwin legs were still running; `win32-x64` failed here alone. `collect` needs every leg, so this is what stands between us and the digest table.

win32 packs are not user-facing — `nativePlatforms` is `["darwin", "linux"]`, so the leg exists for the digest map and for catching pack-build regressions on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qNR584viu78RCTK7obRVU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to download verification in one workflow step; no runtime or security-sensitive application code affected.
> 
> **Overview**
> Fixes **false checksum failures** on the `win32-x64` local-harness pack job by verifying the downloaded Node archive with **`sha256sum` reading from stdin** instead of hashing by path.
> 
> On Windows, `RUNNER_TEMP` paths contain backslashes; GNU `sha256sum` escapes those in its output and prefixes the line with `\`, so `cut` captured `\6cac9ff…` while `SHASUMS256.txt` had the bare hex — identical bytes, failing verification. Redirecting the archive into `sha256sum` avoids filename escaping; inline comments document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2494698e685fc352fcfc09193803ecc58ddd2287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `win32-x64` pack leg by hashing the bundled Node download from stdin instead of by filename. On Windows, `sha256sum` escapes backslashes in filenames, so the old check always compared against a hash prefixed with `\`; the new check reads the file via stdin and verifies cleanly. CI-only change, no effect on packaged output.

<sup>Written for commit 2494698e685fc352fcfc09193803ecc58ddd2287. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

