### PR TITLE
clients: name the unknown config field instead of a 500 that names nothing

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/clients.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/clients.test.ts
@@ -430,6 +430,138 @@ describe("v1 client routes", () => {
       expect(convexMutationMock).not.toHaveBeenCalled();
     });
 
+    // ── CONVEX-1ZM ────────────────────────────────────────────────────────
+    // Convex validates `input` before the mutation runs, and prod Convex
+    // redacts that error to a bare "Server Error", so an unknown config key
+    // reached the caller as a generic 500 naming nothing. One agent caller
+    // retried the identical body five times in three minutes.
+    describe("unknown config fields", () => {
+      it("names a misplaced nested field and points at its real home (400)", async () => {
+        const res = await request("POST", "/api/v1/projects/p1/clients", {
+          body: {
+            name: "Alpha",
+            config: {
+              modelId: "gpt-4o-mini",
+              initialize: {
+                clientInfo: { name: "codex", version: "0.60.0" },
+                supportedProtocolVersions: ["2025-11-25"],
+              },
+            },
+          },
+        });
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as {
+          code?: string;
+          message?: string;
+          details?: { unknownFields?: string[] };
+        };
+        expect(body.code).toBe("VALIDATION_ERROR");
+        expect(body.message).toContain("initialize");
+        expect(body.message).toContain("mcpProfile.initialize");
+        expect(body.details?.unknownFields).toEqual(["initialize"]);
+        expect(convexMutationMock).not.toHaveBeenCalled();
+      });
+
+      it("names the field but never echoes config VALUES", async () => {
+        const res = await request("POST", "/api/v1/projects/p1/clients", {
+          body: {
+            name: "Alpha",
+            config: {
+              modelId: "gpt-4o-mini",
+              connectionDefaults: {
+                headers: { authorization: "Bearer super-secret" },
+                requestTimeout: 10_000,
+              },
+              initialize: { clientInfo: { name: "codex" } },
+            },
+          },
+        });
+        expect(res.status).toBe(400);
+        const raw = await res.text();
+        expect(raw).toContain("initialize");
+        expect(raw).not.toContain("super-secret");
+      });
+
+      it("names every unknown field, not just the first", async () => {
+        const res = await request("POST", "/api/v1/projects/p1/clients", {
+          body: {
+            name: "Alpha",
+            config: { modelId: "gpt-4o-mini", initialize: {}, nonsense: 1 },
+          },
+        });
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as {
+          message?: string;
+          details?: { unknownFields?: string[] };
+        };
+        expect(body.details?.unknownFields).toEqual(["initialize", "nonsense"]);
+        // No invented home for a field that has none.
+        expect(body.message).toContain("`nonsense`");
+        expect(body.message).not.toContain("mcpProfile.nonsense");
+      });
+
+      // The lookup key is caller-supplied, so a prototype-chain hit would
+      // render `function toString() { [native code] }` as the suggested home.
+      it("does not answer a prototype key with an inherited value", async () => {
+        const res = await request("POST", "/api/v1/projects/p1/clients", {
+          body: {
+            name: "Alpha",
+            config: { modelId: "gpt-4o-mini", toString: 1, constructor: 2 },
+          },
+        });
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as { message?: string };
+        expect(body.message).toContain("`toString`");
+        expect(body.message).not.toContain("native code");
+        expect(body.message).not.toContain("did you mean");
+      });
+
+      // Declared on the SDK's `HostConfigInputV2` and canonicalized, but no
+      // backend validator or column accepts it, so it fails closed like any
+      // other unknown key until that gap is closed.
+      it("rejects `oauthProfile`, which no write accepts yet (400)", async () => {
+        const res = await request("POST", "/api/v1/projects/p1/clients", {
+          body: {
+            name: "Alpha",
+            config: { modelId: "gpt-4o-mini", oauthProfile: {} },
+          },
+        });
+        expect(res.status).toBe(400);
+        expect(convexMutationMock).not.toHaveBeenCalled();
+      });
+
+      // The read DTO adds these two; stripping them is what makes the obvious
+      // `get` → edit one field → `update` loop work, so they must not read as
+      // the caller's mistake.
+      it("still accepts the read-only keys a `get` round-trip carries", async () => {
+        convexMutationMock.mockResolvedValue({ hostId: "h1" });
+        mockQuery({ "hosts:getHost": DETAIL_ROW });
+        const res = await request("POST", "/api/v1/projects/p1/clients", {
+          body: {
+            name: "Alpha",
+            config: { modelId: "gpt-4o-mini", id: "hc1", schemaVersion: 2 },
+          },
+        });
+        expect(res.status).toBe(201);
+        expect(createdHostInput()).toEqual({ modelId: "gpt-4o-mini" });
+      });
+
+      // Guards the dangerous direction: an allowlist missing a key our own
+      // templates emit would reject a perfectly valid config.
+      it("accepts a real catalog template posted back as a caller config", async () => {
+        convexMutationMock.mockResolvedValue({ hostId: "h1" });
+        mockQuery({ "hosts:getHost": DETAIL_ROW });
+        const template = getCatalogTemplate(
+          bundledHostCompatCatalog(),
+          "claude"
+        );
+        const res = await request("POST", "/api/v1/projects/p1/clients", {
+          body: { name: "Claude", config: template },
+        });
+        expect(res.status).toBe(201);
+      });
+    });
+
     // ── FORWARD-CLIENT INVARIANT ─────────────────────────────────────────
     // A client with no model cannot back a headless environment: resolution
     // falls through to `ENV_MODEL_REQUIRED` at LAUNCH, long after creation.
