### PR TITLE
fix(ci): stop GNU tar reading the Windows out root as a remote host

### DIFF
--- a/mcpjam-inspector/scripts/build-local-harness-pack.mjs
+++ b/mcpjam-inspector/scripts/build-local-harness-pack.mjs
@@ -691,6 +691,13 @@ function main() {
           // Belt and braces with `flattenHardLinks`: the tree has no shared
           // inodes left to record, and this says so to the one tar that would.
           "--hard-dereference",
+          // GNU tar reads a colon in the archive name as an rmt REMOTE HOST
+          // spec — `host:path` — so on Windows, where the out root is
+          // `D:\a\_temp\…`, it tried to reach a machine called `D` and died
+          // with "Cannot connect to D: resolve failed". Nothing to do with the
+          // archive or the tree. GNU-only, which is why it sits in this array;
+          // no other leg has a colon in the path to misread.
+          "--force-local",
         ]
       : [];
     if (!tar.gnu) {


### PR DESCRIPTION
## Root cause

With #4634 in, `win32-x64` got past the download and died archiving ([run 33700941080](https://github.com/MCPJam/inspector/actions/runs/33700941080)):

```
tar: Cannot connect to D: resolve failed
tar: D\:\\a\\_temp\\pack-out\\local-harness-pack-win32-x64-3.3.6.tar.gz: Cannot write: Broken pipe
tar: Child returned status 128
```

GNU tar treats a colon in the archive name as an rmt **remote host** spec — `host:path`. So `D:\a\_temp\pack-out\…tar.gz` parses as host `D`, and tar went looking for a machine by that name. Nothing to do with the archive or the tree, and Windows-only for the same reason as the last one: no other leg has a colon in its paths.

`--force-local` tells it the name is a local file whatever it contains. It goes in the GNU-only array because that is the only tar with the misfeature and the only one that accepts the flag; the other four legs have no colon to misread.

## The other one in that log

The same misparse appears earlier, from the `-xf` that unpacks the node zip. That one is **not fatal** — it falls back to `unzip` and succeeds — and `--force-local` would not fix it anyway, because GNU tar cannot read a zip at all.

Worth knowing, though: the comment there says Windows ships bsdtar, "which reads zip". In Git Bash `tar` is GNU tar, so that branch has only ever worked through its fallback — the one the comment calls unreliable. Left alone rather than churned blind. It works, and it deserves a green Windows leg before anyone rearranges it.

## Where this leaves the pack build

From run 33700941080, at `pack_version=3.3.6`:

| Leg | Result |
|---|---|
| darwin-arm64, darwin-x64, linux-x64, linux-arm64 | built, verified, **signed** |
| win32-x64 | failed here alone |
| Collect digests | skipped — needs every leg |

`[pack] manifest signed` in those four confirms `LOCAL_HARNESS_PACK_SIGNING_KEY` is live and correct. This is the last thing between us and the digest map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qNR584viu78RCTK7obRVU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI build-script flag for GNU tar on Windows; no runtime or installer behavior change beyond unblocking the win32 pack archive step.
> 
> **Overview**
> Fixes the **win32-x64** local harness pack build failing during the final `tar -czf` step when the output path is on a drive letter (e.g. `D:\a\_temp\…`).
> 
> GNU tar treats `host:path` in archive names as a remote target, so it was trying to connect to host `D` instead of writing locally. The pack script now passes **`--force-local`** alongside the other GNU-only reproducibility flags when archiving, so the archive path is always treated as a local file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9983f83e52c5b5940ec6edbd81561d6bbb50ff9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the win32-x64 pack build failing when GNU tar misreads the Windows output path as a remote host. Adds `--force-local` to the GNU tar invocation so `D:\a\_temp\...` is treated as a local archive name.

- Only the GNU tar invocation gets the flag; other platforms' pack builds are unaffected because their paths have no colon.
- The same misparse appears in the zip extraction step, but that path already falls back to `unzip` and succeeds, so it is left alone.
- This unblocks the digest map, which previously skipped because win32-x64 failed.

<sup>Written for commit 9983f83e52c5b5940ec6edbd81561d6bbb50ff9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

