### PR TITLE
fix: carry the two "Tool list changed" knobs to the connection, hosted and local

### DIFF
--- a/.changeset/tool-list-changed-reaches-hosted-connections.md
+++ b/.changeset/tool-list-changed-reaches-hosted-connections.md
@@ -59,6 +59,14 @@ for the same reason at a different hop: it forwarded the sibling knobs to
 writes it onto the child config, but the hand-off never passed it. Cancellation
 is era-scoped, not transport-scoped, so a stdio connection has to honor it too.
 
+`/api/web/evals/stream-test-case` needed one more fix of the same family. It is
+the only eval route that builds its own manager instead of going through the
+wrappers that extract the body's `mcpProfile` pins, so it accepted every pin its
+schema declares — `clientInfo`, `supportedProtocolVersions`, the per-server
+version map, and now the conformance knobs — and connected as though none had
+been sent. It extracts them now, from the pre-parse raw body for the same reason
+`xaaPolicy` there does.
+
 One thing this does **not** change: on the body-built surfaces a server-side
 host config is not re-derived over the request body. Only chat turns do that
 (`applyHostConformanceKnobs`); everywhere else the body is the source, exactly

--- a/.changeset/tool-list-changed-reaches-hosted-connections.md
+++ b/.changeset/tool-list-changed-reaches-hosted-connections.md
@@ -1,0 +1,37 @@
+---
+"@mcpjam/inspector": patch
+---
+
+The two "Tool list changed" switches now govern hosted connections too
+
+`mcpProfile.toolListChanged` models a host that never opens the listen channel
+(`listens: false`) or that ignores `notifications/tools/list_changed` when it
+arrives (`refetches: false`) — the two ways a real client can leave a server's
+tool list stale. Locally both worked. In hosted mode both were silently
+ignored: every connection listened and refetched no matter how the host was
+configured, so the debugger reported conforming behavior the host does not
+have.
+
+The values were computed correctly and then never handed over. `App.tsx`
+resolved both leaves into `hostedMcpProfilePins` and stopped there, without
+passing them to `useApiContext` — and even had it passed them,
+`projectServerSchema` declared neither field, so Zod would have stripped them
+off the request body before any route could read them. Two more hops down,
+`extractMcpInitializeOptions` did not read them and `toHttpConfig` had nowhere
+to put them. The sibling knobs (`firstPageOnly`, `supportsMrtr`,
+`toolCallCancellation`) travel all four hops; these two never did.
+
+Hosted **chat** turns were right by accident: a turn with a backing host config
+re-derives every conformance knob server-side from that config
+(`applyHostConformanceKnobs`), overwriting whatever the body carried. Every
+other hosted surface — Tools, Resources, Prompts, tasks, evals, bench, apps,
+export, MRTR continuation, and ad-hoc chat turns with no host config — builds
+its connection straight from the request body, and so ran as a fully
+conforming client.
+
+Both switches now travel the same path their siblings do: only the
+non-conforming value reaches the wire, the route schema declares it, the
+extractor reads it, and the pins land on every `HttpServerConfig`. An absent
+field still means the conforming behavior, so a host with no `toolListChanged`
+opinion sends nothing and behaves exactly as before. Server-side host configs
+stay authoritative over the body.

--- a/.changeset/tool-list-changed-reaches-hosted-connections.md
+++ b/.changeset/tool-list-changed-reaches-hosted-connections.md
@@ -2,36 +2,48 @@
 "@mcpjam/inspector": patch
 ---
 
-The two "Tool list changed" switches now govern hosted connections too
+The two "Tool list changed" switches now reach the connection, hosted and local
 
 `mcpProfile.toolListChanged` models a host that never opens the listen channel
 (`listens: false`) or that ignores `notifications/tools/list_changed` when it
 arrives (`refetches: false`) — the two ways a real client can leave a server's
-tool list stale. Locally both worked. In hosted mode both were silently
-ignored: every connection listened and refetched no matter how the host was
-configured, so the debugger reported conforming behavior the host does not
-have.
+tool list stale. **Neither switch reached a connection.** Every connection
+listened and refetched no matter how the host was configured, so the debugger
+reported conforming behavior the host does not have.
 
-The values were computed correctly and then never handed over. `App.tsx`
-resolved both leaves into `hostedMcpProfilePins` and stopped there, without
-passing them to `useApiContext` — and even had it passed them,
-`projectServerSchema` declared neither field, so Zod would have stripped them
-off the request body before any route could read them. Two more hops down,
+The values were computed correctly and then never handed over — at four
+separate hand-offs, all of them silent.
+
+**Hosted.** `App.tsx` resolved both leaves into `hostedMcpProfilePins` and
+stopped there, without passing them to `useApiContext`. Even had it passed
+them, `projectServerSchema` declared neither field, so Zod would have stripped
+them off the request body; two hops further,
 `extractMcpInitializeOptions` did not read them and `toHttpConfig` had nowhere
 to put them. The sibling knobs (`firstPageOnly`, `supportsMrtr`,
-`toolCallCancellation`) travel all four hops; these two never did.
+`toolCallCancellation`) travel every one of those hops; these two never did.
 
 Hosted **chat** turns were right by accident: a turn with a backing host config
-re-derives every conformance knob server-side from that config
-(`applyHostConformanceKnobs`), overwriting whatever the body carried. Every
-other hosted surface — Tools, Resources, Prompts, tasks, evals, bench, apps,
-export, MRTR continuation, and ad-hoc chat turns with no host config — builds
-its connection straight from the request body, and so ran as a fully
-conforming client.
+re-derives every conformance knob server-side (`applyHostConformanceKnobs`),
+overwriting whatever the body carried. Every other hosted surface — Tools,
+Resources, Prompts, tasks, evals, bench, apps, export, MRTR continuation, and
+ad-hoc chat turns with no host config — builds its connection straight from the
+request body, and so ran as a fully conforming client.
 
