### PR TITLE
Show when a client profile was last checked

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-config-comparison-matrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-config-comparison-matrix.test.tsx
@@ -29,7 +29,7 @@ function makeSubject(
   hostName: string,
   overrides: Partial<HostConfigDtoV2> = {},
   configHashShort?: string,
-  verifiedAt?: number
+  verifiedAt?: number,
 ): HostComparisonSubject {
   return {
     hostId,
@@ -55,7 +55,7 @@ describe("HostConfigComparisonMatrix", () => {
     render(
       <HostConfigComparisonMatrix
         subjects={[makeSubject("h_a3f9d2_claude", "Claude Code")]}
-      />
+      />,
     );
     const sections = screen
       .getAllByRole("columnheader", { hidden: true })
@@ -77,10 +77,10 @@ describe("HostConfigComparisonMatrix", () => {
             "h_cursor_002",
             "Cursor",
             { hostStyle: "cursor" },
-            "1b8e44"
+            "1b8e44",
           ),
         ]}
-      />
+      />,
     );
     expect(screen.getByText("Claude Code")).toBeInTheDocument();
     expect(screen.getByText("Cursor")).toBeInTheDocument();
@@ -91,16 +91,16 @@ describe("HostConfigComparisonMatrix", () => {
       <HostConfigComparisonMatrix
         subjects={[makeSubject("preset:mcpjam", "MCPJam")]}
         verifyBaseUrl="https://app.mcpjam.com"
-      />
+      />,
     );
 
     expect(
       screen.getByRole("link", {
         name: "Verify MCPJam against your server",
-      })
+      }),
     ).toHaveAttribute(
       "href",
-      "https://app.mcpjam.com/hosts?template=mcpjam&hostTab=agent"
+      "https://app.mcpjam.com/hosts?template=mcpjam&hostTab=agent",
     );
   });
 
@@ -114,22 +114,22 @@ describe("HostConfigComparisonMatrix", () => {
         ]}
         verifyBaseUrl="https://app.mcpjam.com"
         disabledVerifyTemplateIds={new Set(["claude-code", "codex"])}
-      />
+      />,
     );
 
     expect(
       screen.queryByRole("link", {
         name: "Verify Claude Code against your server",
-      })
+      }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("link", { name: "Verify Codex against your server" })
+      screen.queryByRole("link", { name: "Verify Codex against your server" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "Verify Claude against your server" })
+      screen.getByRole("link", { name: "Verify Claude against your server" }),
     ).toHaveAttribute(
       "href",
-      "https://app.mcpjam.com/hosts?template=claude&hostTab=agent"
+      "https://app.mcpjam.com/hosts?template=claude&hostTab=agent",
     );
   });
 
