### PR TITLE
chore: add release changeset for inspector, CLI, and SDK

### DIFF
--- a/.changeset/releases-2026-09-02b.md
+++ b/.changeset/releases-2026-09-02b.md
@@ -1,0 +1,12 @@
+---
+"@mcpjam/inspector": patch
+"@mcpjam/cli": patch
+"@mcpjam/sdk": patch
+---
+
+Release @mcpjam/inspector, @mcpjam/cli, and @mcpjam/sdk.
+
+Cuts a version for the work that landed without a changeset of its own:
+
+- **Member-only surfaces gate on the Convex actor, not the WorkOS user object.** A signed-in user is served a guest bearer in their HTML too, so for one render WorkOS says member while the socket still carries `guest|<uuid>`. Three surfaces asked member-only Convex functions in that window; they now check who the socket is actually authenticated as.
+- **A swarm shows its own name as its Overview title.** `swarmWaveTitle` hardcoded `Swarm <short id>`, so the name typed in the create flow was invisible after setup. It now prefers the authored name and keeps the short id as the fallback, in both the Overview list and the Swarm Run detail page.


### PR DESCRIPTION
- Adds one changeset that bumps `@mcpjam/inspector`, `@mcpjam/cli`, and `@mcpjam/sdk` a patch version each.
- No code changes — this just tells the release job to cut new versions of those three packages.
- Covers the two user-facing changes that landed since #4630 without a changeset: gating member-only surfaces on the Convex actor instead of the WorkOS user object, and showing a swarm's own name as its Overview title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a release changeset for patch versions of `@mcpjam/inspector`, `@mcpjam/cli`, and `@mcpjam/sdk` so two user-facing fixes ship in the next release.

- Member-only surfaces now authorize against the Convex socket actor instead of the WorkOS user object, preventing guest sockets from calling member-only functions during initial render.
- Swarm Overview titles now use the authored swarm name instead of always showing `Swarm <short id>`, with the short ID as a fallback.
- No code changes are included; the release job will publish the three packages.

<sup>Written for commit 8c666848084a61769f4ebae2a4ed1557b6fff8de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