-Both switches now travel the same path their siblings do: only the
-non-conforming value reaches the wire, the route schema declares it, the
-extractor reads it, and the pins land on every `HttpServerConfig`. An absent
-field still means the conforming behavior, so a host with no `toolListChanged`
-opinion sends nothing and behaves exactly as before. Server-side host configs
-stay authoritative over the body.
+**Local.** The same pair died one hop earlier and for the same reason. The
+client put both leaves on `connectionDefaults` and `/api/mcp/connect` received
+them, but `parseConnectionDefaults` — the shape gate that must name every field
+it keeps — did not read them, and `toMCPServerConfig` had no field to set. A
+local connect was as conforming as a hosted one, whatever the host asked for.
+
+Both switches now travel the same path their siblings do on both surfaces: only
+the non-conforming value reaches the wire, the boundary declares it, the
+extractor or parser reads it, and it lands on the SDK config. An absent field
+still means the conforming behavior, so a host with no `toolListChanged`
+opinion sends nothing and behaves exactly as before, and a server-side host
+config stays authoritative over the body.
+
+One asymmetry is deliberate. `dropToolListChanged` edits an inbound JSON-RPC
+frame, so it is forwarded on stdio as well as HTTP; `suppressListenChannel`
+refuses a server→client GET stream that only Streamable HTTP has, so — like
+`mirrorToolParamHeaders` — it is not written onto a stdio config, where it
+could never act.

--- a/.changeset/tool-list-changed-reaches-hosted-connections.md
+++ b/.changeset/tool-list-changed-reaches-hosted-connections.md
@@ -39,8 +39,30 @@ Both switches now travel the same path their siblings do on both surfaces: only
 the non-conforming value reaches the wire, the boundary declares it, the
 extractor or parser reads it, and it lands on the SDK config. An absent field
 still means the conforming behavior, so a host with no `toolListChanged`
-opinion sends nothing and behaves exactly as before, and a server-side host
-config stays authoritative over the body.
+opinion sends nothing and behaves exactly as before.
+
+**The wire declaration is now written once.** Chasing this bug turned up two
+more instances of it, both the same shape and neither about `toolListChanged`:
+`projectServerSchema` had never declared `toolCallCancellation`, so that knob
+was stripped on every hosted surface except chat (which extracts from the
+pre-parse raw body) since the day it shipped; and `hostedBatchSchema` — the
+schema every hosted **eval** body is parsed through — declared none of the
+conformance knobs at all. Three knobs, three schemas, one failure mode: Zod
+strips what a schema does not name, and the result is not an error but a
+silently conforming session. The six fields now live in one exported
+`conformanceKnobWireShape` that both schemas spread, so a new knob reaches
+every body-built surface by being added in one place.
+
+The hosted local-runtime **stdio** divert was dropping `toolCallCancellation`
+for the same reason at a different hop: it forwarded the sibling knobs to
+`resolveLocalStdioServerConfig`, which has always accepted cancellation and
+writes it onto the child config, but the hand-off never passed it. Cancellation
+is era-scoped, not transport-scoped, so a stdio connection has to honor it too.
+
+One thing this does **not** change: on the body-built surfaces a server-side
+host config is not re-derived over the request body. Only chat turns do that
+(`applyHostConformanceKnobs`); everywhere else the body is the source, exactly
+as it already was for the sibling knobs.
 
 One asymmetry is deliberate. `dropToolListChanged` edits an inbound JSON-RPC
 frame, so it is forwarded on stdio as well as HTTP; `suppressListenChannel`

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -3728,6 +3728,8 @@ export default function App() {
     mirrorToolParamHeaders: hostedMcpProfilePins.mirrorToolParamHeaders,
     firstPageOnly: hostedMcpProfilePins.firstPageOnly,
     supportsMrtr: hostedMcpProfilePins.supportsMrtr,
+    suppressListenChannel: hostedMcpProfilePins.suppressListenChannel,
+    dropToolListChanged: hostedMcpProfilePins.dropToolListChanged,
     toolCallCancellation: hostedMcpProfilePins.toolCallCancellation,
     xaaPolicy: hostedMcpProfilePins.xaaPolicy,
     clientConfigSyncPending:

--- a/mcpjam-inspector/client/src/hooks/hosted/__tests__/use-hosted-api-context.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/hosted/__tests__/use-hosted-api-context.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useApiContext } from "../use-hosted-api-context";
+import { setApiContext, buildServerRequest } from "@/lib/apis/web/context";
+
+/**
+ * The two `mcpProfile.toolListChanged` switches are carried, never derived:
+ * App.tsx resolves them, this hook publishes them onto the global API
+ * context, and every hosted request body spreads them. Each hop is a plain
+ * hand-off, and the failure mode of dropping one is SILENT — the host asks
+ * for a client that never listens, and the hosted connection listens anyway.
+ *
+ * So this asserts the hop end to end (hook → context → wire body) rather than
+ * that the hook stored a field: only the body proves the switch left the
+ * browser.
+ */
+const baseOptions = {
+  projectId: "project-1",
+  serverIdsByName: { asana: "server-1" },
+  getAccessToken: async () => "token",
+} as const;
+
+describe("useApiContext — toolListChanged conformance knobs", () => {
+  afterEach(() => {
+    setApiContext(null);
+  });
+
+  it("puts both switches on the hosted request body", () => {
+    renderHook(() =>
+      useApiContext({
+        ...baseOptions,
+        suppressListenChannel: true,
+        dropToolListChanged: true,
+      }),
+    );
+
+    expect(buildServerRequest("asana")).toMatchObject({
+      suppressListenChannel: true,
+      dropToolListChanged: true,
+    });
+  });
+
+  it("carries one switch without the other", () => {
+    // A host that opens the listen channel but ignores the notification is a
+    // real configuration; the two leaves are independent.
+    renderHook(() =>
+      useApiContext({ ...baseOptions, dropToolListChanged: true }),
+    );
+
+    const body = buildServerRequest("asana");
+    expect(body).toMatchObject({ dropToolListChanged: true });
+    expect(body).not.toHaveProperty("suppressListenChannel");
+  });
+
+  it("emits neither field for a conforming host", () => {
+    // Absence is the conforming default the SDK reads, so a host with no
+    // `toolListChanged` opinion must add nothing to the body.
+    renderHook(() => useApiContext(baseOptions));
+
+    const body = buildServerRequest("asana");
+    expect(body).not.toHaveProperty("suppressListenChannel");
+    expect(body).not.toHaveProperty("dropToolListChanged");
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
@@ -801,6 +801,12 @@ describe("web auth manager batching", () => {
             title: "ChatGPT",
           },
           supportedProtocolVersions: ["2025-11-25", "2025-06-18"],
+          // `mcpProfile.toolListChanged.listens` / `.refetches`. Both were
+          // computed client-side and accepted by every hop below this one, but
+          // never placed on the SDK config — so hosted connections opened the
+          // listen channel and refetched no matter what the host asked for.
+          suppressListenChannel: true,
+          dropToolListChanged: true,
         },
       }
     );
@@ -814,6 +820,8 @@ describe("web auth manager batching", () => {
         title: "ChatGPT",
       },
       supportedProtocolVersions: ["2025-11-25", "2025-06-18"],
+      suppressListenChannel: true,
+      dropToolListChanged: true,
     });
   });
 