@@ -690,6 +822,23 @@ describe("v1 client routes", () => {
       expect(convexMutationMock).not.toHaveBeenCalled();
     });
 
+    // The replacement branch takes a whole config, so it reaches the same
+    // Convex validator create does — and used to fail the same opaque way.
+    it("names an unknown field inside a whole-config replacement (400)", async () => {
+      mockQuery({ "hosts:getHost": DETAIL_ROW });
+      const res = await request("PATCH", "/api/v1/projects/p1/clients/h1", {
+        body: {
+          expectedConfigId: "hc1",
+          config: { modelId: "gpt-4o-mini", initialize: {} },
+        },
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code?: string; message?: string };
+      expect(body.code).toBe("VALIDATION_ERROR");
+      expect(body.message).toContain("mcpProfile.initialize");
+      expect(convexMutationMock).not.toHaveBeenCalled();
+    });
+
     describe("the model invariant", () => {
       it.each([
         ["empty", ""],
@@ -805,8 +954,9 @@ describe("v1 client routes", () => {
     });
 
     // Only the two derived keys are dropped. Anything else the caller invents
-    // still reaches the backend validator and still fails closed there.
-    it("leaves an unrecognized key alone", async () => {
+    // is REFUSED — still never dropped silently, but no longer forwarded for
+    // Convex to reject as a 500 that names nothing (CONVEX-1ZM).
+    it("refuses an unrecognized key instead of forwarding it", async () => {
       convexMutationMock.mockResolvedValue({ hostId: "h1" });
       mockQuery({ "hosts:getHost": DETAIL_ROW });
       const res = await request("PATCH", "/api/v1/projects/p1/clients/h1", {
@@ -815,13 +965,11 @@ describe("v1 client routes", () => {
           config: { modelId: "openai/gpt-5", typodField: 1 },
         },
       });
-      expect(res.status).toBe(200);
-      expect(convexMutationMock).toHaveBeenCalledWith(
-        "hosts:updateHost",
-        expect.objectContaining({
-          input: { modelId: "openai/gpt-5", typodField: 1 },
-        })
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { message?: string }).message).toContain(
+        "typodField"
       );
+      expect(convexMutationMock).not.toHaveBeenCalled();
     });
   });
 
@@ -1164,6 +1312,18 @@ describe("v1 client routes", () => {
         body: { expectedConfigId: "hc1", set: { temperature: 0.2 } },
       });
       expect(res.status).toBe(400);
+      expect(convexMutationMock).not.toHaveBeenCalled();
+    });
+
+    it("names an unknown config field on the alias too (400)", async () => {
+      mockQuery({ "hosts:getHost": DETAIL_ROW });
+      const res = await request("PATCH", "/api/v1/projects/p1/hosts/h1", {
+        body: { config: { modelId: "gpt-4o-mini", initialize: {} } },
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code?: string; message?: string };
+      expect(body.code).toBe("VALIDATION_ERROR");
+      expect(body.message).toContain("mcpProfile.initialize");
       expect(convexMutationMock).not.toHaveBeenCalled();
     });
 

--- a/mcpjam-inspector/server/routes/v1/clients.ts
+++ b/mcpjam-inspector/server/routes/v1/clients.ts
@@ -54,7 +54,10 @@ import {
 // harness added to HARNESS_IDS is accepted here without a second hand-edit
 // nobody would think to make (this route accepts no unknown-harness value, so
 // a stale copy is a silent "that host cannot be created through the API").
-import { HARNESS_IDS } from "@mcpjam/sdk/host-config/internal";
+import {
+  HARNESS_IDS,
+  HOST_CONFIG_INPUT_V2_WIRE_KEYS,
+} from "@mcpjam/sdk/host-config/internal";
 import { parseWithSchema, ErrorCode, WebRouteError } from "../web/errors.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import { logger } from "../../utils/logger.js";
@@ -463,6 +466,82 @@ function hostConfigPinsAModel(config: Record<string, unknown>): boolean {
  */
 const READ_ONLY_CONFIG_KEYS = ["id", "schemaVersion"] as const;
 
+const WRITABLE_CONFIG_KEYS: ReadonlySet<string> = new Set(
+  HOST_CONFIG_INPUT_V2_WIRE_KEYS,
+);
+
+/**
+ * Where a misplaced key actually belongs.
+ *
+ * Every entry is a real config field one level down, so the mistake it catches
+ * is a NESTING error rather than an invented field — a root `initialize` is the
+ * one that reached production, from a caller that pasted an MCP `initialize`
+ * handshake at the top of an otherwise valid config. A key absent from this map
+ * still gets named, just without the pointer, so a stale map costs a hint and
+ * never a wrong rejection.
+ */
+// A Map, not an object literal: the lookup key is caller-supplied, and a plain
+// object would answer `toString` or `constructor` from the prototype chain and
+// interpolate a function into the message.
+const NESTED_CONFIG_FIELD_HOMES = new Map<string, string>([
+  ["apps", "mcpProfile.apps"],
+  ["initialize", "mcpProfile.initialize"],
+  ["mcpProtocolVersion", "mcpProfile.mcpProtocolVersion"],
+  ["mrtrModes", "mcpProfile.mrtrModes"],
+  ["mrtrSupport", "mcpProfile.mrtrSupport"],
+  ["paginationTraversal", "mcpProfile.paginationTraversal"],
+  ["profileVersion", "mcpProfile.profileVersion"],
+  ["toolCallCancellation", "mcpProfile.toolCallCancellation"],
+  ["toolListChanged", "mcpProfile.toolListChanged"],
+  ["toolParamHeaderMirroring", "mcpProfile.toolParamHeaderMirroring"],
+]);
+
+/**
+ * Refuse a caller-supplied config carrying a key no write accepts.
+ *
+ * Convex validates `input` at the CALL boundary, so an unknown top-level key
+ * fails before the mutation runs — and production Convex redacts that
+ * `ArgumentValidationError` to a bare "Server Error", which
+ * `translateConvexWriteError` can only report as a generic 500. The caller was
+ * therefore told that the write failed but never which field failed it, and an
+ * agent caller retried the same body blind. Naming the key is the whole point;
+ * VALUES are never echoed, because a config carries
+ * `connectionDefaults.headers`.
+ *
+ * Only the caller's OWN config is checked. A template resolved from our catalog
+ * stays unchecked deliberately: a metadata leak there is our bug, and a 400
+ * would blame the caller for it.
+ *
+ * Runs AFTER `normalizeConfigForWrite`, so the read-only projection keys a
+ * `get` → edit → `update` round-trip carries are already gone and don't read as
+ * the caller's mistake.
+ *
+ * The cost is a deploy-order coupling the old forward-everything behavior did
+ * not have: a field the backend validator gains is refused here until
+ * `HOST_CONFIG_INPUT_V2_WIRE_KEYS` learns it, so add the key to the SDK list in
+ * the same change that adds the column.
+ */
+function assertConfigKeysAreWritable(config: Record<string, unknown>): void {
+  const unknown = Object.keys(config).filter(
+    (key) => !WRITABLE_CONFIG_KEYS.has(key),
+  );
+  if (unknown.length === 0) return;
+  const described = unknown
+    .map((key) => {
+      const home = NESTED_CONFIG_FIELD_HOMES.get(key);
+      return home ? `\`${key}\` (did you mean \`${home}\`?)` : `\`${key}\``;
+    })
+    .join(", ");
+  throw new WebRouteError(
+    400,
+    ErrorCode.VALIDATION_ERROR,
+    `Unrecognized client config ${
+      unknown.length === 1 ? "field" : "fields"
+    }: ${described}.`,
+    { unknownFields: unknown },
+  );
+}
+
 /**
  * Return `config` ready for the Convex write: `modelId` TRIMMED, and the
  * read-only projection keys dropped so `get` output round-trips into `update`.
@@ -779,6 +858,7 @@ async function createHandler(c: Context, surface: Surface) {
       ? await resolveHostTemplateInput(body.template, body.theme)
       : body.config!,
   );
+  if (!body.template) assertConfigKeysAreWritable(input);
 
   let created: { hostId: string };
   try {
@@ -859,13 +939,15 @@ async function updateClientHandler(c: Context) {
         await readHostDetail(token, projectId, clientId),
         body.config,
       );
+      const input = normalizeConfigForWrite(body.config);
+      assertConfigKeysAreWritable(input);
       await convexClient.mutation(
         "hosts:updateHost" as any,
         {
           hostId: clientId,
           projectId,
           ...(body.name === undefined ? {} : { name: body.name }),
-          input: normalizeConfigForWrite(body.config),
+          input,
           ...tokens,
         } as any,
       );
@@ -907,7 +989,9 @@ async function updateHostAliasHandler(c: Context) {
       await readHostDetail(token, projectId, hostId),
       body.config,
     );
-    updateArgs.input = normalizeConfigForWrite(body.config);
+    const input = normalizeConfigForWrite(body.config);
+    assertConfigKeysAreWritable(input);
+    updateArgs.input = input;
   }
   const convexClient = createConvexClient(token);
   try {

--- a/mcpjam-inspector/server/routes/v1/clients.ts
+++ b/mcpjam-inspector/server/routes/v1/clients.ts
@@ -57,6 +57,7 @@ import {
 import {
   HARNESS_IDS,
   HOST_CONFIG_INPUT_V2_WIRE_KEYS,
+  type HostConfigMcpProfileV1,
 } from "@mcpjam/sdk/host-config/internal";
 import { parseWithSchema, ErrorCode, WebRouteError } from "../web/errors.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
@@ -483,18 +484,28 @@ const WRITABLE_CONFIG_KEYS: ReadonlySet<string> = new Set(
 // A Map, not an object literal: the lookup key is caller-supplied, and a plain
 // object would answer `toString` or `constructor` from the prototype chain and
 // interpolate a function into the message.
+//
+// Keys are checked against the SDK's profile type, so an entry naming a field
+// `mcpProfile` does not have stops compiling. `mrtrModes` was exactly that — it
+// exists on the BACKEND's hand-mirrored copy of the type but not on the SDK's,
+// and since `mcpProfile` reaches Convex as `v.any()`, a caller who followed that
+// hint would have had the field silently dropped by the canonicalizer rather
+// than refused.
+//
+// `extensions` is deliberately absent despite being a real profile field: the
+// name is ambiguous (`clientCapabilities.extensions` is also real, and is what
+// the payload behind CONVEX-1ZM carried), so there is no single home to point at.
 const NESTED_CONFIG_FIELD_HOMES = new Map<string, string>([
   ["apps", "mcpProfile.apps"],
   ["initialize", "mcpProfile.initialize"],
   ["mcpProtocolVersion", "mcpProfile.mcpProtocolVersion"],
-  ["mrtrModes", "mcpProfile.mrtrModes"],
   ["mrtrSupport", "mcpProfile.mrtrSupport"],
   ["paginationTraversal", "mcpProfile.paginationTraversal"],
   ["profileVersion", "mcpProfile.profileVersion"],
   ["toolCallCancellation", "mcpProfile.toolCallCancellation"],
   ["toolListChanged", "mcpProfile.toolListChanged"],
   ["toolParamHeaderMirroring", "mcpProfile.toolParamHeaderMirroring"],
-]);
+] satisfies ReadonlyArray<readonly [keyof HostConfigMcpProfileV1, string]>);
 
 /**
  * Refuse a caller-supplied config carrying a key no write accepts.

--- a/sdk/src/host-config/internal.ts
+++ b/sdk/src/host-config/internal.ts
@@ -24,6 +24,7 @@ export {
 export { sha256Hex, computeHostConfigHashV2 } from "./hash.js";
 export {
   HARNESS_IDS,
+  HOST_CONFIG_INPUT_V2_WIRE_KEYS,
   HOST_CONFIG_SCHEMA_VERSION_V2,
   isHarness,
   OAUTH_AUTH_MODELS,

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -987,6 +987,76 @@ export type HostConfigInputV2 = {
   >;
 };
 
+/**
+ * Every top-level key a host-config WRITE accepts. Portable
+ * **persistence-contract source of truth**, like `HARNESS_IDS`: the backend's
+ * hand-mirrored `hostConfigInputV2Validator` is a strict `v.object` over
+ * exactly these fields, and the inspector's v1 client routes check a
+ * caller-supplied config against this list before the write leaves Node.
+ *
+ * That pre-check is why the list is exported at all. Convex rejects an unknown
+ * field at the CALL boundary, before the handler runs, and production Convex
+ * redacts the resulting `ArgumentValidationError` to a bare "Server Error" — so
+ * without a check on this side the caller is told only that the write failed,
+ * never which field failed it.
+ */
+export const HOST_CONFIG_INPUT_V2_WIRE_KEYS = [
+  "builtInToolIds",
+  "chatUiOverride",
+  "clientCapabilities",
+  "computer",
+  "connectionDefaults",
+  "harness",
+  "hostCapabilitiesOverride",
+  "hostContext",
+  "hostStyle",
+  "mcpProfile",
+  "mcpToolResultImageRendering",
+  "modelId",
+  "modelVisibleMcpToolResults",
+  "optionalServerIds",
+  "progressiveToolDiscovery",
+  "requireToolApproval",
+  "respectToolVisibility",
+  "serverConnectionOverrides",
+  "serverIds",
+  "skillSelection",
+  "systemPrompt",
+  "temperature",
+] as const;
+
+type HostConfigInputV2WireKey = (typeof HOST_CONFIG_INPUT_V2_WIRE_KEYS)[number];
+
+/**
+ * Fields this type declares that no write accepts yet. `oauthProfile` is
+ * canonicalized but has no backend validator or column, so a config carrying it
+ * fails closed. Naming it keeps the guard below honest rather than letting the
+ * gap read as an oversight; closing it means moving the key into the wire list.
+ */
+type HostConfigKeyNotOnTheWire = "oauthProfile";
+
+// Both directions are load-bearing. A key on the type but missing from the list
+// is one the routes would reject on a VALID config; a key in the list but not on
+// the type is one nothing validates. So adding a field to `HostConfigInputV2`
+// stops this compiling until the field is either accepted on the wire or named
+// as a known gap above.
+const _wireKeysMatchTheType: [
+  | Exclude<
+      keyof HostConfigInputV2,
+      HostConfigInputV2WireKey | HostConfigKeyNotOnTheWire
+    >
+  | Exclude<HostConfigInputV2WireKey, keyof HostConfigInputV2>
+] extends [never]
+  ? true
+  : [
+      "HOST_CONFIG_INPUT_V2_WIRE_KEYS is out of sync with HostConfigInputV2",
+      Exclude<
+        keyof HostConfigInputV2,
+        HostConfigInputV2WireKey | HostConfigKeyNotOnTheWire
+      >
+    ] = true;
+void _wireKeysMatchTheType;
+
 export type CanonicalHostConfigV2 = {
   schemaVersion: typeof HOST_CONFIG_SCHEMA_VERSION_V2;
   hostStyle: HostConfigStyle;

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -1035,25 +1035,28 @@ type HostConfigInputV2WireKey = (typeof HOST_CONFIG_INPUT_V2_WIRE_KEYS)[number];
  */
 type HostConfigKeyNotOnTheWire = "oauthProfile";
 
-// Both directions are load-bearing. A key on the type but missing from the list
-// is one the routes would reject on a VALID config; a key in the list but not on
-// the type is one nothing validates. So adding a field to `HostConfigInputV2`
-// stops this compiling until the field is either accepted on the wire or named
-// as a known gap above.
-const _wireKeysMatchTheType: [
+// Every way the three lists can disagree, each a real bug:
+//   1. a field on the type that is neither on the wire nor a declared gap — the
+//      write boundary would reject it on a VALID config;
+//   2. a wire key that is not on the type — nothing validates it;
+//   3. a declared gap whose field no longer exists — stale bookkeeping;
+//   4. a declared gap that IS on the wire — the gap closed and the note lies.
+// (3) and (4) are why the gap is not just a comment: closing `oauthProfile`
+// means moving one key between two lists, and a half-done move must not compile.
+type HostConfigWireKeyDrift =
   | Exclude<
       keyof HostConfigInputV2,
       HostConfigInputV2WireKey | HostConfigKeyNotOnTheWire
     >
   | Exclude<HostConfigInputV2WireKey, keyof HostConfigInputV2>
-] extends [never]
+  | Exclude<HostConfigKeyNotOnTheWire, keyof HostConfigInputV2>
+  | Extract<HostConfigKeyNotOnTheWire, HostConfigInputV2WireKey>;
+
+const _wireKeysMatchTheType: [HostConfigWireKeyDrift] extends [never]
   ? true
   : [
       "HOST_CONFIG_INPUT_V2_WIRE_KEYS is out of sync with HostConfigInputV2",
-      Exclude<
-        keyof HostConfigInputV2,
-        HostConfigInputV2WireKey | HostConfigKeyNotOnTheWire
-      >
+      HostConfigWireKeyDrift,
     ] = true;
 void _wireKeysMatchTheType;
 


### PR DESCRIPTION
## What broke

A caller-supplied client config carrying an unknown top-level key reached Convex verbatim. `hosts:createHost` validates `input` with a strict `v.object`, so the key is rejected at the call boundary before the handler runs — and production Convex redacts that `ArgumentValidationError` to a bare `"Server Error"`, leaving `translateConvexWriteError` nothing to report but a generic 500.

The caller was told the write failed and never which field failed it. In CONVEX-1ZM one caller posted a config with a top-level `initialize` — a real field, but one that only exists at `mcpProfile.initialize` — and retried the identical body five times in three minutes, because nothing in the response said what to change. It also paged #mcpjam-alerts as a new backend issue for what was caller input.

The backend validator is correct; `initialize` is a `mcpProfile` field in both repos. Nothing in this repo produces a top-level one — the payload was hand-assembled (no `builtInToolIds`, which every template emits unconditionally and the catalog zod requires).

## The change

- The v1 client write paths (`create`, the whole-config `PATCH`, and the deprecated `/hosts` alias) check the caller's config against the key set the write accepts and return a 400 naming the offending keys, plus the real home of a misplaced nested field.
- Values are never echoed — a config carries `connectionDefaults.headers`. A test asserts a header value cannot appear in the response.
- The template branch stays unchecked deliberately: a metadata leak there is ours, and a 400 would blame the caller for it.
- `HOST_CONFIG_INPUT_V2_WIRE_KEYS` lives beside `HARNESS_IDS` in the SDK, with a compile-time guard that fails the build when `HostConfigInputV2` gains a field that is neither on the wire list nor named as a known gap. Verified by adding a probe field: the build fails and the error names the offending key.

Because the write no longer reaches Convex, the Sentry error stops too — the inspector's own capture is gated on `status >= 500`, so the 400 is not reported.

## Tradeoff worth reviewing

This adds a deploy-order coupling the old forward-everything behavior did not have: a field the backend validator gains is refused here until the SDK list learns it. The two have to move together. It is documented on the assertion.

## `oauthProfile` is a live gap

The SDK type declares it and the canonicalizer handles it, but `grep -rn oauthProfile convex/` in mcpjam-backend returns nothing — no validator, no column. Any caller sending it fails today; now it fails with a clear 400. Named explicitly in the guard so closing the gap means moving the key into the wire list.

## Not in scope

- The UI writes straight from the browser to Convex (`useClients.ts`), bypassing this route, so an invalid config there still gets the opaque error. Low risk — it always seeds from templates.
- The matching parity test belongs in mcpjam-backend: assert `hostConfigInputV2Validator`'s keys are exactly `HOST_CONFIG_INPUT_V2_WIRE_KEYS`, the way the repo already does for `HARNESS_IDS`.

## Verification

- `server/routes/v1/__tests__/clients.test.ts` + `client-write-freeze.test.ts`: 91 passed
- `sdk` host-config parity / canonicalize / seed-template: 167 passed
- `npm run typecheck -w @mcpjam/sdk`: exit 0
- `tsc -p server/tsconfig.json`: 226 errors, identical to the pre-existing baseline measured with the branch stashed; zero in the touched files

One existing test asserted the old behavior ("leaves an unrecognized key alone"). Its point was that unknown keys must never be silently dropped, which still holds — it now asserts they are refused rather than forwarded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns a 400 naming the offending config field instead of forwarding unknown keys to Convex, where production redacts the validation error to a generic "Server Error" (fixes CONVEX-1ZM).

- The v1 client write routes (create, whole-config PATCH, and the `/hosts` alias) validate config keys against `HOST_CONFIG_INPUT_V2_WIRE_KEYS` from the SDK before writing.
- The 400 names each unknown field, suggests the correct nested home for known misplaced fields (e.g., `initialize` → `mcpProfile.initialize`), and never echoes config values.
- Both hand-kept key lists are compile-time checked: the wire list against `HostConfigInputV2` and the suggestion map against `HostConfigMcpProfileV1`, so a stale or invented entry fails the build (`mrtrModes` was dropped for exactly that).
- `oauthProfile` is rejected because no backend validator or column accepts it; the guard treats it as a declared gap, so closing the gap means moving one key.
- Template-based writes stay unchecked; adding a backend config field now requires updating the SDK list in the same change.

<sup>Written for commit 8fbd9517faa37f02ca4263d467d3a0b8606da2f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

