### PR TITLE
mcp apps: browser e2e for the view's real URL

### DIFF
--- a/mcpjam-inspector/client/src/components/e2e/McpAppViewE2EHarness.tsx
+++ b/mcpjam-inspector/client/src/components/e2e/McpAppViewE2EHarness.tsx
@@ -1,0 +1,138 @@
+import { useCallback, useMemo, useState } from "react";
+import { SandboxedIframe } from "@/components/ui/sandboxed-iframe";
+
+/**
+ * Dev-only harness for the MCP App view-mount e2e.
+ *
+ * It mounts a `SandboxedIframe` directly rather than driving the full
+ * chat/renderer path, because the properties under test all live in the
+ * sandbox layer: the URL the view's document ends up with, the `Referer` a
+ * third party receives, whether the injected CSP still binds after the HTML is
+ * written, and whether a widget's own `location.reload()` restarts it. None of
+ * those can be observed in jsdom — `document.open()` there neither adopts the
+ * entry document's URL nor enforces a policy — so a real browser is the only
+ * place they can be pinned.
+ *
+ * What this deliberately does NOT cover: the renderer's lifecycle/`applied`
+ * plumbing and the Sandbox Stack origin chip, which are asserted in the
+ * component tests where they can be driven directly.
+ */
+
+interface ViewModeEvent {
+  mode: string;
+  url: string;
+}
+
+interface CspViolationEvent {
+  directive: string;
+  blockedUri: string;
+}
+
+declare global {
+  interface Window {
+    __mcpAppViewE2E?: {
+      viewModes: ViewModeEvent[];
+      cspViolations: CspViolationEvent[];
+    };
+  }
+}
+
+function record(
+  update: (state: NonNullable<Window["__mcpAppViewE2E"]>) => void,
+) {
+  const state = (window.__mcpAppViewE2E ??= {
+    viewModes: [],
+    cspViolations: [],
+  });
+  update(state);
+}
+
+/**
+ * The widget under test. It calls the fixture (so the fixture can record what
+ * the browser said about the caller) and then a host that the declared CSP
+ * does not allow (so the injected policy has something to refuse). Both run at
+ * parse time, which is also what proves the CSP `<meta>` bound during the
+ * write rather than after it.
+ */
+function buildWidgetHtml(
+  fixtureOrigin: string,
+  blockedUrl: string,
+  withDoctype: boolean,
+): string {
+  return `${withDoctype ? "<!doctype html>\n" : ""}<html>
+  <head><meta charset="utf-8" /></head>
+  <body>
+    <p id="widget-marker">mcp app view e2e</p>
+    <script>
+      fetch(${JSON.stringify(fixtureOrigin)} + "/echo")
+        .then(function () { window.__fixtureFetched = true; })
+        .catch(function () { window.__fixtureFetched = false; });
+      fetch(${JSON.stringify(blockedUrl)}).catch(function () {});
+    </script>
+  </body>
+</html>`;
+}
+
+export function McpAppViewE2EHarness() {
+  const params = new URLSearchParams(window.location.search);
+  const fixtureOrigin = params.get("fixture") ?? "";
+  const mountMode = params.get("mount") === "srcdoc" ? "srcdoc" : "write";
+  // A written document without a doctype lands in quirks mode, which a srcdoc
+  // document never did. The e2e pins that as a deliberate fidelity choice.
+  const withDoctype = params.get("doctype") !== "none";
+  // A host the declared CSP omits. `.invalid` is reserved by RFC 2606, so the
+  // request can only ever be refused by the policy, never by DNS luck.
+  const blockedUrl = "https://blocked.invalid/probe";
+
+  const [reloadNonce, setReloadNonce] = useState(0);
+  const html = useMemo(
+    () => buildWidgetHtml(fixtureOrigin, blockedUrl, withDoctype),
+    [fixtureOrigin, withDoctype],
+  );
+
+  const onMessage = useCallback((event: MessageEvent) => {
+    const data = event.data;
+    if (!data || typeof data !== "object") return;
+    if (data.type === "mcpjam:view-mode") {
+      record((state) =>
+        state.viewModes.push({ mode: data.mode, url: data.url }),
+      );
+      return;
+    }
+    if (data.type === "mcp-apps:csp-violation") {
+      record((state) =>
+        state.cspViolations.push({
+          directive: data.directive,
+          blockedUri: data.blockedUri,
+        }),
+      );
+    }
+  }, []);
+
+  return (
+    <div style={{ padding: 16 }}>
+      <h1 style={{ fontSize: 14 }}>MCP App view e2e harness</h1>
+      <button
+        type="button"
+        data-testid="remount"
+        onClick={() => setReloadNonce((n) => n + 1)}
+      >
+        remount
+      </button>
+      <div style={{ width: 600, height: 300 }}>
+        <SandboxedIframe
+          key={reloadNonce}
+          html={html}
+          onMessage={onMessage}
+          mountMode={mountMode}
+          // Only the fixture is declared, so the widget's second fetch has to
+          // be refused by the policy the proxy injected.
+          csp={{ connectDomains: [fixtureOrigin] }}
+          permissive={false}
+          title="MCP App view e2e"
+          style={{ width: "100%", height: "100%" }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -503,6 +503,15 @@ export function createAppRouter(): AppRouter {
               return { Component: OAuthDebuggerE2EHarness };
             },
           },
+          {
+            path: "__e2e/mcp-app-view",
+            lazy: async () => {
+              const { McpAppViewE2EHarness } = await import(
+                "./components/e2e/McpAppViewE2EHarness"
+              );
+              return { Component: McpAppViewE2EHarness };
+            },
+          },
         ]
       : []),
     {

--- a/mcpjam-inspector/e2e/fixtures/mcp-app-view-fixture-server.ts
+++ b/mcpjam-inspector/e2e/fixtures/mcp-app-view-fixture-server.ts
@@ -1,0 +1,82 @@
+import http, { type IncomingMessage, type ServerResponse } from "node:http";
+import { once } from "node:events";
+
+/**
+ * A stand-in for the third-party API an MCP App view calls — the Google Maps
+ * of the scenario that drove real-URL views.
+ *
+ * Its whole job is to record what the browser told it about the caller. A
+ * referrer-restricted API key is checked against exactly that, so a fixture
+ * that answers unconditionally and remembers the `Referer` is a truer oracle
+ * than asserting on anything the page reports about itself.
+ *
+ * Note the recorded `Referer` is governed by the SENDING document's referrer
+ * policy, which nothing here can influence — a response header on this fixture
+ * would only affect requests made from its own responses.
+ */
+export interface ViewFixtureRequest {
+  path: string;
+  /** What the browser said the calling page was. */
+  referer?: string;
+  /** The caller's origin, which is what CORS-based allowlists key on. */
+  origin?: string;
+}
+
+export interface ViewFixtureServer {
+  origin: string;
+  requests: ViewFixtureRequest[];
+  close: () => Promise<void>;
+}
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+export async function startViewFixtureServer(): Promise<ViewFixtureServer> {
+  const requests: ViewFixtureRequest[] = [];
+
+  const server = http.createServer(
+    (request: IncomingMessage, response: ServerResponse) => {
+      const url = new URL(
+        request.url ?? "/",
+        `http://${request.headers.host ?? "127.0.0.1"}`,
+      );
+
+      if (request.method === "OPTIONS") {
+        response.writeHead(204, CORS_HEADERS);
+        response.end();
+        return;
+      }
+
+      requests.push({
+        path: url.pathname,
+        referer: request.headers.referer,
+        origin: request.headers.origin,
+      });
+
+      response.writeHead(200, {
+        ...CORS_HEADERS,
+        "Content-Type": "application/json",
+      });
+      response.end(JSON.stringify({ ok: true }));
+    },
+  );
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("View fixture server did not receive a TCP address");
+  }
+
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: async () => {
+      server.close();
+      await once(server, "close");
+    },
+  };
+}