@@ -856,6 +864,11 @@ describe("web auth manager batching", () => {
     const config = mcpClientManagerMock.mock.calls[0]?.[0]?.["server-1"];
     expect(config).not.toHaveProperty("clientInfo");
     expect(config).not.toHaveProperty("supportedProtocolVersions");
+    // Absence is what makes the connection conforming: the SDK opens the
+    // listen channel and honors `notifications/tools/list_changed` unless a
+    // suppression switch is actually present.
+    expect(config).not.toHaveProperty("suppressListenChannel");
+    expect(config).not.toHaveProperty("dropToolListChanged");
   });
 
   // Verify the public `projectServerSchema` declares the two new
@@ -884,6 +897,64 @@ describe("web auth manager batching", () => {
       "2025-11-25",
       "2025-06-18",
     ]);
+  });
+
+  // The hop that ate the two `toolListChanged` knobs. The client computed
+  // them and the body carried them, but `projectServerSchema` declared
+  // neither, so Zod stripped both before any route could read them — every
+  // hosted connection ran as a fully conforming client regardless of the
+  // switch.
+  it("projectServerSchema keeps the toolListChanged conformance knobs", async () => {
+    const { projectServerSchema } = await import("../auth.js");
+    const parsed = projectServerSchema.parse({
+      projectId: "project-1",
+      serverId: "server-1",
+      suppressListenChannel: true,
+      dropToolListChanged: true,
+    });
+    expect(parsed.suppressListenChannel).toBe(true);
+    expect(parsed.dropToolListChanged).toBe(true);
+  });
+
+  it("extractMcpInitializeOptions pins the toolListChanged knobs from the body", async () => {
+    const { extractMcpInitializeOptions } = await import("../auth.js");
+    expect(
+      extractMcpInitializeOptions({
+        projectId: "project-1",
+        serverId: "server-1",
+        suppressListenChannel: true,
+        dropToolListChanged: true,
+      }).initializePins
+    ).toEqual({ suppressListenChannel: true, dropToolListChanged: true });
+  });
+
+  it("extractMcpInitializeOptions ignores the conforming value of the toolListChanged knobs", async () => {
+    const { extractMcpInitializeOptions } = await import("../auth.js");
+    // Same one-explicit-value rule as the sibling knobs: only `true` opts into
+    // the non-conforming simulation, so a body that spells out the default
+    // must produce no pins at all rather than a `false` the SDK would read as
+    // "field present".
+    expect(
+      extractMcpInitializeOptions({
+        projectId: "project-1",
+        serverId: "server-1",
+        suppressListenChannel: false,
+        dropToolListChanged: false,
+      }).initializePins
+    ).toBeUndefined();
+  });
+
+  it("extractMcpInitializeOptions carries one toolListChanged knob without the other", async () => {
+    const { extractMcpInitializeOptions } = await import("../auth.js");
+    // The two switches are independent: a host that listens but ignores the
+    // notification is a real configuration, not a half-applied one.
+    expect(
+      extractMcpInitializeOptions({
+        projectId: "project-1",
+        serverId: "server-1",
+        dropToolListChanged: true,
+      }).initializePins
+    ).toEqual({ dropToolListChanged: true });
   });
 
   // CONTRACT: the swarm runner threads each pinned server's

--- a/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
@@ -916,6 +916,24 @@ describe("web auth manager batching", () => {
     expect(parsed.dropToolListChanged).toBe(true);
   });
 
