### PR TITLE
chore(local-harness): commit the 3.3.6 pack digest table

### DIFF
--- a/.changeset/local-harness-pack-digests-336.md
+++ b/.changeset/local-harness-pack-digests-336.md
@@ -1,0 +1,8 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Ship the local-harness runtime pack digest table at pack version 3.3.6, built
+and signed by CI for darwin-arm64, darwin-x64, linux-x64, linux-arm64 and
+win32-x64. This is also what re-enables the pack build on the release: it runs
+when the committed table names a pack, and until now the table was empty.

--- a/mcpjam-inspector/server/utils/harness/local/__tests__/runtime-identity.test.ts
+++ b/mcpjam-inspector/server/utils/harness/local/__tests__/runtime-identity.test.ts
@@ -231,12 +231,20 @@ describe("managed bundles", () => {
     });
   });
 
-  it("cannot resolve a platform the shipped manifest has no pack digest for", async () => {
-    // The shipped manifest carries no digests until the pack build runs, so it
-    // cannot enable a runtime by accident even if a bundle directory exists.
-    await writeBundle("claude-code", { "bridge.mjs": "x" });
+  it("cannot resolve a target the manifest has no pack digest for", async () => {
+    // A target with no digest refuses rather than accepting whatever bundle
+    // directory happens to be on disk — there would be nothing to check it
+    // against. Asserted against a manifest with the digests removed, because
+    // the property is the manifest's and not the repository's: this used to
+    // pass `LOCAL_HARNESS_MANIFEST` and lean on the SHIPPED table being empty,
+    // which stopped being true the moment the pack digests were committed.
+    const root = await writeBundle("no-digest", { "bridge.mjs": "x" });
+    const withDigests = manifestFor("no-digest", await computeTreeDigest(root));
     const result = await resolveManagedBundle({
-      manifest: LOCAL_HARNESS_MANIFEST["claude-code"],
+      manifest: {
+        ...withDigests,
+        runtime: { ...withDigests.runtime, bundleDigest: {} },
+      } as LocalHarnessCompatibility,
       runtimeRoot,
       platform: "linux",
     });

--- a/mcpjam-inspector/server/utils/harness/local/pack-digests.generated.ts
+++ b/mcpjam-inspector/server/utils/harness/local/pack-digests.generated.ts
@@ -30,7 +30,13 @@ export interface PackDigestRecord {
 export const PACK_TREE_DIGESTS: Readonly<
   Record<SupportedLocalHarnessId, Readonly<Partial<Record<LocalPackTarget, string>>>>
 > = {
-  "claude-code": {},
+  "claude-code": {
+    "darwin-arm64": "sha256:4691b55e3d704e443355bf4e12e1fa2a0dd8d0cd4d38d93fd13bf0d022a92a9a",
+    "darwin-x64": "sha256:6f314d80d2ab3e6361ba52b33a44697085d17d4f2265edafaefae397896ca7e0",
+    "linux-arm64": "sha256:3326079564bafad84322a9d6ea9d7268e1b1fd9a8716d4e3aee4e1058cf53322",
+    "linux-x64": "sha256:9a78a6e369abc0d67ef19c71e751046f48303315cb086098e7728e34f153e3a9",
+    "win32-x64": "sha256:ef8f01c61a4058684c808aee90c063a2d5418337697fec6190ec193041f4e860",
+  },
   codex: {},
 };
 
@@ -44,7 +50,28 @@ export const PACK_RECORDS: Readonly<
     Readonly<Partial<Record<LocalPackTarget, PackDigestRecord>>>
   >
 > = {
-  "claude-code": {},
+  "claude-code": {
+    "darwin-arm64": {
+      packVersion: "3.3.6",
+      treeDigest: "sha256:4691b55e3d704e443355bf4e12e1fa2a0dd8d0cd4d38d93fd13bf0d022a92a9a",
+    },
+    "darwin-x64": {
+      packVersion: "3.3.6",
+      treeDigest: "sha256:6f314d80d2ab3e6361ba52b33a44697085d17d4f2265edafaefae397896ca7e0",
+    },
+    "linux-arm64": {
+      packVersion: "3.3.6",
+      treeDigest: "sha256:3326079564bafad84322a9d6ea9d7268e1b1fd9a8716d4e3aee4e1058cf53322",
+    },
+    "linux-x64": {
+      packVersion: "3.3.6",
+      treeDigest: "sha256:9a78a6e369abc0d67ef19c71e751046f48303315cb086098e7728e34f153e3a9",
+    },
+    "win32-x64": {
+      packVersion: "3.3.6",
+      treeDigest: "sha256:ef8f01c61a4058684c808aee90c063a2d5418337697fec6190ec193041f4e860",
+    },
+  },
   codex: {},
 };
 
@@ -55,4 +82,4 @@ export const PACK_RECORDS: Readonly<
  * adapter pin and the same Node version, so a split would mean two different
  * recipes shipped under one release.
  */
-export const EXPECTED_PACK_VERSION = "";
+export const EXPECTED_PACK_VERSION = "3.3.6";


### PR DESCRIPTION
## What this is

The digest table, written by `write-pack-digests.mjs` from [run 33701822356](https://github.com/MCPJam/inspector/actions/runs/33701822356) — the first pack build with **all five legs green**. Each of darwin-arm64, darwin-x64, linux-x64, linux-arm64 and win32-x64 built, verified against its own archive, and signed by `pack-2026-09`.

## ⚠️ Merging this arms the release gate

`release.yml` reads `EXPECTED_PACK_VERSION` and skips `build-local-harness-pack` while it is empty. With the table populated, `build_harness_pack` is `true` — so **every release from here rebuilds these packs** and fails if they do not hash to what is committed. That adds a ~15 minute five-leg matrix to each release.

That is the intended end state, and it is what makes the digests load-bearing rather than decorative. But it is a real change to the release's shape, so it should not land by accident.

**The version is the thing to watch.** `collect` compares `pack_version` against this table, and the release passes it the version the release itself cuts. `main` is 3.3.5 with patch changesets pending, so that is **3.3.6** — including this PR's own changeset, which is a patch and does not move it.

If a **minor** changeset lands before the release, the version becomes 3.4.0 and the gate fails on the difference. That is the gate working. The fix is to re-dispatch the pack build at the new version and rewrite this file — not to loosen the check. Same applies if Dependabot bumps `@ai-sdk/harness-claude-code` (pinned at 1.0.100 in the lockfile today): a different adapter means different digests.

So: merge and release close together.

## What it does *not* do

Nothing user-facing. The feature still needs the `MCPJAM_LOCAL_HARNESS_ENABLED` kill switch (default off, forced off in hosted mode) **and** the `local-harness-enabled` PostHog flag (fail-closed). This only lets a release publish packs. The npm package and DMG do not grow — the pack is downloaded on demand.

The docs' launch checklist still has open items beyond this one, notably conformance green with `lifecycleConformanceVersion` stamped.

## Verification

- `write-pack-digests.mjs --check --version 3.3.6` — the exact invocation the release gate runs — reports *"the committed table matches these packs"*
- `pack-digests.test.ts` — 8/8
- The extracted preflight plan step now emits `build_harness_pack=true` where it emitted `false` before

## The road here

| | |
|---|---|
| #4633 | Skip the pack until digests exist — unblocked the stuck release |
| #4634 | win32: `sha256sum` line-escaping on backslash paths |
| #4635 | Generate and trust the `pack-2026-09` release key |
| #4641 | win32: GNU tar reading `D:` as a remote host |
| **this** | The digest table — turns the pack build back on |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qNR584viu78RCTK7obRVU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release behavior changes materially: every release rebuilds and verifies harness packs against committed digests, so version or dependency drift will fail the gate until the table is refreshed.
> 
> **Overview**
> **Commits the CI-built local-harness pack digest table** for `claude-code` at pack version **3.3.6**, with per-target `sha256` tree digests for darwin-arm64, darwin-x64, linux-x64, linux-arm64, and win32-x64 in `pack-digests.generated.ts`. **`EXPECTED_PACK_VERSION` moves from empty to `3.3.6`**, which arms the release workflow to run the five-leg pack build and fail if rebuilt packs do not match the committed hashes.
> 
> A patch **changeset** documents shipping this table and re-enabling the release pack gate.
> 
> The **runtime-identity test** for “no digest for target” no longer depends on an empty shipped manifest; it strips digests from a fixture manifest so the assertion stays valid now that real digests are committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dc548851541a276fed7794e69e9f32df98158e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Commits the 3.3.6 local-harness pack digest table for all five platforms, re-enabling the release pack build that was previously skipped while the table was empty. Also pins the no-digest refusal test to the manifest's behavior instead of the repository's state, which changed once the digests were committed.

**Release gate behavior**
- Sets `EXPECTED_PACK_VERSION` to `3.3.6`; every release now rebuilds the five packs and fails if their hashes don't match the committed table.
- The gate fails by design if the release cuts a version other than `3.3.6` (e.g. after a minor changeset), so merge and release should land close together.

**Test update**
- The no-digest refusal test relied on the shipped table being empty; it now builds a manifest with `bundleDigest: {}` so the assertion holds regardless of the table's contents.

<sup>Written for commit 3dc548851541a276fed7794e69e9f32df98158e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