@@ -139,7 +139,7 @@ describe("HostConfigComparisonMatrix", () => {
       "Claude",
       { hostStyle: "claude" },
       "claude",
-      Date.UTC(2026, 6, 8)
+      Date.UTC(2026, 6, 8),
     );
 
     // Freeze the clock 2 days after the verified date so it stays inside the
@@ -151,7 +151,7 @@ describe("HostConfigComparisonMatrix", () => {
     vi.setSystemTime(new Date("2026-07-10T00:00:00.000Z"));
 
     const { rerender } = render(
-      <HostConfigComparisonMatrix subjects={[subject]} />
+      <HostConfigComparisonMatrix subjects={[subject]} />,
     );
     expect(screen.queryByText("Verified at")).not.toBeInTheDocument();
 
@@ -159,7 +159,7 @@ describe("HostConfigComparisonMatrix", () => {
       <HostConfigComparisonMatrix
         subjects={[subject]}
         verifyBaseUrl="https://app.mcpjam.com"
-      />
+      />,
     );
 
     expect(screen.getByText("Verified at")).toBeInTheDocument();
@@ -172,7 +172,7 @@ describe("HostConfigComparisonMatrix", () => {
       "Claude",
       { hostStyle: "claude" },
       "claude",
-      Date.UTC(2026, 6, 8)
+      Date.UTC(2026, 6, 8),
     );
 
     vi.useFakeTimers();
@@ -182,11 +182,11 @@ describe("HostConfigComparisonMatrix", () => {
       <HostConfigComparisonMatrix
         subjects={[subject]}
         verifyBaseUrl="https://app.mcpjam.com"
-      />
+      />,
     );
 
     expect(
-      screen.queryByText("Last checked over 30 days ago")
+      screen.queryByText("Last checked over 30 days ago"),
     ).not.toBeInTheDocument();
 
     vi.setSystemTime(new Date("2026-08-08T00:00:00.001Z"));
@@ -194,13 +194,18 @@ describe("HostConfigComparisonMatrix", () => {
       <HostConfigComparisonMatrix
         subjects={[subject]}
         verifyBaseUrl="https://app.mcpjam.com"
-      />
+      />,
     );
 
     expect(
-      screen.getByText("Last checked over 30 days ago")
+      screen.getByText("Last checked over 30 days ago"),
     ).toBeInTheDocument();
     expect(screen.queryByText("2026-07-08")).not.toBeInTheDocument();
+    // The exact date stays reachable on hover, same as the client header.
+    expect(screen.getByText("Last checked over 30 days ago")).toHaveAttribute(
+      "title",
+      "Last checked 2026-07-08",
+    );
   });
 
   it("uses the dark Goose logo in dark theme column headers", () => {
@@ -210,7 +215,7 @@ describe("HostConfigComparisonMatrix", () => {
           makeSubject("h_goose_001", "Goose", { hostStyle: "goose" }, "goose1"),
         ]}
         themeMode="dark"
-      />
+      />,
     );
 
     const header = screen.getByText("Goose").closest("th");
@@ -225,10 +230,10 @@ describe("HostConfigComparisonMatrix", () => {
           makeSubject("h_a", "A", { temperature: 0.2 }),
           makeSubject("h_b", "B", { temperature: 0.7 }),
         ]}
-      />
+      />,
     );
     expect(
-      screen.getByTestId("diverge-gutter-temperature")
+      screen.getByTestId("diverge-gutter-temperature"),
     ).toBeInTheDocument();
   });
 
@@ -236,10 +241,10 @@ describe("HostConfigComparisonMatrix", () => {
     render(
       <HostConfigComparisonMatrix
         subjects={[makeSubject("h_a", "A"), makeSubject("h_b", "B")]}
-      />
+      />,
     );
     expect(
-      screen.queryByTestId("diverge-gutter-temperature")
+      screen.queryByTestId("diverge-gutter-temperature"),
     ).not.toBeInTheDocument();
   });
 
@@ -251,11 +256,11 @@ describe("HostConfigComparisonMatrix", () => {
           makeSubject("h_b", "B", { temperature: 0.7 }),
         ]}
         divergingOnly
-      />
+      />,
     );
     // temperature differs → still visible
     expect(
-      screen.getByTestId("diverge-gutter-temperature")
+      screen.getByTestId("diverge-gutter-temperature"),
     ).toBeInTheDocument();
     // modelId is identical across both → row hidden
     expect(screen.queryByText("modelId")).not.toBeInTheDocument();
@@ -268,7 +273,7 @@ describe("HostConfigComparisonMatrix", () => {
           makeSubject("h_a", "A", { requireToolApproval: true }),
           makeSubject("h_b", "B", { requireToolApproval: false }),
         ]}
-      />
+      />,
     );
     expect(screen.getAllByText("Yes").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("No").length).toBeGreaterThanOrEqual(1);
@@ -285,13 +290,13 @@ describe("HostConfigComparisonMatrix", () => {
         subjects={[
           makeSubject("h_a", "A", { clientCapabilities: { sampling: {} } }),
         ]}
-      />
+      />,
     );
     // sampling present → Supported
     expect(screen.getAllByText("Supported").length).toBeGreaterThanOrEqual(1);
     // roots/elicitation/experimental absent → Not supported
     expect(screen.getAllByText("Not supported").length).toBeGreaterThanOrEqual(
-      1
+      1,
     );
   });
 
@@ -302,11 +307,11 @@ describe("HostConfigComparisonMatrix", () => {
           makeSubject("h_a", "A", { clientCapabilities: { sampling: {} } }),
           makeSubject("h_b", "B", { clientCapabilities: {} }),
         ]}
-      />
+      />,
     );
     // sampling supported by 1 of 2 hosts
     expect(
-      screen.getByTestId("coverage-capabilities.sampling")
+      screen.getByTestId("coverage-capabilities.sampling"),
     ).toHaveTextContent("1/2");
     // scalar rows get no coverage stat
     expect(screen.queryByTestId("coverage-modelId")).not.toBeInTheDocument();
@@ -316,7 +321,7 @@ describe("HostConfigComparisonMatrix", () => {
     render(
       <HostConfigComparisonMatrix
         subjects={[makeSubject("h_a", "A", { hostStyle: "claude" })]}
-      />
+      />,
     );
     // Effective MCP Apps + OpenAI shim dimensions render as their own rows…
     expect(screen.getByText("openLinks")).toBeInTheDocument();
@@ -326,7 +331,7 @@ describe("HostConfigComparisonMatrix", () => {
     // …and the old opaque override rows are gone.
     expect(screen.queryByText("Spec-bridge overrides")).not.toBeInTheDocument();
     expect(
-      screen.queryByText("Permissions allow-list")
+      screen.queryByText("Permissions allow-list"),
     ).not.toBeInTheDocument();
   });
 
@@ -335,7 +340,7 @@ describe("HostConfigComparisonMatrix", () => {
       <HostConfigComparisonMatrix
         subjects={[makeSubject("h_a", "A")]}
         searchQuery="temperature"
-      />
+      />,
     );
     expect(screen.getByText("Temperature")).toBeInTheDocument();
     expect(screen.queryByText("Model")).not.toBeInTheDocument();
@@ -346,7 +351,7 @@ describe("HostConfigComparisonMatrix", () => {
       <HostConfigComparisonMatrix
         subjects={[makeSubject("h_a", "A")]}
         searchQuery="zzz-no-such-field"
-      />
+      />,
     );
     expect(screen.getByText(/No fields match/i)).toBeInTheDocument();
   });
@@ -359,7 +364,7 @@ describe("HostConfigComparisonMatrix", () => {
           makeSubject("h_b", "B", { clientCapabilities: { sampling: {} } }),
         ]}
         supportFilter="missing"
-      />
+      />,
     );
     // sampling supported by all → hidden
     expect(screen.queryByText("Sampling")).not.toBeInTheDocument();
@@ -381,7 +386,7 @@ describe("HostConfigComparisonMatrix", () => {
         ]}
         searchQuery="sampling"
         supportFilter="missing"
-      />
+      />,
     );
 
     expect(screen.getByText("Sampling")).toBeInTheDocument();
