### PR TITLE
mcp apps: show the view's origin in the Sandbox Stack panel

### DIFF
--- a/mcpjam-inspector/Dockerfile
+++ b/mcpjam-inspector/Dockerfile
@@ -41,6 +41,7 @@ ARG VITE_WORKOS_API_HOSTNAME
 ARG VITE_CONVEX_URL
 ARG VITE_WORKOS_CLIENT_ID
 ARG VITE_MCPJAM_SANDBOX_ORIGIN
+ARG VITE_MCPJAM_VIEW_MOUNT
 # Not a VITE_ var — it is never bundled. `sentryVitePlugin` in
 # client/vite.config.ts reads it at BUILD time to upload source maps for the
 # release, and without it every hosted prod stack trace stays minified
@@ -119,6 +120,7 @@ RUN if [ -n "$VITE_MCPJAM_HOSTED_MODE" ]; then export VITE_MCPJAM_HOSTED_MODE; f
     if [ -n "$VITE_CONVEX_URL" ]; then export VITE_CONVEX_URL; fi; \
     if [ -n "$VITE_WORKOS_CLIENT_ID" ]; then export VITE_WORKOS_CLIENT_ID; fi; \
     if [ -n "$VITE_MCPJAM_SANDBOX_ORIGIN" ]; then export VITE_MCPJAM_SANDBOX_ORIGIN; fi; \
+    if [ -n "$VITE_MCPJAM_VIEW_MOUNT" ]; then export VITE_MCPJAM_VIEW_MOUNT; fi; \
     if [ -n "$SENTRY_AUTH_TOKEN" ]; then export SENTRY_AUTH_TOKEN; fi; \
     MCPJAM_BUILD_SURFACE=web npm run build:client -w @mcpjam/inspector
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/SandboxStackTab.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/SandboxStackTab.tsx
@@ -4,6 +4,7 @@ import type {
   WidgetMount,
   WidgetSandboxApplied,
 } from "@/stores/widget-debug-store";