--- a/mcpjam-inspector/e2e/mcp-app-view-origin.spec.ts
+++ b/mcpjam-inspector/e2e/mcp-app-view-origin.spec.ts
@@ -1,0 +1,268 @@
+import { expect, type Frame, type Page, test } from "@playwright/test";
+import {
+  startViewFixtureServer,
+  type ViewFixtureServer,
+} from "./fixtures/mcp-app-view-fixture-server";
+
+/**
+ * MCP App views run at a real URL.
+ *
+ * A customer with a referrer-restricted Google Maps key could not render a map
+ * in MCPJam: the view was loaded via `iframe.srcdoc`, so its document URL was
+ * `about:srcdoc` and no allowlist could name it. The proxy now writes the HTML
+ * into a blank same-origin frame, and per the HTML spec's document-open steps
+ * the written document adopts the entry document's URL — the proxy's.
+ *
+ * jsdom models none of that (`document.open()` there only clears child nodes),
+ * so these are the only assertions that can hold the behaviour: the view's own
+ * `location.href`, what a third-party server actually receives, and whether the
+ * injected CSP still binds after the write.
+ */
+
+const HARNESS = "/__e2e/mcp-app-view";
+const PROXY_PATH = "/api/apps/mcp-apps/sandbox-proxy";
+
+interface HarnessState {
+  viewModes: Array<{ mode: string; url: string }>;
+  cspViolations: Array<{ directive: string; blockedUri: string }>;
+}
+
+function harnessUrl(
+  fixture: ViewFixtureServer,
+  options: { mount?: "srcdoc"; doctype?: "none" } = {},
+): string {
+  const params = new URLSearchParams({ fixture: fixture.origin });
+  if (options.mount) params.set("mount", options.mount);
+  if (options.doctype) params.set("doctype", options.doctype);
+  return `${HARNESS}?${params.toString()}`;
+}
+
+/** The outer sandbox-proxy frame, which is a direct child of the page. */
+function proxyFrame(page: Page): Frame {
+  const frame = page
+    .frames()
+    .find(
+      (f) =>
+        f.parentFrame() === page.mainFrame() && f.url().includes(PROXY_PATH),
+    );
+  if (!frame) throw new Error("sandbox proxy frame not found");
+  return frame;
+}
+
+/**
+ * The view frame, reached through Playwright's frame tree rather than by URL.
+ *
+ * Two reasons not to match on the URL: once the view is mounted by
+ * `document.write` it reports the SAME url as its parent — the property under
+ * test — so a URL match would happily return the proxy and pass even if the
+ * view never mounted; and the proxy is cross-origin to the page (127.0.0.1 vs
+ * localhost), so the page cannot reach into it with `contentDocument` at all.
+ */
+async function viewFrame(page: Page): Promise<Frame> {
+  let found: Frame | undefined;
+  await expect
+    .poll(
+      async () => {
+        const outer = page
+          .frames()
+          .find(
+            (f) =>
+              f.parentFrame() === page.mainFrame() &&
+              f.url().includes(PROXY_PATH),
+          );
+        const children = outer?.childFrames() ?? [];
+        if (children.length !== 1) return false;
+        try {
+          const mounted = await children[0].evaluate(
+            () => !!document.querySelector("#widget-marker"),
+          );
+          if (mounted) found = children[0];
+          return mounted;
+        } catch {
+          // The frame can navigate mid-evaluation (a remount); poll again.
+          return false;
+        }
+      },
+      { timeout: 20_000 },
+    )
+    .toBe(true);
+  return found!;
+}
+
+function readHarness(page: Page): Promise<HarnessState> {
+  return page.evaluate(
+    () => window.__mcpAppViewE2E ?? { viewModes: [], cspViolations: [] },
+  ) as Promise<HarnessState>;
+}
+
+test.describe("MCP App view origin", () => {
+  let fixture: ViewFixtureServer;
+
+  test.beforeEach(async () => {
+    fixture = await startViewFixtureServer();
+  });
+
+  test.afterEach(async () => {
+    await fixture.close();
+  });
+
+  test("the view runs at the sandbox proxy's URL, on the sandbox origin", async ({
+    page,
+    baseURL,
+  }) => {
+    await page.goto(harnessUrl(fixture));
+    const view = await viewFrame(page);
+
+    const viewLocation = await view.evaluate(() => ({
+      href: location.href,
+      origin: location.origin,
+      // The property the whole change exists for: a widget asking where it is
+      // gets an answer a third-party allowlist can match.
+      documentUrl: document.URL,
+      hasSrcdocAttribute: !!window.frameElement?.hasAttribute("srcdoc"),
+    }));
+
+    // Origin separation is still intact: the app is on localhost, the view is
+    // on 127.0.0.1 (the local stand-in for a distinct sandbox origin).
+    const appOrigin = new URL(baseURL!).origin;
+    expect(viewLocation.origin).not.toBe(appOrigin);
+    expect(viewLocation.origin).toBe(
+      appOrigin.replace("localhost", "127.0.0.1"),
+    );
+    expect(viewLocation.href).toContain(PROXY_PATH);
+    expect(viewLocation.documentUrl).toBe(viewLocation.href);
+    expect(viewLocation.hasSrcdocAttribute).toBe(false);
+
+    const state = await readHarness(page);
+    expect(state.viewModes).toHaveLength(1);
+    expect(state.viewModes[0].mode).toBe("url");
+    expect(state.viewModes[0].url).toBe(viewLocation.href);
+  });
+
+  test("a third party sees the view's real page URL as the referrer", async ({
+    page,
+  }) => {
+    // This is the customer's failure, inverted: Google rejected the key because
+    // the request carried nothing an allowlist could match.
+    await page.goto(harnessUrl(fixture));
+    const view = await viewFrame(page);
+    const href = await view.evaluate(() => location.href);
+    const viewOrigin = new URL(href).origin;
+
+    await expect
+      .poll(() => fixture.requests.filter((r) => r.path === "/echo").length)
+      .toBeGreaterThan(0);
+
+    const echo = fixture.requests.find((r) => r.path === "/echo")!;
+
+    // The app sends `Referrer-Policy: strict-origin-when-cross-origin`, so a
+    // cross-origin request carries the origin and not the path. That is the
+    // granularity a referrer allowlist matches on anyway (`http://127.0.0.1:*/*`),
+    // and it is what changed: the value is a real origin rather than absent.
+    expect(echo.referer).toBe(`${viewOrigin}/`);
+    expect(echo.referer).not.toBe("");
+    // Specifically NOT the app's own origin — the sandbox is a separate origin
+    // and the third party must see the sandbox, or the allowlist a developer
+    // was told to add would be the wrong one.
+    expect(echo.referer).not.toContain("localhost");
+    // Allowlists that key on `Origin` (WebKit strips `Referer` cross-origin,
+    // which is why Claude's docs tell iOS developers to use it) agree.
+    expect(echo.origin).toBe(viewOrigin);
+  });
+
+  test("the injected CSP still binds to the written document", async ({
+    page,
+  }) => {
+    // The policy travels as a `<meta>` inside the HTML the proxy writes. If it
+    // failed to bind during the write, an undeclared host would simply be
+    // fetched and the view would silently have no policy at all.
+    await page.goto(harnessUrl(fixture));
+    await viewFrame(page);
+
+    await expect
+      .poll(async () => (await readHarness(page)).cspViolations.length)
+      .toBeGreaterThan(0);
+
+    const state = await readHarness(page);
+    expect(state.cspViolations[0].blockedUri).toContain("blocked.invalid");
+    expect(state.cspViolations[0].directive).toContain("connect-src");
+    // The declared host was not collateral damage.
+    expect(fixture.requests.some((r) => r.path === "/echo")).toBe(true);
+  });
+
+  test("a widget reloading itself restarts rather than blanking", async ({
+    page,
+  }) => {
+    // Chromium answers `location.reload()` in a written document by reloading
+    // the frame's history entry — the initial about:blank — so without the
+    // proxy's remount the widget would vanish and nothing would report it.
+    await page.goto(harnessUrl(fixture));
+    const view = await viewFrame(page);
+    const before = (await readHarness(page)).viewModes.length;
+
+    await view
+      .evaluate(() => location.reload())
+      .catch(() => {
+        // The frame navigates out from under the evaluation; the assertions
+        // below are what decide the outcome.
+      });
+
+    await expect
+      .poll(async () => (await readHarness(page)).viewModes.length)
+      .toBeGreaterThan(before);
+
+    const restored = await viewFrame(page);
+    expect(
+      await restored.evaluate(
+        () => document.querySelector("#widget-marker")?.textContent,
+      ),
+    ).toBe("mcp app view e2e");
+    const state = await readHarness(page);
+    expect(state.viewModes.at(-1)!.mode).toBe("url");
+  });
+
+  test("the srcdoc mount path still renders, and reports that it has no origin", async ({
+    page,
+  }) => {
+    // The fallback the proxy keeps for a frame whose document is unreachable.
+    // It must still render — and must say it has no URL, so the Inspector's
+    // origin chip never offers a value no allowlist would accept.
+    await page.goto(harnessUrl(fixture, { mount: "srcdoc" }));
+    const view = await viewFrame(page);
+
+    expect(
+      await view.evaluate(
+        () => document.querySelector("#widget-marker")?.textContent,
+      ),
+    ).toBe("mcp app view e2e");
+    expect(await view.evaluate(() => location.href)).toBe("about:srcdoc");
+
+    const state = await readHarness(page);
+    expect(state.viewModes).toHaveLength(1);
+    expect(state.viewModes[0]).toEqual({
+      mode: "srcdoc",
+      url: "about:srcdoc",
+    });
+  });
+
+  test("HTML without a doctype renders in quirks mode, as it does on Claude", async ({
+    page,
+  }) => {
+    // A real behaviour change from the srcdoc era: a srcdoc document is never
+    // in quirks mode, a written one without a doctype is (HTML parsing, the
+    // "initial" insertion mode). claude.ai behaves the same way, so MCPJam
+    // matching it is the point — pinned here so it stays a deliberate fidelity
+    // choice rather than resurfacing as a mystery layout report.
+    await page.goto(harnessUrl(fixture));
+    const withDoctype = await viewFrame(page);
+    expect(await withDoctype.evaluate(() => document.compatMode)).toBe(
+      "CSS1Compat",
+    );
+
+    await page.goto(harnessUrl(fixture, { doctype: "none" }));
+    const withoutDoctype = await viewFrame(page);
+    expect(await withoutDoctype.evaluate(() => document.compatMode)).toBe(
+      "BackCompat",
+    );
+  });
+});

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -102,6 +102,7 @@
     "test:coverage": "cross-env NODE_OPTIONS=--max-old-space-size=6144 vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:oauth-debugger": "npm run sdk:build && playwright test -c playwright.oauth-debugger.config.ts",
