### PR TITLE
B3b W4 re-land: retire the browser's re-derivation of a graded verdict

### DIFF
--- a/.changeset/retire-client-verdict-rederivation.md
+++ b/.changeset/retire-client-verdict-rederivation.md
@@ -1,0 +1,31 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Stop re-grading eval iterations in the browser.
+
+The run-detail view used to re-run the tool-call matcher over an iteration's
+`actualToolCalls` and compute its own pass/fail — a second grader, in a second
+implementation, over evidence the server had already graded. It only deferred
+to the stored verdict when `resultSource` was exactly `"reported"`; a `derived`
+row was re-derived client-side every time.
+
+A stored terminal `result` is now the only source for a row that has one.
+
+This matters more than it used to. Under the versioned score contract at
+grading mode `enforce`, an iteration's verdict comes from its gating score rows
+— predicates, gates, tool errors, the whole set — and the browser can see none
+of that. It sees the tool calls. Re-deriving from them is not a check on the
+server; it is a different answer to the same question, reached with less
+information, and the two silently disagreeing is exactly the failure this
+removes.
+
+The matcher itself is untouched and still runs where there is nothing stored to
+defer to: legacy rows that never persisted a result (falling back to "failed"
+would silently re-grade years of history), and the live-grading preview, whose
+synthetic per-turn rows were never persisted at all. What retires is the
+unverified re-derivation of an iteration that has already been graded — not the
+matcher, and not the evaluation.
+
+This one is not behind a flag. Restoring the old behaviour means reverting this
+change.