+import { copyToClipboard } from "@/lib/clipboard";
 
 interface SandboxStackTabProps {
   applied?: WidgetSandboxApplied;
@@ -56,6 +57,51 @@ function lifecycleStatus(events: WidgetLifecycleEvent[] | undefined): {
   if (lastEvent(events, "bridge-connect-ready"))
     return { tone: "live", text: "bridge connected" };
   return { tone: "muted", text: "loading" };
+}
+
+/**
+ * The origin the view's document actually runs at — the value a developer
+ * pastes into a third-party allowlist that keys on the page URL (a
+ * referrer-restricted API key, an OAuth redirect URI). Renders nothing until
+ * the proxy has reported a mount, and says plainly when there is no origin to
+ * copy because the view fell back to `srcdoc`.
+ */
+function ViewOriginChip({ applied }: { applied?: WidgetSandboxApplied }) {
+  const [copied, setCopied] = useState(false);
+  const viewMode = applied?.viewMode;
+  const origin = applied?.assignedOrigin;
+
+  if (!viewMode) return null;
+  if (viewMode !== "url" || !origin) {
+    return (
+      <Chip label="View origin" value="about:srcdoc · no origin" tone="muted" />
+    );
+  }
+
+  const handleCopy = async () => {
+    if (await copyToClipboard(origin)) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
+  };
+
+  return (
+    <Chip
+      label="View origin"
+      value={
+        <span className="inline-flex items-center gap-1.5 min-w-0 max-w-full">
+          <span className="truncate">{origin}</span>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="shrink-0 text-[10.5px] text-muted-foreground hover:text-foreground"
+          >
+            {copied ? "copied" : "copy"}
+          </button>
+        </span>
+      }
+    />
+  );
 }
 
 /** Wrap a comma-joined list so the chip can show "N, M, …" + "+K more". */
@@ -163,6 +209,7 @@ export function SandboxStackTab({
               }
               tone={lc.tone === "muted" ? "muted" : "neutral"}
             />
+            <ViewOriginChip applied={applied} />
             {mountCount > 1 && (
               <Chip
                 label="Mount count"

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/__tests__/sandbox-stack-origin.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/__tests__/sandbox-stack-origin.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * The Sandbox Stack "View origin" chip.
+ *
+ * This is the answer to "which origin do I allowlist?" — the question that
+ * drove the document.write mount. A developer with a referrer-restricted
+ * third-party key (Google Maps, an OAuth redirect URI) reads the value here
+ * and pastes it into that provider's allowlist, so the chip must show the
+ * view's real origin when there is one and say plainly when there is not,
+ * rather than rendering a stale or empty value.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { WidgetSandboxApplied } from "@/stores/widget-debug-store";
+import { SandboxStackTab } from "../SandboxStackTab";
+
+const copyToClipboard = vi.hoisted(() => vi.fn(async () => true));
+vi.mock("@/lib/clipboard", () => ({ copyToClipboard }));
+
+const BASE: WidgetSandboxApplied = {
+  permissive: false,
+  hostPolicyApplied: false,
+};
+
+describe("SandboxStackTab — view origin chip", () => {
+  beforeEach(() => {
+    copyToClipboard.mockClear();
+    copyToClipboard.mockResolvedValue(true);
+  });
+
+  it("shows the origin of the view's document URL", () => {
+    render(
+      <SandboxStackTab
+        applied={{
+          ...BASE,
+          viewMode: "url",
+          viewUrl: "http://127.0.0.1:6274/api/apps/mcp-apps/sandbox-proxy?v=1",
+          assignedOrigin: "http://127.0.0.1:6274",
+        }}
+      />,
+    );
+    expect(screen.getByText("View origin")).toBeTruthy();
+    // The origin, not the full URL: the query string is a cache-buster and
+    // allowlists are keyed on the origin.
+    expect(screen.getByText("http://127.0.0.1:6274")).toBeTruthy();
+  });
+
+  it("copies the origin to the clipboard", async () => {
+    render(
+      <SandboxStackTab
+        applied={{
+          ...BASE,
+          viewMode: "url",
+          assignedOrigin: "https://sandbox.mcpjam.com",
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "copy" }));
+    await waitFor(() => {
+      expect(copyToClipboard).toHaveBeenCalledWith(
+        "https://sandbox.mcpjam.com",
+      );
+    });
+    await waitFor(() => expect(screen.getByText("copied")).toBeTruthy());
+  });
+
+  it("says there is no origin when the view fell back to srcdoc", () => {
+    render(
+      <SandboxStackTab
+        applied={{
+          ...BASE,
+          viewMode: "srcdoc-fallback",
+          viewUrl: "about:srcdoc",
+        }}
+      />,
+    );
+    expect(screen.getByText("about:srcdoc · no origin")).toBeTruthy();
+    // Nothing to copy — offering a button that yields "about:srcdoc" would
+    // send the developer to paste a value no allowlist accepts.
+    expect(screen.queryByRole("button", { name: "copy" })).toBeNull();
+  });
+
+  it("says the same for an explicitly requested srcdoc mount", () => {
+    render(<SandboxStackTab applied={{ ...BASE, viewMode: "srcdoc" }} />);
+    expect(screen.getByText("about:srcdoc · no origin")).toBeTruthy();
+  });
+
+  it("renders no chip before the proxy has reported a mount", () => {
+    render(<SandboxStackTab applied={BASE} />);
+    expect(screen.queryByText("View origin")).toBeNull();
+  });
+
+  it("renders no chip when there is no applied policy at all", () => {
+    render(<SandboxStackTab />);
+    expect(screen.queryByText("View origin")).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -2581,6 +2581,87 @@ describe("MCPAppsRenderer tool input streaming", () => {
     });
   });
 
+  it("records the view mount reported by the sandbox proxy", async () => {
+    // The proxy posts `mcpjam:view-mode` once per mount. It has to land in
+    // two places: the lifecycle list (so the panel shows the view came up)
+    // and `applied` (so the Sandbox Stack chip can show the origin a
+    // developer allowlists with a referrer-restricted third party). The
+    // status is derived from the mode, not a method suffix.
+    render(<HostedRenderer {...baseProps} cachedWidgetHtmlUrl="blob:cached" />);
+
+    await vi.waitFor(() => {
+      expect(sandboxedIframePropsRef.current?.onMessage).toBeTypeOf("function");
+    });
+
+    act(() => {
+      sandboxedIframePropsRef.current.onMessage({
+        data: {
+          type: "mcpjam:view-mode",
+          mode: "url",
+          url: "http://127.0.0.1:6274/api/apps/mcp-apps/sandbox-proxy?v=1",
+        },
+      } as MessageEvent);
+    });
+
+    await vi.waitFor(() => {
+      expect(stableStoreFns.appendLifecycle).toHaveBeenCalledWith(
+        "call-1",
+        expect.objectContaining({ kind: "view-mounted", status: "ok" }),
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(stableStoreFns.setSandboxApplied).toHaveBeenCalledWith(
+        "call-1",
+        expect.objectContaining({
+          viewMode: "url",
+          viewUrl: "http://127.0.0.1:6274/api/apps/mcp-apps/sandbox-proxy?v=1",
+          assignedOrigin: "http://127.0.0.1:6274",
+        }),
+        undefined,
+        null,
+      );
+    });
+  });
+
+  it("marks a srcdoc mount as a degraded view (no origin to allowlist)", async () => {
+    render(<HostedRenderer {...baseProps} cachedWidgetHtmlUrl="blob:cached" />);
+
+    await vi.waitFor(() => {
+      expect(sandboxedIframePropsRef.current?.onMessage).toBeTypeOf("function");
+    });
+
+    act(() => {
+      sandboxedIframePropsRef.current.onMessage({
+        data: {
+          type: "mcpjam:view-mode",
+          mode: "srcdoc-fallback",
+          url: "about:srcdoc",
+        },
+      } as MessageEvent);
+    });
+
+    await vi.waitFor(() => {
+      expect(stableStoreFns.appendLifecycle).toHaveBeenCalledWith(
+        "call-1",
+        expect.objectContaining({ kind: "view-mounted", status: "error" }),
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(stableStoreFns.setSandboxApplied).toHaveBeenCalledWith(
+        "call-1",
+        expect.objectContaining({
+          viewMode: "srcdoc-fallback",
+          // `about:srcdoc` has no origin — the chip must not offer one.
+          assignedOrigin: undefined,
+        }),
+        undefined,
+        null,
+      );
+    });
+  });
+
   it("sends partial tool input during input-streaming", async () => {
     const partialInput = { elements: '[{"type":"rectangle"' };
     render(

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/use-widget-host.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/use-widget-host.tsx
@@ -16,7 +16,7 @@
 // pre-resolving them into `WidgetHost.resolveEnvironment` is the Phase-3 target.
 
 import { useMemo, useRef, type ReactNode } from "react";
-import { HOSTED_MODE, SANDBOX_ORIGIN } from "@/lib/config";
+import { HOSTED_MODE, SANDBOX_ORIGIN, VIEW_MOUNT_MODE } from "@/lib/config";
 import { authFetch } from "@/lib/session-token";
 import { useIsScenarioSurface } from "@/contexts/scenario-surface-context";
 import { useWebManagedServers } from "@/contexts/web-managed-servers-context";
@@ -189,6 +189,7 @@ export function useWidgetHost(): WidgetHostImpl {
       webManagedServers,
       hostedMode: HOSTED_MODE,
       sandboxOrigin: SANDBOX_ORIGIN ?? "",
+      viewMountMode: VIEW_MOUNT_MODE,
       playgroundCspMode,
     }),
     [kind, persistentSurfaceHost, webManagedServers, playgroundCspMode],

--- a/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
@@ -629,3 +629,86 @@ describe("SandboxedIframe — non-JSON-RPC message allow-list", () => {
     expect(onMessage).not.toHaveBeenCalled();
   });
 });
+
+describe("SandboxedIframe — view mount reporting", () => {
+  function dispatchFromIframe(iframe: HTMLIFrameElement, data: unknown): void {
+    const proxyOrigin = new URL(iframe.src).origin;
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data,
+        source: iframe.contentWindow!,
+        origin: proxyOrigin,
+      }),
+    );
+  }
+
+  it("forwards mcpjam:view-mode to the host", () => {
+    // The proxy reports where it mounted the view; the renderer turns this
+    // into the Sandbox Stack origin chip. It is not JSON-RPC, so it only
+    // reaches the host if the allow-list names it.
+    const onMessage = vi.fn();
+    const { container } = render(
+      <SandboxedIframe html={null} onMessage={onMessage} />,
+    );
+    const iframe = container.querySelector("iframe")!;
+    const payload = {
+      type: "mcpjam:view-mode",
+      mode: "url",
+      url: "http://127.0.0.1:6274/api/apps/mcp-apps/sandbox-proxy?v=1",
+    };
+    act(() => dispatchFromIframe(iframe, payload));
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0].data).toEqual(payload);
+  });
+
+  it("forwards mountMode in the payload and resends when it changes", async () => {
+    // mountMode decides how the proxy mounts the HTML, so it belongs to the
+    // render recipe: changing it must re-send rather than leave the previous
+    // mount on screen.
+    const { container, rerender } = render(
+      <SandboxedIframe
+        html="<html><body>a</body></html>"
+        onMessage={() => {}}
+        mountMode="write"
+      />,
+    );
+    const iframe = container.querySelector("iframe")!;
+    const postMessage = vi.spyOn(iframe.contentWindow!, "postMessage");
+    act(() => {
+      dispatchFromIframe(iframe, {
+        jsonrpc: "2.0",
+        method: "ui/notifications/sandbox-proxy-ready",
+        params: {},
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({ mountMode: "write" }),
+        }),
+        expect.any(String),
+      );
+    });
+    const afterFirst = postMessage.mock.calls.length;
+
+    rerender(
+      <SandboxedIframe
+        html="<html><body>a</body></html>"
+        onMessage={() => {}}
+        mountMode="srcdoc"
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(postMessage.mock.calls.length).toBeGreaterThan(afterFirst);
+    });
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ mountMode: "srcdoc" }),
+      }),
+      expect.any(String),
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/lib/config.ts
+++ b/mcpjam-inspector/client/src/lib/config.ts
@@ -52,6 +52,22 @@ export const SANDBOX_ORIGIN: string | null = (() => {
 })();
 
 /**
+ * How the sandbox proxy mounts an MCP App view.
+ *
+ * `"write"` (the default) writes the widget HTML into a blank same-origin
+ * iframe, so the view runs at the proxy's URL and a third party that keys on
+ * the page URL — a referrer-restricted API key, an OAuth redirect URI — sees a
+ * real origin. `"srcdoc"` restores the legacy `iframe.srcdoc` mount, where the
+ * view's URL is `about:srcdoc` and no such allowlist can match.
+ *
+ * Set via `VITE_MCPJAM_VIEW_MOUNT` at build time. It exists to exercise the
+ * srcdoc branch (the e2e fallback case); being a build-time constant it is not
+ * an incident switch, since flipping it costs the same redeploy as a revert.
+ */
+export const VIEW_MOUNT_MODE: "write" | "srcdoc" =
+  import.meta.env.VITE_MCPJAM_VIEW_MOUNT === "srcdoc" ? "srcdoc" : "write";
+
+/**
  * The Discord application the agent bot runs as, used to build the "add to
  * server" URL on the Integrations page.
  *

--- a/mcpjam-inspector/client/src/stores/__tests__/widget-debug-store.test.ts
+++ b/mcpjam-inspector/client/src/stores/__tests__/widget-debug-store.test.ts
@@ -56,6 +56,21 @@ describe("widget-debug-store — sandbox + lifecycle", () => {
         kind: "widget-content-requested",
       });
     });
+    it("round-trips the view-mount fields the Sandbox Stack origin chip reads", () => {
+      // These three travel from the sandbox proxy through the renderer into
+      // `applied`; the chip is their only consumer, so a drop here is silent.
+      const applied: WidgetSandboxApplied = {
+        permissive: false,
+        hostPolicyApplied: false,
+        viewMode: "url",
+        viewUrl: "http://127.0.0.1:6274/api/apps/mcp-apps/sandbox-proxy?v=1",
+        assignedOrigin: "http://127.0.0.1:6274",
+      };
+      useWidgetDebugStore.getState().setSandboxApplied("tool-view", applied);
+
+      const info = useWidgetDebugStore.getState().widgets.get("tool-view");
+      expect(info!.applied).toEqual(applied);
+    });
   });
 
   describe("appendLifecycle", () => {

--- a/mcpjam-inspector/client/src/stores/widget-debug-store.ts
+++ b/mcpjam-inspector/client/src/stores/widget-debug-store.ts
@@ -109,6 +109,23 @@ export interface WidgetSandboxApplied {
     geolocation?: {};
     clipboardWrite?: {};
   };
+  /**
+   * How the sandbox proxy mounted the view. `"url"` means it was written into
+   * a blank same-origin frame and runs at the proxy's URL; the srcdoc values
+   * mean it has no URL of its own (`"srcdoc"` was asked for via the build-time
+   * mount switch, `"srcdoc-fallback"` was forced because the frame's document
+   * was unreachable). Twin of the same field in
+   * `@mcpjam/widget-react`'s `widget-host.ts` — edit both.
+   */
+  viewMode?: "url" | "srcdoc" | "srcdoc-fallback";
+  /** The view's document URL as reported by the proxy. */
+  viewUrl?: string;
+  /**
+   * Origin of `viewUrl` — the origin a developer allowlists with a third party
+   * that keys on the page URL (a referrer-restricted API key, an OAuth
+   * redirect URI). Absent on the srcdoc paths, which have no origin.
+   */
+  assignedOrigin?: string;
 }
 
 /**
@@ -146,7 +163,8 @@ export interface WidgetLifecycleEvent {
     | "bridge-connect-ready"
     | "bridge-connect-error"
     | "bridge-connect-skipped"
-    | "app-initialized";
+    | "app-initialized"
+    | "view-mounted";
   status: "ok" | "error" | "pending";
   message?: string;
   timestamp: number;

--- a/mcpjam-inspector/client/src/vite-env.d.ts
+++ b/mcpjam-inspector/client/src/vite-env.d.ts
@@ -6,6 +6,7 @@ interface ImportMetaEnv {
   readonly VITE_RUNTIME?: string;
   readonly VITE_MCPJAM_HOSTED_MODE?: string;
   readonly VITE_MCPJAM_SANDBOX_ORIGIN?: string;
+  readonly VITE_MCPJAM_VIEW_MOUNT?: string;
   readonly VITE_ENVIRONMENT?: string;
   // more env variables...
 }

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-mount.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-mount.test.ts
@@ -72,6 +72,8 @@ interface MountHarness {
   getInner: () => HTMLIFrameElement | null;
   getLastMount: () => Record<string, unknown> | null;
   setInner: (frame: HTMLIFrameElement | null) => void;
+  /** Every `window.parent.postMessage` the proxy made. */
+  posted: Array<[unknown, string]>;
 }
 
 /**
@@ -85,9 +87,18 @@ function harness(): { dom: JSDOM; h: MountHarness } {
       url: "http://127.0.0.1:6274/api/apps/mcp-apps/sandbox-proxy?v=1",
     },
   );
+  const posted: Array<[unknown, string]> = [];
+  const win = {
+    parent: {
+      postMessage: (data: unknown, targetOrigin: string) =>
+        posted.push([data, targetOrigin]),
+    },
+  };
   // eslint-disable-next-line @typescript-eslint/no-implied-eval
   const factory = new Function(
     "document",
+    "window",
+    "posted",
     `
     const INNER_STYLE = "width:100%; height:100%; border:none;";
     let inner = null;
@@ -102,10 +113,15 @@ function harness(): { dom: JSDOM; h: MountHarness } {
       getInner: () => inner,
       getLastMount: () => lastMount,
       setInner: (frame) => { inner = frame; },
+      posted,
     };
     `,
-  ) as (document: Document) => MountHarness;
-  return { dom, h: factory(dom.window.document) };
+  ) as (
+    document: Document,
+    window: unknown,
+    posted: Array<[unknown, string]>,
+  ) => MountHarness;
+  return { dom, h: factory(dom.window.document, win, posted) };
 }
 
 const WIDGET = "<!doctype html><html><body><p id='w'>hi</p></body></html>";
@@ -174,6 +190,35 @@ describe("sandbox-proxy mountInner", () => {
       colorScheme: "dark",
       mountMode: undefined,
     });
+  });
+
+  it("reports where the view landed so the host can show the origin", () => {
+    // The Inspector's "View origin" chip is fed by this message, and it is
+    // the answer to "what do I allowlist with my third-party API key" — a
+    // mount that reports nothing is a mount the developer cannot act on.
+    const { h } = harness();
+    h.mountInner(WIDGET, "allow-same-origin allow-scripts", "", "light");
+    expect(h.posted).toEqual([
+      [
+        {
+          type: "mcpjam:view-mode",
+          mode: "url",
+          // jsdom's document.open() does not adopt the entry document's URL
+          // (the browser e2e pins that); what matters here is that the proxy
+          // reports its own document URL rather than a hardcoded string.
+          url: "http://127.0.0.1:6274/api/apps/mcp-apps/sandbox-proxy?v=1",
+        },
+        "*",
+      ],
+    ]);
+  });
+
+  it("reports about:srcdoc when the view has no URL of its own", () => {
+    const { h } = harness();
+    h.mountInner(WIDGET, "allow-scripts", "", "light", "srcdoc");
+    expect(h.posted).toEqual([
+      [{ type: "mcpjam:view-mode", mode: "srcdoc", url: "about:srcdoc" }, "*"],
+    ]);
   });
 
   it("removes the previous frame and repoints `inner` on every mount", () => {

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -904,6 +904,21 @@ document.addEventListener('securitypolicyviolation', function(e) {
         inner = next;
         next.style.colorScheme = applyColorScheme(colorScheme);
         lastMount = { html, sandboxValue, allowValue, colorScheme, mountMode };
+        // Tell the host where the view actually landed. `document.URL` is this
+        // proxy's URL, which the written document adopts (see above), so this
+        // is the origin a developer allowlists with a third party that keys on
+        // the page URL — a referrer-restricted API key, an OAuth redirect. The
+        // srcdoc branch has no URL of its own and says so. Posted from here
+        // rather than the call sites so a remount reports too.
+        // targetOrigin is "*" until host-origin pinning narrows it.
+        window.parent.postMessage(
+          {
+            type: "mcpjam:view-mode",
+            mode,
+            url: mode === "url" ? document.URL : "about:srcdoc",
+          },
+          "*",
+        );
         return mode;
       }
 

--- a/widget-react/src/mcp-apps-modal.tsx
+++ b/widget-react/src/mcp-apps-modal.tsx
@@ -442,6 +442,10 @@ export function McpAppsModal({
     if (data.type === "mcp-apps:csp-violation") {
       onCspViolation(event);
     }
+    // `mcpjam:view-mode` also arrives here (the modal mounts its own view).
+    // Deliberately ignored: the Sandbox Stack panel describes the inline
+    // view, and both mount on the same origin, so recording the modal's
+    // would just overwrite the inline one with an identical value.
   };
 
   // Modal chrome is host-injected (the inspector's design-system <Dialog>). A
@@ -469,6 +473,7 @@ export function McpAppsModal({
             title={`MCP App Modal: ${title}`}
             hostedMode={host.surface.hostedMode}
             sandboxOrigin={host.surface.sandboxOrigin}
+            mountMode={host.surface.viewMountMode}
             className="min-w-full border-0 rounded-md bg-transparent overflow-hidden"
             style={{
               height: "100%",

--- a/widget-react/src/mcp-apps-renderer.tsx
+++ b/widget-react/src/mcp-apps-renderer.tsx
@@ -455,11 +455,17 @@ function mapLogToLifecycle(
     "debug/bridge-connect-error": "bridge-connect-error",
     "debug/bridge-connect-skipped": "bridge-connect-skipped",
     "debug/app-initialized": "app-initialized",
+    "debug/view-mounted": "view-mounted",
   };
   const kind = kindByMethod[method];
   if (!kind) return null;
   let status: WidgetLifecycleEvent["status"];
-  if (
+  if (method === "debug/view-mounted") {
+    // No -ready/-error suffix to read: the mount mode IS the status. A srcdoc
+    // mount means the view has no real URL, which is the degraded outcome
+    // this event exists to make visible.
+    status = details.mode === "url" ? "ok" : "error";
+  } else if (
     method.endsWith("-error") ||
     method === "debug/widget-content-invalid-mimetype"
   ) {
@@ -478,6 +484,8 @@ function mapLogToLifecycle(
       ? details.error
       : typeof details.reason === "string"
       ? details.reason
+      : method === "debug/view-mounted" && typeof details.url === "string"
+      ? details.url
       : undefined;
   return { kind, status, message, timestamp: Date.now() };
 }
@@ -1220,6 +1228,12 @@ export function MCPAppsRendererSurface({
     string | null
   >(null);
   const [sandboxProxyReady, setSandboxProxyReady] = useState(false);
+  // Where the proxy mounted the view, reported once per mount. Surfaced as the
+  // Sandbox Stack "View origin" chip.
+  const [viewMount, setViewMount] = useState<{
+    mode: "url" | "srcdoc" | "srcdoc-fallback";
+    url: string;
+  } | null>(null);
   const [bridgeTransportReady, setBridgeTransportReady] = useState(false);
   const explicitOpenInAppBaseUrl = useMemo(
     () => resolveExplicitBaseUrl(widgetHtml, resourceUri),
@@ -3054,6 +3068,17 @@ export function MCPAppsRendererSurface({
     [resolvedBridgeHostInfo]
   );
 
+  // Origin of the view's document URL — what a developer allowlists with a
+  // third party that keys on the page URL. The srcdoc paths have none.
+  const viewAssignedOrigin = useMemo(() => {
+    if (!viewMount || viewMount.mode !== "url") return undefined;
+    try {
+      return new URL(viewMount.url).origin;
+    } catch {
+      return undefined;
+    }
+  }, [viewMount]);
+
   useEffect(() => {
     if (!toolCallId) return;
     setSandboxAppliedStore(
@@ -3068,6 +3093,9 @@ export function MCPAppsRendererSurface({
         restrictTo: sandboxCspPolicy?.restrictTo,
         cspMode: sandboxCspPolicy?.mode,
         permissions: effectiveSandbox.permissions,
+        viewMode: viewMount?.mode,
+        viewUrl: viewMount?.url,
+        assignedOrigin: viewAssignedOrigin,
       },
       undefined,
       sandboxHostInfo
@@ -3078,6 +3106,8 @@ export function MCPAppsRendererSurface({
     sandboxCspPolicy,
     sandboxHostInfo,
     setSandboxAppliedStore,
+    viewMount,
+    viewAssignedOrigin,
   ]);
 
   // Keep bridge callbacks in sync before ResizeObserver/rAF-driven widget
@@ -3829,6 +3859,19 @@ export function MCPAppsRendererSurface({
       return;
     }
 
+    // Where the proxy mounted the view. `url` is the view's real document URL
+    // when it was written into a blank frame; "about:srcdoc" on the srcdoc
+    // paths, which have no origin to allowlist.
+    if (data.type === "mcpjam:view-mode") {
+      const mode = data.mode;
+      if (mode === "url" || mode === "srcdoc" || mode === "srcdoc-fallback") {
+        const url = typeof data.url === "string" ? data.url : "";
+        setViewMount({ mode, url });
+        logWidgetDebug("ui-to-host", "debug/view-mounted", { mode, url });
+      }
+      return;
+    }
+
     // Tier 2 recorder: forward captured steps + readiness to the host.
     if (data.type === "recorder:step") {
       recorderDebug("step from sandbox", {
@@ -4214,6 +4257,7 @@ export function MCPAppsRendererSurface({
       title={`MCP App: ${toolName}`}
       hostedMode={host.surface.hostedMode}
       sandboxOrigin={host.surface.sandboxOrigin}
+      mountMode={host.surface.viewMountMode}
       className={`bg-transparent overflow-hidden ${
         isFullscreen
           ? "flex-1 border-0 rounded-none"

--- a/widget-react/src/sandboxed-iframe.tsx
+++ b/widget-react/src/sandboxed-iframe.tsx
@@ -241,6 +241,15 @@ interface SandboxedIframeProps {
    * (`host.surface.sandboxOrigin`).
    */
   sandboxOrigin?: string;