+    "test:e2e:mcp-apps": "npm run predev && playwright test -c playwright.mcp-apps.config.ts",
     "ship": "bash scripts/ship.sh"
   },
   "dependencies": {

--- a/mcpjam-inspector/playwright.config.ts
+++ b/mcpjam-inspector/playwright.config.ts
@@ -27,7 +27,9 @@ const packageRoot = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig({
   testDir: "./e2e",
-  testIgnore: /oauth-debugger\.spec\.ts/,
+  // Both run only against a DEV server (their `/__e2e/*` harness routes are
+  // registered behind `import.meta.env.DEV`), so they have their own configs.
+  testIgnore: /(oauth-debugger|mcp-app-view-origin)\.spec\.ts/,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/mcpjam-inspector/playwright.mcp-apps.config.ts
+++ b/mcpjam-inspector/playwright.mcp-apps.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig, devices } from "@playwright/test";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = fileURLToPath(new URL(".", import.meta.url));
+
+/**
+ * The MCP Apps view-mount suite runs against a DEV server: its harness lives at
+ * `/__e2e/mcp-app-view`, a route registered only when `import.meta.env.DEV` is
+ * set. Ports are its own so it can run beside the oauth-debugger config.
+ *
+ * `mountMode` is a harness query parameter rather than a second server with
+ * `VITE_MCPJAM_VIEW_MOUNT=srcdoc`, so both mount paths are covered by one
+ * browser against one build.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: /mcp-app-view-origin\.spec\.ts/,
+  timeout: 90_000,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "dev",
+      use: {
+        ...devices["Desktop Chrome"],
+        baseURL: "http://localhost:5375",
+      },
+    },
+  ],
+  webServer: [
+    {
+      command: "npm run dev:app:default",
+      url: "http://localhost:5375/__e2e/mcp-app-view",
+      cwd: packageRoot,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        MCPJAM_INSPECTOR_SUPPRESS_AUTO_OPEN: "1",
+        VITE_WORKOS_CLIENT_ID: "mcp-apps-e2e-workos-client",
+        VITE_CONVEX_URL: "https://mcp-apps-e2e.convex.cloud",
+        CLIENT_PORT: "5375",
+        SERVER_PORT: "6475",
+        VITE_API_BASE_URL: "http://localhost:6475",
+        WEB_ALLOWED_ORIGINS: "http://localhost:5375,http://127.0.0.1:5375",
+        CLIENT_CACHE_DIR: "node_modules/.vite-mcp-apps-e2e",
+      },
+    },
+  ],
+});


### PR DESCRIPTION
## Why

The properties that justify mounting views by `document.write` (#4661) are all browser-level, and **jsdom models none of them** — its `document.open()` only clears child nodes, adopting no URL and enforcing no policy. Up to now they were verified by a throwaway Playwright script I ran by hand. This makes them a checked-in gate.

Completes Phase 1. Remaining in the plan: host-origin pinning (1B), then the `_meta.ui.domain` work.

## The six cases

| | asserts |
|---|---|
| **Real URL** | the view's own `location.href` is the proxy URL, on the sandbox origin (`127.0.0.1`) and **not** the app's (`localhost`), with no `srcdoc` attribute |
| **Third-party referrer** | a fixture server records what the browser actually sent it |
| **CSP after the write** | an undeclared host is refused; the declared fixture is not |
| **Widget self-reload** | `location.reload()` inside the view restarts it instead of blanking |
| **srcdoc path** | still renders, and reports it has no URL |
| **Quirks mode** | doctype-less HTML → `BackCompat`, with a doctype control → `CSS1Compat` |

**One finding worth flagging.** My first version of the referrer test asserted the fixture would see the view's full URL. It doesn't: the app sends `Referrer-Policy: strict-origin-when-cross-origin`, so a cross-origin request carries the **origin only** — `http://127.0.0.1:5375/`. That's correct and privacy-preserving, it's the granularity a referrer allowlist matches anyway (`http://127.0.0.1:*/*`), and the thing that changed is that the value is a real origin rather than absent. The test now pins that, plus the two regressions that would matter: it must not be empty, and must not be the *app's* origin — otherwise the origin we tell developers to allowlist would be the wrong one.

## Scope choice

The harness mounts `SandboxedIframe` directly rather than driving the chat renderer against a live MCP connection. Every property above lives in the sandbox layer, and the renderer's lifecycle/`applied` plumbing and the Sandbox Stack origin chip already have component tests that drive them directly. Building a fixture MCP server plus a connection flow to re-assert them through the UI would be a lot of machinery for coverage that exists — the harness header says so explicitly.

## Infrastructure notes for the reviewer

- **`test:e2e:mcp-apps` runs `predev` first.** `dev:app:default` assumes the generated server bundles already exist; in this fresh worktree the dev server died on a missing `codex-appserver-bridge.bundled.js` and every test timed out on a page that rendered but never mounted. `playwright.oauth-debugger.config.ts` has the same latent dependency — it survives because a dev has usually run `npm run dev` first. Worth considering the same change there separately.
- **The default suite ignores this spec** (`playwright.config.ts` `testIgnore`), because it boots a *production* server where `/__e2e/*` is not registered. Verified: `--list` on the default config matches 0 of these, and the oauth-debugger config still matches only its own.
- **`mountMode` is a harness query parameter**, not a second dev server with `VITE_MCPJAM_VIEW_MOUNT=srcdoc` — one build, one browser, both mount paths.
- **`viewFrame()` deliberately does not match on URL.** Once mounted, the view reports the *same* URL as its parent proxy — the property under test — so a URL match would return the proxy and pass even if the view never mounted. It walks the frame tree instead. (My first attempt reached through `outer.contentDocument` from the page, which is null cross-origin; that's what the first red run was.)
- **`client/src/router.tsx`:** my `lazy` block matches the formatting of the identical `OAuthDebuggerE2EHarness` block directly above it. Prettier v3 would reformat *both*; I left the neighbour consistency rather than making two adjacent identical imports look different. Say the word if you'd rather I match prettier.

## Verification

`npm run test:e2e:mcp-apps` — 6 passed (~17s). `npm run typecheck:client` clean; `route-elements-coverage` still green with the new route; new files are prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds dev-only routes, e2e fixtures, and npm/Playwright config only; no production sandbox or proxy behavior changes in this diff.
> 
> **Overview**
> Adds a **checked-in browser e2e suite** for MCP App view mounting behaviors that jsdom cannot model (proxy URL adoption, cross-origin `Referer`/`Origin`, CSP binding after `document.write`, widget `location.reload()`, srcdoc fallback, and quirks mode without a doctype).
> 
> A dev-only **`/__e2e/mcp-app-view` harness** mounts `SandboxedIframe` directly (query params for `mount`, `doctype`, fixture origin) and records `mcpjam:view-mode` / CSP violation messages on `window.__mcpAppViewE2E`. Playwright drives six cases against a local **fixture HTTP server** that logs incoming `Referer` and `Origin`.
> 
> **CI wiring:** new `test:e2e:mcp-apps` (runs `predev` then `playwright.mcp-apps.config.ts` on a dedicated dev port), and the default `playwright.config.ts` now **ignores** `mcp-app-view-origin.spec.ts` like the oauth-debugger suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28788168991241c430f42625c032b66e1b1a6c58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds browser e2e coverage for MCP App views mounted by `document.write`, pinning the real-URL behavior that jsdom can't model. Six cases verify the view runs at the sandbox proxy's URL on `127.0.0.1` (never the app's `localhost`), a third-party fixture sees the sandbox origin as referrer (trimmed by `strict-origin-when-cross-origin`, which is the granularity a referrer allowlist matches anyway), the injected CSP still binds after the write, `location.reload()` restarts a widget instead of blanking it, the `srcdoc` fallback still renders and reports no URL, and doctype-less HTML lands in quirks mode (matching claude.ai).

**Infrastructure**
- New `playwright.mcp-apps.config.ts` runs a dev server, since the `/__e2e/mcp-app-view` harness route exists only behind `import.meta.env.DEV`; the default production suite ignores this spec.
- `mountMode` is a harness query parameter, so one browser build covers both mount paths against one server.
- The harness mounts `SandboxedIframe` directly rather than driving the chat renderer; renderer `applied` plumbing and the origin chip already have component tests.
- `test:e2e:mcp-apps` runs `predev` first, because the dev server dies in a fresh worktree on missing generated server bundles.

<sup>Written for commit 28788168991241c430f42625c032b66e1b1a6c58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