+  // The same hop had eaten `toolCallCancellation` since that knob shipped:
+  // the extractor read it and every pin site carried it, but this schema
+  // never declared it, so it was stripped before the extractor ran. Chat was
+  // unaffected (it extracts from the pre-parse raw body); every other hosted
+  // surface cancelled normally no matter what the host was configured to do.
+  it("projectServerSchema keeps the per-era cancellation record", async () => {
+    const { projectServerSchema } = await import("../auth.js");
+    const parsed = projectServerSchema.parse({
+      projectId: "project-1",
+      serverId: "server-1",
+      toolCallCancellation: { legacy: false, modern: false },
+    });
+    expect(parsed.toolCallCancellation).toEqual({
+      legacy: false,
+      modern: false,
+    });
+  });
+
   it("extractMcpInitializeOptions pins the toolListChanged knobs from the body", async () => {
     const { extractMcpInitializeOptions } = await import("../auth.js");
     expect(

--- a/mcpjam-inspector/server/routes/web/__tests__/evals.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/evals.test.ts
@@ -405,6 +405,16 @@ describe("web routes — evals", () => {
         clientInfo: { name: "Pinned Client", version: "1.0.0" },
         supportedProtocolVersions: ["2025-11-25"],
         mcpProtocolVersionsByServerId: { "server-1": "2025-11-25" },
+        // The client-conformance knobs. This body is parsed by
+        // `hostedBatchSchema` BEFORE `extractMcpInitializeOptions` reads the
+        // pins off it, so a schema that does not name them strips them and
+        // the eval runs as a fully conforming client — silently, against a
+        // host configured to be anything but.
+        suppressListenChannel: true,
+        dropToolListChanged: true,
+        firstPageOnly: true,
+        supportsMrtr: false,
+        toolCallCancellation: { legacy: false, modern: false },
       },
       token,
     );
@@ -446,6 +456,11 @@ describe("web routes — evals", () => {
           clientInfo: { name: "Pinned Client", version: "1.0.0" },
           supportedProtocolVersions: ["2025-11-25"],
           mcpProtocolVersion: "2025-11-25",
+          suppressListenChannel: true,
+          dropToolListChanged: true,
+          firstPageOnly: true,
+          supportsMrtr: false,
+          toolCallCancellation: { legacy: false, modern: false },
         }),
       }),
     );

--- a/mcpjam-inspector/server/routes/web/__tests__/evals.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/evals.test.ts
@@ -593,6 +593,16 @@ describe("web routes — evals", () => {
         model: "openai/gpt-5-mini",
         provider: "openai",
         compareRunId: "cmp_stream",
+        // Pins and knobs on the ONE eval route that builds its own manager
+        // rather than going through the wrappers that extract them. Its
+        // schema has always accepted these; until the extraction below it
+        // connected as though none had been sent.
+        clientInfo: { name: "Pinned Client", version: "1.0.0" },
+        supportedProtocolVersions: ["2025-11-25"],
+        mcpProtocolVersionsByServerId: { "server-1": "2025-11-25" },
+        suppressListenChannel: true,
+        dropToolListChanged: true,
+        toolCallCancellation: { legacy: false, modern: false },
       },
       token,
     );