+  /**
+   * How the proxy mounts the view: `"write"` (default) writes the HTML into a
+   * blank same-origin iframe so the view runs at the proxy's URL; `"srcdoc"`
+   * restores the legacy `iframe.srcdoc` mount, where the view has no URL of
+   * its own. Supplied by the host (`host.surface.viewMountMode`); build-time
+   * only, so it exists to exercise the srcdoc branch rather than to switch
+   * behaviour at runtime.
+   */
+  mountMode?: "write" | "srcdoc";
 }
 
 /**
@@ -275,6 +284,7 @@ export const SandboxedIframe = forwardRef<
     title = "Sandboxed Content",
     hostedMode = false,
     sandboxOrigin = "",
+    mountMode,
   },
   ref
 ) {
@@ -333,6 +343,14 @@ export const SandboxedIframe = forwardRef<
         event.data?.type === "openai:setWidgetState" ||
         event.data?.type === "openai:setOpenInAppUrl"
       ) {
+        onMessageRef.current(event);
+        return;
+      }
+
+      // Where the proxy mounted the view (not JSON-RPC) — carries the view's
+      // real document URL, which the Sandbox Stack panel surfaces so a
+      // developer can allowlist it with a referrer-restricted third party.
+      if (event.data?.type === "mcpjam:view-mode") {
         onMessageRef.current(event);
         return;
       }
@@ -431,6 +449,9 @@ export const SandboxedIframe = forwardRef<
         // Include recordMode so record-capable surfaces receive the recorder
         // shim, and stale/non-recordable surfaces reload without it.
         recordMode: recordMode ?? null,
+        // Part of the render recipe: it decides how the proxy mounts the HTML,
+        // so a change must re-send rather than leave the previous mount up.
+        mountMode: mountMode ?? null,
       }),
     [
       csp,
@@ -443,6 +464,7 @@ export const SandboxedIframe = forwardRef<
       sandbox,
       sandboxAttrs,
       recordMode,
+      mountMode,
     ]
   );
 
@@ -481,6 +503,7 @@ export const SandboxedIframe = forwardRef<
           colorScheme,
           recordMode,
           recorderDebug: isRecorderDebugEnabled(),
+          mountMode,
         },
       },
       sandboxProxyOrigin

--- a/widget-react/src/widget-host.ts
+++ b/widget-react/src/widget-host.ts
@@ -212,6 +212,11 @@ export interface WidgetSurfaceInfo {
   /** SANDBOX_ORIGIN (VITE_MCPJAM_SANDBOX_ORIGIN); "" when unset. */
   sandboxOrigin: string;
   /**
+   * VIEW_MOUNT_MODE (VITE_MCPJAM_VIEW_MOUNT) — how the sandbox proxy mounts
+   * the view. Absent means `"write"`, which is what gives the view a real URL.
+   */
+  viewMountMode?: "write" | "srcdoc";
+  /**
    * Playground CSP-mode selection (useUIPlaygroundStore.mcpAppsCspMode) — an
    * INPUT, not the effective mode. The renderer derives the effective sandbox
    * CSP mode from `kind` + this + the per-widget `minimalMode` prop (kept as an
@@ -254,7 +259,8 @@ export interface WidgetLifecycleEvent {
     | "bridge-connect-ready"
     | "bridge-connect-error"
     | "bridge-connect-skipped"
-    | "app-initialized";
+    | "app-initialized"
+    | "view-mounted";
   status: "ok" | "error" | "pending";
   message?: string;
   timestamp: number;
@@ -280,6 +286,20 @@ export interface WidgetSandboxApplied {
     geolocation?: {};
     clipboardWrite?: {};
   };
+  /**
+   * How the proxy mounted the view. `"url"` means it was written into a blank
+   * same-origin frame and runs at the proxy's URL; the srcdoc values mean it
+   * has no URL of its own (`"srcdoc"` was asked for, `"srcdoc-fallback"` was
+   * forced because the frame's document was unreachable).
+   */
+  viewMode?: "url" | "srcdoc" | "srcdoc-fallback";
+  /** The view's document URL as reported by the proxy. */
+  viewUrl?: string;
+  /**
+   * Origin of `viewUrl` — what a developer allowlists with a third party that
+   * keys on the page URL. Absent on the srcdoc paths, which have no origin.
+   */
+  assignedOrigin?: string;
 }
 
 export interface WidgetSandboxInfo {


### PR DESCRIPTION
## Why

#4661 gave MCP App views a real URL. Nothing surfaces it, so a developer still can't answer the question that started this work — *which origin do I allowlist for my referrer-restricted Google Maps key / OAuth redirect URI?* This adds the answer to the CSP Workbench's Sandbox Stack tab.

Stacked on `main` after #4661. Next in the sequence: host-origin pinning (1B), then the checked-in browser e2e (1D).

## What changed

**Wire.** The proxy posts `mcpjam:view-mode` (`{ mode, url }`) from inside `mountInner`, so remounts — including the reload-remount from #4661 — report too. `targetOrigin` is `"*"` until 1B's host-origin pinning narrows it.

**Plumbing.** `SandboxedIframe` allow-lists the message (it isn't JSON-RPC) and gains a `mountMode` prop, forwarded in the resource-ready payload and folded into the resource-ready key — it decides *how* the HTML is mounted, so a change has to re-send rather than leave the old mount on screen. The renderer records the mount as a `view-mounted` lifecycle event and publishes `viewMode` / `viewUrl` / `assignedOrigin` into `applied`.

**UI.** A "View origin" chip on the inner (View iframe) card:
- `http://127.0.0.1:6274` with a copy button on the normal path — the origin only, since the URL's `?v=` cache-buster is not what an allowlist takes.
- `about:srcdoc · no origin` and **no** copy button on the srcdoc paths, so nobody pastes a value no provider accepts.
- Nothing at all before the proxy has reported a mount.

**Lifecycle status.** `view-mounted` has no `-ready`/`-error` suffix for `mapLogToLifecycle` to read, so the status comes from the mode: a srcdoc mount is the degraded outcome this event exists to make visible, and reads as an error.

**Flag.** `VITE_MCPJAM_VIEW_MOUNT` (`"write"` default | `"srcdoc"`) → `client/src/lib/config.ts` → `WidgetSurfaceInfo.viewMountMode` → both `SandboxedIframe` call sites, plus the Dockerfile `ARG` + export it needs to reach a hosted bundle (without those a `VITE_*` service variable is silently `undefined`). Build-time, so it exists to exercise the srcdoc branch in 1D — not an incident switch; flipping it costs the same redeploy as a revert.

## Reviewer notes

- **Type twins.** `WidgetLifecycleEvent` and `WidgetSandboxApplied` exist in both `widget-react/src/widget-host.ts` and `client/src/stores/widget-debug-store.ts` and are **not** cross-checked by tsc (the host binds the sink structurally). Both copies are edited here; the store copy carries a comment saying so.
- **The modal** mounts its own view and therefore also receives `mcpjam:view-mode`. It deliberately ignores it: the panel describes the inline view and both mount on the same origin, so recording the modal's would overwrite the inline value with an identical one. Comment in `handleModalMessage`.
- **`assignedOrigin`** is derived with `new URL(...).origin` and left `undefined` when the mode isn't `"url"` — the chip's "no origin" branch is driven by that, not by string-matching `about:srcdoc`.

## Verification

- `npm run test -w @mcpjam/inspector -- sandbox-proxy` (67) and the client suites — `sandboxed-iframe`, `mcp-apps-renderer`, `csp-workbench`, `widget-debug-store` — 203 tests green. New coverage: the proxy reports its own `document.URL` (not a hardcoded string) and `about:srcdoc` on the srcdoc branch; `mountMode` forwarded + resend-on-change; `view-mode` reaches `onMessage`; lifecycle `ok`/`error` by mode; `applied` round-trip through the store; and six chip cases (origin, copy, both srcdoc modes, pre-mount, no policy).
- `npm run typecheck:client -w @mcpjam/inspector` clean.
- Chromium, against the real proxy served from a static server: exactly one `mcpjam:view-mode` per mount carrying the proxy URL — on first mount, on re-send, and on the reload-remount.
- Pre-existing prettier drift in these files is untouched; only my own lines are formatted (verified by intersecting prettier's hunks with the diff's line ranges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to sandbox debug plumbing, developer-facing UI, and iframe postMessage forwarding; `targetOrigin` remains `"*"` until a follow-up pins the host origin.
> 
> **Overview**
> Surfaces **which origin to allowlist** for referrer-restricted third-party keys (Maps, OAuth) after MCP App views run at a real proxy URL.
> 
> The sandbox proxy now **`postMessage`s `mcpjam:view-mode`** on each mount (including remounts) with `mode` and `url`. **`SandboxedIframe`** forwards that non–JSON-RPC message and passes **`mountMode`** (`write` vs `srcdoc`) in the resource-ready payload so mount strategy changes trigger a re-send. The renderer records a **`view-mounted`** lifecycle event, stores **`viewMode` / `viewUrl` / `assignedOrigin`** on sandbox `applied`, and the Sandbox Stack tab shows a **“View origin”** chip (copyable origin on the URL path, **`about:srcdoc · no origin`** on srcdoc, hidden until mount is reported).
> 
> Build-time **`VITE_MCPJAM_VIEW_MOUNT`** (`write` default, `srcdoc` for legacy/e2e) flows through config → **`viewMountMode`** on the widget host surface and the Docker client build. The modal iframe **ignores** duplicate `view-mode` messages so it does not overwrite the inline view’s origin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2febc3460a1253c7116df4e30148390a48c0e66c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
MCP App views now run at a real URL, but nothing surfaced it — a developer couldn't tell which origin to allowlist for a referrer-restricted API key or OAuth redirect URI. The Sandbox Stack panel now shows a View origin chip with the view's origin and a copy button, or `about:srcdoc · no origin` with no copy button when the view fell back to `srcdoc`.

**Data flow**
- The sandbox proxy posts `mcpjam:view-mode` (`{ mode, url }`) from inside `mountInner`, so remounts and reload-remounts report too; `targetOrigin` stays `"*"` until host-origin pinning lands.
- `SandboxedIframe` allow-lists the non-JSON-RPC message and forwards a new `mountMode` prop in the resource-ready payload, folded into the resource-ready key so a change re-sends.
- The renderer records the mount as a `view-mounted` lifecycle event and publishes `viewMode`/`viewUrl`/`assignedOrigin` into `applied`; `srcdoc` mounts read as errors since they have no origin to allowlist.
- `VITE_MCPJAM_VIEW_MOUNT` (`"write"` default | `"srcdoc"`) flows through config → `WidgetSurfaceInfo` → both `SandboxedIframe` call sites, plus the Dockerfile `ARG`; build-time only, to exercise the `srcdoc` branch.

**Reviewer notes**
- `WidgetLifecycleEvent` and `WidgetSandboxApplied` are duplicated in `widget-react` and the inspector store without tsc cross-checks; both copies are edited here.
- The modal receives `mcpjam:view-mode` too but ignores it — both mounts share the same origin, so recording the modal's would overwrite the inline value with an identical one.
- `assignedOrigin` is derived via `new URL(...).origin` and left `undefined` for non-`"url"` modes; the chip's "no origin" branch keys off that, not string-matching `about:srcdoc`.

<sup>Written for commit 2febc3460a1253c7116df4e30148390a48c0e66c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

