### PR TITLE
sandbox proxy: mount MCP App views by document.write so they run at a real URL

### DIFF
--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
@@ -662,8 +662,26 @@ describe("sandbox-proxy connect guard — CSP source matching", () => {
     return nativeFetch.mock.calls.length === 1;
   }
 
-  describe("srcdoc base URL", () => {
-    it("resolves relative requests against document.baseURI", async () => {
+  describe("document base URL", () => {
+    // The view is written into a same-origin frame, so its document URL is
+    // the proxy URL (the srcdoc fallback inherits the same baseURI). Both
+    // shapes must resolve relative requests and 'self' the same way.
+    const PROXY_URL =
+      "http://127.0.0.1:6274/api/apps/mcp-apps/sandbox-proxy?v=1";
+
+    it("resolves relative requests against the proxy URL", async () => {
+      await expect(
+        fetchAllowed(["http://127.0.0.1:6274"], "/api/data", PROXY_URL),
+      ).resolves.toBe(true);
+    });
+
+    it("matches 'self' against the proxy origin", async () => {
+      await expect(
+        fetchAllowed(["'self'"], "http://127.0.0.1:6274/api/data", PROXY_URL),
+      ).resolves.toBe(true);
+    });
+
+    it("resolves relative requests against document.baseURI (srcdoc fallback)", async () => {
       await expect(
         fetchAllowed(
           ["https://widget.example.test"],
@@ -674,7 +692,7 @@ describe("sandbox-proxy connect guard — CSP source matching", () => {
       ).resolves.toBe(true);
     });
 
-    it("matches 'self' against document.baseURI origin", async () => {
+    it("matches 'self' against document.baseURI origin (srcdoc fallback)", async () => {
       await expect(
         fetchAllowed(
           ["'self'"],

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-mount.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-mount.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Sandbox Proxy mount tests.
+ *
+ * `mountInner` / `createInnerFrame` live inline in `sandbox-proxy.html` (they
+ * run in the proxy iframe, not Node). We lift them out of the HTML with the
+ * same brace-walking extractor `sandbox-proxy-buildCSP.test.ts` uses and
+ * evaluate them against a jsdom document.
+ *
+ * What is pinned here: the frame is created with its final `sandbox=` /
+ * `allow=` BEFORE insertion (both are fixed at document creation), the
+ * previous frame is removed and the `inner` binding repointed, the explicit
+ * `"srcdoc"` mount mode and the opaque-origin fallback both assign `srcdoc`,
+ * and a nested `sandbox-proxy-ready` (a widget reloading itself) remounts
+ * from the cached arguments instead of being relayed.
+ *
+ * What is NOT pinned here: that the written document takes the proxy's URL.
+ * jsdom's `document.open()` only clears child nodes — it models neither the
+ * URL adoption nor the listener reset the HTML spec's document-open steps
+ * require — so that property is asserted in the browser e2e, not here.
+ */
+import { describe, it, expect, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { JSDOM } from "jsdom";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const html = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    "..",
+    "routes",
+    "apps",
+    "mcp-apps",
+    "sandbox-proxy.html",
+  ),
+  "utf8",
+);
+
+function extract(name: string): string {
+  const sig = new RegExp(`function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`);
+  const m = sig.exec(html);
+  if (!m) throw new Error(`Could not extract function ${name}`);
+  let i = m.index + m[0].length;
+  let depth = 1;
+  while (i < html.length && depth > 0) {
+    const ch = html[i++];
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+  }
+  if (depth !== 0) throw new Error(`Unbalanced braces in ${name}`);
+  return html.slice(m.index, i);
+}
+
+const applyColorSchemeSrc = extract("applyColorScheme");
+const createInnerFrameSrc = extract("createInnerFrame");
+const mountInnerSrc = extract("mountInner");
+
+interface MountHarness {
+  mountInner: (
+    html: string,
+    sandboxValue: string,
+    allowValue: string,
+    colorScheme: unknown,
+    mountMode?: "write" | "srcdoc",
+  ) => "url" | "srcdoc" | "srcdoc-fallback";
+  createInnerFrame: (
+    sandboxValue: string,
+    allowValue: string,
+  ) => HTMLIFrameElement;
+  getInner: () => HTMLIFrameElement | null;
+  getLastMount: () => Record<string, unknown> | null;
+  setInner: (frame: HTMLIFrameElement | null) => void;
+}
+
+/**
+ * Rehydrate the proxy's mount helpers against a jsdom document, with the
+ * top-level `inner` / `lastMount` bindings they close over.
+ */
+function harness(): { dom: JSDOM; h: MountHarness } {
+  const dom = new JSDOM(
+    "<!doctype html><html><head></head><body></body></html>",
+    {
+      url: "http://127.0.0.1:6274/api/apps/mcp-apps/sandbox-proxy?v=1",
+    },
+  );
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const factory = new Function(
+    "document",
+    `
+    const INNER_STYLE = "width:100%; height:100%; border:none;";
+    let inner = null;
+    let lastMount = null;
+    ${applyColorSchemeSrc}
+    ${createInnerFrameSrc}
+    ${mountInnerSrc}
+    return {
+      mountInner,
+      createInnerFrame,
+      getInner: () => inner,
+      getLastMount: () => lastMount,
+      setInner: (frame) => { inner = frame; },
+    };
+    `,
+  ) as (document: Document) => MountHarness;
+  return { dom, h: factory(dom.window.document) };
+}
+
+const WIDGET = "<!doctype html><html><body><p id='w'>hi</p></body></html>";
+
+describe("sandbox-proxy createInnerFrame", () => {
+  it("sets sandbox and allow on the element without appending it", () => {
+    const { dom, h } = harness();
+    const frame = h.createInnerFrame(
+      "allow-scripts allow-same-origin",
+      "camera *",
+    );
+    expect(frame.getAttribute("sandbox")).toBe(
+      "allow-scripts allow-same-origin",
+    );
+    expect(frame.getAttribute("allow")).toBe("camera *");
+    expect(frame.isConnected).toBe(false);
+    expect(dom.window.document.querySelectorAll("iframe")).toHaveLength(0);
+  });
+
+  it("omits allow when there are no permissions", () => {
+    const { h } = harness();
+    const frame = h.createInnerFrame("allow-scripts allow-same-origin", "");
+    expect(frame.hasAttribute("allow")).toBe(false);
+  });
+});
+
+describe("sandbox-proxy mountInner", () => {
+  it("writes the HTML into a fresh frame that carries its attributes at insertion", () => {
+    const { dom, h } = harness();
+    const body = dom.window.document.body;
+    const seen: Array<{ sandbox: string | null; allow: string | null }> = [];
+    const realAppend = body.appendChild.bind(body);
+    vi.spyOn(body, "appendChild").mockImplementation((node: Node) => {
+      const el = node as HTMLIFrameElement;
+      seen.push({
+        sandbox: el.getAttribute("sandbox"),
+        allow: el.getAttribute("allow"),
+      });
+      return realAppend(node);
+    });
+
+    const mode = h.mountInner(
+      WIDGET,
+      "allow-forms allow-same-origin allow-scripts",
+      "geolocation *",
+      "dark",
+    );
+
+    expect(mode).toBe("url");
+    expect(seen).toEqual([
+      {
+        sandbox: "allow-forms allow-same-origin allow-scripts",
+        allow: "geolocation *",
+      },
+    ]);
+    const inner = h.getInner()!;
+    expect(inner.isConnected).toBe(true);
+    expect(inner.hasAttribute("srcdoc")).toBe(false);
+    expect(inner.contentDocument!.querySelector("#w")!.textContent).toBe("hi");
+    expect(inner.style.colorScheme).toBe("dark");
+    expect(dom.window.document.documentElement.style.colorScheme).toBe("dark");
+    expect(h.getLastMount()).toEqual({
+      html: WIDGET,
+      sandboxValue: "allow-forms allow-same-origin allow-scripts",
+      allowValue: "geolocation *",
+      colorScheme: "dark",
+      mountMode: undefined,
+    });
+  });
+
+  it("removes the previous frame and repoints `inner` on every mount", () => {
+    const { dom, h } = harness();
+    const placeholder = h.createInnerFrame(
+      "allow-scripts allow-same-origin",
+      "",
+    );
+    dom.window.document.body.appendChild(placeholder);
+    h.setInner(placeholder);
+
+    h.mountInner(WIDGET, "allow-same-origin allow-scripts", "", "light");
+    const first = h.getInner()!;
+    expect(placeholder.isConnected).toBe(false);
+    expect(first).not.toBe(placeholder);
+
+    h.mountInner(WIDGET, "allow-same-origin allow-scripts", "", "light");
+    const second = h.getInner()!;
+    expect(first.isConnected).toBe(false);
+    expect(second).not.toBe(first);
+    expect(dom.window.document.querySelectorAll("iframe")).toHaveLength(1);
+  });
+
+  it('assigns srcdoc when the host asks for mountMode "srcdoc"', () => {
+    const { h } = harness();
+    const mode = h.mountInner(
+      WIDGET,
+      "allow-same-origin allow-scripts",
+      "",
+      "light",
+      "srcdoc",
+    );
+    expect(mode).toBe("srcdoc");
+    expect(h.getInner()!.getAttribute("srcdoc")).toBe(WIDGET);
+    expect(h.getLastMount()!.mountMode).toBe("srcdoc");
+  });
+
+  it("falls back to srcdoc when the frame's document is unreachable", () => {
+    const { dom, h } = harness();
+    const doc = dom.window.document;
+    const create = doc.createElement.bind(doc);
+    vi.spyOn(doc, "createElement").mockImplementation((tag: string) => {
+      const el = create(tag);
+      if (tag === "iframe") {
+        // An opaque-origin frame exposes no contentDocument.
+        Object.defineProperty(el, "contentDocument", { get: () => null });
+      }
+      return el;
+    });
+
+    const mode = h.mountInner(WIDGET, "allow-scripts", "", "light");
+    expect(mode).toBe("srcdoc-fallback");
+    expect(h.getInner()!.getAttribute("srcdoc")).toBe(WIDGET);
+  });
+
+  it("normalizes an unknown color scheme to light dark", () => {
+    const { h } = harness();
+    h.mountInner(WIDGET, "allow-same-origin allow-scripts", "", "sepia");
+    expect(h.getInner()!.style.colorScheme).toBe("light dark");
+  });
+});
+
+describe("sandbox-proxy nested sandbox-proxy-ready guard", () => {
+  // The relay branch is inline in the listener (not a named function), so
+  // pin the contract at the source level: the guard precedes the relay
+  // allow-list and remounts from `lastMount` rather than forwarding.
+  it("remounts instead of relaying a nested proxy-ready", () => {
+    const guardIdx = html.indexOf(
+      'data.method === "ui/notifications/sandbox-proxy-ready"',
+    );
+    const relayIdx = html.indexOf('data.type === "mcp-apps:csp-violation"');
+    expect(guardIdx).toBeGreaterThan(0);
+    expect(relayIdx).toBeGreaterThan(guardIdx);
+    const guard = html.slice(guardIdx, relayIdx);
+    expect(guard).toContain("mountInner(");
+    expect(guard).toContain("lastMount.html");
+    expect(guard).toContain("return;");
+    expect(guard).not.toContain("window.parent.postMessage");
+  });
+});

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-mount.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-mount.test.ts
@@ -55,6 +55,7 @@ function extract(name: string): string {
 const applyColorSchemeSrc = extract("applyColorScheme");
 const createInnerFrameSrc = extract("createInnerFrame");
 const mountInnerSrc = extract("mountInner");
+const remountLastSrc = extract("remountLast");
 
 interface MountHarness {
   mountInner: (
@@ -94,6 +95,7 @@ function harness(): { dom: JSDOM; h: MountHarness } {
     ${applyColorSchemeSrc}
     ${createInnerFrameSrc}
     ${mountInnerSrc}
+    ${remountLastSrc}
     return {
       mountInner,
       createInnerFrame,
@@ -234,6 +236,66 @@ describe("sandbox-proxy mountInner", () => {
   });
 });
 
+describe("sandbox-proxy blank-reload remount", () => {
+  // Chromium answers location.reload() in a written document by reloading
+  // the initial about:blank entry. jsdom cannot reload a frame, so the
+  // frame's post-navigation state is stubbed and the `load` event fired
+  // by hand; the listener's decision rule is what is under test.
+  function loadWith(frame: HTMLIFrameElement, href: string | Error) {
+    Object.defineProperty(frame, "contentWindow", {
+      configurable: true,
+      get: () => ({
+        get location() {
+          if (href instanceof Error) throw href;
+          return { href };
+        },
+      }),
+    });
+    frame.dispatchEvent(new frame.ownerDocument.defaultView!.Event("load"));
+  }
+
+  it("remounts the last view when the frame comes back as about:blank", () => {
+    const { h } = harness();
+    h.mountInner(WIDGET, "allow-same-origin allow-scripts", "camera *", "dark");
+    const before = h.getInner()!;
+    loadWith(before, "about:blank");
+    const after = h.getInner()!;
+    expect(after).not.toBe(before);
+    expect(before.isConnected).toBe(false);
+    expect(after.getAttribute("allow")).toBe("camera *");
+    expect(after.contentDocument!.querySelector("#w")!.textContent).toBe("hi");
+  });
+
+  it("leaves the frame alone after its own write (href is the proxy URL)", () => {
+    const { h } = harness();
+    h.mountInner(WIDGET, "allow-same-origin allow-scripts", "", "light");
+    const frame = h.getInner()!;
+    loadWith(
+      frame,
+      "http://127.0.0.1:6274/api/apps/mcp-apps/sandbox-proxy?v=1",
+    );
+    expect(h.getInner()).toBe(frame);
+  });
+
+  it("leaves a widget's own cross-origin navigation alone", () => {
+    const { h } = harness();
+    h.mountInner(WIDGET, "allow-same-origin allow-scripts", "", "light");
+    const frame = h.getInner()!;
+    loadWith(frame, new Error("SecurityError"));
+    expect(h.getInner()).toBe(frame);
+  });
+
+  it("ignores a load from a frame that is no longer current", () => {
+    const { h } = harness();
+    h.mountInner(WIDGET, "allow-same-origin allow-scripts", "", "light");
+    const stale = h.getInner()!;
+    h.mountInner(WIDGET, "allow-same-origin allow-scripts", "", "light");
+    const current = h.getInner()!;
+    loadWith(stale, "about:blank");
+    expect(h.getInner()).toBe(current);
+  });
+});
+
 describe("sandbox-proxy nested sandbox-proxy-ready guard", () => {
   // The relay branch is inline in the listener (not a named function), so
   // pin the contract at the source level: the guard precedes the relay
@@ -246,8 +308,7 @@ describe("sandbox-proxy nested sandbox-proxy-ready guard", () => {
     expect(guardIdx).toBeGreaterThan(0);
     expect(relayIdx).toBeGreaterThan(guardIdx);
     const guard = html.slice(guardIdx, relayIdx);
-    expect(guard).toContain("mountInner(");
-    expect(guard).toContain("lastMount.html");
+    expect(guard).toContain("remountLast();");
     expect(guard).toContain("return;");
     expect(guard).not.toContain("window.parent.postMessage");
   });

--- a/mcpjam-inspector/server/routes/apps/__tests__/sandbox-proxy-routes.test.ts
+++ b/mcpjam-inspector/server/routes/apps/__tests__/sandbox-proxy-routes.test.ts
@@ -24,6 +24,12 @@ describe("Sandbox proxy routes", () => {
     expect(body).toContain('(guardScript || "") +');
     expect(body).toContain("cspMeta +");
     expect(body).toContain("violationListener;");
+    // The view is mounted by document.write into a fresh frame, never by
+    // assigning the processed HTML to srcdoc (that path is the opaque-origin
+    // fallback inside mountInner only).
+    expect(body).toContain("function mountInner");
+    expect(body).toContain("function createInnerFrame");
+    expect(body).not.toContain("inner.srcdoc = processedHtml");
     expect(body).not.toContain("recorder:proxy-status");
     expect(body).not.toContain(
       'const RECORDER_SHIM = "__MCPJAM_RECORDER_SHIM__";'

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -872,6 +872,28 @@ document.addEventListener('securitypolicyviolation', function(e) {
           doc.write(html);
           doc.close();
           mode = "url";
+          // Chromium answers location.reload() in a written document by
+          // reloading the frame's history entry — the initial about:blank —
+          // which leaves a blank frame and tells nobody. Remount when the
+          // frame comes back blank. (Engines that reload the document URL
+          // instead land on a nested copy of this proxy; that case is
+          // caught by the sandbox-proxy-ready guard in the relay.) Any
+          // other navigation the widget made — a real href, cross-origin
+          // (location unreadable) — is the widget's own business.
+          // Attached after the write so the frame's own load events only
+          // ever observe the written document, never the pre-write blank.
+          next.addEventListener("load", function () {
+            if (inner !== next || !lastMount) return;
+            let href;
+            try {
+              href = next.contentWindow.location.href;
+            } catch (error) {
+              return;
+            }
+            if (href === "about:blank") {
+              remountLast();
+            }
+          });
         } else {
           next.srcdoc = html;
           mode = mountMode === "srcdoc" ? "srcdoc" : "srcdoc-fallback";
@@ -883,6 +905,21 @@ document.addEventListener('securitypolicyviolation', function(e) {
         next.style.colorScheme = applyColorScheme(colorScheme);
         lastMount = { html, sandboxValue, allowValue, colorScheme, mountMode };
         return mode;
+      }
+
+      /**
+       * Mount the most recent view again (a widget reloaded itself).
+       * @returns {"url" | "srcdoc" | "srcdoc-fallback" | "none"}
+       */
+      function remountLast() {
+        if (!lastMount) return "none";
+        return mountInner(
+          lastMount.html,
+          lastMount.sandboxValue,
+          lastMount.allowValue,
+          lastMount.colorScheme,
+          lastMount.mountMode,
+        );
       }
 
       // The current inner view frame. Replaced on every mount (see mountInner);
@@ -1092,21 +1129,15 @@ document.addEventListener('securitypolicyviolation', function(e) {
               data.jsonrpc === "2.0" &&
               data.method === "ui/notifications/sandbox-proxy-ready"
             ) {
-              // The view lives at this proxy's URL, so a widget calling
-              // location.reload() reloads THIS document inside the inner
-              // frame; that nested proxy announces itself here. The host
-              // has nothing to do with it (relaying would leave a blank
-              // frame) — remount the last view instead, which is the
-              // restart a widget author expects from reload().
-              if (lastMount) {
-                mountInner(
-                  lastMount.html,
-                  lastMount.sandboxValue,
-                  lastMount.allowValue,
-                  lastMount.colorScheme,
-                  lastMount.mountMode,
-                );
-              }
+              // The view lives at this proxy's URL, so an engine that
+              // answers a widget's location.reload() by reloading the
+              // document URL loads THIS proxy inside the inner frame, and
+              // that nested proxy announces itself here. The host has
+              // nothing to do with it (relaying would leave a blank frame)
+              // — remount the last view instead, which is the restart a
+              // widget author expects. Chromium reloads about:blank
+              // instead; see the load listener in mountInner.
+              remountLast();
               return;
             }
             if (

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -3,11 +3,12 @@
   <head>
     <meta charset="utf-8" />
     <meta name="color-scheme" content="light dark" />
-    <!-- Permissive CSP so nested srcdoc content is not constrained by host CSP.
+    <!-- Permissive CSP so the inner view is not constrained by host CSP.
          The actual security enforcement is done by the dynamically-generated CSP
-         injected into the inner srcdoc iframe based on widget declarations (SEP-1865).
-         This outer CSP must allow external scripts since srcdoc network requests
-         are subject to the parent document's CSP. -->
+         injected into the inner view's HTML based on widget declarations (SEP-1865).
+         The view is written into a blank same-origin iframe (see mountInner), so
+         it inherits this document's policy container — this outer CSP must
+         therefore allow everything the widget-declared CSP might allow. -->
     <meta
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; img-src * data: blob: 'unsafe-inline'; media-src * blob: data:; font-src * blob: data:; script-src * 'wasm-unsafe-eval' 'unsafe-inline' 'unsafe-eval' blob: data:; style-src * blob: data: 'unsafe-inline'; connect-src * data: blob: about:; frame-src * blob: data: http://localhost:* https://localhost:* http://127.0.0.1:* https://127.0.0.1:*;"
@@ -47,10 +48,13 @@
        * Host Page → Sandbox Proxy (this page, different origin) → Guest UI
        *
        * This proxy:
-       * 1. Creates inner iframe immediately
+       * 1. Creates a placeholder inner iframe immediately
        * 2. Waits for HTML content via ui/notifications/sandbox-resource-ready
        * 3. Builds CSP from metadata and injects into HTML
-       * 4. Loads HTML via srcdoc with configurable sandbox attributes
+       * 4. Mounts the HTML into a FRESH inner iframe by writing it into the
+       *    frame's blank document (document.open/write/close) so the view
+       *    runs at a real URL — this proxy's URL — instead of about:srcdoc.
+       *    `srcdoc` is kept only as the opaque-origin fallback. See mountInner.
        * 5. Forwards all non-sandbox messages between host and guest
        *
        * Reference: https://gist.github.com/ochafik/a9603ba2d6757d6038ce066eded4c354
@@ -74,8 +78,10 @@
        * @param {Object} permissions - Permissions metadata (camera, microphone, geolocation, clipboardWrite)
        * @returns {string} Permission Policy allow attribute string
        *
-       * Note: For srcdoc iframes, we use '*' allowlist since they don't have a defined origin.
-       * This allows the sandboxed content to request these permissions.
+       * Note: the '*' allowlist predates the document.write mount, when the
+       * inner frame had no defined origin. The view now runs at this proxy's
+       * origin, so the list could be scoped to it; '*' is kept so behavior is
+       * unchanged for every host profile that pins these permissions.
        */
       function buildAllowAttribute(permissions) {
         if (!permissions) return "";
@@ -153,8 +159,10 @@
         }
 
         // Per SEP-1865: If no CSP declared, use restrictive defaults
-        // Note: 'self' doesn't work in srcdoc iframes (refers to about:srcdoc)
-        // So we use 'unsafe-inline' for scripts/styles since all widget code is inline
+        // Note: 'self' names this proxy's origin (the view is written into a
+        // same-origin frame, see mountInner), which is never where widget
+        // assets live — so 'unsafe-inline' carries scripts/styles, since all
+        // widget code is inline.
         let directives;
         if (!csp) {
           // Two baselines for the no-csp branch:
@@ -439,10 +447,11 @@ document.addEventListener('securitypolicyviolation', function(e) {
     }
     catch (_) { return null; }
   }
-  // Scheme/origin of the document the emulated policy protects. A srcdoc frame's
-  // location is about:srcdoc, but its baseURI inherits the embedding proxy
-  // document; that is the origin CSP would evaluate against. Falling back to
-  // "" makes schemeless expressions match nothing, which fails closed.
+  // Scheme/origin of the document the emulated policy protects. The view is
+  // written into a same-origin frame, so its baseURI is the proxy URL (the
+  // srcdoc fallback inherits the same baseURI); that is the origin CSP would
+  // evaluate against. Falling back to "" makes schemeless expressions match
+  // nothing, which fails closed.
   var protectedScheme = protectedBaseUrl
     ? protectedBaseUrl.protocol.slice(0, -1).toLowerCase()
     : "";
@@ -788,15 +797,107 @@ document.addEventListener('securitypolicyviolation', function(e) {
         return colorScheme;
       }
 
-      // Create inner iframe immediately (before HTML arrives)
-      const inner = document.createElement("iframe");
-      inner.style =
+      const INNER_STYLE =
         "width:100%; height:100%; border:none; background-color:transparent; color-scheme:light dark;";
+
+      /**
+       * Build the inner view iframe with its final `sandbox=` / `allow=`
+       * attributes, NOT yet appended. Both attributes are fixed when the
+       * frame's document is created (on insertion), and document.open()
+       * reuses that document without re-evaluating either — so a frame can
+       * never be re-attributed in place, only replaced. See mountInner.
+       * @param {string} sandboxValue - Space-separated sandbox tokens
+       * @param {string} allowValue - Permission Policy allow attribute ("" for none)
+       * @returns {HTMLIFrameElement}
+       */
+      function createInnerFrame(sandboxValue, allowValue) {
+        const frame = document.createElement("iframe");
+        frame.style = INNER_STYLE;
+        frame.setAttribute("sandbox", sandboxValue);
+        if (allowValue) {
+          frame.setAttribute("allow", allowValue);
+        }
+        return frame;
+      }
+
+      /**
+       * Mount processed widget HTML into a fresh inner iframe.
+       *
+       * The HTML is written into the new frame's initial about:blank document
+       * (document.open/write/close) rather than assigned to `srcdoc`. Per the
+       * HTML spec's document-open steps the written document takes the ENTRY
+       * document's URL — this proxy's — so the view has a real URL and origin:
+       * `location.href`, `document.URL`, canvas taint rules and third-party
+       * referrer allowlists (Google Maps, OAuth redirect matching) all see the
+       * sandbox origin instead of `about:srcdoc`. This is how claude.ai's proxy
+       * mounts views; our eval browser harness already does the same.
+       *
+       * A new frame per mount (old one removed afterwards) means a re-send is
+       * a clean restart — old Window, timers and listeners are gone — and the
+       * `sandbox=` / `allow=` attributes are genuinely applied (see
+       * createInnerFrame). Late messages from the removed frame fail the
+       * `event.source === inner.contentWindow` check and are dropped.
+       *
+       * `srcdoc` remains for two cases: the frame's document is unreachable
+       * (opaque origin — cannot happen while `allow-same-origin` is force-added
+       * above, kept as defense in depth), or the host asked for it via
+       * `mountMode: "srcdoc"` (a build-time test hook for this branch).
+       *
+       * Note: a document written this way is parsed like any navigated HTML
+       * document — without a `<!DOCTYPE html>` it renders in quirks mode,
+       * whereas a srcdoc document never does. That matches claude.ai.
+       *
+       * @param {string} html - Processed widget HTML (CSP + shims injected)
+       * @param {string} sandboxValue - Final inner `sandbox=` value
+       * @param {string} allowValue - Final inner `allow=` value ("" for none)
+       * @param {unknown} colorScheme - Host theme for applyColorScheme
+       * @param {"write" | "srcdoc" | undefined} mountMode - Mount strategy
+       * @returns {"url" | "srcdoc" | "srcdoc-fallback"} How the view was mounted
+       */
+      function mountInner(
+        html,
+        sandboxValue,
+        allowValue,
+        colorScheme,
+        mountMode,
+      ) {
+        const next = createInnerFrame(sandboxValue, allowValue);
+        // Appending creates the frame's initial about:blank document
+        // synchronously, same-origin with this proxy.
+        document.body.appendChild(next);
+        const doc = mountMode === "srcdoc" ? null : next.contentDocument;
+        let mode;
+        if (doc) {
+          doc.open();
+          doc.write(html);
+          doc.close();
+          mode = "url";
+        } else {
+          next.srcdoc = html;
+          mode = mountMode === "srcdoc" ? "srcdoc" : "srcdoc-fallback";
+        }
+        if (inner && inner !== next) {
+          inner.remove();
+        }
+        inner = next;
+        next.style.colorScheme = applyColorScheme(colorScheme);
+        lastMount = { html, sandboxValue, allowValue, colorScheme, mountMode };
+        return mode;
+      }
+
+      // The current inner view frame. Replaced on every mount (see mountInner);
+      // the message relay below reads this binding live.
+      let inner = null;
+      // Arguments of the most recent mount, replayed when a widget reloads
+      // itself (see the nested sandbox-proxy-ready guard in the relay).
+      let lastMount = null;
+
+      // Placeholder frame before HTML arrives, so layout and color-scheme
+      // behave as they always have. Replaced by the first mount.
       applyColorScheme("light dark");
-      // Default minimal sandbox before HTML arrives
-      inner.setAttribute(
-        "sandbox",
-        "allow-scripts allow-same-origin allow-forms"
+      inner = createInnerFrame(
+        "allow-scripts allow-same-origin allow-forms",
+        "",
       );
       document.body.appendChild(inner);
 
@@ -830,6 +931,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
               colorScheme,
               recordMode,
               recorderDebug: nextRecorderDebug,
+              mountMode,
             } = event.data.params || {};
             recorderDebugEnabled = !!nextRecorderDebug;
             try {
@@ -841,7 +943,6 @@ document.addEventListener('securitypolicyviolation', function(e) {
             } catch (error) {
               // debug flag propagation is best-effort
             }
-            inner.style.colorScheme = applyColorScheme(colorScheme);
             // Tier 2: inject the recorder shim into the guest when recording.
             const recorderScript = buildRecorderScript(recordMode);
             const connectGuardScript = buildConnectGuardScript(
@@ -897,10 +998,8 @@ document.addEventListener('securitypolicyviolation', function(e) {
               sandboxTokens.add("allow-scripts");
               sandboxTokens.add("allow-same-origin");
             }
-            inner.setAttribute(
-              "sandbox",
-              Array.from(sandboxTokens).sort().join(" ")
-            );
+            // Applied by createInnerFrame on the fresh frame (never in place).
+            const sandboxValue = Array.from(sandboxTokens).sort().join(" ");
 
             // Set Permission Policy `allow=` attribute for the inner iframe
             // from the requested spec-4 permissions only (SEP-1865:
@@ -912,14 +1011,12 @@ document.addEventListener('securitypolicyviolation', function(e) {
             // pattern: outer grants extras for the wrapper, inner trims to
             // spec so the widget only experiences what's documented.
             const baseAllow = buildAllowAttribute(permissions);
-            if (baseAllow) {
-              inner.setAttribute("allow", baseAllow);
-            }
 
             if (typeof html === "string") {
               if (permissive) {
                 // Permissive mode: inject maximally permissive CSP
-                // Must explicitly allow everything since srcdoc inherits parent CSP
+                // Must explicitly allow everything since the view inherits this
+                // document's policy container (see mountInner).
                 const permissiveCsp = [
                   "default-src * 'unsafe-inline' 'unsafe-eval' data: blob: filesystem: about:",
                   "script-src * 'unsafe-inline' 'unsafe-eval' data: blob:",
@@ -939,7 +1036,14 @@ document.addEventListener('securitypolicyviolation', function(e) {
                   recorderScript,
                   browserStorageGuardScript
                 );
-                inner.srcdoc = processedHtml;
+                const mode = mountInner(
+                  processedHtml,
+                  sandboxValue,
+                  baseAllow,
+                  colorScheme,
+                  mountMode,
+                );
+                recorderDebug("view mounted", { mode });
               } else {
                 // Build CSP and inject into HTML (SEP-1865). cspDirectives
                 // is the inspector-only per-directive source-expression
@@ -951,7 +1055,14 @@ document.addEventListener('securitypolicyviolation', function(e) {
                   recorderScript,
                   connectGuardScript + browserStorageGuardScript
                 );
-                inner.srcdoc = processedHtml;
+                const mode = mountInner(
+                  processedHtml,
+                  sandboxValue,
+                  baseAllow,
+                  colorScheme,
+                  mountMode,
+                );
+                recorderDebug("view mounted", { mode });
               }
             }
           } else if (
@@ -961,6 +1072,9 @@ document.addEventListener('securitypolicyviolation', function(e) {
           ) {
             const { colorScheme } = event.data.params || {};
             inner.style.colorScheme = applyColorScheme(colorScheme);
+            if (lastMount) {
+              lastMount.colorScheme = colorScheme;
+            }
           } else {
             // Forward other messages to inner iframe (guest UI)
             if (inner && inner.contentWindow) {
@@ -974,6 +1088,27 @@ document.addEventListener('securitypolicyviolation', function(e) {
           // from reaching PostMessageTransport and causing parse errors.
           var data = event.data;
           if (data && typeof data === "object") {
+            if (
+              data.jsonrpc === "2.0" &&
+              data.method === "ui/notifications/sandbox-proxy-ready"
+            ) {
+              // The view lives at this proxy's URL, so a widget calling
+              // location.reload() reloads THIS document inside the inner
+              // frame; that nested proxy announces itself here. The host
+              // has nothing to do with it (relaying would leave a blank
+              // frame) — remount the last view instead, which is the
+              // restart a widget author expects from reload().
+              if (lastMount) {
+                mountInner(
+                  lastMount.html,
+                  lastMount.sandboxValue,
+                  lastMount.allowValue,
+                  lastMount.colorScheme,
+                  lastMount.mountMode,
+                );
+              }
+              return;
+            }
             if (
               data.jsonrpc === "2.0" ||
               data.type === "mcp-apps:csp-violation" ||


### PR DESCRIPTION
## Why

A customer building an MCP App with the Google Maps JS API (referrer-restricted key) hit `RefererNotAllowedMapError` in MCPJam: the sandbox proxy loaded the view via `iframe.srcdoc`, so inside the widget `location.href` was `about:srcdoc`. Anything keyed on the page URL failed — Maps' referrer check, canvas taint rules, OAuth redirect matching. There was no origin they could allowlist.

claude.ai's proxy (`https://<hash>.claudemcpcontent.com/mcp_apps`, publicly readable) and the ext-apps reference host both mount views by **writing the HTML into a blank same-origin iframe** instead. Per the HTML spec's document-open steps, the written document takes the *entry document's* URL — the proxy's — so the view has a real URL and origin. Our eval browser harness already renders this way (`browser-harness/host-page.ts`).

This is step 1A of the plan; it unblocks the customer on its own. Follow-ups (separate PRs): view-mode chip in the Sandbox Stack tab, host-origin pinning + `frame-ancestors` helper, checked-in e2e, `_meta.ui.domain` surfacing, per-app proxy origins.

## What changed

`server/routes/apps/mcp-apps/sandbox-proxy.html` only (plus tests):

- **`mountInner()`** — per render, a *fresh* `<iframe>` with the final `sandbox=`/`allow=` set **before** insertion (both are fixed when the frame's document is created and `document.open()` re-evaluates neither — Claude's proxy sets `allow` on the live frame and gets this wrong), the processed HTML written into its blank document, the previous frame removed. A re-send is therefore a clean restart. `srcdoc` survives only as the opaque-origin fallback (`contentDocument === null`) and behind an explicit `mountMode: "srcdoc"` param (test hook for that branch; nothing sends it yet).
- **Widget-initiated reload.** Verified in Chromium: `location.reload()` inside a written document reloads the frame's history entry — the initial `about:blank` — leaving a blank frame with no signal. A `load` listener on each written frame remounts the last view when the frame comes back as `about:blank`; a real href or a cross-origin navigation is left alone. A nested `sandbox-proxy-ready` (engines that reload the document URL instead) is caught in the relay and answered by remounting rather than forwarded to the host.
- CSP `<meta>` injection, recorder shim, connect/storage guards: **untouched**. The written document inherits the proxy's policy container exactly as the srcdoc one did.

**Behaviour change to release-note:** a doctype-less widget now renders in **quirks mode** (a srcdoc document never does — HTML parsing "initial" insertion mode). This matches claude.ai; a readiness lint for it is a follow-up.

## Verification

- `npm run test -w @mcpjam/inspector -- sandbox-proxy` — 7 files / 113 tests green (new `sandbox-proxy-mount.test.ts`: attributes at insertion, frame replacement, srcdoc mode + opaque fallback, blank-reload remount rules, nested proxy-ready guard; connect-guard base-URL cases now cover the proxy URL; routes test pins that processed HTML is never assigned to srcdoc).
- jsdom does **not** model URL adoption (`document.open()` only clears children there), so that property was proven in real Chromium with a scratch Playwright script against the proxy served from a static server:
  - inside the widget: `location.href` = `http://127.0.0.1:<port>/api/apps/mcp-apps/sandbox-proxy?v=1`, no `srcdoc` attribute, `sandbox="allow-forms allow-same-origin allow-scripts"`
  - `Referer` received by a same-origin fetch = that URL
  - `securitypolicyviolation` still fires for an undeclared `connect-src` after the write
  - re-send → new frame; `location.reload()` inside the widget → remounted widget (was a blank frame before the second commit)
  - `<html>` without doctype → `document.compatMode === "BackCompat"`

## Reviewer notes

- `mountInner` returns `"url" | "srcdoc" | "srcdoc-fallback"` (the plan said two values; distinguishing an explicit srcdoc mode from a fallback keeps the future chip honest).
- Helper functions are top-level `function` declarations because the tests brace-walk them out of the HTML.
- Pre-existing prettier drift in these files is untouched; only my own lines are formatted.
- Customer guidance once merged: allowlist `http://localhost:*` and `http://127.0.0.1:*` locally and `https://sandbox.mcpjam.com` hosted; still declare the Maps domains in `_meta.ui.csp` (`resourceDomains` for script + tiles, `connectDomains` for XHR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core iframe mounting and navigation/reload handling in the MCP Apps security boundary; behavior shifts URL/referrer semantics and quirks mode, though CSP injection and sandbox rules are largely preserved with added remount logic.
> 
> **Overview**
> MCP App widget HTML is no longer loaded with **`iframe.srcdoc`** (which exposed `about:srcdoc` and broke referrer-restricted APIs like Google Maps). The sandbox proxy now **`mountInner`s** each render into a **new inner iframe** with final **`sandbox` / `allow` set before append**, then **`document.open` / `write` / `close`** so the guest document adopts the **proxy URL** and a real origin.
> 
> **Reload and remount behavior** is new: a **`load` listener** remounts from cached **`lastMount`** when Chromium leaves the frame at **`about:blank`** after `location.reload()`, and a nested **`sandbox-proxy-ready`** from the inner frame triggers **`remountLast()`** instead of forwarding to the host. **`srcdoc`** remains only for opaque-origin fallback or optional **`mountMode: "srcdoc"`**.
> 
> Tests add **`sandbox-proxy-mount.test.ts`**, extend CSP connect-guard cases for the proxy document URL, and assert the served HTML never assigns **`inner.srcdoc = processedHtml`**. **Note:** doctype-less widgets may render in **quirks mode** under the write path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74d76b14862d3c79e335f192d148e1833a40610f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
MCP App views in the sandbox proxy now run at a real URL instead of `about:srcdoc`, which unblocks widgets keyed on the page URL — Google Maps referrer checks, canvas taint rules, OAuth redirect matching. The proxy writes widget HTML into a fresh blank same-origin iframe, matching how claude.ai mounts views.

- `srcdoc` remains only as an opaque-origin fallback and an explicit `mountMode` test hook.
- A widget-initiated reload restarts the view instead of leaving a blank frame.
- Re-sending a view is a clean restart: the previous frame, its timers, and listeners are removed.
- A doctype-less widget now renders in quirks mode (srcdoc documents never do).

<sup>Written for commit 74d76b14862d3c79e335f192d148e1833a40610f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