--- a/mcpjam-inspector/client/src/components/evals/__tests__/stored-result-authority.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/stored-result-authority.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test, vi } from "vitest";
+
+// The matcher is spied at the module boundary, so "was it invoked?" is a fact
+// about the call graph rather than about a value that happened to agree. That
+// is the whole assertion here: a row with a stored result must not be RE-GRADED
+// in the browser, and a test that only compared verdicts would pass just as
+// happily while the second grader ran and agreed by luck.
+const evaluateToolCalls = vi.fn(() => ({
+  passed: true,
+  missing: [],
+  extra: [],
+  unexpected: [],
+  outOfOrder: [],
+  argumentMismatches: [],
+  matched: [],
+}));
+
+vi.mock("@/shared/eval-matching", async () => {
+  const actual = await vi.importActual<typeof import("@/shared/eval-matching")>(
+    "@/shared/eval-matching"
+  );
+  return { ...actual, evaluateToolCalls };
+});
+
+const { computeIterationPassed, computeIterationResult } = await import(
+  "../pass-criteria"
+);
+
+// =============================================================================
+// B3b W4 — the retirement pin.
+//
+// What retires is the browser's UNVERIFIED RE-DERIVATION of an iteration that
+// has already been graded. What survives is the matcher itself, for rows that
+// carry no stored result: legacy history, and the live-grading preview whose
+// synthetic per-turn rows were never persisted at all.
+//
+// After this ships, restoring the old behaviour means reverting the PR that
+// introduced it — there is no flag.
+// =============================================================================
+
+/** A row that was graded server-side, whose tool calls DISAGREE with the verdict. */
+function storedRow(result: "passed" | "failed", resultSource?: string) {
+  return {
+    _id: "iter1",
+    result,
+    ...(resultSource ? { resultSource } : {}),
+    status: "completed",
+    // Deliberately contradictory evidence: the matcher, if it ran, would say
+    // "passed" (see the stub above) regardless of what the server decided.
+    actualToolCalls: [],
+    testCaseSnapshot: { expectedToolCalls: [{ toolName: "x", arguments: {} }] },
+  } as never;
+}
+
+describe("a stored result is the only source for a row that has one", () => {
+  test.each(["reported", "derived", undefined] as const)(
+    "resultSource %s — the matcher is never invoked",
+    (resultSource) => {
+      evaluateToolCalls.mockClear();
+      expect(computeIterationPassed(storedRow("failed", resultSource))).toBe(
+        false
+      );
+      // `derived` is the case that changed. Before W4 only `reported`
+      // short-circuited, so a derived row was re-graded in the browser from
+      // `actualToolCalls` alone — blind to predicates, gates and tool errors,
+      // which at `enforce` are most of what decided the verdict.
+      expect(evaluateToolCalls).not.toHaveBeenCalled();
+    }
+  );
+
+  test("a stored pass is a pass even when the tool calls do not match", () => {
+    evaluateToolCalls.mockClear();
+    expect(computeIterationPassed(storedRow("passed", "derived"))).toBe(true);
+    expect(evaluateToolCalls).not.toHaveBeenCalled();
+  });
+
+  test("computeIterationResult agrees, through the same rule", () => {
+    expect(computeIterationResult(storedRow("failed", "derived"))).toBe(
+      "failed"
+    );
+  });
+});
+
+describe("the matcher survives where there is nothing stored to trust", () => {
+  test("a legacy row with no result is still graded by the matcher", () => {
+    evaluateToolCalls.mockClear();
+    // Falling back to "not passed" here would silently re-grade years of
+    // history as failures, which is why absence keeps the old path rather than
+    // taking the new one's default.
+    const legacy = {
+      _id: "legacy",
+      status: "completed",
+      actualToolCalls: [{ toolName: "x", arguments: {} }],
+      testCaseSnapshot: {
+        expectedToolCalls: [{ toolName: "x", arguments: {} }],
+      },
+    } as never;
+
+    expect(computeIterationPassed(legacy)).toBe(true);
+    expect(evaluateToolCalls).toHaveBeenCalledTimes(1);
+  });
+
+  test("a live-grading style projection is still graded by the matcher", () => {
+    evaluateToolCalls.mockClear();
+    // `eval-live-grading.ts` builds these per user turn. They are a PREVIEW of
+    // a verdict, not a re-derivation of a decided one, so they were never
+    // persisted and have no stored result to defer to.
+    const preview = {
+      status: "completed",
+      actualToolCalls: [{ toolName: "search", arguments: {} }],
+      testCaseSnapshot: {
+        expectedToolCalls: [{ toolName: "search", arguments: {} }],
+      },
+    } as never;
+
+    expect(computeIterationPassed(preview)).toBe(true);
+    expect(evaluateToolCalls).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/pass-criteria.ts
+++ b/mcpjam-inspector/client/src/components/evals/pass-criteria.ts
@@ -69,7 +69,7 @@ export function computeIterationResult(
       arguments: Record<string, any>;
     }>;
   },
-  criteria?: PassCriteria,
+  criteria?: PassCriteria
 ):
   | "pending"
   | "passed"
@@ -117,15 +117,48 @@ export function computeIterationResult(
 }
 
 /**
- * Compute if an individual iteration passed based on its data.
- * Uses the shared two-pass matching algorithm from @/shared/eval-matching.
+ * Did this iteration pass?
+ *
+ * ── B3b W4: the stored result is the ONLY source for a row that has one ─────
+ *
+ * A STORED terminal `result` wins outright, whatever `resultSource` says. That
+ * is the retirement this step is for: the browser used to re-run the tool-call
+ * matcher over `actualToolCalls` and grade the iteration a second time, in a
+ * second implementation, from evidence that had already been graded server-side
+ * — and by the score contract at `enforce`, from evidence the browser cannot
+ * see at all (predicates, gates, tool errors, the whole gating row set). A
+ * client re-derivation is not a check on the server; it is a different answer
+ * to the same question, arrived at with less information, and the two silently
+ * disagreeing is the failure mode that ends here.
+ *
+ * ── What survives, and why it is not the same thing ─────────────────────────
+ *
+ * The matcher below is UNTOUCHED and still runs for a row with NO stored
+ * result. Two real populations need it:
+ *
+ *   - LEGACY ROWS that never persisted one. Falling back to "not passed" would
+ *     silently re-grade years of history as failures.
+ *   - LIVE GRADING (`eval-live-grading.ts`), which hands this function
+ *     synthetic per-turn projections that were never persisted at all. It is a
+ *     PREVIEW of a verdict, not a re-derivation of a decided one.
+ *
+ * So the matcher does not retire as an evaluator; what retires is the
+ * UNVERIFIED CLIENT RE-DERIVATION of an iteration that has already been graded.
+ *
+ * Restoring the old behaviour after this ships requires reverting the PR that
+ * introduced it, not flipping a flag.
  */
 export function computeIterationPassed(
   iteration: EvalIteration,
-  criteria?: PassCriteria,
+  criteria?: PassCriteria
 ): boolean {
-  if (iteration.resultSource === "reported") {
+  if (iteration.result === "passed" || iteration.result === "failed") {
     return iteration.result === "passed";
+  }
+  if (iteration.resultSource === "reported") {
+    // A reported row whose result is non-terminal (`pending`, `cancelled`,
+    // `timed_out`) still says what it says. Unchanged from before W4.
+    return false;
   }
 
   const actual = iteration.actualToolCalls || [];
@@ -185,7 +218,7 @@ export function computeIterationPassed(
 export function evaluatePassCriteria(
   run: EvalSuiteRun,
   iterations: EvalIteration[],
-  criteria: PassCriteria = DEFAULT_CRITERIA,
+  criteria: PassCriteria = DEFAULT_CRITERIA
 ): PassCriteriaEvaluation {
   // Filter to only this run's iterations
   const runIterations = iterations.filter((it) => it.suiteRunId === run._id);
@@ -205,7 +238,7 @@ export function evaluatePassCriteria(
       (it) =>
         it.result === "passed" ||
         it.result === "failed" ||
-        it.result === "timed_out",
+        it.result === "timed_out"
     );
 
   const totalCount = iterationsWithResults.length;
@@ -222,7 +255,9 @@ export function evaluatePassCriteria(
         passed,
         reason: passed
           ? undefined
-          : `Pass rate ${overallPassRate.toFixed(1)}% below threshold ${threshold}%`,
+          : `Pass rate ${overallPassRate.toFixed(
+              1
+            )}% below threshold ${threshold}%`,
         details: {
           overallPassRate,
           threshold,
@@ -254,7 +289,7 @@ export function evaluatePassCriteria(
       // Check each template
       for (const [templateKey, templateIterations] of byTemplate) {
         const templatePassed = templateIterations.filter(
-          (it) => it.passed,
+          (it) => it.passed
         ).length;
         const templateTotal = templateIterations.length;
         const templatePassRate =

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -321,11 +321,17 @@ export function RunIterationsSidebar({
         }
       );
     }
+    // B3b W4: `computeIterationPassed` now reads a row's STORED result when it
+    // has one, so this override no longer re-runs the tool-call matcher in the
+    // browser to second-guess a verdict the server already reached — which at
+    // grading mode `enforce` was reached from gating evidence (predicates,
+    // gates, tool errors) the browser cannot see at all. The matcher survives
+    // inside that helper for rows with no stored result; see its docblock.
     const passed = caseGroupsForSelectedRun.filter((i) =>
-      computeIterationPassed(i),
+      computeIterationPassed(i)
     ).length;
     const failed = caseGroupsForSelectedRun.filter(
-      (i) => !computeIterationPassed(i),
+      (i) => !computeIterationPassed(i)
     ).length;
     const total = caseGroupsForSelectedRun.length;
     const passRate = total > 0 ? passed / total : 0;
@@ -336,7 +342,7 @@ export function RunIterationsSidebar({
     if (!runForOverview) return null;
     return getSidebarRunInsightsPassRateLabel(
       runForOverview,
-      overviewStatsOverride,
+      overviewStatsOverride
     );
   }, [runForOverview, overviewStatsOverride]);
 
@@ -344,7 +350,7 @@ export function RunIterationsSidebar({
     () =>
       groupRunIterationsByTestCase(caseGroupsForSelectedRun, runDetailSortBy)
         .length,
-    [caseGroupsForSelectedRun, runDetailSortBy],
+    [caseGroupsForSelectedRun, runDetailSortBy]
   );
 
   const sortHeaderControl = (
@@ -397,7 +403,7 @@ export function RunIterationsSidebar({
             <div
               className={cn(
                 showRunOverviewNav && runForOverview && "border-t",
-                "px-4 pb-2 pt-2",
+                "px-4 pb-2 pt-2"
               )}
             >
               {runOverviewExtra}
@@ -411,7 +417,7 @@ export function RunIterationsSidebar({
             flushChrome
               ? "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-card"
               : caseListCardClassName,
-            "min-h-0 min-w-0 flex-1 overflow-hidden",
+            "min-h-0 min-w-0 flex-1 overflow-hidden"
           )}
         >
           <div className="min-h-0 flex-1 overflow-y-auto bg-muted/10 dark:bg-muted/15">
@@ -478,7 +484,7 @@ export function RunDetailView({
           type: "test-edit",
           suiteId: selectedRunDetails.suiteId,
           testId: testCaseId,
-        }),
+        })
       ));
   useRunInsights(selectedRunDetails, { autoRequest: true });
 
@@ -522,7 +528,7 @@ export function RunDetailView({
     selectedRunDetails.configSnapshot?.environment?.computerEnvironmentId ??
     null;
   const runEnvironments = useSandboxImages(
-    runComputerEnvId ? selectedRunDetails.projectId ?? null : null,
+    runComputerEnvId ? selectedRunDetails.projectId ?? null : null
   );
   // Friendly name when resolvable; otherwise the RAW id (never truncated — it's
   // the only durable identifier once the environment is deleted).
@@ -567,7 +573,7 @@ export function RunDetailView({
     const anchorEl = document.createElement("a");
     anchorEl.href = url;
     anchorEl.download = `openai-submission-${formatRunId(
-      selectedRunDetails._id,
+      selectedRunDetails._id
     )}.md`;
     anchorEl.click();
     URL.revokeObjectURL(url);
@@ -609,7 +615,7 @@ export function RunDetailView({
             source,
           })
         : [],
-    [kpiPlacement, selectedRunDetails, caseGroupsForSelectedRun, source],
+    [kpiPlacement, selectedRunDetails, caseGroupsForSelectedRun, source]
   );
 
   const embeddedInResultsSplit = hideKpiStrip;
@@ -736,7 +742,7 @@ export function RunDetailView({
   // side card. Null when nothing is graded, which skips badge rendering.
   const judgeByCaseKey = useMemo(
     () => buildJudgeCaseMap(goalCompletionResult),
-    [goalCompletionResult],
+    [goalCompletionResult]
   );
 
   // Run-level judge headline for the collapsed insight band (the per-case detail
@@ -749,7 +755,7 @@ export function RunDetailView({
     const deterministicByCaseKey = new Map<string, boolean | null>();
     for (const group of groupRunIterationsByTestCase(
       caseGroupsForSelectedRun,
-      "test",
+      "test"
     )) {
       const key = caseKeyForGroup(group);
       if (key) deterministicByCaseKey.set(key, deterministicCasePassed(group));
@@ -757,8 +763,8 @@ export function RunDetailView({
     const disagreements = cases.filter((c) =>
       judgeDisagreesWithVerdict(
         deterministicByCaseKey.get(c.caseKey) ?? null,
-        c.passed,
-      ),
+        c.passed
+      )
     ).length;
     return { meet, total: cases.length, disagreements };
   }, [goalCompletionResult, caseGroupsForSelectedRun]);
@@ -822,7 +828,7 @@ export function RunDetailView({
             type: "run-detail",
             suiteId: selectedRunDetails.suiteId,
             runId,
-          }),
+          })
         );
       }}
       className="mb-4"
@@ -969,7 +975,7 @@ export function RunDetailView({
         serverQuality: serverQualityResult ?? null,
         iterations: caseGroupsForSelectedRun,
       }).length,
-    [serverQualityResult, caseGroupsForSelectedRun],
+    [serverQualityResult, caseGroupsForSelectedRun]
   );
 
   const bandPassRatePercent = useMemo(() => {
@@ -1010,11 +1016,11 @@ export function RunDetailView({
         secondaryParts.push(
           `${judgeHeadline.disagreements} judge disagreement${
             judgeHeadline.disagreements === 1 ? "" : "s"
-          }`,
+          }`
         );
       } else {
         secondaryParts.push(
-          `Judge ${judgeHeadline.meet}/${judgeHeadline.total} meet goal`,
+          `Judge ${judgeHeadline.meet}/${judgeHeadline.total} meet goal`
         );
       }
     } else if (
@@ -1023,7 +1029,7 @@ export function RunDetailView({
       judgeHeadline.disagreements === 0
     ) {
       secondaryParts.push(
-        `${judgeHeadline.meet}/${judgeHeadline.total} meet goal`,
+        `${judgeHeadline.meet}/${judgeHeadline.total} meet goal`
       );
     }
 
@@ -1195,7 +1201,7 @@ export function RunDetailView({
         useTwoColumnLayout
           ? cn("overflow-hidden", embeddedInResultsSplit ? "p-0" : "p-4")
           : "overflow-y-auto p-4",
-        omitIterationList && "px-3 py-3",
+        omitIterationList && "px-3 py-3"
       )}
     >
       {/* Renders nothing. Sits above every layout branch below because all of
@@ -1290,7 +1296,7 @@ export function RunDetailView({
                 withHandle={!embeddedInResultsSplit}
                 className={cn(
                   embeddedInResultsSplit &&
-                    "w-px bg-border/60 after:w-0 [&>div]:hidden",
+                    "w-px bg-border/60 after:w-0 [&>div]:hidden"
                 )}
               />
               <ResizablePanel


### PR DESCRIPTION
## What

Re-lands B3b **W4** — retire the browser's re-derivation of a graded verdict — by reapplying `eb3c3466d7`, which was deliberately dropped from #4347 during review (`4071e3cf23`) under the one-step-per-PR rule. One incidental conflict in `run-detail-view.tsx` resolved by keeping `main`'s newer `runHasInsightContent` probe (W4 does not touch that logic). Changeset included (rode along in the original commit).

## Why now — the soak evidence

The lane gated W4 on the enforce soak. Enforce went live at 100% on 2026-09-01 (see the B3b board row: replay, calibration, live drill in both verdict directions, rollback drill, backend #1218 + #1222). Soak reading as of 2026-09-03:

- 111 runs since cutover; the 2 enforce-stamped runs both carry `scoreIntegrity: valid` (one passed, one failed — both directions corroborated by the seam).
- Zero `grading_shadow_mismatch` lines in prod logs; zero runs with `scoreIntegrity: invalid`.

## Tests

- `stored-result-authority.test.ts` restored; full client evals test sweep: **143 files / 1,368 tests pass**.
- Client `tsc`: 629 errors on this branch and **exactly 629 on pristine `main`**, same files, same counts — the re-land introduces none (CI is the arbiter; the known "nothing typechecks server" board item is unrelated to this diff).

## Sequencing

Backend #1222 (W3 re-land) is unmerged and this PR does not depend on it: W4 removes a CLIENT fallback; the stored verdict it defers to is written by code already deployed. Merge order between the two is free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jtk7WXyh4GTsP8CvGbsGY5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how pass/fail and run overview stats display for server-graded iterations (especially `derived` rows), which is correct for enforce but could surprise anyone who relied on client-side tool-call re-grading.
> 
> **Overview**
> **Stops the inspector from second-guessing server grades** for eval iterations that already have a terminal `passed`/`failed` on the row.
> 
> Previously `computeIterationPassed` only short-circuited when `resultSource === "reported"`; **`derived` (and other stored results) were re-scored in the browser** via the tool-call matcher. Under grading **`enforce`**, that could disagree with the real verdict (predicates, gates, tool errors) because the client only sees `actualToolCalls`.
> 
> **Now any row with `result === "passed"` or `"failed"` uses that value**, regardless of `resultSource`. The matcher is unchanged for rows **without** a stored terminal result (legacy history and live-grading preview rows).
> 
> Adds **`stored-result-authority.test.ts`**, which asserts `evaluateToolCalls` is not invoked when a stored result exists (including deliberately contradictory tool-call evidence). Run-detail overview pass-rate stats inherit the same rule through `computeIterationPassed`; mostly comment/formatting there plus a changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83366147bc515e1e3a6030d147b3b2213d0d7f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the browser's re-derivation of a graded verdict so a stored result is the only source for an iteration that has one — previously only `reported` rows deferred to the stored verdict, while `derived` rows were re-graded client-side from `actualToolCalls`, which cannot see the gating score rows that decide the verdict at grading mode `enforce`. The tool-call matcher still runs for rows with no stored result (legacy rows and live-grading previews), and this is not behind a flag.

**Verification**
- Soak since enforce went live at 100% on 2026-09-01: zero `grading_shadow_mismatch` log lines and zero runs with `scoreIntegrity: invalid`.
- Added `stored-result-authority.test.ts`; the client evals sweep passes 143 files / 1,368 tests.
- Client `tsc` reports the same 629 errors as pristine `main`, so this re-land introduces no new type errors.

<sup>Written for commit 83366147bc515e1e3a6030d147b3b2213d0d7f76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

