### PR TITLE
chore(local-harness): stamp the claude-code conformance evidence

### DIFF
--- a/.changeset/local-harness-conformance-stamp.md
+++ b/.changeset/local-harness-conformance-stamp.md
@@ -1,0 +1,9 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Record the local-harness lifecycle conformance evidence for claude-code
+(`local-1f3f53f38f40`). Until now the manifest carried no evidence, which
+`resolveLocalCompatibility` treats as expired — so every platform refused with
+`conformance-missing` regardless of packs, digests or flags. Codex stays empty:
+it is native nowhere and the suite does not run for it.

--- a/mcpjam-inspector/server/utils/harness/local/__tests__/compatibility.test.ts
+++ b/mcpjam-inspector/server/utils/harness/local/__tests__/compatibility.test.ts
@@ -22,8 +22,8 @@ const PINNED = LOCAL_HARNESS_MANIFEST["claude-code"].adapterVersion;
 const PINNED_CODEX = LOCAL_HARNESS_MANIFEST.codex.adapterVersion;
 
 /** A manifest with conformance recorded, so the platform/profile rules can be
- *  exercised on their own. Everything shipped has an EMPTY conformance version
- *  until evidence exists, which the first test below is about. */
+ *  exercised on their own. Overrides are applied last, so passing an empty
+ *  `lifecycleConformanceVersion` is how the no-evidence case is expressed. */
 function conformed(
   base: LocalHarnessCompatibility,
   overrides: Partial<LocalHarnessCompatibility> = {},
@@ -38,18 +38,41 @@ function conformed(
 }
 
 describe("the shipped manifest", () => {
-  it("enables nothing until conformance evidence is recorded", () => {
-    for (const harnessId of ["claude-code", "codex"] as const) {
-      const result = resolveLocalCompatibility({
-        harnessId,
-        platform: "linux",
-        targetKind: "local-native",
-        installedAdapterVersion:
-          LOCAL_HARNESS_MANIFEST[harnessId].adapterVersion,
-        permissionProfile: "workspace-edits",
-      });
+  it("enables nothing for a harness with no conformance evidence", () => {
+    // The property is the resolver's, not the repository's: no evidence means
+    // no local execution, whatever the shipped manifest happens to carry. This
+    // used to query LOCAL_HARNESS_MANIFEST directly and lean on every entry
+    // being empty, which stopped being true the moment claude-code's
+    // conformance run was stamped.
+    for (const harnessId of SUPPORTED_LOCAL_HARNESS_IDS) {
+      const result = resolveLocalCompatibility(
+        {
+          harnessId,
+          platform: "linux",
+          targetKind: "local-native",
+          installedAdapterVersion:
+            LOCAL_HARNESS_MANIFEST[harnessId].adapterVersion,
+          permissionProfile: "workspace-edits",
+        },
+        conformed(LOCAL_HARNESS_MANIFEST[harnessId], {
+          lifecycleConformanceVersion: "",
+        }),
+      );
       expect(result.ok).toBe(false);
       expect(result).toMatchObject({ status: "conformance-missing" });
+    }
+  });
+
+  it("records conformance evidence for every harness it calls native", () => {
+    // The invariant that replaces "everything shipped is empty", and the one
+    // that actually matters now. A non-empty `nativePlatforms` is the manifest
+    // claiming a platform can run this harness locally; an empty conformance
+    // version is the manifest saying nobody proved it. Both at once is the
+    // state `conformance-missing` exists to catch at runtime — and it should
+    // never get as far as runtime.
+    for (const manifest of Object.values(LOCAL_HARNESS_MANIFEST)) {
+      if (manifest.nativePlatforms.length === 0) continue;
+      expect(manifest.lifecycleConformanceVersion).not.toBe("");
     }
   });
 

--- a/mcpjam-inspector/server/utils/harness/local/compatibility.ts
+++ b/mcpjam-inspector/server/utils/harness/local/compatibility.ts
@@ -233,7 +233,22 @@ export const LOCAL_HARNESS_MANIFEST: Readonly<
     nativePlatforms: ["darwin", "linux"],
     // Empty until a backend's escape probes actually pass (I6).
     isolatedBackends: {},
-    lifecycleConformanceVersion: "",
+    // Names the RUN that earned it, not the commit that records it: this is
+    // evidence, and evidence is traceable or it is decoration. From
+    // `local-harness-conformance.yml` run 33707770702 on 1f3f53f38f, where
+    // linux-x64 and darwin-arm64 scenarios both passed against a real pack, a
+    // real supervisor, a real bridge and the real vendor CLI.
+    //
+    // Windows is not in that evidence and does not need to be — `summarize`
+    // deliberately does not wait for its leg, because `nativePlatforms`
+    // refuses win32 anyway. A stamp records what the SUPPORTED platforms
+    // proved.
+    //
+    // Re-earned, not carried: a change under `harness/local/` re-runs the
+    // suite on every PR, and an adapter bump already fails the version check
+    // above it. If this value ever outlives the code it vouched for, that is
+    // the bug — clear it rather than leave it standing.
+    lifecycleConformanceVersion: "local-1f3f53f38f40",
     adapterBootstrapDir: ".harness-bootstrap/claude-code",
     adapterBootstrapFiles: [
       "package.json",


### PR DESCRIPTION
## What this is

`lifecycleConformanceVersion` was `""`, which `compatibility.ts` treats as **expired** rather than absent — so every platform refused with `conformance-missing` no matter how many packs were built, signed or digested. This is the last code-level refusal in the chain.

The stamp comes from conformance [run 33707770702](https://github.com/MCPJam/inspector/actions/runs/33707770702) on main:

| Leg | Result |
|---|---|
| foundation unit tests | pass |
| linux-x64 scenarios | pass |
| darwin-arm64 scenarios | pass |
| conformance version | `local-1f3f53f38f40` |
| windows-latest (not gating) | fail, as designed |

Real pack, real supervisor, real bridge, real vendor CLI — mock upstream standing in only for Anthropic. The value names that **run**, not this commit: it is evidence, and evidence is traceable or it is decoration.

Windows is not in that evidence and does not need to be — `summarize` deliberately does not wait for its leg, since `nativePlatforms` refuses win32 regardless. Codex stays `""`: native nowhere, and the suite does not run for it.

## ⚠️ What merging this changes

Every PR before this was plumbing that no user could reach. This one removes the last refusal that lives in code. After it, what stands between a user and a local turn is entirely operational:

- `MCPJAM_LOCAL_HARNESS_ENABLED` — default **off**, forced off when `HOSTED_MODE`
- `local-harness-enabled` PostHog flag — fail-closed (`=== true`)
- an installed, digest-verified pack (explicit install step)
- a workspace grant
- an unexpired consent capability

All five still have to line up, and two of them are off by default. Nothing ships enabled. But the gating is now configuration rather than structure, so this is the point to be deliberate about who gets the flag.

## Tests

Third time in this series a test pinned the pre-launch repo state instead of the behaviour, and it moves the same way. "Enables nothing until conformance evidence is recorded" queried `LOCAL_HARNESS_MANIFEST` directly and leaned on every entry being empty; it now passes a manifest with the version explicitly cleared, so it keeps testing the **resolver's** property after the repository stops being empty.

Its neighbour two tests down already had this instinct — *"written this way rather than 'the map is empty' so it keeps meaning something after a release fills it"* — which is the standard the others should have been held to.

Plus the inverse invariant, which is what actually guards the launch now:

> a harness the manifest calls native must carry evidence

A non-empty `nativePlatforms` claims a platform can run this locally; an empty conformance version says nobody proved it. Both at once is exactly what `conformance-missing` catches at runtime, and it should never get that far. Verified with teeth — removing the stamp fails that test.

## Verification

- `local/__tests__` — 519 passed, 29 skipped
- `compatibility.test.ts` — 29/29
- `server/tsconfig.json` — clean
- `runtime-install.test.ts` still fails locally on its `tar` helper, identically on clean `main` (macOS bsdtar); green in CI

## Remaining on the launch checklist

Not this PR: the PostHog flag created employees-only and verified by evaluation, `MCPJAM_LOCAL_HARNESS_ENABLED` confirmed off in every deployed environment, the backend PR deployed to **prod**, and the dogfood pass — install from a real release asset, then `pwd` / read / edit-with-approval / MCP tool through the proxy / abort / resume / stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This removes a structural code gate for claude-code local native resolution; operational flags, packs, and consent still apply, but mis-stamped or stale evidence could admit local execution paths reviewers relied on being blocked.
> 
> **Overview**
> **Stamps claude-code local-harness conformance** so `resolveLocalCompatibility` no longer always returns `conformance-missing` for that harness. The manifest’s `lifecycleConformanceVersion` moves from empty to **`local-1f3f53f38f40`**, naming CI run evidence for darwin/linux native legs; **codex stays empty** (not native anywhere).
> 
> Tests no longer assume every shipped entry lacks evidence: the “no conformance” case clears the version via overrides, and a new invariant requires **any harness with non-empty `nativePlatforms` to carry non-empty conformance**. A patch changeset documents the release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c80ee84e727fab2ffa0e0ba1d739723cb08b5c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stamps claude-code's lifecycle conformance evidence in the local-harness manifest, so platforms no longer refuse with `conformance-missing`. Previously the empty conformance version was treated as expired, blocking every platform regardless of built packs or flags. The stamp points to the passing conformance run; codex stays empty because it's native nowhere.

Tests now verify the no-evidence case explicitly and assert that any harness listed as native must carry evidence.

<sup>Written for commit 7c80ee84e727fab2ffa0e0ba1d739723cb08b5c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

