### PR TITLE
fix(connect): surface OAuth pre-registration without opening Advanced Settings

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -392,258 +392,6 @@ export function AuthenticationSection({
     oauthPlan != null &&
     (oauthPlanVisibleBlockers.length > 0 || oauthPlan.warnings.length > 0);
 
-  // Protocol, registration strategy and the client credentials that go with
-  // them. Rendered up front once the user picks OAuth explicitly; on "auto"
-  // the flow may never reach OAuth, so they stay inside Advanced Settings.
-  const oauthRegistrationFields = (
-    <>
-      <div className="grid gap-3 md:grid-cols-2">
-        <div className="space-y-2">
-          <label className="block text-sm font-medium text-foreground">
-            Protocol
-          </label>
-          <Select
-            value={oauthProtocolMode}
-            onValueChange={(value: ServerFormOAuthProtocolMode) =>
-              onOauthProtocolModeChange(value)
-            }
-          >
-            <SelectTrigger className="w-full h-10">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {PROTOCOL_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="space-y-2">
-          <label className="block text-sm font-medium text-foreground">
-            Registration Strategy
-          </label>
-          <Select
-            value={registrationMode}
-            onValueChange={(value: RegistrationMode) => {
-              onOauthRegistrationModeChange(value);
-              onUseCustomClientIdChange(value === "preregistered");
-            }}
-          >
-            <SelectTrigger className="w-full h-10">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {REGISTRATION_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {registrationMode === "cimd" && oauthPlan?.clientIdMetadataUrl && (
-            <p className="text-xs text-muted-foreground break-all">
-              SDK client metadata URL: {oauthPlan.clientIdMetadataUrl}
-            </p>
-          )}
-        </div>
-      </div>
-
-      {showClientCredentials && (
-        <div className="space-y-3">
-          <div className="space-y-2">
-            <label className="block text-sm font-medium text-foreground">
-              Client ID
-              {registrationMode === "preregistered" ? (
-                <span className="text-destructive" aria-hidden="true">
-                  {" *"}
-                </span>
-              ) : null}
-            </label>
-            <Input
-              value={clientId}
-              onChange={(e) => onClientIdChange(e.target.value)}
-              placeholder="Your OAuth Client ID"
-              aria-required={
-                registrationMode === "preregistered" ? true : undefined
-              }
-              spellCheck={false}
-              autoComplete="off"
-              data-1p-ignore
-              data-lpignore="true"
-              data-form-type="other"
-              className={`h-10 ${clientIdError ? "border-red-500" : ""}`}
-            />
-            {clientIdError && (
-              <p className="text-xs text-red-500">{clientIdError}</p>
-            )}
-          </div>
-
-          <div className="space-y-2">
-            <div className="flex items-center justify-between gap-3">
-              <label className="block text-sm font-medium text-foreground">
-                Client Secret (Optional)
-              </label>
-              <div className="flex items-center gap-1">
-                {canRevealClientSecret && !visibleRevealedClientSecret && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 px-2 text-xs"
-                    onClick={() => void handleRevealClientSecret()}
-                    disabled={isRevealingClientSecret}
-                  >
-                    {isRevealingClientSecret ? (
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                    ) : (
-                      "Reveal"
-                    )}
-                  </Button>
-                )}
-                {visibleRevealedClientSecret && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 px-2 text-xs"
-                    onClick={handleHideRevealedSecret}
-                  >
-                    Hide
-                  </Button>
-                )}
-                {hasStoredClientSecret && !clearClientSecret && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 px-2 text-xs"
-                    onClick={handleClearClientSecret}
-                  >
-                    Clear
-                  </Button>
-                )}
-                {hasStoredClientSecret && clearClientSecret && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 px-2 text-xs"
-                    onClick={onUndoClearClientSecret}
-                  >
-                    Undo
-                  </Button>
-                )}
-              </div>
-            </div>
-            {hasStoredClientSecret && clearClientSecret ? (
-              <p className="text-xs text-muted-foreground">
-                Saved client secret will be removed when you save.
-              </p>
-            ) : visibleRevealedClientSecret !== null ? (
-              <>
-                <div className="relative">
-                  <Input
-                    type={isRevealedSecretVisible ? "text" : "password"}
-                    value={secretFieldValue}
-                    onChange={(e) => {
-                      if (!isReplacingSecret) setIsReplacingSecret(true);
-                      onClientSecretChange(e.target.value);
-                    }}
-                    placeholder="Enter a new value to replace."
-                    data-testid="revealed-client-secret"
-                    spellCheck={false}
-                    autoComplete="off"
-                    data-1p-ignore
-                    data-lpignore="true"
-                    data-form-type="other"
-                    className={`h-10 pr-16 font-mono ${
-                      clientSecretError ? "border-red-500" : ""
-                    }`}
-                  />
-                  <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
-                    <button
-                      type="button"
-                      aria-label={
-                        isRevealedSecretVisible
-                          ? "Hide client secret"
-                          : "Show client secret"
-                      }
-                      title={
-                        isRevealedSecretVisible
-                          ? "Hide client secret"
-                          : "Show client secret"
-                      }
-                      onClick={() =>
-                        setIsRevealedSecretVisible((prev) => !prev)
-                      }
-                      className="p-1 text-muted-foreground/60 transition-colors hover:text-foreground cursor-pointer"
-                    >
-                      {isRevealedSecretVisible ? (
-                        <EyeOff className="h-4 w-4" />
-                      ) : (
-                        <Eye className="h-4 w-4" />
-                      )}
-                    </button>
-                    <button
-                      type="button"
-                      aria-label="Copy client secret"
-                      title="Copy client secret"
-                      onClick={() =>
-                        void handleCopyRevealedSecret(secretFieldValue)
-                      }
-                      className="p-1 text-muted-foreground/50 transition-colors hover:text-foreground cursor-pointer"
-                    >
-                      {didCopyRevealedSecret ? (
-                        <Check className="h-4 w-4 text-green-500" />
-                      ) : (
-                        <Copy className="h-4 w-4" />
-                      )}
-                    </button>
-                  </div>
-                </div>
-                {!isReplacingSecret && (
-                  <p className="text-xs text-muted-foreground">
-                    Editing this replaces the saved secret when you save.
-                  </p>
-                )}
-              </>
-            ) : canRevealClientSecret ? (
-              <p className="text-xs text-muted-foreground">
-                A client secret is saved. Reveal it to view or replace it.
-              </p>
-            ) : (
-              <Input
-                type="password"
-                value={clientSecret}
-                onChange={(e) => onClientSecretChange(e.target.value)}
-                placeholder={
-                  hasStoredClientSecret
-                    ? "Enter a new value to replace."
-                    : "Your OAuth Client Secret"
-                }
-                spellCheck={false}
-                autoComplete="off"
-                data-1p-ignore
-                data-lpignore="true"
-                data-form-type="other"
-                className={`h-10 ${clientSecretError ? "border-red-500" : ""}`}
-              />
-            )}
-            {clientSecretError && (
-              <p className="text-xs text-red-500">{clientSecretError}</p>
-            )}
-            {revealError && (
-              <p className="text-xs text-red-500">{revealError}</p>
-            )}
-          </div>
-        </div>
-      )}
-    </>
-  );
-
   return (
     <div className="space-y-4">
       <div className="border border-border rounded-lg overflow-hidden">
@@ -779,11 +527,263 @@ export function AuthenticationSection({
               </div>
             )}
 
-            {authType === "oauth" && (
-              <div className="px-3 pt-3 pb-3 space-y-3">
-                {oauthRegistrationFields}
+            <div className="px-3 pt-3 pb-3 space-y-3">
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="block text-sm font-medium text-foreground">
+                    Protocol
+                  </label>
+                  <Select
+                    value={oauthProtocolMode}
+                    onValueChange={(value: ServerFormOAuthProtocolMode) =>
+                      onOauthProtocolModeChange(value)
+                    }
+                  >
+                    <SelectTrigger className="w-full h-10">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PROTOCOL_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="block text-sm font-medium text-foreground">
+                    Registration Strategy
+                  </label>
+                  <Select
+                    value={registrationMode}
+                    onValueChange={(value: RegistrationMode) => {
+                      onOauthRegistrationModeChange(value);
+                      onUseCustomClientIdChange(value === "preregistered");
+                    }}
+                  >
+                    <SelectTrigger className="w-full h-10">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {REGISTRATION_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {registrationMode === "cimd" &&
+                    oauthPlan?.clientIdMetadataUrl && (
+                      <p className="text-xs text-muted-foreground break-all">
+                        SDK client metadata URL: {oauthPlan.clientIdMetadataUrl}
+                      </p>
+                    )}
+                </div>
               </div>
-            )}
+
+              {showClientCredentials && (
+                <div className="space-y-3">
+                  <div className="space-y-2">
+                    <label className="block text-sm font-medium text-foreground">
+                      Client ID
+                      {registrationMode === "preregistered" ? (
+                        <span className="text-destructive" aria-hidden="true">
+                          {" *"}
+                        </span>
+                      ) : null}
+                    </label>
+                    <Input
+                      value={clientId}
+                      onChange={(e) => onClientIdChange(e.target.value)}
+                      placeholder="Your OAuth Client ID"
+                      aria-required={
+                        registrationMode === "preregistered" ? true : undefined
+                      }
+                      spellCheck={false}
+                      autoComplete="off"
+                      data-1p-ignore
+                      data-lpignore="true"
+                      data-form-type="other"
+                      className={`h-10 ${
+                        clientIdError ? "border-red-500" : ""
+                      }`}
+                    />
+                    {clientIdError && (
+                      <p className="text-xs text-red-500">{clientIdError}</p>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between gap-3">
+                      <label className="block text-sm font-medium text-foreground">
+                        Client Secret (Optional)
+                      </label>
+                      <div className="flex items-center gap-1">
+                        {canRevealClientSecret &&
+                          !visibleRevealedClientSecret && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 px-2 text-xs"
+                              onClick={() => void handleRevealClientSecret()}
+                              disabled={isRevealingClientSecret}
+                            >
+                              {isRevealingClientSecret ? (
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                              ) : (
+                                "Reveal"
+                              )}
+                            </Button>
+                          )}
+                        {visibleRevealedClientSecret && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 px-2 text-xs"
+                            onClick={handleHideRevealedSecret}
+                          >
+                            Hide
+                          </Button>
+                        )}
+                        {hasStoredClientSecret && !clearClientSecret && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 px-2 text-xs"
+                            onClick={handleClearClientSecret}
+                          >
+                            Clear
+                          </Button>
+                        )}
+                        {hasStoredClientSecret && clearClientSecret && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 px-2 text-xs"
+                            onClick={onUndoClearClientSecret}
+                          >
+                            Undo
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                    {hasStoredClientSecret && clearClientSecret ? (
+                      <p className="text-xs text-muted-foreground">
+                        Saved client secret will be removed when you save.
+                      </p>
+                    ) : visibleRevealedClientSecret !== null ? (
+                      <>
+                        <div className="relative">
+                          <Input
+                            type={isRevealedSecretVisible ? "text" : "password"}
+                            value={secretFieldValue}
+                            onChange={(e) => {
+                              if (!isReplacingSecret)
+                                setIsReplacingSecret(true);
+                              onClientSecretChange(e.target.value);
+                            }}
+                            placeholder="Enter a new value to replace."
+                            data-testid="revealed-client-secret"
+                            spellCheck={false}
+                            autoComplete="off"
+                            data-1p-ignore
+                            data-lpignore="true"
+                            data-form-type="other"
+                            className={`h-10 pr-16 font-mono ${
+                              clientSecretError ? "border-red-500" : ""
+                            }`}
+                          />
+                          <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
+                            <button
+                              type="button"
+                              aria-label={
+                                isRevealedSecretVisible
+                                  ? "Hide client secret"
+                                  : "Show client secret"
+                              }
+                              title={
+                                isRevealedSecretVisible
+                                  ? "Hide client secret"
+                                  : "Show client secret"
+                              }
+                              onClick={() =>
+                                setIsRevealedSecretVisible((prev) => !prev)
+                              }
+                              className="p-1 text-muted-foreground/60 transition-colors hover:text-foreground cursor-pointer"
+                            >
+                              {isRevealedSecretVisible ? (
+                                <EyeOff className="h-4 w-4" />
+                              ) : (
+                                <Eye className="h-4 w-4" />
+                              )}
+                            </button>
+                            <button
+                              type="button"
+                              aria-label="Copy client secret"
+                              title="Copy client secret"
+                              onClick={() =>
+                                void handleCopyRevealedSecret(secretFieldValue)
+                              }
+                              className="p-1 text-muted-foreground/50 transition-colors hover:text-foreground cursor-pointer"
+                            >
+                              {didCopyRevealedSecret ? (
+                                <Check className="h-4 w-4 text-green-500" />
+                              ) : (
+                                <Copy className="h-4 w-4" />
+                              )}
+                            </button>
+                          </div>
+                        </div>
+                        {!isReplacingSecret && (
+                          <p className="text-xs text-muted-foreground">
+                            Editing this replaces the saved secret when you
+                            save.
+                          </p>
+                        )}
+                      </>
+                    ) : canRevealClientSecret ? (
+                      <p className="text-xs text-muted-foreground">
+                        A client secret is saved. Reveal it to view or replace
+                        it.
+                      </p>
+                    ) : (
+                      <Input
+                        type="password"
+                        value={clientSecret}
+                        onChange={(e) => onClientSecretChange(e.target.value)}
+                        placeholder={
+                          hasStoredClientSecret
+                            ? "Enter a new value to replace."
+                            : "Your OAuth Client Secret"
+                        }
+                        spellCheck={false}
+                        autoComplete="off"
+                        data-1p-ignore
+                        data-lpignore="true"
+                        data-form-type="other"
+                        className={`h-10 ${
+                          clientSecretError ? "border-red-500" : ""
+                        }`}
+                      />
+                    )}
+                    {clientSecretError && (
+                      <p className="text-xs text-red-500">
+                        {clientSecretError}
+                      </p>
+                    )}
+                    {revealError && (
+                      <p className="text-xs text-red-500">{revealError}</p>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
 
             <button
               type="button"
@@ -802,8 +802,6 @@ export function AuthenticationSection({
 
             {showAdvancedOAuth && (
               <div className="px-3 pb-3 space-y-3">
-                {authType !== "oauth" && oauthRegistrationFields}
-
                 <div className="space-y-2">
                   <label className="block text-sm font-medium text-foreground">
                     Scope Override

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -527,6 +527,264 @@ export function AuthenticationSection({
               </div>
             )}
 
+            <div className="px-3 pt-3 pb-3 space-y-3">
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="block text-sm font-medium text-foreground">
+                    Protocol
+                  </label>
+                  <Select
+                    value={oauthProtocolMode}
+                    onValueChange={(value: ServerFormOAuthProtocolMode) =>
+                      onOauthProtocolModeChange(value)
+                    }
+                  >
+                    <SelectTrigger className="w-full h-10">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PROTOCOL_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="block text-sm font-medium text-foreground">
+                    Registration Strategy
+                  </label>
+                  <Select
+                    value={registrationMode}
+                    onValueChange={(value: RegistrationMode) => {
+                      onOauthRegistrationModeChange(value);
+                      onUseCustomClientIdChange(value === "preregistered");
+                    }}
+                  >
+                    <SelectTrigger className="w-full h-10">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {REGISTRATION_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {registrationMode === "cimd" &&
+                    oauthPlan?.clientIdMetadataUrl && (
+                      <p className="text-xs text-muted-foreground break-all">
+                        SDK client metadata URL: {oauthPlan.clientIdMetadataUrl}
+                      </p>
+                    )}
+                </div>
+              </div>
+
+              {showClientCredentials && (
+                <div className="space-y-3">
+                  <div className="space-y-2">
+                    <label className="block text-sm font-medium text-foreground">
+                      Client ID
+                      {registrationMode === "preregistered" ? (
+                        <span className="text-destructive" aria-hidden="true">
+                          {" *"}
+                        </span>
+                      ) : null}
+                    </label>
+                    <Input
+                      value={clientId}
+                      onChange={(e) => onClientIdChange(e.target.value)}
+                      placeholder="Your OAuth Client ID"
+                      aria-required={
+                        registrationMode === "preregistered" ? true : undefined
+                      }
+                      spellCheck={false}
+                      autoComplete="off"
+                      data-1p-ignore
+                      data-lpignore="true"
+                      data-form-type="other"
+                      className={`h-10 ${
+                        clientIdError ? "border-red-500" : ""
+                      }`}
+                    />
+                    {clientIdError && (
+                      <p className="text-xs text-red-500">{clientIdError}</p>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between gap-3">
+                      <label className="block text-sm font-medium text-foreground">
+                        Client Secret (Optional)
+                      </label>
+                      <div className="flex items-center gap-1">
+                        {canRevealClientSecret &&
+                          !visibleRevealedClientSecret && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 px-2 text-xs"
+                              onClick={() => void handleRevealClientSecret()}
+                              disabled={isRevealingClientSecret}
+                            >
+                              {isRevealingClientSecret ? (
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                              ) : (
+                                "Reveal"
+                              )}
+                            </Button>
+                          )}
+                        {visibleRevealedClientSecret && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 px-2 text-xs"
+                            onClick={handleHideRevealedSecret}
+                          >
+                            Hide
+                          </Button>
+                        )}
+                        {hasStoredClientSecret && !clearClientSecret && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 px-2 text-xs"
+                            onClick={handleClearClientSecret}
+                          >
+                            Clear
+                          </Button>
+                        )}
+                        {hasStoredClientSecret && clearClientSecret && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 px-2 text-xs"
+                            onClick={onUndoClearClientSecret}
+                          >
+                            Undo
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                    {hasStoredClientSecret && clearClientSecret ? (
+                      <p className="text-xs text-muted-foreground">
+                        Saved client secret will be removed when you save.
+                      </p>
+                    ) : visibleRevealedClientSecret !== null ? (
+                      <>
+                        <div className="relative">
+                          <Input
+                            type={isRevealedSecretVisible ? "text" : "password"}
+                            value={secretFieldValue}
+                            onChange={(e) => {
+                              if (!isReplacingSecret)
+                                setIsReplacingSecret(true);
+                              onClientSecretChange(e.target.value);
+                            }}
+                            placeholder="Enter a new value to replace."
+                            data-testid="revealed-client-secret"
+                            spellCheck={false}
+                            autoComplete="off"
+                            data-1p-ignore
+                            data-lpignore="true"
+                            data-form-type="other"
+                            className={`h-10 pr-16 font-mono ${
+                              clientSecretError ? "border-red-500" : ""
+                            }`}
+                          />
+                          <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
+                            <button
+                              type="button"
+                              aria-label={
+                                isRevealedSecretVisible
+                                  ? "Hide client secret"
+                                  : "Show client secret"
+                              }
+                              title={
+                                isRevealedSecretVisible
+                                  ? "Hide client secret"
+                                  : "Show client secret"
+                              }
+                              onClick={() =>
+                                setIsRevealedSecretVisible((prev) => !prev)
+                              }
+                              className="p-1 text-muted-foreground/60 transition-colors hover:text-foreground cursor-pointer"
+                            >
+                              {isRevealedSecretVisible ? (
+                                <EyeOff className="h-4 w-4" />
+                              ) : (
+                                <Eye className="h-4 w-4" />
+                              )}
+                            </button>
+                            <button
+                              type="button"
+                              aria-label="Copy client secret"
+                              title="Copy client secret"
+                              onClick={() =>
+                                void handleCopyRevealedSecret(secretFieldValue)
+                              }
+                              className="p-1 text-muted-foreground/50 transition-colors hover:text-foreground cursor-pointer"
+                            >
+                              {didCopyRevealedSecret ? (
+                                <Check className="h-4 w-4 text-green-500" />
+                              ) : (
+                                <Copy className="h-4 w-4" />
+                              )}
+                            </button>
+                          </div>
+                        </div>
+                        {!isReplacingSecret && (
+                          <p className="text-xs text-muted-foreground">
+                            Editing this replaces the saved secret when you
+                            save.
+                          </p>
+                        )}
+                      </>
+                    ) : canRevealClientSecret ? (
+                      <p className="text-xs text-muted-foreground">
+                        A client secret is saved. Reveal it to view or replace
+                        it.
+                      </p>
+                    ) : (
+                      <Input
+                        type="password"
+                        value={clientSecret}
+                        onChange={(e) => onClientSecretChange(e.target.value)}
+                        placeholder={
+                          hasStoredClientSecret
+                            ? "Enter a new value to replace."
+                            : "Your OAuth Client Secret"
+                        }
+                        spellCheck={false}
+                        autoComplete="off"
+                        data-1p-ignore
+                        data-lpignore="true"
+                        data-form-type="other"
+                        className={`h-10 ${
+                          clientSecretError ? "border-red-500" : ""
+                        }`}
+                      />
+                    )}
+                    {clientSecretError && (
+                      <p className="text-xs text-red-500">
+                        {clientSecretError}
+                      </p>
+                    )}
+                    {revealError && (
+                      <p className="text-xs text-red-500">{revealError}</p>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+
             <button
               type="button"
               onClick={() => setShowAdvancedOAuth(!showAdvancedOAuth)}
@@ -544,62 +802,6 @@ export function AuthenticationSection({
 
             {showAdvancedOAuth && (
               <div className="px-3 pb-3 space-y-3">
-                <div className="grid gap-3 md:grid-cols-2">
-                  <div className="space-y-2">
-                    <label className="block text-sm font-medium text-foreground">
-                      Protocol
-                    </label>
-                    <Select
-                      value={oauthProtocolMode}
-                      onValueChange={(value: ServerFormOAuthProtocolMode) =>
-                        onOauthProtocolModeChange(value)
-                      }
-                    >
-                      <SelectTrigger className="w-full h-10">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {PROTOCOL_OPTIONS.map((option) => (
-                          <SelectItem key={option.value} value={option.value}>
-                            {option.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div className="space-y-2">
-                    <label className="block text-sm font-medium text-foreground">
-                      Registration Strategy
-                    </label>
-                    <Select
-                      value={registrationMode}
-                      onValueChange={(value: RegistrationMode) => {
-                        onOauthRegistrationModeChange(value);
-                        onUseCustomClientIdChange(value === "preregistered");
-                      }}
-                    >
-                      <SelectTrigger className="w-full h-10">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {REGISTRATION_OPTIONS.map((option) => (
-                          <SelectItem key={option.value} value={option.value}>
-                            {option.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    {registrationMode === "cimd" &&
-                      oauthPlan?.clientIdMetadataUrl && (
-                        <p className="text-xs text-muted-foreground break-all">
-                          SDK client metadata URL:{" "}
-                          {oauthPlan.clientIdMetadataUrl}
-                        </p>
-                      )}
-                  </div>
-                </div>
-
                 <div className="space-y-2">
                   <label className="block text-sm font-medium text-foreground">
                     Scope Override
@@ -639,213 +841,6 @@ export function AuthenticationSection({
                     </p>
                   </div>
                 </div>
-
-                {showClientCredentials && (
-                  <div className="space-y-3">
-                    <div className="space-y-2">
-                      <label className="block text-sm font-medium text-foreground">
-                        Client ID
-                        {registrationMode === "preregistered" ? (
-                          <span className="text-destructive" aria-hidden="true">
-                            {" *"}
-                          </span>
-                        ) : null}
-                      </label>
-                      <Input
-                        value={clientId}
-                        onChange={(e) => onClientIdChange(e.target.value)}
-                        placeholder="Your OAuth Client ID"
-                        aria-required={
-                          registrationMode === "preregistered"
-                            ? true
-                            : undefined
-                        }
-                        spellCheck={false}
-                        autoComplete="off"
-                        data-1p-ignore
-                        data-lpignore="true"
-                        data-form-type="other"
-                        className={`h-10 ${
-                          clientIdError ? "border-red-500" : ""
-                        }`}
-                      />
-                      {clientIdError && (
-                        <p className="text-xs text-red-500">{clientIdError}</p>
-                      )}
-                    </div>
-
-                    <div className="space-y-2">
-                      <div className="flex items-center justify-between gap-3">
-                        <label className="block text-sm font-medium text-foreground">
-                          Client Secret (Optional)
-                        </label>
-                        <div className="flex items-center gap-1">
-                          {canRevealClientSecret &&
-                            !visibleRevealedClientSecret && (
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="sm"
-                                className="h-8 px-2 text-xs"
-                                onClick={() => void handleRevealClientSecret()}
-                                disabled={isRevealingClientSecret}
-                              >
-                                {isRevealingClientSecret ? (
-                                  <Loader2 className="h-3 w-3 animate-spin" />
-                                ) : (
-                                  "Reveal"
-                                )}
-                              </Button>
-                            )}
-                          {visibleRevealedClientSecret && (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              className="h-8 px-2 text-xs"
-                              onClick={handleHideRevealedSecret}
-                            >
-                              Hide
-                            </Button>
-                          )}
-                          {hasStoredClientSecret && !clearClientSecret && (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              className="h-8 px-2 text-xs"
-                              onClick={handleClearClientSecret}
-                            >
-                              Clear
-                            </Button>
-                          )}
-                          {hasStoredClientSecret && clearClientSecret && (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              className="h-8 px-2 text-xs"
-                              onClick={onUndoClearClientSecret}
-                            >
-                              Undo
-                            </Button>
-                          )}
-                        </div>
-                      </div>
-                      {hasStoredClientSecret && clearClientSecret ? (
-                        <p className="text-xs text-muted-foreground">
-                          Saved client secret will be removed when you save.
-                        </p>
-                      ) : visibleRevealedClientSecret !== null ? (
-                        <>
-                          <div className="relative">
-                            <Input
-                              type={
-                                isRevealedSecretVisible ? "text" : "password"
-                              }
-                              value={secretFieldValue}
-                              onChange={(e) => {
-                                if (!isReplacingSecret)
-                                  setIsReplacingSecret(true);
-                                onClientSecretChange(e.target.value);
-                              }}
-                              placeholder="Enter a new value to replace."
-                              data-testid="revealed-client-secret"
-                              spellCheck={false}
-                              autoComplete="off"
-                              data-1p-ignore
-                              data-lpignore="true"
-                              data-form-type="other"
-                              className={`h-10 pr-16 font-mono ${
-                                clientSecretError ? "border-red-500" : ""
-                              }`}
-                            />
-                            <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
-                              <button
-                                type="button"
-                                aria-label={
-                                  isRevealedSecretVisible
-                                    ? "Hide client secret"
-                                    : "Show client secret"
-                                }
-                                title={
-                                  isRevealedSecretVisible
-                                    ? "Hide client secret"
-                                    : "Show client secret"
-                                }
-                                onClick={() =>
-                                  setIsRevealedSecretVisible((prev) => !prev)
-                                }
-                                className="p-1 text-muted-foreground/60 transition-colors hover:text-foreground cursor-pointer"
-                              >
-                                {isRevealedSecretVisible ? (
-                                  <EyeOff className="h-4 w-4" />
-                                ) : (
-                                  <Eye className="h-4 w-4" />
-                                )}
-                              </button>
-                              <button
-                                type="button"
-                                aria-label="Copy client secret"
-                                title="Copy client secret"
-                                onClick={() =>
-                                  void handleCopyRevealedSecret(
-                                    secretFieldValue
-                                  )
-                                }
-                                className="p-1 text-muted-foreground/50 transition-colors hover:text-foreground cursor-pointer"
-                              >
-                                {didCopyRevealedSecret ? (
-                                  <Check className="h-4 w-4 text-green-500" />
-                                ) : (
-                                  <Copy className="h-4 w-4" />
-                                )}
-                              </button>
-                            </div>
-                          </div>
-                          {!isReplacingSecret && (
-                            <p className="text-xs text-muted-foreground">
-                              Editing this replaces the saved secret when you
-                              save.
-                            </p>
-                          )}
-                        </>
-                      ) : canRevealClientSecret ? (
-                        <p className="text-xs text-muted-foreground">
-                          A client secret is saved. Reveal it to view or replace
-                          it.
-                        </p>
-                      ) : (
-                        <Input
-                          type="password"
-                          value={clientSecret}
-                          onChange={(e) => onClientSecretChange(e.target.value)}
-                          placeholder={
-                            hasStoredClientSecret
-                              ? "Enter a new value to replace."
-                              : "Your OAuth Client Secret"
-                          }
-                          spellCheck={false}
-                          autoComplete="off"
-                          data-1p-ignore
-                          data-lpignore="true"
-                          data-form-type="other"
-                          className={`h-10 ${
-                            clientSecretError ? "border-red-500" : ""
-                          }`}
-                        />
-                      )}
-                      {clientSecretError && (
-                        <p className="text-xs text-red-500">
-                          {clientSecretError}
-                        </p>
-                      )}
-                      {revealError && (
-                        <p className="text-xs text-red-500">{revealError}</p>
-                      )}
-                    </div>
-                  </div>
-                )}
               </div>
             )}
           </div>

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -392,6 +392,258 @@ export function AuthenticationSection({
     oauthPlan != null &&
     (oauthPlanVisibleBlockers.length > 0 || oauthPlan.warnings.length > 0);
 
+  // Protocol, registration strategy and the client credentials that go with
+  // them. Rendered up front once the user picks OAuth explicitly; on "auto"
+  // the flow may never reach OAuth, so they stay inside Advanced Settings.
+  const oauthRegistrationFields = (
+    <>
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-foreground">
+            Protocol
+          </label>
+          <Select
+            value={oauthProtocolMode}
+            onValueChange={(value: ServerFormOAuthProtocolMode) =>
+              onOauthProtocolModeChange(value)
+            }
+          >
+            <SelectTrigger className="w-full h-10">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PROTOCOL_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-foreground">
+            Registration Strategy
+          </label>
+          <Select
+            value={registrationMode}
+            onValueChange={(value: RegistrationMode) => {
+              onOauthRegistrationModeChange(value);
+              onUseCustomClientIdChange(value === "preregistered");
+            }}
+          >
+            <SelectTrigger className="w-full h-10">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {REGISTRATION_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {registrationMode === "cimd" && oauthPlan?.clientIdMetadataUrl && (
+            <p className="text-xs text-muted-foreground break-all">
+              SDK client metadata URL: {oauthPlan.clientIdMetadataUrl}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {showClientCredentials && (
+        <div className="space-y-3">
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-foreground">
+              Client ID
+              {registrationMode === "preregistered" ? (
+                <span className="text-destructive" aria-hidden="true">
+                  {" *"}
+                </span>
+              ) : null}
+            </label>
+            <Input
+              value={clientId}
+              onChange={(e) => onClientIdChange(e.target.value)}
+              placeholder="Your OAuth Client ID"
+              aria-required={
+                registrationMode === "preregistered" ? true : undefined
+              }
+              spellCheck={false}
+              autoComplete="off"
+              data-1p-ignore
+              data-lpignore="true"
+              data-form-type="other"
+              className={`h-10 ${clientIdError ? "border-red-500" : ""}`}
+            />
+            {clientIdError && (
+              <p className="text-xs text-red-500">{clientIdError}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <label className="block text-sm font-medium text-foreground">
+                Client Secret (Optional)
+              </label>
+              <div className="flex items-center gap-1">
+                {canRevealClientSecret && !visibleRevealedClientSecret && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 px-2 text-xs"
+                    onClick={() => void handleRevealClientSecret()}
+                    disabled={isRevealingClientSecret}
+                  >
+                    {isRevealingClientSecret ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      "Reveal"
+                    )}
+                  </Button>
+                )}
+                {visibleRevealedClientSecret && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 px-2 text-xs"
+                    onClick={handleHideRevealedSecret}
+                  >
+                    Hide
+                  </Button>
+                )}
+                {hasStoredClientSecret && !clearClientSecret && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 px-2 text-xs"
+                    onClick={handleClearClientSecret}
+                  >
+                    Clear
+                  </Button>
+                )}
+                {hasStoredClientSecret && clearClientSecret && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 px-2 text-xs"
+                    onClick={onUndoClearClientSecret}
+                  >
+                    Undo
+                  </Button>
+                )}
+              </div>
+            </div>
+            {hasStoredClientSecret && clearClientSecret ? (
+              <p className="text-xs text-muted-foreground">
+                Saved client secret will be removed when you save.
+              </p>
+            ) : visibleRevealedClientSecret !== null ? (
+              <>
+                <div className="relative">
+                  <Input
+                    type={isRevealedSecretVisible ? "text" : "password"}
+                    value={secretFieldValue}
+                    onChange={(e) => {
+                      if (!isReplacingSecret) setIsReplacingSecret(true);
+                      onClientSecretChange(e.target.value);
+                    }}
+                    placeholder="Enter a new value to replace."
+                    data-testid="revealed-client-secret"
+                    spellCheck={false}
+                    autoComplete="off"
+                    data-1p-ignore
+                    data-lpignore="true"
+                    data-form-type="other"
+                    className={`h-10 pr-16 font-mono ${
+                      clientSecretError ? "border-red-500" : ""
+                    }`}
+                  />
+                  <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
+                    <button
+                      type="button"
+                      aria-label={
+                        isRevealedSecretVisible
+                          ? "Hide client secret"
+                          : "Show client secret"
+                      }
+                      title={
+                        isRevealedSecretVisible
+                          ? "Hide client secret"
+                          : "Show client secret"
+                      }
+                      onClick={() =>
+                        setIsRevealedSecretVisible((prev) => !prev)
+                      }
+                      className="p-1 text-muted-foreground/60 transition-colors hover:text-foreground cursor-pointer"
+                    >
+                      {isRevealedSecretVisible ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      aria-label="Copy client secret"
+                      title="Copy client secret"
+                      onClick={() =>
+                        void handleCopyRevealedSecret(secretFieldValue)
+                      }
+                      className="p-1 text-muted-foreground/50 transition-colors hover:text-foreground cursor-pointer"
+                    >
+                      {didCopyRevealedSecret ? (
+                        <Check className="h-4 w-4 text-green-500" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
+                </div>
+                {!isReplacingSecret && (
+                  <p className="text-xs text-muted-foreground">
+                    Editing this replaces the saved secret when you save.
+                  </p>
+                )}
+              </>
+            ) : canRevealClientSecret ? (
+              <p className="text-xs text-muted-foreground">
+                A client secret is saved. Reveal it to view or replace it.
+              </p>
+            ) : (
+              <Input
+                type="password"
+                value={clientSecret}
+                onChange={(e) => onClientSecretChange(e.target.value)}
+                placeholder={
+                  hasStoredClientSecret
+                    ? "Enter a new value to replace."
+                    : "Your OAuth Client Secret"
+                }
+                spellCheck={false}
+                autoComplete="off"
+                data-1p-ignore
+                data-lpignore="true"
+                data-form-type="other"
+                className={`h-10 ${clientSecretError ? "border-red-500" : ""}`}
+              />
+            )}
+            {clientSecretError && (
+              <p className="text-xs text-red-500">{clientSecretError}</p>
+            )}
+            {revealError && (
+              <p className="text-xs text-red-500">{revealError}</p>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+
   return (
     <div className="space-y-4">
       <div className="border border-border rounded-lg overflow-hidden">
@@ -527,263 +779,11 @@ export function AuthenticationSection({
               </div>
             )}
 
-            <div className="px-3 pt-3 pb-3 space-y-3">
-              <div className="grid gap-3 md:grid-cols-2">
-                <div className="space-y-2">
-                  <label className="block text-sm font-medium text-foreground">
-                    Protocol
-                  </label>
-                  <Select
-                    value={oauthProtocolMode}
-                    onValueChange={(value: ServerFormOAuthProtocolMode) =>
-                      onOauthProtocolModeChange(value)
-                    }
-                  >
-                    <SelectTrigger className="w-full h-10">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {PROTOCOL_OPTIONS.map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <div className="space-y-2">
-                  <label className="block text-sm font-medium text-foreground">
-                    Registration Strategy
-                  </label>
-                  <Select
-                    value={registrationMode}
-                    onValueChange={(value: RegistrationMode) => {
-                      onOauthRegistrationModeChange(value);
-                      onUseCustomClientIdChange(value === "preregistered");
-                    }}
-                  >
-                    <SelectTrigger className="w-full h-10">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {REGISTRATION_OPTIONS.map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  {registrationMode === "cimd" &&
-                    oauthPlan?.clientIdMetadataUrl && (
-                      <p className="text-xs text-muted-foreground break-all">
-                        SDK client metadata URL: {oauthPlan.clientIdMetadataUrl}
-                      </p>
-                    )}
-                </div>
+            {authType === "oauth" && (
+              <div className="px-3 pt-3 pb-3 space-y-3">
+                {oauthRegistrationFields}
               </div>
-
-              {showClientCredentials && (
-                <div className="space-y-3">
-                  <div className="space-y-2">
-                    <label className="block text-sm font-medium text-foreground">
-                      Client ID
-                      {registrationMode === "preregistered" ? (
-                        <span className="text-destructive" aria-hidden="true">
-                          {" *"}
-                        </span>
-                      ) : null}
-                    </label>
-                    <Input
-                      value={clientId}
-                      onChange={(e) => onClientIdChange(e.target.value)}
-                      placeholder="Your OAuth Client ID"
-                      aria-required={
-                        registrationMode === "preregistered" ? true : undefined
-                      }
-                      spellCheck={false}
-                      autoComplete="off"
-                      data-1p-ignore
-                      data-lpignore="true"
-                      data-form-type="other"
-                      className={`h-10 ${
-                        clientIdError ? "border-red-500" : ""
-                      }`}
-                    />
-                    {clientIdError && (
-                      <p className="text-xs text-red-500">{clientIdError}</p>
-                    )}
-                  </div>
-
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between gap-3">
-                      <label className="block text-sm font-medium text-foreground">
-                        Client Secret (Optional)
-                      </label>
-                      <div className="flex items-center gap-1">
-                        {canRevealClientSecret &&
-                          !visibleRevealedClientSecret && (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              className="h-8 px-2 text-xs"
-                              onClick={() => void handleRevealClientSecret()}
-                              disabled={isRevealingClientSecret}
-                            >
-                              {isRevealingClientSecret ? (
-                                <Loader2 className="h-3 w-3 animate-spin" />
-                              ) : (
-                                "Reveal"
-                              )}
-                            </Button>
-                          )}
-                        {visibleRevealedClientSecret && (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            className="h-8 px-2 text-xs"
-                            onClick={handleHideRevealedSecret}
-                          >
-                            Hide
-                          </Button>
-                        )}
-                        {hasStoredClientSecret && !clearClientSecret && (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            className="h-8 px-2 text-xs"
-                            onClick={handleClearClientSecret}
-                          >
-                            Clear
-                          </Button>
-                        )}
-                        {hasStoredClientSecret && clearClientSecret && (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            className="h-8 px-2 text-xs"
-                            onClick={onUndoClearClientSecret}
-                          >
-                            Undo
-                          </Button>
-                        )}
-                      </div>
-                    </div>
-                    {hasStoredClientSecret && clearClientSecret ? (
-                      <p className="text-xs text-muted-foreground">
-                        Saved client secret will be removed when you save.
-                      </p>
-                    ) : visibleRevealedClientSecret !== null ? (
-                      <>
-                        <div className="relative">
-                          <Input
-                            type={isRevealedSecretVisible ? "text" : "password"}
-                            value={secretFieldValue}
-                            onChange={(e) => {
-                              if (!isReplacingSecret)
-                                setIsReplacingSecret(true);
-                              onClientSecretChange(e.target.value);
-                            }}
-                            placeholder="Enter a new value to replace."
-                            data-testid="revealed-client-secret"
-                            spellCheck={false}
-                            autoComplete="off"
-                            data-1p-ignore
-                            data-lpignore="true"
-                            data-form-type="other"
-                            className={`h-10 pr-16 font-mono ${
-                              clientSecretError ? "border-red-500" : ""
-                            }`}
-                          />
-                          <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
-                            <button
-                              type="button"
-                              aria-label={
-                                isRevealedSecretVisible
-                                  ? "Hide client secret"
-                                  : "Show client secret"
-                              }
-                              title={
-                                isRevealedSecretVisible
-                                  ? "Hide client secret"
-                                  : "Show client secret"
-                              }
-                              onClick={() =>
-                                setIsRevealedSecretVisible((prev) => !prev)
-                              }
-                              className="p-1 text-muted-foreground/60 transition-colors hover:text-foreground cursor-pointer"
-                            >
-                              {isRevealedSecretVisible ? (
-                                <EyeOff className="h-4 w-4" />
-                              ) : (
-                                <Eye className="h-4 w-4" />
-                              )}
-                            </button>
-                            <button
-                              type="button"
-                              aria-label="Copy client secret"
-                              title="Copy client secret"
-                              onClick={() =>
-                                void handleCopyRevealedSecret(secretFieldValue)
-                              }
-                              className="p-1 text-muted-foreground/50 transition-colors hover:text-foreground cursor-pointer"
-                            >
-                              {didCopyRevealedSecret ? (
-                                <Check className="h-4 w-4 text-green-500" />
-                              ) : (
-                                <Copy className="h-4 w-4" />
-                              )}
-                            </button>
-                          </div>
-                        </div>
-                        {!isReplacingSecret && (
-                          <p className="text-xs text-muted-foreground">
-                            Editing this replaces the saved secret when you
-                            save.
-                          </p>
-                        )}
-                      </>
-                    ) : canRevealClientSecret ? (
-                      <p className="text-xs text-muted-foreground">
-                        A client secret is saved. Reveal it to view or replace
-                        it.
-                      </p>
-                    ) : (
-                      <Input
-                        type="password"
-                        value={clientSecret}
-                        onChange={(e) => onClientSecretChange(e.target.value)}
-                        placeholder={
-                          hasStoredClientSecret
-                            ? "Enter a new value to replace."
-                            : "Your OAuth Client Secret"
-                        }
-                        spellCheck={false}
-                        autoComplete="off"
-                        data-1p-ignore
-                        data-lpignore="true"
-                        data-form-type="other"
-                        className={`h-10 ${
-                          clientSecretError ? "border-red-500" : ""
-                        }`}
-                      />
-                    )}
-                    {clientSecretError && (
-                      <p className="text-xs text-red-500">
-                        {clientSecretError}
-                      </p>
-                    )}
-                    {revealError && (
-                      <p className="text-xs text-red-500">{revealError}</p>
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
+            )}
 
             <button
               type="button"
@@ -802,6 +802,8 @@ export function AuthenticationSection({
 
             {showAdvancedOAuth && (
               <div className="px-3 pb-3 space-y-3">
+                {authType !== "oauth" && oauthRegistrationFields}
+
                 <div className="space-y-2">
                   <label className="block text-sm font-medium text-foreground">
                     Scope Override


### PR DESCRIPTION
- Someone churned because they never found out MCPJam supports pre-registration — it was buried behind "Advanced Settings".
- Picking OAuth now shows Protocol, Registration Strategy and, for pre-registration, Client ID and Client Secret right away. No disclosure to open, no scrolling past other fields.
- "Advanced Settings" now holds only Scope Override and the path-scoped authorization server switch — the two knobs that really are for debugging.
- No copy changes, no logic changes. Same fields, same behavior, just reordered and un-hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces OAuth protocol, registration strategy, and client credentials as soon as OAuth is selected, so MCPJam's pre-registration support is no longer buried behind Advanced Settings.

When the auth type is "auto", those fields stay inside Advanced Settings because the flow may never reach OAuth. Advanced Settings otherwise keeps only Scope Override and the path-scoped authorization server switch. No copy changes.

<sup>Written for commit 36f65b196c684452ced2fb5e97d987f8c7e22aff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

