### PR TITLE
evals: Enter in the accuracy field reports one edit, not two

### DIFF
--- a/.changeset/pass-criteria-enter-commits-once.md
+++ b/.changeset/pass-criteria-enter-commits-once.md
@@ -1,0 +1,10 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Pressing Enter in the accuracy field reports one edit, not two
+
+Enter leaves the field by blurring it, and blurring is what commits — so
+committing before the blur as well filed the same edit twice. The test that
+covered Enter only checked the value it reported, which is why the duplicate
+went unnoticed; it now pins the call count too.

--- a/mcpjam-inspector/client/src/components/evals/__tests__/pass-criteria-selector.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/pass-criteria-selector.test.tsx
@@ -155,12 +155,16 @@ describe("committing and abandoning", () => {
     expect(onChange).toHaveBeenCalledWith(70);
   });
 
-  it("Enter commits", () => {
+  it("Enter commits exactly once", () => {
     const { input, onChange } = renderSelector(80);
 
+    input.focus();
     fireEvent.change(input, { target: { value: "70" } });
     fireEvent.keyDown(input, { key: "Enter" });
 
+    // Enter leaves the field by blurring it, and blurring is what commits.
+    // Committing before the blur as well reported the same edit twice.
+    expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith(70);
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/pass-criteria-selector.tsx
+++ b/mcpjam-inspector/client/src/components/evals/pass-criteria-selector.tsx
@@ -82,7 +82,8 @@ export function PassCriteriaSelector({
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter") {
-      commit();
+      // Just leave the field — the blur below IS the commit. Calling `commit`
+      // here as well reported the same edit twice, once from each path.
       (e.target as HTMLInputElement).blur();
     } else if (e.key === "Escape") {
       cancelled.current = true;


### PR DESCRIPTION
A follow-up to #4629, which merged before this landed.

## What happened

Enter leaves the accuracy field by calling `.blur()`, and blurring is what commits — so committing before the blur as well filed the same edit twice, once from each path.

```ts
if (e.key === "Enter") {
  commit();                                // once
  (e.target as HTMLInputElement).blur();   // and again, via onBlur
}
```

Enter now just leaves the field.

## Why it survived a test that covered Enter

The test asserted the value that was reported and nothing else:

```ts
expect(onChange).toHaveBeenCalledWith(70);
```

`toHaveBeenCalledWith` passes on the second call as readily as the first, so a duplicate of the same value is invisible to it. The test pins the count now, and the count assertion fails against the previous code — confirmed before writing the fix, not after.

That is the more useful half of this change. Every other test in that file already asserted counts; this one did not, which is exactly where the defect sat.

## Impact

Small today: the duplicate dispatched the same draft edit twice, and the reducer is idempotent for an unchanged value, so nothing was corrupted. It matters more once a control commits straight through to the mutation, where two identical writes are two round trips and two revisions.

## Verification

```
npm run typecheck:client -w @mcpjam/inspector
npx vitest run client/src/components/evals    # 154 files, 1,474 passing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186pEE7gijs5VcpLbXoTzdW

---
_Generated by [Claude Code](https://claude.ai/code/session_0186pEE7gijs5VcpLbXoTzdW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized evals UI input handling; duplicate callbacks were idempotent today but would matter if commits hit the network directly.
> 
> **Overview**
> **Enter in the minimum-accuracy field no longer fires `onMinimumPassRateChange` twice.** Previously, Enter called `commit()` and then blurred the input, and blur also committed—so the same value was reported on both paths.
> 
> Enter now only blurs the input and relies on `handleBlur` as the single commit path, matching how Escape already avoids double-commit via the cancel guard.
> 
> The **Enter** test was renamed and tightened to assert **`onChange` is called exactly once**, not just with the right value (which hid the duplicate). A patch changeset documents the fix for `@mcpjam/inspector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf3dfc65276115eb7d682f83920d1a5c0c228c1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the accuracy field in the eval pass-criteria selector reporting the same edit twice when Enter is pressed. Enter now just blurs the field, which is what commits, so only one edit is reported.

**Bug Fixes**
- Removed the explicit commit on Enter; blur alone now commits.
- The Enter test now asserts the call count, which fails against the previous code.

<sup>Written for commit cf3dfc65276115eb7d682f83920d1a5c0c228c1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

