### PR TITLE
Track each saved client setting

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -41,6 +41,7 @@ import { HostCanvasSelector } from "./HostCanvasSelector";
 import { parseHostVerifyTabParam } from "../host-verify-deep-link";
 import { buildRedesignedHostCanvas } from "./canvas/canvasBuilder";
 import { HostFocusPanel } from "./focus/HostFocusPanel";
+import { emitClientSaveTelemetry } from "./client-save-telemetry";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { useSkillsEnabled } from "@/hooks/useSkillsEnabled";
 import { HOSTED_MODE } from "@/lib/config";
@@ -437,15 +438,7 @@ export function HostBuilderViewRedesigned({
     if (!draftConfig) return;
     setIsSaving(true);
     try {
-      const changedFields = savedConfig
-        ? (Object.keys(draftConfig) as Array<keyof HostConfigInputV2>).filter(
-            (key) =>
-              JSON.stringify(draftConfig[key]) !==
-              JSON.stringify(savedConfig[key])
-          )
-        : [];
-      // Reuse the same draft-vs-saved comparison the telemetry diff uses,
-      // rather than introducing a second notion of "changed".
+      // Compare the same persisted and draft snapshots used by save telemetry.
       const cancellationChanged = toolCallCancellationChanged(
         savedConfig,
         draftConfig
@@ -475,19 +468,15 @@ export function HostBuilderViewRedesigned({
       if (cancellationChanged && onReconnect) {
         setPendingCancellationReconnect(hostConfigId);
       }
-      // Telemetry is best-effort: a posthog throw must not bubble into the
-      // shared catch and surface "Failed to save host" after the config
-      // has already been persisted.
-      try {
-        track("client_config_saved", {
-          location: "client_builder",
-          client_id: hostId,
-          client_config_id: hostConfigId,
-          server_count: draftConfig.serverIds?.length ?? 0,
-          changed_fields: changedFields,
+      if (host && savedConfig) {
+        emitClientSaveTelemetry(track, {
+          clientId: hostId,
+          clientConfigId: hostConfigId,
+          savedName: host.name,
+          draftName,
+          savedConfig,
+          draftConfig,
         });
-      } catch {
-        // swallow — analytics must not block the success path
       }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to save client");
@@ -499,6 +488,7 @@ export function HostBuilderViewRedesigned({
     draftName,
     draftConfig,
     savedConfig,
+    host,
     updateHost,
   ]);
 

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/client-save-telemetry.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/client-save-telemetry.test.ts
@@ -39,6 +39,20 @@ describe("changedClientSettings", () => {
         }),
       }),
     ).toEqual(["mcp.tool_call_cancellation.modern"]);
+
+    expect(
+      changedClientSettings({
+        savedName: "Client",
+        draftName: "Client",
+        savedConfig: config(),
+        draftConfig: config({
+          mcpProfile: {
+            profileVersion: 1,
+            toolCallCancellation: { legacy: false },
+          },
+        }),
+      }),
+    ).toEqual(["mcp.tool_call_cancellation.legacy"]);
   });
 
   it("returns each changed setting once for a multi-setting save", () => {

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/client-save-telemetry.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/client-save-telemetry.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from "vitest";
+import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
+import type { HostConfigInputV2 } from "@/lib/client-config-v2";
+import {
+  changedClientSettings,
+  emitClientSaveTelemetry,
+} from "../client-save-telemetry";
+
+const config = (
+  overrides: Partial<HostConfigInputV2> = {},
+): HostConfigInputV2 => ({
+  ...emptyHostConfigInputV2(),
+  ...overrides,
+});
+
+describe("changedClientSettings", () => {
+  it("detects a name-only save without recording the name", () => {
+    expect(
+      changedClientSettings({
+        savedName: "Before",
+        draftName: "After",
+        savedConfig: config(),
+        draftConfig: config(),
+      }),
+    ).toEqual(["client.name"]);
+  });
+
+  it("distinguishes legacy and modern tool cancellation", () => {
+    expect(
+      changedClientSettings({
+        savedName: "Client",
+        draftName: "Client",
+        savedConfig: config(),
+        draftConfig: config({
+          mcpProfile: {
+            profileVersion: 1,
+            toolCallCancellation: { modern: false },
+          },
+        }),
+      }),
+    ).toEqual(["mcp.tool_call_cancellation.modern"]);
+  });
+
+  it("returns each changed setting once for a multi-setting save", () => {
+    expect(
+      changedClientSettings({
+        savedName: "Before",
+        draftName: "After",
+        savedConfig: config(),
+        draftConfig: config({
+          modelId: "anthropic/claude-sonnet-4-6",
+          temperature: 0.2,
+        }),
+      }),
+    ).toEqual(["client.name", "model", "temperature"]);
+  });
+
+  it("emits nothing when no setting changed", () => {
+    const saved = config();
+    expect(
+      changedClientSettings({
+        savedName: "Client",
+        draftName: "Client",
+        savedConfig: saved,
+        draftConfig: structuredClone(saved),
+      }),
+    ).toEqual([]);
+  });
+
+  it("detects nested, array, and dynamic-record changes without returning values", () => {
+    const changed = changedClientSettings({
+      savedName: "Client",
+      draftName: "Client",
+      savedConfig: config(),
+      draftConfig: config({
+        builtInToolIds: ["secret-tool-id"],
+        connectionDefaults: {
+          headers: { Authorization: "secret-value" },
+          requestTimeout: 60_000,
+        },
+        mcpProfile: {
+          profileVersion: 1,
+          apps: { sandbox: { browserStorage: { indexedDB: false } } },
+        },
+      }),
+    });
+
+    expect(changed).toEqual([
+      "built_in_tools",
+      "connection.headers",
+      "connection.request_timeout",
+      "mcp.apps.sandbox.browser_storage.indexed_db",
+    ]);
+    expect(JSON.stringify(changed)).not.toContain("secret");
+  });
+});
+
+describe("emitClientSaveTelemetry", () => {
+  it("keeps the summary event and emits one event per saved setting", () => {
+    const capture = vi.fn();
+    emitClientSaveTelemetry(capture, {
+      clientId: "client-1",
+      clientConfigId: "config-2",
+      savedName: "Before",
+      draftName: "After",
+      savedConfig: config(),
+      draftConfig: config({ temperature: 0.2 }),
+    });
+
+    expect(capture).toHaveBeenNthCalledWith(
+      1,
+      "client_config_saved",
+      expect.objectContaining({ changed_fields: ["temperature"] }),
+    );
+    expect(capture).toHaveBeenNthCalledWith(
+      2,
+      "client_setting_saved",
+      expect.objectContaining({ setting: "client.name" }),
+    );
+    expect(capture).toHaveBeenNthCalledWith(
+      3,
+      "client_setting_saved",
+      expect.objectContaining({ setting: "temperature" }),
+    );
+  });
+
+  it("does not leak changed values in setting events", () => {
+    const capture = vi.fn();
+    emitClientSaveTelemetry(capture, {
+      clientId: "client-1",
+      clientConfigId: "config-2",
+      savedName: "Before",
+      draftName: "private-client-name",
+      savedConfig: config(),
+      draftConfig: config({ systemPrompt: "private system prompt" }),
+    });
+
+    const settingEvents = capture.mock.calls.filter(
+      ([event]) => event === "client_setting_saved",
+    );
+    expect(settingEvents).toHaveLength(2);
+    expect(JSON.stringify(settingEvents)).not.toContain("private");
+  });
+
+  it("swallows capture failures and continues with later setting events", () => {
+    const capture = vi.fn(() => {
+      throw new Error("blocked");
+    });
+    expect(() =>
+      emitClientSaveTelemetry(capture, {
+        clientId: "client-1",
+        clientConfigId: "config-2",
+        savedName: "Before",
+        draftName: "After",
+        savedConfig: config(),
+        draftConfig: config({ temperature: 0.2 }),
+      }),
+    ).not.toThrow();
+    expect(capture).toHaveBeenCalledTimes(3);
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/client-save-telemetry.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/client-save-telemetry.ts
@@ -1,0 +1,333 @@
+import type { ClientAnalyticsEventName } from "@/shared/analytics-events";
+import { stableStringifyJson } from "@/lib/client-config";
+import type { HostConfigInputV2 } from "@/lib/client-config-v2";
+
+export const CLIENT_SETTING_IDS = [
+  "client.name",
+  "client.profile",
+  "model",
+  "system_prompt",
+  "temperature",
+  "tool_approval",
+  "tool_visibility",
+  "progressive_tool_discovery",
+  "model_visible_tool_results",
+  "tool_result_image_rendering",
+  "servers",
+  "optional_servers",
+  "built_in_tools",
+  "computer",
+  "harness",
+  "connection.headers",
+  "connection.request_timeout",
+  "client_capabilities",
+  "host_context",
+  "host_capabilities",
+  "appearance",
+  "mcp.protocol_version",
+  "mcp.tool_param_header_mirroring",
+  "mcp.pagination_traversal",
+  "mcp.mrtr_support",
+  "mcp.tool_call_cancellation.legacy",
+  "mcp.tool_call_cancellation.modern",
+  "mcp.tool_list_changed.listens",
+  "mcp.tool_list_changed.refetches",
+  "mcp.initialize.supported_protocol_versions",
+  "mcp.initialize.client_info",
+  "mcp.apps.sandbox.csp",
+  "mcp.apps.sandbox.permissions",
+  "mcp.apps.sandbox.browser_storage.local_storage",
+  "mcp.apps.sandbox.browser_storage.session_storage",
+  "mcp.apps.sandbox.browser_storage.indexed_db",
+  "mcp.apps.sandbox.attributes",
+  "mcp.apps.sandbox.allowed_features",
+  "mcp.apps.ui_initialize.host_info",
+  "mcp.apps.compat_runtime",
+  "mcp.apps.capabilities",
+  "mcp.extensions",
+  "server_connection.headers",
+  "server_connection.request_timeout",
+  "server_connection.protocol_version",
+] as const;
+
+export type ClientSettingId = (typeof CLIENT_SETTING_IDS)[number];
+
+type SettingDetector = (
+  saved: HostConfigInputV2,
+  draft: HostConfigInputV2,
+) => readonly ClientSettingId[];
+
+const equal = (left: unknown, right: unknown): boolean =>
+  stableStringifyJson(left) === stableStringifyJson(right);
+
+const one =
+  (
+    id: ClientSettingId,
+    select: (config: HostConfigInputV2) => unknown,
+  ): SettingDetector =>
+  (saved, draft) =>
+    equal(select(saved), select(draft)) ? [] : [id];
+
+const mcpProfileChanges: SettingDetector = (saved, draft) => {
+  const before = saved.mcpProfile;
+  const after = draft.mcpProfile;
+  const pairs: ReadonlyArray<readonly [ClientSettingId, unknown, unknown]> = [
+    [
+      "mcp.protocol_version",
+      before?.mcpProtocolVersion,
+      after?.mcpProtocolVersion,
+    ],
+    [
+      "mcp.tool_param_header_mirroring",
+      before?.toolParamHeaderMirroring,
+      after?.toolParamHeaderMirroring,
+    ],
+    [
+      "mcp.pagination_traversal",
+      before?.paginationTraversal,
+      after?.paginationTraversal,
+    ],
+    ["mcp.mrtr_support", before?.mrtrSupport, after?.mrtrSupport],
+    [
+      "mcp.tool_call_cancellation.legacy",
+      before?.toolCallCancellation?.legacy,
+      after?.toolCallCancellation?.legacy,
+    ],
+    [
+      "mcp.tool_call_cancellation.modern",
+      before?.toolCallCancellation?.modern,
+      after?.toolCallCancellation?.modern,
+    ],
+    [
+      "mcp.tool_list_changed.listens",
+      before?.toolListChanged?.listens,
+      after?.toolListChanged?.listens,
+    ],
+    [
+      "mcp.tool_list_changed.refetches",
+      before?.toolListChanged?.refetches,
+      after?.toolListChanged?.refetches,
+    ],
+    [
+      "mcp.initialize.supported_protocol_versions",
+      before?.initialize?.supportedProtocolVersions,
+      after?.initialize?.supportedProtocolVersions,
+    ],
+    [
+      "mcp.initialize.client_info",
+      before?.initialize?.clientInfo,
+      after?.initialize?.clientInfo,
+    ],
+    [
+      "mcp.apps.sandbox.csp",
+      before?.apps?.sandbox?.csp,
+      after?.apps?.sandbox?.csp,
+    ],
+    [
+      "mcp.apps.sandbox.permissions",
+      before?.apps?.sandbox?.permissions,
+      after?.apps?.sandbox?.permissions,
+    ],
+    [
+      "mcp.apps.sandbox.browser_storage.local_storage",
+      before?.apps?.sandbox?.browserStorage?.localStorage,
+      after?.apps?.sandbox?.browserStorage?.localStorage,
+    ],
+    [
+      "mcp.apps.sandbox.browser_storage.session_storage",
+      before?.apps?.sandbox?.browserStorage?.sessionStorage,
+      after?.apps?.sandbox?.browserStorage?.sessionStorage,
+    ],
+    [
+      "mcp.apps.sandbox.browser_storage.indexed_db",
+      before?.apps?.sandbox?.browserStorage?.indexedDB,
+      after?.apps?.sandbox?.browserStorage?.indexedDB,
+    ],
+    [
+      "mcp.apps.sandbox.attributes",
+      before?.apps?.sandbox?.sandboxAttrs,
+      after?.apps?.sandbox?.sandboxAttrs,
+    ],
+    [
+      "mcp.apps.sandbox.allowed_features",
+      before?.apps?.sandbox?.allowFeatures,
+      after?.apps?.sandbox?.allowFeatures,
+    ],
+    [
+      "mcp.apps.ui_initialize.host_info",
+      before?.apps?.uiInitialize?.hostInfo,
+      after?.apps?.uiInitialize?.hostInfo,
+    ],
+    [
+      "mcp.apps.compat_runtime",
+      before?.apps?.compatRuntime,
+      after?.apps?.compatRuntime,
+    ],
+    [
+      "mcp.apps.capabilities",
+      before?.apps?.mcpAppsOverrides,
+      after?.apps?.mcpAppsOverrides,
+    ],
+    ["mcp.extensions", before?.extensions, after?.extensions],
+  ];
+
+  return pairs
+    .filter(([, left, right]) => !equal(left, right))
+    .map(([id]) => id);
+};
+
+type ServerOverride = NonNullable<
+  HostConfigInputV2["serverConnectionOverrides"]
+>[string];
+
+const projectServerOverrides = (
+  config: HostConfigInputV2,
+  key: keyof ServerOverride,
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(config.serverConnectionOverrides ?? {}).map(
+      ([serverId, value]) => [serverId, value[key]],
+    ),
+  );
+
+const serverOverrideChanges: SettingDetector = (saved, draft) => {
+  const pairs: ReadonlyArray<readonly [ClientSettingId, keyof ServerOverride]> =
+    [
+      ["server_connection.headers", "headersOverride"],
+      ["server_connection.request_timeout", "requestTimeoutOverride"],
+      ["server_connection.protocol_version", "mcpProtocolVersionOverride"],
+    ];
+  return pairs
+    .filter(
+      ([, key]) =>
+        !equal(
+          projectServerOverrides(saved, key),
+          projectServerOverrides(draft, key),
+        ),
+    )
+    .map(([id]) => id);
+};
+
+/**
+ * Exhaustive at the HostConfigInputV2 boundary. Adding a new top-level client
+ * setting is a type error until its privacy-safe telemetry detector is chosen.
+ */
+const CLIENT_SETTING_DETECTORS = {
+  hostStyle: one("client.profile", (config) => config.hostStyle),
+  modelId: one("model", (config) => config.modelId),
+  systemPrompt: one("system_prompt", (config) => config.systemPrompt),
+  temperature: one("temperature", (config) => config.temperature),
+  requireToolApproval: one(
+    "tool_approval",
+    (config) => config.requireToolApproval,
+  ),
+  respectToolVisibility: one(
+    "tool_visibility",
+    (config) => config.respectToolVisibility,
+  ),
+  progressiveToolDiscovery: one(
+    "progressive_tool_discovery",
+    (config) => config.progressiveToolDiscovery,
+  ),
+  modelVisibleMcpToolResults: one(
+    "model_visible_tool_results",
+    (config) => config.modelVisibleMcpToolResults,
+  ),
+  mcpToolResultImageRendering: one(
+    "tool_result_image_rendering",
+    (config) => config.mcpToolResultImageRendering,
+  ),
+  serverIds: one("servers", (config) => config.serverIds),
+  optionalServerIds: one(
+    "optional_servers",
+    (config) => config.optionalServerIds,
+  ),
+  builtInToolIds: one("built_in_tools", (config) => config.builtInToolIds),
+  computer: one("computer", (config) => config.computer),
+  harness: one("harness", (config) => config.harness),
+  connectionDefaults: (saved, draft) => [
+    ...(equal(
+      saved.connectionDefaults.headers,
+      draft.connectionDefaults.headers,
+    )
+      ? []
+      : (["connection.headers"] as const)),
+    ...(equal(
+      saved.connectionDefaults.requestTimeout,
+      draft.connectionDefaults.requestTimeout,
+    )
+      ? []
+      : (["connection.request_timeout"] as const)),
+  ],
+  clientCapabilities: one(
+    "client_capabilities",
+    (config) => config.clientCapabilities,
+  ),
+  hostContext: one("host_context", (config) => config.hostContext),
+  hostCapabilitiesOverride: one(
+    "host_capabilities",
+    (config) => config.hostCapabilitiesOverride,
+  ),
+  chatUiOverride: one("appearance", (config) => config.chatUiOverride),
+  mcpProfile: mcpProfileChanges,
+  serverConnectionOverrides: serverOverrideChanges,
+} satisfies Record<keyof HostConfigInputV2, SettingDetector>;
+
+export function changedClientSettings(input: {
+  savedName: string;
+  draftName: string;
+  savedConfig: HostConfigInputV2;
+  draftConfig: HostConfigInputV2;
+}): ClientSettingId[] {
+  const changed: ClientSettingId[] =
+    input.savedName === input.draftName ? [] : ["client.name" as const];
+  for (const detector of Object.values(CLIENT_SETTING_DETECTORS)) {
+    changed.push(...detector(input.savedConfig, input.draftConfig));
+  }
+  return changed;
+}
+
+type Capture = (
+  event: ClientAnalyticsEventName,
+  props: Record<string, unknown>,
+) => void;
+
+export function emitClientSaveTelemetry(
+  capture: Capture,
+  input: {
+    clientId: string;
+    clientConfigId: string;
+    savedName: string;
+    draftName: string;
+    savedConfig: HostConfigInputV2;
+    draftConfig: HostConfigInputV2;
+  },
+): void {
+  const changedFields = (
+    Object.keys(input.draftConfig) as Array<keyof HostConfigInputV2>
+  ).filter((key) => !equal(input.draftConfig[key], input.savedConfig[key]));
+  const settings = changedClientSettings(input);
+  const common = {
+    location: "client_builder",
+    client_id: input.clientId,
+    client_config_id: input.clientConfigId,
+  };
+
+  try {
+    capture("client_config_saved", {
+      ...common,
+      server_count: input.draftConfig.serverIds?.length ?? 0,
+      changed_fields: changedFields,
+    });
+  } catch {
+    // Analytics is best-effort and must never affect a successful save.
+  }
+
+  for (const setting of settings) {
+    try {
+      capture("client_setting_saved", { ...common, setting });
+    } catch {
+      // One failed capture must not stop the save or the remaining events.
+    }
+  }
+}

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -155,6 +155,7 @@ export const ANALYTICS_EVENTS = {
   scenario_bootstrap_started: { source: "client" },
   client_builder_viewed: { source: "client" },
   client_config_saved: { source: "client" },
+  client_setting_saved: { source: "client" },
   client_created: { source: "client" },
   client_deleted: { source: "client" },
   client_selected: { source: "client" },


### PR DESCRIPTION
## Summary
- keep the existing client save event
- emit one value-free event per changed client setting after a successful save
- distinguish client-name changes and legacy/modern tool cancellation
- keep the setting catalog exhaustive at the client-config boundary

## Tests
- 16 focused tests passed
- client typecheck passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tracks each saved client setting by emitting one `client_setting_saved` event per changed setting after a successful save, alongside the existing `client_config_saved` summary event.

- Emits only the setting identifier, never its value, so saved data stays out of analytics.
- Distinguishes client-name changes and legacy versus modern tool cancellation.
- Keeps the setting catalog exhaustive at the `HostConfigInputV2` boundary, so new settings require a telemetry detector.

<sup>Written for commit 687983265c9a04cfa9e157e9748f7cf3d5ed0cca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