@@ -610,6 +620,18 @@ describe("web routes — evals", () => {
         provider: "openai",
         compareRunId: "cmp_stream",
         convexAuthToken: token,
+      }),
+    );
+    expect(managerConfigsMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        "server-1": expect.objectContaining({
+          clientInfo: { name: "Pinned Client", version: "1.0.0" },
+          supportedProtocolVersions: ["2025-11-25"],
+          mcpProtocolVersion: "2025-11-25",
+          suppressListenChannel: true,
+          dropToolListChanged: true,
+          toolCallCancellation: { legacy: false, modern: false },
+        }),
       }),
     );
   });

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -1575,6 +1575,9 @@ export async function createAuthorizedManager(
               effectiveInitializePins?.supportedProtocolVersions,
             firstPageOnly: effectiveInitializePins?.firstPageOnly,
             supportsMrtr: effectiveInitializePins?.supportsMrtr,
+            // Only the drop half reaches a stdio child: there is no GET
+            // listen stream on stdio for `suppressListenChannel` to refuse.
+            dropToolListChanged: effectiveInitializePins?.dropToolListChanged,
             xaaPolicy: options?.xaaPolicy,
             // The local reread + secret reveal must carry the same scope and
             // delegated identity as the hosted mint path below — a harness

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -166,6 +166,13 @@ export const projectServerSchema = z.object({
   // as a fully conforming client. Only the non-default value is ever sent.
   firstPageOnly: z.boolean().optional(),
   supportsMrtr: z.boolean().optional(),
+  // `mcpProfile.toolListChanged.listens` / `.refetches`, as the two
+  // suppression switches the SDK reads. Same declaration reason and the same
+  // one-non-default-value rule as the pair above: without these two lines the
+  // client could send them faithfully and every hosted connection would still
+  // open the listen channel and refetch on `notifications/tools/list_changed`.
+  suppressListenChannel: z.boolean().optional(),
+  dropToolListChanged: z.boolean().optional(),
   // Host enterprise-managed authorization policy, resolved client-side from
   // `hostConfig.mcpProfile.extensions`. Declared here (like the pins above)
   // so the wire contract documents it, but VALIDATED by
@@ -825,6 +832,14 @@ export function toHttpConfig(
      */
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
+    /**
+     * `mcpProfile.toolListChanged`, forwarded onto
+     * `BaseServerConfig.suppressListenChannel` / `.dropToolListChanged`:
+     * `listens: false` never opens the GET listen stream, `refetches: false`
+     * drops `notifications/tools/list_changed` before the client sees it.
+     */
+    suppressListenChannel?: boolean;
+    dropToolListChanged?: boolean;
     toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   },
   /**
@@ -874,6 +889,12 @@ export function toHttpConfig(
           : {}),
         ...(initializePins?.supportsMrtr === false
           ? { supportsMrtr: false }
+          : {}),
+        ...(initializePins?.suppressListenChannel === true
+          ? { suppressListenChannel: true }
+          : {}),
+        ...(initializePins?.dropToolListChanged === true
+          ? { dropToolListChanged: true }
           : {}),
         ...(initializePins?.toolCallCancellation
           ? { toolCallCancellation: initializePins.toolCallCancellation }
@@ -959,6 +980,12 @@ export function toHttpConfig(
     // resolve against.
     ...(initializePins?.firstPageOnly === true ? { firstPageOnly: true } : {}),
     ...(initializePins?.supportsMrtr === false ? { supportsMrtr: false } : {}),
+    ...(initializePins?.suppressListenChannel === true
+      ? { suppressListenChannel: true }
+      : {}),
+    ...(initializePins?.dropToolListChanged === true
+      ? { dropToolListChanged: true }
+      : {}),
     ...(initializePins?.toolCallCancellation
       ? { toolCallCancellation: initializePins.toolCallCancellation }
       : {}),
@@ -982,6 +1009,8 @@ function resolveEffectiveInitializePinsForServer(
     mirrorToolParamHeaders?: boolean;
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
+    suppressListenChannel?: boolean;
+    dropToolListChanged?: boolean;
     toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   },
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>
@@ -996,6 +1025,8 @@ function resolveEffectiveInitializePinsForServer(
       mirrorToolParamHeaders?: boolean;
       firstPageOnly?: boolean;
       supportsMrtr?: boolean;
+      suppressListenChannel?: boolean;
+      dropToolListChanged?: boolean;
       toolCallCancellation?: { legacy?: boolean; modern?: boolean };
     }
   | undefined {
@@ -1030,6 +1061,12 @@ function resolveEffectiveInitializePinsForServer(
     // resolve against.
     ...(initializePins?.firstPageOnly === true ? { firstPageOnly: true } : {}),
     ...(initializePins?.supportsMrtr === false ? { supportsMrtr: false } : {}),
+    ...(initializePins?.suppressListenChannel === true
+      ? { suppressListenChannel: true }
+      : {}),
+    ...(initializePins?.dropToolListChanged === true
+      ? { dropToolListChanged: true }
+      : {}),
     ...(initializePins?.toolCallCancellation
       ? { toolCallCancellation: initializePins.toolCallCancellation }
       : {}),
@@ -1101,6 +1138,8 @@ export async function createAuthorizedManager(
       /** Client-conformance knobs; host-level, so batch-uniform. */
       firstPageOnly?: boolean;
       supportsMrtr?: boolean;
+      suppressListenChannel?: boolean;
+      dropToolListChanged?: boolean;
       toolCallCancellation?: { legacy?: boolean; modern?: boolean };
     };
     /**
@@ -1969,6 +2008,8 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
     mirrorToolParamHeaders?: boolean;
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
+    suppressListenChannel?: boolean;
+    dropToolListChanged?: boolean;
     toolCallCancellation?: { legacy?: boolean; modern?: boolean };
   };
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
@@ -2005,6 +2046,8 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
   // Same one-explicit-value rule for the sibling knobs.
   const truncatePagination = raw.firstPageOnly === true;
   const disableMrtr = raw.supportsMrtr === false;
+  const suppressListenChannel = raw.suppressListenChannel === true;
+  const dropToolListChanged = raw.dropToolListChanged === true;
   const rawCancellation =
     raw.toolCallCancellation && typeof raw.toolCallCancellation === "object"
       ? (raw.toolCallCancellation as { legacy?: unknown; modern?: unknown })
@@ -2020,6 +2063,8 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
     suppressParamMirroring ||
     truncatePagination ||
     disableMrtr ||
+    suppressListenChannel ||
+    dropToolListChanged ||
     disableCancellation
       ? {
           ...(initializeClientInfo ? { clientInfo: initializeClientInfo } : {}),
@@ -2031,6 +2076,8 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
             : {}),
           ...(truncatePagination ? { firstPageOnly: true } : {}),
           ...(disableMrtr ? { supportsMrtr: false } : {}),
+          ...(suppressListenChannel ? { suppressListenChannel: true } : {}),
+          ...(dropToolListChanged ? { dropToolListChanged: true } : {}),
           ...(disableCancellation
             ? { toolCallCancellation: cancellationLeaves }
             : {}),

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -118,6 +118,47 @@ export const mcpProtocolVersionsByServerIdSchema = z
   .record(z.string().min(1), mcpProtocolVersionEnum)
   .optional();
 
+/**
+ * The client-conformance knobs as they travel on the wire.
+ *
+ * ONE declaration, spread into every hosted route schema that builds a
+ * connection out of the request body. Zod strips what it does not declare, so
+ * a schema missing one of these does not fail — it silently runs the session
+ * as a fully conforming client, which is indistinguishable from the host
+ * having no opinion at all. That has now shipped three times (mirroring, then
+ * cancellation, then both `toolListChanged` halves): a knob the client
+ * computed correctly and a route schema quietly ate.
+ *
+ * Only the non-default value is ever sent, so an absent field means the
+ * conforming behavior and a host with no opinion sends nothing.
+ *
+ * Spread this rather than re-declaring the fields: a new knob reaches every
+ * body-built surface by being added HERE, once.
+ */
+export const conformanceKnobWireShape = {
+  // SEP-2243 `Mcp-Param-*` mirroring, from
+  // `hostConfig.mcpProfile.toolParamHeaderMirroring`. Only `false` is ever
+  // sent: `"mirror"` is the SDK's no-field default.
+  mirrorToolParamHeaders: z.boolean().optional(),
+  // `mcpProfile.paginationTraversal` / `.mrtrSupport`.
+  firstPageOnly: z.boolean().optional(),
+  supportsMrtr: z.boolean().optional(),
+  // `mcpProfile.toolListChanged.listens` / `.refetches`, as the two
+  // suppression switches the SDK reads.
+  suppressListenChannel: z.boolean().optional(),
+  dropToolListChanged: z.boolean().optional(),
+  // `mcpProfile.toolCallCancellation`, per era. Carried as a record because
+  // the era that governs is only known once the connection negotiates:
+  // `extractMcpInitializeOptions` keeps the `false` leaves and the SDK picks
+  // between them after the handshake.
+  toolCallCancellation: z
+    .object({
+      legacy: z.boolean().optional(),
+      modern: z.boolean().optional(),
+    })
+    .optional(),
+} as const;
+
 export const projectServerSchema = z.object({
   projectId: z.string().min(1),
   serverId: z.string().min(1),
@@ -154,25 +195,7 @@ export const projectServerSchema = z.object({
   // and never reach the SDK's open-routing predicate. Absent means
   // "use SDK default (negotiates at request time)".
   mcpProtocolVersion: mcpProtocolVersionEnum.optional(),
-  // SEP-2243 `Mcp-Param-*` mirroring, resolved client-side from
-  // `hostConfig.mcpProfile.toolParamHeaderMirroring`. Declared here for the
-  // same reason as the pins above — Zod strips undeclared fields, and the
-  // client sends it on every hosted route call once the host opts in. Only
-  // `false` is ever sent: `"mirror"` is the SDK's no-field default.
-  mirrorToolParamHeaders: z.boolean().optional(),
-  // Sibling client-conformance knobs. Declared for the SAME reason as the
-  // field above: Zod strips what it does not declare, so a knob the client
-  // faithfully sends would vanish here and the hosted session would execute
-  // as a fully conforming client. Only the non-default value is ever sent.
-  firstPageOnly: z.boolean().optional(),
-  supportsMrtr: z.boolean().optional(),
-  // `mcpProfile.toolListChanged.listens` / `.refetches`, as the two
-  // suppression switches the SDK reads. Same declaration reason and the same
-  // one-non-default-value rule as the pair above: without these two lines the
-  // client could send them faithfully and every hosted connection would still
-  // open the listen channel and refetch on `notifications/tools/list_changed`.
-  suppressListenChannel: z.boolean().optional(),
-  dropToolListChanged: z.boolean().optional(),
+  ...conformanceKnobWireShape,
   // Host enterprise-managed authorization policy, resolved client-side from
   // `hostConfig.mcpProfile.extensions`. Declared here (like the pins above)
   // so the wire contract documents it, but VALIDATED by
@@ -1578,6 +1601,12 @@ export async function createAuthorizedManager(
             // Only the drop half reaches a stdio child: there is no GET
             // listen stream on stdio for `suppressListenChannel` to refuse.
             dropToolListChanged: effectiveInitializePins?.dropToolListChanged,
+            // Era-scoped, not transport-scoped: a 2026 stdio connection
+            // cancels with `notifications/cancelled` exactly as a 2025 one
+            // does, so a host that cancels on neither must be honored here as
+            // well. `resolveLocalStdioServerConfig` has accepted this since
+            // the knob shipped; only the hand-off was missing.
+            toolCallCancellation: effectiveInitializePins?.toolCallCancellation,
             xaaPolicy: options?.xaaPolicy,
             // The local reread + secret reveal must carry the same scope and
             // delegated identity as the hosted mint path below — a harness

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -18,6 +18,7 @@ import {
   callerContextFromHono,
   conformanceKnobWireShape,
   createManualHostedConnection,
+  extractMcpInitializeOptions,
   handleRoute,
   parseWithSchema,
   readJsonBody,
@@ -275,6 +276,20 @@ evals.post("/stream-test-case", async (c) => {
     xaaPolicy = parseXaaPolicyValue(rawBody.xaaPolicy);
   }
 
+  // This is the ONE eval route that builds its own manager instead of going
+  // through `createManualHostedConnection` / `withEphemeralConnection`, and
+  // those wrappers are what normally extract the host's `mcpProfile` pins from
+  // the body. Without this call the endpoint accepted every pin its schema
+  // declares — clientInfo, supportedProtocolVersions, the per-server version
+  // map, and the conformance knobs — and connected as if none had been sent.
+  //
+  // Read from the PRE-PARSE raw body for the same reason `xaaPolicy` above
+  // does: the extractor is itself the validator (every field is shape-gated,
+  // and unknown protocol versions are dropped), so going through the parsed
+  // body would only add a second place for a field to be silently stripped.
+  const { initializePins, mcpProtocolVersionsByServerId } =
+    extractMcpInitializeOptions(rawBody);
+
   const { manager } = await createAuthorizedManager(
     callerContextFromHono(c),
     bearerToken,
@@ -291,6 +306,8 @@ evals.post("/stream-test-case", async (c) => {
       scenarioId: evalScenarioId,
       accessVersion: body.accessVersion as number | undefined,
       serverNames: body.serverNames,
+      initializePins,
+      mcpProtocolVersionsByServerId,
       xaaPolicy,
       xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),
     },

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -16,6 +16,7 @@ import { logger } from "../../utils/logger.js";
 import {
   createAuthorizedManager,
   callerContextFromHono,
+  conformanceKnobWireShape,
   createManualHostedConnection,
   handleRoute,
   parseWithSchema,
@@ -60,6 +61,12 @@ const hostedBatchSchema = z.object({
     .optional(),
   supportedProtocolVersions: z.array(z.string().min(1)).optional(),
   mcpProtocolVersionsByServerId: mcpProtocolVersionsByServerIdSchema,
+  // The client-conformance knobs, spread from their one declaration rather
+  // than re-listed here. This schema strips what it does not name, and every
+  // hosted eval body is parsed through it BEFORE
+  // `extractMcpInitializeOptions` reads the pins — so an eval run against a
+  // non-conforming host was executing as a fully conforming client.
+  ...conformanceKnobWireShape,
   oauthTokens: z.record(z.string(), z.string()).optional(),
   accessScope: z.enum(["project_member", "chat_v2"]).optional(),
   scenarioId: z.string().min(1).optional(),

--- a/mcpjam-inspector/server/utils/__tests__/local-server-resolver.tool-list-changed.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/local-server-resolver.tool-list-changed.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseConnectionDefaults,
+  toMCPServerConfig,
+} from "../local-server-resolver.js";
+
+const httpRow = {
+  serverConfig: {
+    transportType: "http",
+    url: "https://example.test/mcp",
+    headers: {},
+    timeout: 30000,
+  },
+} as never;
+
+const stdioRow = {
+  serverConfig: {
+    transportType: "stdio",
+    command: "node",
+    args: ["server.js"],
+    timeout: 30000,
+  },
+} as never;
+
+/**
+ * `mcpProfile.toolListChanged` reaches a LOCAL connect the same way its
+ * siblings do: the client puts the resolved leaves on `connectionDefaults`,
+ * `parseConnectionDefaults` gates the shape at the /api/mcp boundary, and
+ * `toMCPServerConfig` lands them on the SDK config. Both hops used to drop
+ * the pair on the floor — the wire carried them and the connection listened
+ * and refetched anyway.
+ */
+describe("local connect: toolListChanged -> MCPServerConfig", () => {
+  it("lands both switches on the http config", () => {
+    const defaults = parseConnectionDefaults({
+      suppressListenChannel: true,
+      dropToolListChanged: true,
+    });
+    expect(defaults).toEqual({
+      suppressListenChannel: true,
+      dropToolListChanged: true,
+    });
+
+    expect(
+      toMCPServerConfig(httpRow, {
+        suppressListenChannel: defaults?.suppressListenChannel,
+        dropToolListChanged: defaults?.dropToolListChanged,
+      })
+    ).toMatchObject({
+      suppressListenChannel: true,
+      dropToolListChanged: true,
+    });
+  });
+
+  it("keeps the conforming default off the config", () => {
+    // Only the explicit `true` opts into the simulation; an absent field is
+    // what tells the SDK to listen and refetch.
+    expect(
+      parseConnectionDefaults({
+        suppressListenChannel: false,
+        dropToolListChanged: false,
+      })
+    ).toBeUndefined();
+
+    const config = toMCPServerConfig(httpRow, {});
+    expect(config).not.toHaveProperty("suppressListenChannel");
+    expect(config).not.toHaveProperty("dropToolListChanged");
+  });
+
+  it("forwards only the drop half on stdio", () => {
+    // `dropToolListChanged` edits an inbound frame, so it applies on stdio.
+    // `suppressListenChannel` refuses a GET stream that stdio does not have,
+    // so it stays off the config rather than riding along inert — the same
+    // split `mirrorToolParamHeaders` already makes.
+    const config = toMCPServerConfig(stdioRow, {
+      suppressListenChannel: true,
+      dropToolListChanged: true,
+    });
+    expect(config).toMatchObject({ dropToolListChanged: true });
+    expect(config).not.toHaveProperty("suppressListenChannel");
+  });
+});

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -478,6 +478,12 @@ export function parseConnectionDefaults(
   if (input.supportsMrtr === false) {
     out.supportsMrtr = false;
   }
+  if (input.suppressListenChannel === true) {
+    out.suppressListenChannel = true;
+  }
+  if (input.dropToolListChanged === true) {
+    out.dropToolListChanged = true;
+  }
   if (input.toolCallCancellation && typeof input.toolCallCancellation === "object") {
     const raw = input.toolCallCancellation as {
       legacy?: unknown;
@@ -631,6 +637,15 @@ export function toMCPServerConfig(
     supportsMrtr?: boolean;
     toolCallCancellation?: { legacy?: boolean; modern?: boolean };
     /**
+     * `mcpProfile.toolListChanged`. Split by transport, unlike the pair above:
+     * `suppressListenChannel` refuses the server→client GET stream, which
+     * only exists on Streamable HTTP, so it is HTTP-only like the mirroring
+     * flag; `dropToolListChanged` edits an inbound JSON-RPC frame and is
+     * forwarded on stdio too.
+     */
+    suppressListenChannel?: boolean;
+    dropToolListChanged?: boolean;
+    /**
      * The host's enterprise-managed authorization policy (validated `on`
      * value). Present ⇒ the EMA extension is advertised on EVERY server of
      * this host — including explicit-OAuth overrides and stdio servers: the
@@ -705,6 +720,11 @@ export function toMCPServerConfig(
     // unlike the mirroring flag they are forwarded here as well as on HTTP.
     if (options?.firstPageOnly === true) stdio.firstPageOnly = true;
     if (options?.supportsMrtr === false) stdio.supportsMrtr = false;
+    // Only the drop half: a stdio connection has no GET listen stream to
+    // refuse, so `suppressListenChannel` is inert here (see the options
+    // docblock) and writing it would put a field on a config that can never
+    // act on it.
+    if (options?.dropToolListChanged === true) stdio.dropToolListChanged = true;
     if (options?.toolCallCancellation)
       stdio.toolCallCancellation = options.toolCallCancellation;
     return stdio as MCPServerConfig;
@@ -786,6 +806,9 @@ export function toMCPServerConfig(
     http.mirrorToolParamHeaders = false;
   if (options?.firstPageOnly === true) http.firstPageOnly = true;
   if (options?.supportsMrtr === false) http.supportsMrtr = false;
+  if (options?.suppressListenChannel === true)
+    http.suppressListenChannel = true;
+  if (options?.dropToolListChanged === true) http.dropToolListChanged = true;
   if (options?.toolCallCancellation)
     http.toolCallCancellation = options.toolCallCancellation;
 
@@ -1083,6 +1106,12 @@ export async function resolveLocalStdioServerConfig(
     supportedProtocolVersions?: string[];
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
+    /**
+     * The drop half of `mcpProfile.toolListChanged` only: this helper
+     * resolves stdio rows exclusively (it 409s on anything else), and there
+     * is no listen channel on stdio for `suppressListenChannel` to refuse.
+     */
+    dropToolListChanged?: boolean;
     toolCallCancellation?: { legacy?: boolean; modern?: boolean };
     xaaPolicy?: XaaEnterprisePolicy;
     /**
@@ -1143,6 +1172,7 @@ export async function resolveLocalStdioServerConfig(
     supportedProtocolVersions: options?.supportedProtocolVersions,
     firstPageOnly: options?.firstPageOnly,
     supportsMrtr: options?.supportsMrtr,
+    dropToolListChanged: options?.dropToolListChanged,
     toolCallCancellation: options?.toolCallCancellation,
     // Advertises the EMA extension host-wide on stdio too, matching the
     // /api/mcp path; stdio never gets OAuth/XAA hooks, so no
@@ -1426,6 +1456,8 @@ export async function resolveLocalServerForConnect(
     // Same path again for the sibling conformance knobs.
     firstPageOnly: options?.defaults?.firstPageOnly,
     supportsMrtr: options?.defaults?.supportsMrtr,
+    suppressListenChannel: options?.defaults?.suppressListenChannel,
+    dropToolListChanged: options?.defaults?.dropToolListChanged,
     toolCallCancellation: options?.defaults?.toolCallCancellation,
     oauthAccessToken: resolvedOauthAccessToken,
     refreshContext: {


### PR DESCRIPTION
## The bug

`mcpProfile.toolListChanged` models a host that never opens the listen channel (`listens: false`) or that ignores `notifications/tools/list_changed` when it arrives (`refetches: false`) — the two ways a real client leaves a server's tool list stale.

**Neither switch reached a connection**, hosted or local. Every connection listened and refetched no matter how the host was configured, so the debugger reported conforming behavior the host does not have.

The knobs were introduced in `47c2423f5`; this predates the cancellation work.

> This PR opened as a hosted-only fix, on the premise that local mode already worked. Verifying cubic's review comment on the stdio divert showed that premise was wrong — the local path drops the same pair one hop earlier. Both are fixed here; see the second commit.

## Why it was invisible

The values were computed correctly and then never handed over, at four separate hand-offs — all of them silent.

**Hosted** (`affa3de`):

1. `App.tsx` resolved both leaves into `hostedMcpProfilePins` and stopped there, without passing them to `useApiContext`.
2. `projectServerSchema` declared neither field, so Zod would have stripped them off the body even if it had. **This is the hop that would have made a client-only fix a no-op.**
3. `extractMcpInitializeOptions` did not read them.
4. `toHttpConfig` (both branches) and `resolveEffectiveInitializePinsForServer` had nowhere to put them.

The sibling knobs — `firstPageOnly`, `supportsMrtr`, `toolCallCancellation` — travel all four hops. These two never did.

Hosted **chat** turns were right by accident: a turn with a backing host config re-derives every conformance knob server-side (`applyHostConformanceKnobs`), overwriting whatever the body carried. Every other hosted surface — Tools, Resources, Prompts, tasks, servers, evals, bench, apps, export, MRTR continuation, and ad-hoc chat turns with no host config — builds its connection straight from the request body via `runEphemeralConnection` / `withEphemeralConnection` / `createManualHostedConnection`, and so ran as a fully conforming client.

**Local** (`78ba438`): the same pair died one hop earlier and for the same reason. The client puts both leaves on `connectionDefaults` and `/api/mcp/connect` receives them, but `parseConnectionDefaults` — the shape gate that must name every field it keeps — did not read them, and `toMCPServerConfig` had no field to set.

## The fix

Mirrors `firstPageOnly` hop for hop on both surfaces — no new mechanism, no host-config overlay on the one-shot routes (the siblings don't have one there either). Only the explicit non-default value ever travels; absent means conforming.

**Client** (`client/src/App.tsx`) — pass `suppressListenChannel` / `dropToolListChanged` to `useApiContext` beside `firstPageOnly`. Everything downstream (`use-hosted-api-context.ts`, `apis/web/context.ts`, `servers-api.ts`) was already wired.

**Hosted server** (`server/routes/web/auth.ts`):
- `projectServerSchema` declares both optional booleans.
- `extractMcpInitializeOptions` reads `=== true` under the same one-explicit-value rule as `firstPageOnly`, and includes them in the presence check, the returned object, and the return type.
- The four `initializePins` type declarations carry them; the three spreads onto `HttpServerConfig` place them.
- The local-runtime stdio divert threads the drop half to `resolveLocalStdioServerConfig`.

**Local server** (`server/utils/local-server-resolver.ts`) — `parseConnectionDefaults` reads both, and `toMCPServerConfig` applies them.

**Transport split, deliberate:** `dropToolListChanged` edits an inbound JSON-RPC frame, so it is forwarded on stdio as well as HTTP. `suppressListenChannel` refuses a server→client GET stream that only Streamable HTTP has, so — like `mirrorToolParamHeaders` — it is not written onto a stdio config where it could never act. That is also why the stdio-only helper and the divert take only the drop half.

**SDK**: untouched. `MCPServerConfig.suppressListenChannel` / `.dropToolListChanged` already exist and `MCPClientManager` honors them per connection (listen guard on the composed fetch, dropped-notification transport wrapper). `conformanceKnobsFromMcpProfile` / `applyHostConformanceKnobs` already handle both names.

## Verification

- `npm run test -w @mcpjam/inspector` — 22606 passed, 81 skipped (1707 files).
- `npm run test -w @mcpjam/sdk` — 7021 passed, 8 skipped (319 files).
- `npm run typecheck:client -w @mcpjam/inspector` — clean.
- Reverting only `auth.ts` fails exactly the four new/extended hosted assertions; reverting only the resolver fails two of the three local ones. Nothing else moves either way.

New/extended coverage:
- `auth-manager.test.ts` — both pins land on the per-server `HttpServerConfig`; neither appears when no profile is set; the schema round-trip keeps both; the extractor pins both, ignores the conforming `false`, and carries one leaf without the other.
- `local-server-resolver.tool-list-changed.test.ts` — defaults → http config, the conforming `false` producing no pins at all, and the stdio split.
- `use-hosted-api-context.test.tsx` — the hook → API context → hosted request body hop, in the both / one / neither cases.

**Not run here:** the hosted-mode end-to-end pass against the prober (both switches on, then each off, plus a hosted chat turn), and the equivalent local pass. This container has no hosted deployment or backend to point at. Those are still worth doing before release; the automated coverage above is unit-level.

## Out of scope, noticed in passing

The local-runtime stdio divert forwards `firstPageOnly` / `supportsMrtr` (and now `dropToolListChanged`) but still not `toolCallCancellation` — a pre-existing gap for a different knob, left for its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3SgDD5hvUP3i3qhX6Y43d