@@ -389,7 +394,7 @@ describe("HostConfigComparisonMatrix", () => {
     expect(screen.getByText("Missing A")).toBeInTheDocument();
     expect(screen.getByText("Missing B")).toBeInTheDocument();
     expect(
-      screen.getByTestId("coverage-capabilities.sampling")
+      screen.getByTestId("coverage-capabilities.sampling"),
     ).toHaveTextContent("1/3");
   });
 
@@ -404,13 +409,13 @@ describe("HostConfigComparisonMatrix", () => {
         ]}
         searchQuery="sampling"
         supportFilter="supported"
-      />
+      />,
     );
 
     expect(screen.getByText("Supported Host")).toBeInTheDocument();
     expect(screen.queryByText("Missing Host")).not.toBeInTheDocument();
     expect(
-      screen.getByTestId("coverage-capabilities.sampling")
+      screen.getByTestId("coverage-capabilities.sampling"),
     ).toHaveTextContent("1/2");
   });
 
@@ -422,7 +427,7 @@ describe("HostConfigComparisonMatrix", () => {
       <HostConfigComparisonMatrix
         subjects={[makeSubject("h_a", "A"), makeSubject("h_b", "B")]}
         onRemoveHost={onRemoveHost}
-      />
+      />,
     );
 
     await user.click(screen.getByTestId("host-compare-remove-h_b"));

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-presets.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-presets.ts
@@ -7,6 +7,7 @@ import {
   type HostCompatCatalog,
 } from "@mcpjam/sdk/host-compat";
 import { MCPJAM_WEB_DEPLOYED_AT } from "@/generated/mcpjam-web-deployed-at";
+import { resolveVerifiedAt } from "../verified-at";
 
 /**
  * Static host profiles surfaced in Host Compare so a user can compare against
@@ -34,22 +35,6 @@ export interface PresetCompareEntries {
 interface PresetCompareOptions {
   excludedTemplateIds?: ReadonlySet<string>;
   mcpjamWebDeployedAt?: number | null;
-}
-
-function resolveVerifiedAt(
-  hostId: string,
-  catalogVerifiedAt: number | undefined,
-  mcpjamWebDeployedAt: number | null,
-): number | undefined {
-  if (
-    hostId !== "mcpjam" ||
-    mcpjamWebDeployedAt === null ||
-    !Number.isFinite(mcpjamWebDeployedAt) ||
-    mcpjamWebDeployedAt <= 0
-  ) {
-    return catalogVerifiedAt;
-  }
-  return mcpjamWebDeployedAt;
 }
 
 /**

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
@@ -36,14 +36,11 @@ import {
   type SupportFilterMode,
   type SupportLevel,
 } from "./support-level";
-
-const VERIFIED_DATE_FORMATTER = new Intl.DateTimeFormat("en-CA", {
-  timeZone: "UTC",
-  year: "numeric",
-  month: "2-digit",
-  day: "2-digit",
-});
-const STALE_VERIFICATION_MS = 30 * 24 * 60 * 60 * 1000;
+import {
+  formatVerifiedAt,
+  isVerifiedAtStale,
+  STALE_VERIFIED_AT_LABEL,
+} from "../verified-at";
 
 interface HostConfigComparisonMatrixProps {
   subjects: ReadonlyArray<HostComparisonSubject>;
@@ -129,18 +126,18 @@ export function HostConfigComparisonMatrix({
       supportFilter,
       searchQuery,
       useCellSupportFilter,
-    ]
+    ],
   );
   const visibleFields = useMemo(
     () => fields.filter((field) => visibleFieldIds.has(field.id)),
-    [fields, visibleFieldIds]
+    [fields, visibleFieldIds],
   );
   const displaySubjects = useMemo(() => {
     if (!useCellSupportFilter) return subjects;
     return subjects.filter((subject) =>
       visibleFields.some((field) =>
-        cellPassesSupportFilter(field, subject.config, supportFilter)
-      )
+        cellPassesSupportFilter(field, subject.config, supportFilter),
+      ),
     );
   }, [subjects, supportFilter, useCellSupportFilter, visibleFields]);
 
@@ -197,7 +194,7 @@ export function HostConfigComparisonMatrix({
         // put the dead band back for a one- or two-row result. Nothing renders
         // here that needs a floor — every empty case returns above this.
         "flex max-h-full min-w-0 flex-col overflow-hidden rounded-xl border border-border bg-card shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_30px_-18px_rgba(0,0,0,0.18)]",
-        mobileOptimized && "max-w-full"
+        mobileOptimized && "max-w-full",
       )}
     >
       <div
@@ -208,13 +205,13 @@ export function HostConfigComparisonMatrix({
           // `overflow-auto` show a scrollbar only once the table actually
           // exceeds that height, not unconditionally.
           "min-h-0 overflow-auto",
-          mobileOptimized && "max-w-full [-webkit-overflow-scrolling:touch]"
+          mobileOptimized && "max-w-full [-webkit-overflow-scrolling:touch]",
         )}
       >
         <table
           className={cn(
             "border-collapse text-center text-[13px]",
-            mobileOptimized ? "w-max min-w-full" : "w-full"
+            mobileOptimized ? "w-max min-w-full" : "w-full",
           )}
         >
           <colgroup>
@@ -297,16 +294,6 @@ export function HostConfigComparisonMatrix({
   );
 }
 
-function formatVerifiedAt(verifiedAt: number | undefined): string {
-  if (verifiedAt === undefined || !Number.isFinite(verifiedAt)) return "—";
-  return VERIFIED_DATE_FORMATTER.format(new Date(verifiedAt));
-}
-
-function isVerifiedAtStale(verifiedAt: number | undefined): boolean {
-  if (verifiedAt === undefined || !Number.isFinite(verifiedAt)) return false;
-  return Date.now() - verifiedAt > STALE_VERIFICATION_MS;
-}
-
 function VerifiedAtRow({
   subjects,
   mobileOptimized,
@@ -319,7 +306,7 @@ function VerifiedAtRow({
       <td
         className={cn(
           "sticky left-0 z-10 bg-card px-3 py-1.5 text-left after:pointer-events-none after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border after:content-[''] sm:px-5",
-          mobileOptimized && "min-w-0"
+          mobileOptimized && "min-w-0",
         )}
       >
         <span className="text-[12px] font-medium leading-tight text-muted-foreground">
@@ -335,7 +322,7 @@ function VerifiedAtRow({
             {isVerifiedAtStale(subject.verifiedAt) ? (
               <span className="inline-flex items-center gap-1 whitespace-nowrap text-[12px] leading-tight text-muted-foreground">
                 <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
-                Last checked over 30 days ago
+                {STALE_VERIFIED_AT_LABEL}
               </span>
             ) : (
               <span className="text-[12px] tabular-nums text-muted-foreground">
@@ -416,10 +403,7 @@ function SectionRows({
             )}
           </motion.div>
         </th>
-        <td
-          colSpan={colSpan - 1}
-          className="border-y border-border bg-muted"
-        />
+        <td colSpan={colSpan - 1} className="border-y border-border bg-muted" />
       </tr>
 
       {subsections.map((sub) => {
@@ -468,10 +452,7 @@ function SubsectionRows({
         <td className="sticky left-0 z-10 border-b border-border bg-card px-3 py-1.5 text-left text-[10px] uppercase tracking-wider text-muted-foreground after:pointer-events-none after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border after:content-[''] sm:px-5">
           {label}
         </td>
-        <td
-          colSpan={colSpan - 1}
-          className="border-b border-border bg-card"
-        />
+        <td colSpan={colSpan - 1} className="border-b border-border bg-card" />
       </tr>
       {fields.map((field) => (
         <FieldRow
@@ -508,12 +489,12 @@ function FieldRow({
     coverageSubjects.length >= 2
       ? rowCoverage(
           field,
-          coverageSubjects.map((s) => s.config)
+          coverageSubjects.map((s) => s.config),
         )
       : null;
   const labelClassName = cn(
     "text-[13px] font-medium leading-tight text-foreground",
-    mobileOptimized && "min-w-0 break-words"
+    mobileOptimized && "min-w-0 break-words",
   );
   return (
     <tr className="border-b border-border last:border-b-0">
@@ -537,7 +518,7 @@ function FieldRow({
         <div
           className={cn(
             "flex items-center gap-1.5",
-            mobileOptimized && "min-w-0"
+            mobileOptimized && "min-w-0",
           )}
         >
           <span className={labelClassName}>{field.label}</span>
@@ -686,7 +667,7 @@ function FieldCell({
         <span
           className={cn(
             "text-[13px] text-foreground",
-            mobileOptimized && "break-words"
+            mobileOptimized && "break-words",
           )}
         >
           {String(value)}
@@ -748,7 +729,10 @@ function FieldCell({
             // `items-center` centers the theme label over the swatch+value row
             // it names; the row itself keeps its own left edge, so the two
             // themes still line up with each other for reading down the cell.
-            <span key={theme} className="flex w-full flex-col items-center gap-0.5">
+            <span
+              key={theme}
+              className="flex w-full flex-col items-center gap-0.5"
+            >
               <span className="text-[10px] uppercase leading-none tracking-wide text-muted-foreground/60">
                 {theme}
               </span>
@@ -804,7 +788,7 @@ function FieldCell({
         <span
           className={cn(
             "text-[13px] leading-snug text-foreground",
-            mobileOptimized && "break-words"
+            mobileOptimized && "break-words",
           )}
         >
           {value.join(", ")}
@@ -918,13 +902,13 @@ function HostColumnHeader({
   const logoSrc = getScenarioHostLogo(
     subject.hostStyle,
     subject.config.chatUiOverride,
-    themeMode
+    themeMode,
   );
   const reduceMotion = useReducedMotion();
   const verifyHref = buildVerifyHref(
     verifyBaseUrl,
     subject.hostId,
-    disabledVerifyTemplateIds
+    disabledVerifyTemplateIds,
   );
 
   return (
@@ -933,7 +917,7 @@ function HostColumnHeader({
         key={subject.hostId}
         className={cn(
           "relative flex items-start justify-center gap-2",
-          onRemove && "pl-5"
+          onRemove && "pl-5",
         )}
         initial={reduceMotion ? false : { opacity: 0, x: -6 }}
         animate={{ opacity: 1, x: 0 }}
@@ -995,7 +979,7 @@ function HostColumnHeader({
 function buildVerifyHref(
   baseUrl: string | undefined,
   hostId: string,
-  disabledVerifyTemplateIds?: ReadonlySet<string>
+  disabledVerifyTemplateIds?: ReadonlySet<string>,
 ): string | null {
   if (!baseUrl) return null;
   if (!hostId.startsWith(PRESET_HOST_ID_PREFIX)) return baseUrl;
@@ -1036,7 +1020,7 @@ function ExpandablePreview({
           "max-h-[400px] overflow-auto p-3",
           mobileOptimized
             ? "max-w-[calc(100vw-24px)] sm:max-w-[520px]"
-            : "max-w-[520px]"
+            : "max-w-[520px]",
         )}
       >
         {children}

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
@@ -320,7 +320,10 @@ function VerifiedAtRow({
         >
           <div className="flex min-h-5 items-center justify-center">
             {isVerifiedAtStale(subject.verifiedAt) ? (
-              <span className="inline-flex items-center gap-1 whitespace-nowrap text-[12px] leading-tight text-muted-foreground">
+              <span
+                title={`Last checked ${formatVerifiedAt(subject.verifiedAt)}`}
+                className="inline-flex items-center gap-1 whitespace-nowrap text-[12px] leading-tight text-muted-foreground"
+              >
                 <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
                 {STALE_VERIFIED_AT_LABEL}
               </span>

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusPanel.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusPanel.tsx
@@ -23,6 +23,7 @@ import {
 } from "./host-focus-tab-defs";
 import { HostIdentityRow } from "./HostIdentityRow";
 import { UpdateHostToLatestButton } from "./UpdateHostToLatestButton";
+import { HostVerifiedAtStamp } from "./HostVerifiedAtStamp";
 import {
   hostFocusShellHeaderRowClass,
   hostFocusShellRootClass,
@@ -52,7 +53,7 @@ interface HostFocusPanelProps {
   draft: HostConfigInputV2;
   savedDraft?: HostConfigInputV2;
   onDraftChange: (
-    updater: (prev: HostConfigInputV2) => HostConfigInputV2
+    updater: (prev: HostConfigInputV2) => HostConfigInputV2,
   ) => void;
   attention: ReadonlyArray<HostAttentionIssue>;
   onClose: () => void;
@@ -100,22 +101,27 @@ export function HostFocusPanel({
         hasNameIssue={behaviorIssues.has("hostDisplayName")}
         logoSrc={logoSrc}
         action={
-          <UpdateHostToLatestButton
-            hostId={hostId}
-            draft={draft}
-            savedDraft={savedDraft}
-            hostDisplayName={hostDisplayName}
-            savedHostDisplayName={savedHostDisplayName}
-            onHostDisplayNameChange={onHostDisplayNameChange}
-            themeMode={themeMode}
-            onDraftChange={onDraftChange}
-          />
+          // The stamp sits left of the button on purpose: it says how old the
+          // profile is, the button is what fixes that.
+          <div className="flex items-center gap-2">
+            <HostVerifiedAtStamp hostStyle={draft.hostStyle} />
+            <UpdateHostToLatestButton
+              hostId={hostId}
+              draft={draft}
+              savedDraft={savedDraft}
+              hostDisplayName={hostDisplayName}
+              savedHostDisplayName={savedHostDisplayName}
+              onHostDisplayNameChange={onHostDisplayNameChange}
+              themeMode={themeMode}
+              onDraftChange={onDraftChange}
+            />
+          </div>
         }
       />
       <header
         className={cn(
           hostFocusShellHeaderRowClass,
-          "items-stretch gap-2 py-1 sm:items-center"
+          "items-stretch gap-2 py-1 sm:items-center",
         )}
       >
         <HostFocusTabBar

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostVerifiedAtStamp.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostVerifiedAtStamp.tsx
@@ -1,0 +1,72 @@
+import { TriangleAlert } from "lucide-react";
+import { getCatalogHost } from "@mcpjam/sdk/host-compat";
+import { useHostCatalog } from "@/lib/host-compat/use-host-catalog";
+import { MCPJAM_WEB_DEPLOYED_AT } from "@/generated/mcpjam-web-deployed-at";
+import {
+  formatVerifiedAt,
+  isVerifiedAtStale,
+  resolveVerifiedAt,
+  STALE_VERIFIED_AT_LABEL,
+} from "../../verified-at";
+import { cn } from "@/lib/utils";
+
+interface HostVerifiedAtStampProps {
+  /** Catalog host id the client is built from (`draft.hostStyle`). */
+  hostStyle: string;
+  className?: string;
+}
+
+/**
+ * When we last checked this client profile against the real app, shown beside
+ * "Update to latest" — the date is what makes that button worth pressing.
+ *
+ * Same date, same 30-day staleness wording as the Host Compare matrix (both
+ * read `../../verified-at`). Renders nothing for a client whose catalog row we
+ * have never verified, rather than printing an empty placeholder.
+ */
+export function HostVerifiedAtStamp({
+  hostStyle,
+  className,
+}: HostVerifiedAtStampProps) {
+  const catalogState = useHostCatalog();
+  const catalogHost =
+    catalogState.status === "live"
+      ? getCatalogHost(catalogState.catalog, hostStyle)
+      : undefined;
+  const verifiedAt = resolveVerifiedAt(
+    hostStyle,
+    catalogHost?.verifiedAt,
+    MCPJAM_WEB_DEPLOYED_AT,
+  );
+  if (verifiedAt === undefined || !Number.isFinite(verifiedAt)) return null;
+
+  const formatted = formatVerifiedAt(verifiedAt);
+
+  if (isVerifiedAtStale(verifiedAt)) {
+    return (
+      <span
+        data-testid="host-verified-at-stamp"
+        title={`Last checked ${formatted}`}
+        className={cn(
+          "inline-flex items-center gap-1 whitespace-nowrap text-[11.5px] leading-tight text-muted-foreground",
+          className,
+        )}
+      >
+        <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
+        {STALE_VERIFIED_AT_LABEL}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      data-testid="host-verified-at-stamp"
+      className={cn(
+        "whitespace-nowrap text-[11.5px] leading-tight tabular-nums text-muted-foreground",
+        className,
+      )}
+    >
+      Last checked {formatted}
+    </span>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostVerifiedAtStamp.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostVerifiedAtStamp.tsx
@@ -29,13 +29,16 @@ export function HostVerifiedAtStamp({
   className,
 }: HostVerifiedAtStampProps) {
   const catalogState = useHostCatalog();
-  const catalogHost =
-    catalogState.status === "live"
-      ? getCatalogHost(catalogState.catalog, hostStyle)
-      : undefined;
-  // No catalog row (still loading, degraded, or a style we don't track) means
-  // no claim to make — including for MCPJam, whose deploy stamp would
-  // otherwise print a date for a profile we can't read.
+  // Whichever catalog we ended up with, live or bundled fallback — Host
+  // Compare reads it the same way, and a date that disagrees with the table
+  // is worse than a date from the fallback. `catalog` is null only while
+  // loading or after a hard failure.
+  const catalogHost = catalogState.catalog
+    ? getCatalogHost(catalogState.catalog, hostStyle)
+    : undefined;
+  // No catalog row (still loading, or a style we don't track) means no claim
+  // to make — including for MCPJam, whose deploy stamp would otherwise print
+  // a date for a profile we can't read.
   if (!catalogHost) return null;
   const verifiedAt = resolveVerifiedAt(
     hostStyle,

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostVerifiedAtStamp.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostVerifiedAtStamp.tsx
@@ -33,9 +33,13 @@ export function HostVerifiedAtStamp({
     catalogState.status === "live"
       ? getCatalogHost(catalogState.catalog, hostStyle)
       : undefined;
+  // No catalog row (still loading, degraded, or a style we don't track) means
+  // no claim to make — including for MCPJam, whose deploy stamp would
+  // otherwise print a date for a profile we can't read.
+  if (!catalogHost) return null;
   const verifiedAt = resolveVerifiedAt(
     hostStyle,
-    catalogHost?.verifiedAt,
+    catalogHost.verifiedAt,
     MCPJAM_WEB_DEPLOYED_AT,
   );
   if (verifiedAt === undefined || !Number.isFinite(verifiedAt)) return null;

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/HostVerifiedAtStamp.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/HostVerifiedAtStamp.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HostVerifiedAtStamp } from "../HostVerifiedAtStamp";
+
+const CATALOG_VERIFIED_AT = Date.UTC(2026, 8, 2); // 2026-09-02
+
+vi.mock("@/lib/host-compat/use-host-catalog", () => ({
+  useHostCatalog: () => ({
+    status: "live",
+    catalog: {},
+    version: 1,
+    source: "live",
+  }),
+}));
+
+vi.mock("@mcpjam/sdk/host-compat", () => ({
+  getCatalogHost: (_catalog: unknown, hostId: string) =>
+    hostId === "unverified"
+      ? { id: hostId }
+      : hostId === "missing"
+        ? undefined
+        : { id: hostId, verifiedAt: CATALOG_VERIFIED_AT },
+}));
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function renderAt(now: number, hostStyle = "cursor") {
+  vi.useFakeTimers();
+  vi.setSystemTime(now);
+  render(<HostVerifiedAtStamp hostStyle={hostStyle} />);
+}
+
+describe("HostVerifiedAtStamp", () => {
+  it("prints the verification date while it is fresh", () => {
+    renderAt(CATALOG_VERIFIED_AT + 5 * 24 * 60 * 60 * 1000);
+    expect(screen.getByTestId("host-verified-at-stamp")).toHaveTextContent(
+      "Last checked 2026-09-02",
+    );
+  });
+
+  it("swaps the date for the compare matrix's staleness wording past 30 days", () => {
+    renderAt(CATALOG_VERIFIED_AT + 31 * 24 * 60 * 60 * 1000);
+    const stamp = screen.getByTestId("host-verified-at-stamp");
+    expect(stamp).toHaveTextContent("Last checked over 30 days ago");
+    // The exact date stays reachable on hover.
+    expect(stamp).toHaveAttribute("title", "Last checked 2026-09-02");
+  });
+
+  it("renders nothing for a catalog host we have never verified", () => {
+    renderAt(CATALOG_VERIFIED_AT, "unverified");
+    expect(screen.queryByTestId("host-verified-at-stamp")).toBeNull();
+  });
+
+  it("renders nothing for a client with no catalog row", () => {
+    renderAt(CATALOG_VERIFIED_AT, "missing");
+    expect(screen.queryByTestId("host-verified-at-stamp")).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/HostVerifiedAtStamp.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/HostVerifiedAtStamp.test.tsx
@@ -2,37 +2,46 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { HostVerifiedAtStamp } from "../HostVerifiedAtStamp";
 
-const CATALOG_VERIFIED_AT = Date.UTC(2026, 8, 2); // 2026-09-02
+const { CATALOG_VERIFIED_AT, CATALOG, catalogState } = vi.hoisted(() => {
+  const verifiedAt = Date.UTC(2026, 8, 2); // 2026-09-02
+  const catalog = {
+    hostsById: {
+      cursor: { id: "cursor", verifiedAt },
+      unverified: { id: "unverified" },
+    },
+  };
+  return {
+    CATALOG_VERIFIED_AT: verifiedAt,
+    CATALOG: catalog,
+    catalogState: {
+      current: {
+        status: "live",
+        catalog: catalog as unknown,
+        version: 1,
+        source: "live",
+      },
+    },
+  };
+});
 
 const LIVE_STATE = {
   status: "live",
-  catalog: {},
+  catalog: CATALOG,
   version: 1,
   source: "live",
 };
-
-const catalogState = vi.hoisted(() => ({
-  current: {
-    status: "live",
-    catalog: {} as unknown,
-    version: 1,
-    source: "live",
-  },
-}));
 
 vi.mock("@/lib/host-compat/use-host-catalog", () => ({
   useHostCatalog: () => catalogState.current,
 }));
 
-// "mcpjam" and "missing" are deliberately absent: a client can name a style
-// the catalog we fetched doesn't carry.
-const CATALOG_HOSTS: Record<string, { id: string; verifiedAt?: number }> = {
-  cursor: { id: "cursor", verifiedAt: CATALOG_VERIFIED_AT },
-  unverified: { id: "unverified" },
-};
-
 vi.mock("@mcpjam/sdk/host-compat", () => ({
-  getCatalogHost: (_catalog: unknown, hostId: string) => CATALOG_HOSTS[hostId],
+  getCatalogHost: (
+    catalog: {
+      hostsById: Record<string, { id: string; verifiedAt?: number }>;
+    },
+    hostId: string,
+  ) => catalog.hostsById[hostId],
 }));
 
 // Production web stamps this with the deploy time, which only ever applies to
@@ -83,7 +92,7 @@ describe("HostVerifiedAtStamp", () => {
     // blank while the table shows a date.
     catalogState.current = {
       status: "fallback",
-      catalog: {},
+      catalog: CATALOG,
       version: 1,
       source: "bundled",
     };

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/HostVerifiedAtStamp.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/HostVerifiedAtStamp.test.tsx
@@ -4,13 +4,24 @@ import { HostVerifiedAtStamp } from "../HostVerifiedAtStamp";
 
 const CATALOG_VERIFIED_AT = Date.UTC(2026, 8, 2); // 2026-09-02
 
-vi.mock("@/lib/host-compat/use-host-catalog", () => ({
-  useHostCatalog: () => ({
+const LIVE_STATE = {
+  status: "live",
+  catalog: {},
+  version: 1,
+  source: "live",
+};
+
+const catalogState = vi.hoisted(() => ({
+  current: {
     status: "live",
-    catalog: {},
+    catalog: {} as unknown,
     version: 1,
     source: "live",
-  }),
+  },
+}));
+
+vi.mock("@/lib/host-compat/use-host-catalog", () => ({
+  useHostCatalog: () => catalogState.current,
 }));
 
 // "mcpjam" and "missing" are deliberately absent: a client can name a style
@@ -32,6 +43,7 @@ vi.mock("@/generated/mcpjam-web-deployed-at", () => ({
 
 afterEach(() => {
   vi.useRealTimers();
+  catalogState.current = { ...LIVE_STATE };
 });
 
 function renderAt(now: number, hostStyle = "cursor") {
@@ -63,6 +75,32 @@ describe("HostVerifiedAtStamp", () => {
 
   it("renders nothing for a client with no catalog row", () => {
     renderAt(CATALOG_VERIFIED_AT, "missing");
+    expect(screen.queryByTestId("host-verified-at-stamp")).toBeNull();
+  });
+
+  it("still shows the date when the proxy served the bundled fallback catalog", () => {
+    // Host Compare reads the fallback catalog too — the header must not go
+    // blank while the table shows a date.
+    catalogState.current = {
+      status: "fallback",
+      catalog: {},
+      version: 1,
+      source: "bundled",
+    };
+    renderAt(CATALOG_VERIFIED_AT + 5 * 24 * 60 * 60 * 1000);
+    expect(screen.getByTestId("host-verified-at-stamp")).toHaveTextContent(
+      "Last checked 2026-09-02",
+    );
+  });
+
+  it("renders nothing while no catalog has loaded", () => {
+    catalogState.current = {
+      status: "loading",
+      catalog: null,
+      version: 1,
+      source: "live",
+    };
+    renderAt(CATALOG_VERIFIED_AT);
     expect(screen.queryByTestId("host-verified-at-stamp")).toBeNull();
   });
 

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/HostVerifiedAtStamp.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/HostVerifiedAtStamp.test.tsx
@@ -13,13 +13,21 @@ vi.mock("@/lib/host-compat/use-host-catalog", () => ({
   }),
 }));
 
+// "mcpjam" and "missing" are deliberately absent: a client can name a style
+// the catalog we fetched doesn't carry.
+const CATALOG_HOSTS: Record<string, { id: string; verifiedAt?: number }> = {
+  cursor: { id: "cursor", verifiedAt: CATALOG_VERIFIED_AT },
+  unverified: { id: "unverified" },
+};
+
 vi.mock("@mcpjam/sdk/host-compat", () => ({
-  getCatalogHost: (_catalog: unknown, hostId: string) =>
-    hostId === "unverified"
-      ? { id: hostId }
-      : hostId === "missing"
-        ? undefined
-        : { id: hostId, verifiedAt: CATALOG_VERIFIED_AT },
+  getCatalogHost: (_catalog: unknown, hostId: string) => CATALOG_HOSTS[hostId],
+}));
+
+// Production web stamps this with the deploy time, which only ever applies to
+// the MCPJam profile.
+vi.mock("@/generated/mcpjam-web-deployed-at", () => ({
+  MCPJAM_WEB_DEPLOYED_AT: Date.UTC(2026, 8, 20),
 }));
 
 afterEach(() => {
@@ -55,6 +63,12 @@ describe("HostVerifiedAtStamp", () => {
 
   it("renders nothing for a client with no catalog row", () => {
     renderAt(CATALOG_VERIFIED_AT, "missing");
+    expect(screen.queryByTestId("host-verified-at-stamp")).toBeNull();
+  });
+
+  it("renders nothing for MCPJam when the catalog has no row for it", () => {
+    // The deploy stamp alone must not stand in for a profile we can't read.
+    renderAt(CATALOG_VERIFIED_AT, "mcpjam");
     expect(screen.queryByTestId("host-verified-at-stamp")).toBeNull();
   });
 });

--- a/mcpjam-inspector/client/src/components/hosts/verified-at.ts
+++ b/mcpjam-inspector/client/src/components/hosts/verified-at.ts
@@ -1,0 +1,49 @@
+/**
+ * One definition of "when did we last check this client profile" — shared by
+ * the Host Compare matrix (caniuse) and the client editor header, so the two
+ * surfaces can never disagree on the date, the format, or when it goes stale.
+ */
+
+const VERIFIED_DATE_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "UTC",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+/** Past this age the exact date stops being useful — we say so instead. */
+export const STALE_VERIFICATION_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Shown in place of the date once it crosses `STALE_VERIFICATION_MS`. */
+export const STALE_VERIFIED_AT_LABEL = "Last checked over 30 days ago";
+
+export function formatVerifiedAt(verifiedAt: number | undefined): string {
+  if (verifiedAt === undefined || !Number.isFinite(verifiedAt)) return "—";
+  return VERIFIED_DATE_FORMATTER.format(new Date(verifiedAt));
+}
+
+export function isVerifiedAtStale(verifiedAt: number | undefined): boolean {
+  if (verifiedAt === undefined || !Number.isFinite(verifiedAt)) return false;
+  return Date.now() - verifiedAt > STALE_VERIFICATION_MS;
+}
+
+/**
+ * The MCPJam profile describes THIS app, so its facts are as fresh as the
+ * deploy that shipped them — the catalog's hand-stamped date would age even
+ * though the profile never does. Every other host keeps its catalog date.
+ */
+export function resolveVerifiedAt(
+  hostId: string,
+  catalogVerifiedAt: number | undefined,
+  mcpjamWebDeployedAt: number | null,
+): number | undefined {
+  if (
+    hostId !== "mcpjam" ||
+    mcpjamWebDeployedAt === null ||
+    !Number.isFinite(mcpjamWebDeployedAt) ||
+    mcpjamWebDeployedAt <= 0
+  ) {
+    return catalogVerifiedAt;
+  }
+  return mcpjamWebDeployedAt;
+}


### PR DESCRIPTION
- Adds a "Last checked 2026-09-02" line next to the "Update to latest" button in the client editor header, so you can see how old the client profile is right where you'd refresh it.
- Once the date is more than 30 days old it turns into the same warning caniuse shows: "Last checked over 30 days ago" with the triangle icon. Hovering still gives the exact date.
- Clients we've never verified (or with no catalog row) show nothing instead of a blank dash.
- Moved the date formatting and the 30-day staleness rule into one shared file so the header and the compare table can't disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows when a client profile was last checked beside "Update to latest" in the client editor header, so you can see how stale a profile is right where you'd refresh it.

- After 30 days the date is replaced by "Last checked over 30 days ago" with a warning icon; hovering still shows the exact date in the header and the Host Compare matrix.
- Clients never verified or with no catalog row show nothing instead of a blank dash; the MCPJam deploy stamp no longer stands in for a profile that hasn't loaded.
- Moved date formatting and the 30-day staleness rule into `verified-at.ts` so the header and Host Compare matrix can't disagree; the stamp also reads the bundled fallback catalog when the live one is unavailable.

<sup>Written for commit a8b834c16a4186cd76bc25aa6610e46d2ad14971. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

