### PR TITLE
Local inspector reaches OAuth servers on your own network

### DIFF
--- a/.changeset/local-inspector-reaches-private-networks.md
+++ b/.changeset/local-inspector-reaches-private-networks.md
@@ -1,0 +1,46 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/cli": minor
+"@mcpjam/inspector": patch
+---
+
+The local inspector reaches OAuth servers on your own network
+
+Testing a fully local OAuth setup failed with `OAuth proxy target resolves to
+a private/reserved IP address (127.0.0.1)` whenever the authorization server
+had a hostname of its own — `auth.local`, or anything else answering
+loopback. The address guard could not tell a developer's laptop from our
+hosted infrastructure, so it applied the policy written for the second to
+both, and the official MCP Inspector, which has no guard at all, worked where
+we did not.
+
+**What changed.** The guard now distinguishes two questions instead of
+answering one. "Is this private?" still governs the hosted app, which fetches
+from our nodes where a private address means our own network. "Is this ever
+dialable?" governs the local inspector and the CLI, and refuses only what is
+never a real OAuth endpoint: link-local and every cloud metadata service,
+including the two that hide inside ranges corporate networks legitimately use
+(Alibaba's inside CGNAT, AWS's inside the unique-local range), plus the
+unspecified address, multicast and reserved space.
+
+So `npx @mcpjam/inspector` and `mcpjam oauth …` now reach loopback, LAN,
+CGNAT and unique-local targets, and hostnames that resolve to them, with no
+flag to set. The hosted app is unchanged. The CLI's three OAuth proxy
+commands, which hardcoded the hosted policy and could not be talked out of
+it, gain `--https-only` for reproducing what the hosted app would do.
+
+**For SDK consumers.** `allowPrivateNetwork` (and `allowPrivateMetadataFetch`
+on the state-machine surfaces) is additive and defaults to false, so existing
+callers keep today's behaviour without changing a line, and `httpsOnly` still
+overrides it. The one visible difference for an unchanged caller is wording:
+a link-local or metadata destination now says so, instead of being reported
+as "private/reserved".
+
+**What is still refused locally.** The allowance belongs to the chain, and
+the chain's character is decided by where its first hop actually landed
+rather than by how the hostname looked — a name that looks public and answers
+`127.0.0.1` is the case this exists to serve, so a name-based test would
+refuse the thing it permits. A public server that answers `302 Location:
+http://192.168.1.1/…` therefore cannot make your inspector fetch it. DNS is
+still resolved once and pinned into the socket, so rebinding is closed, and
+cross-origin redirects still drop credentials.

--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -151,6 +151,14 @@ interface OAuthProxyCommandOptions {
   method?: string;
   header?: string[];
   body?: string;
+  /**
+   * Opt IN to the hosted policy: HTTPS-only, no private destinations. The CLI
+   * runs on the user's own machine, so the default is the local one — these
+   * commands exist to debug a server you are developing, which is routinely on
+   * loopback or a LAN address. `--https-only` is for reproducing what the
+   * hosted app would do with the same URL.
+   */
+  httpsOnly?: boolean;
 }
 
 export function registerOAuthCommands(program: Command): void {
@@ -535,15 +543,22 @@ export function registerOAuthCommands(program: Command): void {
     .command("metadata")
     .description("Fetch OAuth metadata from a URL")
     .requiredOption("--url <url>", "OAuth metadata URL")
+    .option(
+      "--https-only",
+      "Apply the hosted policy: reject non-HTTPS and private targets",
+    )
     .action(async (options, command) => {
       const format = getOAuthFormat(command);
-      const result = await runOAuthMetadata(options.url as string);
+      const result = await runOAuthMetadata(
+        options.url as string,
+        options.httpsOnly === true,
+      );
       writeResult(result, format);
     });
 
   oauth
     .command("proxy")
-    .description("Proxy an OAuth request with hosted-mode safety checks")
+    .description("Proxy an OAuth request through the SSRF-hardened transport")
     .requiredOption("--url <url>", "OAuth request URL")
     .option("--method <method>", "HTTP method", "GET")
     .option(
@@ -555,6 +570,10 @@ export function registerOAuthCommands(program: Command): void {
     .option(
       "--body <value>",
       "Request body as JSON, raw string, @path, or - for stdin",
+    )
+    .option(
+      "--https-only",
+      "Apply the hosted policy: reject non-HTTPS and private targets",
     )
     .action(async (options, command) => {
       const format = getOAuthFormat(command);
@@ -564,7 +583,9 @@ export function registerOAuthCommands(program: Command): void {
 
   oauth
     .command("debug-proxy")
-    .description("Proxy an OAuth debug request with hosted-mode safety checks")
+    .description(
+      "Proxy an OAuth debug request through the SSRF-hardened transport",
+    )
     .requiredOption("--url <url>", "OAuth request URL")
     .option("--method <method>", "HTTP method", "GET")
     .option(
@@ -576,6 +597,10 @@ export function registerOAuthCommands(program: Command): void {
     .option(
       "--body <value>",
       "Request body as JSON, raw string, @path, or - for stdin",
+    )
+    .option(
+      "--https-only",
+      "Apply the hosted policy: reject non-HTTPS and private targets",
     )
     .action(async (options, command) => {
       const format = getOAuthFormat(command);
@@ -690,6 +715,9 @@ export function buildOAuthConformanceConfig(
     serverUrl,
     protocolVersion,
     registrationStrategy,
+    // The CLI runs on the user's machine, where the server under test is
+    // routinely on loopback or a LAN address.
+    allowPrivateNetwork: true,
     auth,
     client,
     scopes: options.scopes?.trim() || undefined,
@@ -822,6 +850,8 @@ export function buildOAuthLoginConfig(
     ...(registrationStrategy ? { registrationStrategy } : {}),
     protocolMode: protocolVersion ?? "auto",
     registrationMode: registrationStrategy ?? "auto",
+    // See buildOAuthConformanceConfig: a local server under test is the norm.
+    allowPrivateNetwork: true,
     auth,
     client,
     scopes: options.scopes?.trim() || undefined,
@@ -1017,9 +1047,12 @@ function parseAuthMode(
   );
 }
 
-export async function runOAuthMetadata(url: string) {
+export async function runOAuthMetadata(url: string, httpsOnly = false) {
   try {
-    const result = await fetchOAuthMetadata(url, true);
+    const result = await fetchOAuthMetadata(url, {
+      httpsOnly,
+      allowPrivateNetwork: !httpsOnly,
+    });
     if ("status" in result && result.status !== undefined) {
       throw cliError(
         statusToErrorCode(result.status),
@@ -1040,7 +1073,8 @@ export async function runOAuthProxy(options: OAuthProxyCommandOptions) {
       method: options.method,
       headers: parseHeadersOption(options.header),
       body: parseProxyBody(options.body),
-      httpsOnly: true,
+      httpsOnly: options.httpsOnly === true,
+      allowPrivateNetwork: options.httpsOnly !== true,
     });
   } catch (error) {
     throw mapOAuthProxyError(error);
@@ -1054,7 +1088,8 @@ export async function runOAuthDebugProxy(options: OAuthProxyCommandOptions) {
       method: options.method,
       headers: parseHeadersOption(options.header),
       body: parseProxyBody(options.body),
-      httpsOnly: true,
+      httpsOnly: options.httpsOnly === true,
+      allowPrivateNetwork: options.httpsOnly !== true,
     });
   } catch (error) {
     throw mapOAuthProxyError(error);

--- a/cli/src/commands/server.ts
+++ b/cli/src/commands/server.ts
@@ -139,6 +139,9 @@ export function registerServerCommands(program: Command): void {
         result = await probeMcpServer({
           url: probeUrl,
           protocolVersion,
+          // Local tool, local servers: probing http://127.0.0.1:3000/mcp is
+          // the ordinary case, not the exception.
+          allowPrivateNetwork: true,
           headers: parseHeadersOption(options.header),
           accessToken,
           clientCapabilities:

--- a/cli/src/commands/xaa.ts
+++ b/cli/src/commands/xaa.ts
@@ -393,6 +393,9 @@ export function buildXaaConfig(
     ...(options.scopes?.trim() ? { scope: options.scopes.trim() } : {}),
     ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     httpsOnly: options.httpsOnly ?? false,
+    // The inverse of the hosted switch: without --https-only this is a local
+    // dev run, and the mock IdP plus the RS it talks to are on loopback.
+    allowPrivateNetwork: options.httpsOnly !== true,
   };
 }
 

--- a/cli/src/lib/mcp-server.ts
+++ b/cli/src/lib/mcp-server.ts
@@ -820,6 +820,8 @@ export function createMcpJamMcpServer(
           url,
           accessToken,
           headers,
+          // See the `server probe` command: this runs on the user's machine.
+          allowPrivateNetwork: true,
           timeoutMs: timeoutMs ?? defaultTimeoutMs,
         });
         return redactForTelemetry(result);

--- a/docs/cli/oauth-login.mdx
+++ b/docs/cli/oauth-login.mdx
@@ -83,7 +83,9 @@ mcpjam oauth metadata --url https://auth.example.com/.well-known/oauth-authoriza
 
 ### `oauth proxy`
 
-Send an arbitrary HTTP request through the OAuth proxy with hosted-mode safety checks. Useful for testing individual OAuth endpoints (registration, token, etc.) without building raw HTTP requests.
+Send an arbitrary HTTP request through the SSRF-hardened OAuth proxy. Useful for testing individual OAuth endpoints (registration, token, etc.) without building raw HTTP requests.
+
+Private targets — loopback, your LAN, or a hostname that resolves to one — are reachable by default, since the CLI runs on your machine. Add `--https-only` to apply the hosted app's stricter policy instead.
 
 ```bash
 # Test a DCR registration

--- a/docs/cli/oauth-login.mdx
+++ b/docs/cli/oauth-login.mdx
@@ -85,7 +85,7 @@ mcpjam oauth metadata --url https://auth.example.com/.well-known/oauth-authoriza
 
 Send an arbitrary HTTP request through the SSRF-hardened OAuth proxy. Useful for testing individual OAuth endpoints (registration, token, etc.) without building raw HTTP requests.
 
-Private targets — loopback, your LAN, or a hostname that resolves to one — are reachable by default, since the CLI runs on your machine. Add `--https-only` to apply the hosted app's stricter policy instead.
+Private targets — loopback, your LAN, or a hostname that resolves to one — are reachable by default, since the CLI runs on your machine. Add `--https-only` to apply the hosted app's stricter policy instead. Neither mode will dial a link-local or cloud-metadata address, and neither sends a plaintext request to a public host.
 
 ```bash
 # Test a DCR registration

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -354,6 +354,7 @@ For a cloud authorization server, expose the inspector origin through a tunnel a
 | Flag | Required | Description |
 |------|----------|-------------|
 | `--url <url>` | Yes | OAuth metadata URL to fetch |
+| `--https-only` | No | Apply the hosted policy: reject non-HTTPS and private targets |
 
 ### `oauth proxy` / `oauth debug-proxy`
 
@@ -363,6 +364,13 @@ For a cloud authorization server, expose the inspector origin through a tunnel a
 | `--method <method>` | No | `GET` | HTTP method |
 | `--header <header>` | No | | HTTP header `Key: Value` (repeatable) |
 | `--body <value>` | No | | Request body as JSON, raw string, `@path`, or `-` for stdin |
+| `--https-only` | No | | Apply the hosted policy: reject non-HTTPS and private targets |
+
+These three commands reach private destinations by default — a server on
+loopback, on your LAN, or on a hostname that resolves to one — because the CLI
+runs on your own machine. `--https-only` opts in to the policy the hosted web
+app enforces, which is what you want when reproducing a hosted failure. Neither
+mode will dial a link-local or cloud-metadata address.
 
 ---
 

--- a/docs/sdk/reference/oauth-emulation.mdx
+++ b/docs/sdk/reference/oauth-emulation.mdx
@@ -80,6 +80,7 @@ console.log(result.comparison);    // "not_compared" — always, until step 6
 | `completeAuthorization` | `(input: { authorizationUrl: string; callbackUrl: string }) => Promise<{ code: string }>` | No | | Headless consent handler. Absent means the run stops at the redirect and reports `stopped_at_redirect`. |
 | `requestExecutor` | `OAuthRequestExecutor` | No | Hardened default | Override the outbound executor (tests, alternate transports). The default uses DNS pinning, total-deadline timeouts, body caps, redirect caps, and cross-origin credential stripping. |
 | `allowLoopbackMetadataFetch` | `boolean` | No | `false` | Allow fetching OAuth metadata from loopback addresses. |
+| `allowPrivateMetadataFetch` | `boolean` | No | `false` | Allow fetching OAuth metadata from any private address (loopback, RFC 1918, CGNAT, unique-local) and from hostnames that resolve to one. Set by local surfaces; supersedes `allowLoopbackMetadataFetch`. Link-local and cloud-metadata addresses stay refused. |
 | `resourceIndicatorEnforcement` | `"warn" \| "reject" \| "reject-rfc9728"` | No | `"warn"` | How to handle unexpected resource indicators. Defaults to `"warn"` so the run exposes server behavior rather than hiding it. |
 
 ### `EmulatedOAuthPreflightOutcome`

--- a/docs/troubleshooting/common-errors.mdx
+++ b/docs/troubleshooting/common-errors.mdx
@@ -94,6 +94,31 @@ This response comes from **your MCP server**, not from MCPJam Inspector. The ser
 - **Bearer Token** - Use this if you already have an API token from the server
 - **OAuth 2.0** - Use this for servers that require OAuth authorization flow
 
+### "resolves to a private/reserved IP address" during OAuth discovery
+
+The **web app at app.mcpjam.com runs on our servers**, so it can only reach
+authorization servers that are reachable from the public internet. A local
+authorization server — on `localhost`, on your LAN, or on a hostname like
+`auth.local` that resolves to `127.0.0.1` — is not, and discovery is refused
+with a message naming the address it resolved to.
+
+**Solution:** use the local inspector for a local OAuth setup:
+
+```bash
+npx @mcpjam/inspector
+```
+
+The local inspector reaches loopback, LAN, CGNAT, and unique-local addresses,
+including hostnames that resolve to them, because it runs on your machine. No
+flag or configuration is needed. The same applies to the CLI, which reaches
+private targets by default and takes `--https-only` when you want to reproduce
+the hosted policy.
+
+Link-local and cloud-metadata addresses (`169.254.169.254` and friends) are
+refused everywhere, including locally. If you see the message naming a
+"link-local or cloud-metadata host", something is pointing discovery at an
+instance-metadata endpoint rather than at an authorization server.
+
 ### Getting 401 Unauthorized errors
 
 If you're seeing **401 Unauthorized** errors when trying to connect to your server, this typically means the server requires authentication that hasn't been set up yet.

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-adapter.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-adapter.test.ts
@@ -317,4 +317,15 @@ describe("Inspector OAuth adapter SSRF loopback opt-in", () => {
     }) as unknown as Record<string, unknown>;
     expect(config.allowLoopbackMetadataFetch).toBe(false);
   });
+
+  // The loopback-literal test above cannot recognise the case that prompted
+  // this: an authorization server on a custom hostname (`auth.local`) that
+  // resolves to 127.0.0.1. Outside hosted mode the wider allowance covers it,
+  // whatever the server URL happens to look like.
+  it("allows private metadata fetches outside hosted mode", () => {
+    const config = buildMachineConfig({
+      serverUrl: "https://mcp.example.com/mcp",
+    }) as unknown as Record<string, unknown>;
+    expect(config.allowPrivateMetadataFetch).toBe(true);
+  });
 });

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -669,7 +669,7 @@ describe("mcp-oauth", () => {
       );
     });
 
-    it("rejects a proxied metadata response whose real upstream URL redirected to loopback", async () => {
+    it("rejects a proxied metadata response whose real upstream URL redirected to cloud metadata", async () => {
       const metadataResponse = new Response(
         JSON.stringify({
           authorization_servers: ["https://auth.example.com"],
@@ -678,7 +678,7 @@ describe("mcp-oauth", () => {
           status: 200,
           headers: {
             "X-MCPJam-OAuth-Upstream-URL":
-              "http://127.0.0.1:8787/private-metadata",
+              "http://169.254.169.254/latest/meta-data/",
           },
         }
       );
@@ -711,11 +711,11 @@ describe("mcp-oauth", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain(
-        'Refusing OAuth response from private/reserved host "127.0.0.1"'
+        'Refusing OAuth response from link-local or cloud-metadata host "169.254.169.254"'
       );
     });
 
-    it("rejects a proxied OAuth endpoint response whose real upstream URL redirected to loopback", async () => {
+    it("rejects a proxied OAuth endpoint response whose real upstream URL redirected to cloud metadata", async () => {
       authFetch.mockImplementation(
         async () =>
           new Response(
@@ -724,14 +724,14 @@ describe("mcp-oauth", () => {
               statusText: "OK",
               headers: { "content-type": "application/json" },
               body: { access_token: "should-not-be-consumed" },
-              finalUrl: "http://127.0.0.1:8787/private-token",
+              finalUrl: "http://169.254.169.254/latest/meta-data/",
             }),
             {
               status: 200,
               headers: {
                 "Content-Type": "application/json",
                 "X-MCPJam-OAuth-Upstream-URL":
-                  "http://127.0.0.1:8787/private-token",
+                  "http://169.254.169.254/latest/meta-data/",
               },
             }
           )
@@ -753,7 +753,7 @@ describe("mcp-oauth", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain(
-        'Refusing OAuth response from private/reserved host "127.0.0.1"'
+        'Refusing OAuth response from link-local or cloud-metadata host "169.254.169.254"'
       );
       expect(authFetch).toHaveBeenCalledWith(
         expect.stringMatching(/\/api\/mcp\/oauth\/proxy$/),

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -379,8 +379,10 @@ export function createInspectorOAuthStateMachine(
     // The debugger is a local-dev inspection surface: when the server under
     // test is itself loopback (e.g. a `127.0.0.1` dev MCP server), its metadata
     // fetches must be permitted. Mirror the Connect flow — allow loopback only
-    // when the debugged server URL is loopback; the guard still blocks
-    // LAN/link-local/reserved destinations regardless.
+    // when the debugged server URL is loopback. On its own this flag leaves
+    // LAN/link-local/reserved destinations blocked; outside hosted mode the
+    // wider allowance below supersedes it for the private ranges, and
+    // link-local/cloud-metadata stays refused in both.
     allowLoopbackMetadataFetch: isLoopbackOAuthUrl(machineConfig.serverUrl),
     // Outside hosted mode the backend proxy behind this adapter runs on the
     // developer's machine, so the whole private range is in scope — including

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -382,6 +382,11 @@ export function createInspectorOAuthStateMachine(
     // when the debugged server URL is loopback; the guard still blocks
     // LAN/link-local/reserved destinations regardless.
     allowLoopbackMetadataFetch: isLoopbackOAuthUrl(machineConfig.serverUrl),
+    // Outside hosted mode the backend proxy behind this adapter runs on the
+    // developer's machine, so the whole private range is in scope — including
+    // an authorization server on a custom hostname that answers 127.0.0.1,
+    // which the loopback-literal test above cannot recognise.
+    allowPrivateMetadataFetch: !HOSTED_MODE,
     // One step per "Continue" click: `scheduleAutoAdvance` is intentionally not
     // provided. The SDK state machines call it via optional chaining, so when
     // it is absent each `proceedToNextStep()` stops at the next step instead of

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -12,6 +12,7 @@ import {
   getSupportedRegistrationStrategies,
   EMPTY_OAUTH_FLOW_STATE,
   isLoopbackOAuthUrl,
+  isNeverDialableHost,
   isPrivateHost,
   isStatelessProtocolVersion,
   projectOAuthTraceSnapshot,
@@ -617,6 +618,7 @@ async function executeRequestViaProxy(
     response.headers.get(OAUTH_UPSTREAM_URL_HEADER) ?? undefined,
     {
       allowLoopback: isLoopbackOAuthUrl(serverUrl),
+      allowPrivateNetwork: !HOSTED_MODE,
     }
   );
 
@@ -673,7 +675,7 @@ function createTraceResponseFromResult(
  */
 function assertFinalResponseUrlAllowed(
   finalUrl: string | undefined,
-  options: { allowLoopback?: boolean } = {}
+  options: { allowLoopback?: boolean; allowPrivateNetwork?: boolean } = {}
 ): void {
   if (!finalUrl) return;
   if (options.allowLoopback && isLoopbackOAuthUrl(finalUrl)) {
@@ -685,6 +687,16 @@ function assertFinalResponseUrlAllowed(
   } catch {
     return;
   }
+  // The never-dialable floor is checked first and ignores every opt-in: a
+  // response that came back from cloud metadata is not one to consume, in any
+  // mode. (The proxy refuses to make that request at all; this is the
+  // browser-side half for a direct fetch.)
+  if (isNeverDialableHost(host)) {
+    throw new Error(
+      `Refusing OAuth response from link-local or cloud-metadata host "${host}" (possible SSRF via redirect)`
+    );
+  }
+  if (options.allowPrivateNetwork) return;
   if (isPrivateHost(host)) {
     throw new Error(
       `Refusing OAuth response from private/reserved host "${host}" (possible SSRF via redirect)`
@@ -720,6 +732,7 @@ function createOAuthRequestExecutor(fetchFn: typeof fetch, serverUrl?: string) {
         : directResponse.url;
       assertFinalResponseUrlAllowed(finalUrl, {
         allowLoopback: isLoopbackOAuthUrl(serverUrl),
+        allowPrivateNetwork: !HOSTED_MODE,
       });
       response = {
         status: directResponse.status,
@@ -2760,6 +2773,10 @@ export async function initiateOAuth(
       // itself loopback does the SSRF guard permit loopback metadata fetches
       // (a public server can never steer one at the user's own 127.0.0.1).
       allowLoopbackMetadataFetch: isLoopbackOAuthUrl(options.serverUrl),
+      // Outside hosted mode the fetch runs on the developer's own machine, so
+      // the wider private allowance applies: a server on their LAN, or an
+      // authorization server named for loopback, is the ordinary local case.
+      allowPrivateMetadataFetch: !HOSTED_MODE,
       allowPathScopedIssuer: options.allowPathScopedIssuer,
       hasClientSecret: Boolean(options.clientSecret || options.hasClientSecret),
       sanitizeTrace: SANITIZE_OAUTH_TRACES,
@@ -3588,6 +3605,8 @@ export async function handleOAuthCallback(
         // Exact-origin loopback allowance (see initiate path): opt in only for a
         // user-configured loopback server, never for a public/remote one.
         allowLoopbackMetadataFetch: isLoopbackOAuthUrl(serverUrl),
+        // See the initiate path.
+        allowPrivateMetadataFetch: !HOSTED_MODE,
         allowPathScopedIssuer: storedSession.allowPathScopedIssuer,
         sanitizeTrace: SANITIZE_OAUTH_TRACES,
         requestExecutor,

--- a/mcpjam-inspector/server/routes/mcp/oauth.ts
+++ b/mcpjam-inspector/server/routes/mcp/oauth.ts
@@ -55,6 +55,10 @@ oauth.post("/debug/proxy", async (c) => {
       method,
       body,
       headers,
+      // This router is mounted only outside hosted mode, so the target is a
+      // server on the developer's own machine or network as often as not.
+      // The hosted twin in routes/web/oauth.ts keeps httpsOnly: true.
+      allowPrivateNetwork: true,
       // Only the two fetch redirect modes we support; anything else is ignored
       // so a crafted value cannot reach fetch().
       ...(redirect === "manual" || redirect === "follow" ? { redirect } : {}),
@@ -123,7 +127,14 @@ oauth.post("/proxy", async (c) => {
   try {
     const { url, method, body, headers } = await c.req.json();
     proxyUrl = url;
-    const result = await executeOAuthProxy({ url, method, body, headers });
+    const result = await executeOAuthProxy({
+      url,
+      method,
+      body,
+      headers,
+      // Local router — see the debug proxy above.
+      allowPrivateNetwork: true,
+    });
     c.header(OAUTH_UPSTREAM_URL_HEADER, result.finalUrl);
     return c.json(result);
   } catch (error) {
@@ -188,7 +199,11 @@ oauth.get("/metadata", async (c) => {
       return c.json({ error: "Missing url parameter" }, 400);
     }
 
-    const result = await fetchOAuthMetadata(metadataUrl);
+    const result = await fetchOAuthMetadata(metadataUrl, {
+      // Local router — see the debug proxy above. This is the call that
+      // refused an authorization server named `auth.local` on 127.0.0.1.
+      allowPrivateNetwork: true,
+    });
     if ("status" in result && result.status !== undefined) {
       return c.json(
         {

--- a/mcpjam-inspector/server/services/__tests__/server-connection-discovery.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/server-connection-discovery.test.ts
@@ -296,8 +296,11 @@ describe("runDiscoveryPreflight", () => {
   it("refuses loopback unless the local-dev opt-in is set", async () => {
     const probeServer = vi.fn();
 
+    // `allowPrivateNetwork: false` is what a HOSTED deployment resolves to;
+    // it is spelled out because the default now follows `!HOSTED_MODE`, and
+    // this test is about the hosted policy rather than the local one.
     const blocked = await runDiscoveryPreflight(
-      { serverUrl: "http://127.0.0.1:3000/mcp" },
+      { serverUrl: "http://127.0.0.1:3000/mcp", allowPrivateNetwork: false },
       { probeServer: probeServer as never },
     );
 
@@ -326,7 +329,54 @@ describe("runDiscoveryPreflight", () => {
     // A LAN address is not loopback. The opt-in exists for local development
     // against 127.0.0.1, not as a general private-network escape hatch.
     const outcome = await runDiscoveryPreflight(
-      { serverUrl: "http://192.168.1.10/mcp", allowLoopback: true },
+      {
+        serverUrl: "http://192.168.1.10/mcp",
+        allowLoopback: true,
+        allowPrivateNetwork: false,
+      },
+      { probeServer: probeServer as never },
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "terminal",
+      errorCode: "URL_NOT_ALLOWED",
+    });
+    expect(probeServer).not.toHaveBeenCalled();
+  });
+
+  it("probes a loopback server by default, the way a local inspector does", async () => {
+    // The local default. Testing a server on the developer's own machine is
+    // the inspector's whole job, so the preflight must not stand in its way.
+    const probeServer = ready();
+
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "http://127.0.0.1:3000/mcp" },
+      { probeServer },
+    );
+
+    expect(outcome).toMatchObject({ kind: "discovered", authMethod: "none" });
+    expect(probeServer).toHaveBeenCalledTimes(1);
+  });
+
+  it("probes a LAN server by default too", async () => {
+    const probeServer = ready();
+
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "http://192.168.1.10/mcp" },
+      { probeServer },
+    );
+
+    expect(outcome).toMatchObject({ kind: "discovered", authMethod: "none" });
+    expect(probeServer).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses cloud metadata even by default", async () => {
+    // The floor under the local allowance: no opt-in reaches it, and the
+    // probe must never run.
+    const probeServer = vi.fn();
+
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "http://169.254.169.254/latest/meta-data/" },
       { probeServer: probeServer as never },
     );
 

--- a/mcpjam-inspector/server/services/__tests__/server-connection-discovery.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/server-connection-discovery.test.ts
@@ -370,13 +370,17 @@ describe("runDiscoveryPreflight", () => {
     expect(probeServer).toHaveBeenCalledTimes(1);
   });
 
-  it("refuses cloud metadata even by default", async () => {
-    // The floor under the local allowance: no opt-in reaches it, and the
-    // probe must never run.
+  it("refuses cloud metadata even when the caller asks for private networks", async () => {
+    // The floor under the allowance, stated where it can actually be tested:
+    // the default case is already covered above, so this one names the opt-in
+    // explicitly and shows it does not reach the never-dialable set.
     const probeServer = vi.fn();
 
     const outcome = await runDiscoveryPreflight(
-      { serverUrl: "http://169.254.169.254/latest/meta-data/" },
+      {
+        serverUrl: "http://169.254.169.254/latest/meta-data/",
+        allowPrivateNetwork: true,
+      },
       { probeServer: probeServer as never },
     );
 

--- a/mcpjam-inspector/server/services/bench-probe-child.ts
+++ b/mcpjam-inspector/server/services/bench-probe-child.ts
@@ -322,6 +322,10 @@ export async function runBenchmarkAuthProbe(
     {
       serverUrl: args.serverUrl,
       ...(args.allowLoopback ? { allowLoopback: true } : {}),
+      // Explicitly strict whatever the deployment: the preflight's local
+      // default permits private targets, and a scorecard about a server
+      // nobody else can reach is still not evidence.
+      allowPrivateNetwork: args.allowLoopback === true,
       ...(args.timeoutMs !== undefined ? { timeoutMs: args.timeoutMs } : {}),
     },
     dependencies,

--- a/mcpjam-inspector/server/services/bench-probe-child.ts
+++ b/mcpjam-inspector/server/services/bench-probe-child.ts
@@ -324,8 +324,10 @@ export async function runBenchmarkAuthProbe(
       ...(args.allowLoopback ? { allowLoopback: true } : {}),
       // Explicitly strict whatever the deployment: the preflight's local
       // default permits private targets, and a scorecard about a server
-      // nobody else can reach is still not evidence.
-      allowPrivateNetwork: args.allowLoopback === true,
+      // nobody else can reach is still not evidence. Note this stays `false`
+      // even when `allowLoopback` is set — that opt-in is for loopback, and
+      // deriving this from it would quietly widen it to the whole LAN.
+      allowPrivateNetwork: false,
       ...(args.timeoutMs !== undefined ? { timeoutMs: args.timeoutMs } : {}),
     },
     dependencies,

--- a/mcpjam-inspector/server/services/registry-derive.ts
+++ b/mcpjam-inspector/server/services/registry-derive.ts
@@ -135,6 +135,13 @@ export async function deriveRegistryEntry(
     {
       serverUrl: input.url,
       allowLoopback: input.allowLoopback,
+      // Explicitly strict, in EVERY deployment. The preflight now permits
+      // private targets by default when it runs locally, which is right for
+      // "connect me to my own server" and wrong here: an org registry entry is
+      // shared with everyone in the org, and an address that resolves on one
+      // machine is not a thing to share. See the caller's note in
+      // routes/web/registry.ts.
+      allowPrivateNetwork: false,
       timeoutMs: input.timeoutMs ?? DISCOVERY_TIMEOUT_MS,
     },
     dependencies

--- a/mcpjam-inspector/server/services/server-connection-discovery.ts
+++ b/mcpjam-inspector/server/services/server-connection-discovery.ts
@@ -32,6 +32,7 @@
 import {
   assertOutboundOAuthUrlAllowed,
   isLoopbackOAuthUrl,
+  isPrivateHost,
   OAuthOutboundUrlBlockedError,
 } from "@mcpjam/sdk/oauth/node";
 import { probeMcpServer } from "@mcpjam/sdk";
@@ -41,6 +42,19 @@ import {
   EgressResolutionError,
 } from "../utils/hosted-egress-guard.js";
 import { createPinnedFetch } from "../utils/pinned-fetch.js";
+import { HOSTED_MODE } from "../config.js";
+
+/**
+ * Whether this preflight may reach a private destination.
+ *
+ * One helper rather than three copies of the `??`, so the pre-flight guard,
+ * the plaintext rule, the transport, and the probe cannot disagree about a
+ * single request — the shape of bug where discovery succeeds and the probe it
+ * authorized is then refused.
+ */
+function allowsPrivateNetwork(input: RunDiscoveryPreflightInput): boolean {
+  return input.allowPrivateNetwork ?? !HOSTED_MODE;
+}
 
 /** The three values the backend's `reportDiscovery` accepts. */
 export type DiscoveredAuthMethod = "none" | "oauth" | "unsupported";
@@ -58,6 +72,7 @@ function createDefaultDiscoveryFetch(
 ): typeof fetch {
   return createPinnedFetch({
     allowLoopback: input.allowLoopback === true,
+    allowPrivateNetwork: allowsPrivateNetwork(input),
     timeoutMs: clampTimeout(input.timeoutMs),
   });
 }
@@ -258,6 +273,13 @@ export interface RunDiscoveryPreflightInput {
    * NAT64-private, or IPv4-mapped-private targets.
    */
   allowLoopback?: boolean;
+  /**
+   * Permit private destinations (loopback, RFC 1918, CGNAT, unique-local).
+   * Defaults to `!HOSTED_MODE`: locally, probing a server on the developer's
+   * own network is the product. Callers for whom a private target is never
+   * evidence — registry derive, benchmark scorecards — pass `false`.
+   */
+  allowPrivateNetwork?: boolean;
   timeoutMs?: number;
 }
 
@@ -373,6 +395,7 @@ export async function probeThroughEgressGuard(
   try {
     const url = assertOutboundOAuthUrlAllowed(input.serverUrl, {
       allowLoopback: input.allowLoopback === true,
+      allowPrivateNetwork: allowsPrivateNetwork(input),
     });
     // The classifier accepts http AND https — it judges addresses, not
     // transport. Hosted targets are HTTPS-only, so that has to be enforced
@@ -382,7 +405,13 @@ export async function probeThroughEgressGuard(
     //
     // Loopback keeps its plaintext exception, and only when the caller opted
     // in: `http://127.0.0.1:3000/mcp` IS the local-development product.
-    if (url.protocol !== "https:" && !isLoopbackOAuthUrl(input.serverUrl)) {
+    if (
+      url.protocol !== "https:" &&
+      !isLoopbackOAuthUrl(input.serverUrl) &&
+      // Same exception one range wider in local mode: a LAN MCP server is
+      // plaintext as routinely as a loopback one.
+      !(allowsPrivateNetwork(input) && isPrivateHost(url.hostname))
+    ) {
       return {
         kind: "refused",
         errorCode: "URL_NOT_ALLOWED",
@@ -460,6 +489,7 @@ export async function probeThroughEgressGuard(
         url: input.serverUrl,
         timeoutMs: clampTimeout(input.timeoutMs),
         fetchFn,
+        allowPrivateNetwork: allowsPrivateNetwork(input),
       }),
       deadline,
     ]);

--- a/mcpjam-inspector/server/services/server-connection-discovery.ts
+++ b/mcpjam-inspector/server/services/server-connection-discovery.ts
@@ -53,7 +53,12 @@ import { HOSTED_MODE } from "../config.js";
  * authorized is then refused.
  */
 function allowsPrivateNetwork(input: RunDiscoveryPreflightInput): boolean {
-  return input.allowPrivateNetwork ?? !HOSTED_MODE;
+  // `!HOSTED_MODE &&` rather than a default the caller can override: hosted is
+  // OUR network, and an argument arriving from a route body must not be able to
+  // open egress there. Locally the caller keeps both directions — the default
+  // is on, and an explicit `false` (registry derive, benchmark probes) is
+  // honoured.
+  return !HOSTED_MODE && (input.allowPrivateNetwork ?? true);
 }
 
 /** The three values the backend's `reportDiscovery` accepts. */
@@ -410,6 +415,14 @@ export async function probeThroughEgressGuard(
       !isLoopbackOAuthUrl(input.serverUrl) &&
       // Same exception one range wider in local mode: a LAN MCP server is
       // plaintext as routinely as a loopback one.
+      //
+      // LIMITED TO ADDRESS LITERALS, because this check runs before any
+      // resolution and `isPrivateHost` only judges the string: `http://10.0.0.5/mcp`
+      // is probed, `http://raspberrypi.local:3000/mcp` is still refused here.
+      // The transport behind this decides the same question on the resolved
+      // address, so it is stricter than the transport rather than looser —
+      // a refusal, never a hole. Widening it needs a resolution step this
+      // pre-flight does not have; see the plaintext rule in `pinned-dns.ts`.
       !(allowsPrivateNetwork(input) && isPrivateHost(url.hostname))
     ) {
       return {

--- a/mcpjam-inspector/server/utils/__tests__/pinned-fetch-chain.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/pinned-fetch-chain.test.ts
@@ -31,13 +31,21 @@ vi.mock("@mcpjam/sdk/oauth/node", async () => {
 const { createPinnedFetch } = await import("../pinned-fetch.js");
 const { BlockedEgressTargetError } = await import("../hosted-egress-guard.js");
 
-function respond(status: number, headers: Record<string, string> = {}) {
+function respond(
+  status: number,
+  headers: Record<string, string> = {},
+  targetIsPrivate = false,
+) {
   return {
     status,
     statusText: "",
     headers,
     body: "",
     finalUrl: "",
+    // Where the transport says the hop LANDED. The adapter fixes the chain's
+    // character from this rather than from the hostname, so the mock has to
+    // answer it for the derivation under test to mean anything.
+    targetIsPrivate,
   };
 }
 
@@ -48,29 +56,81 @@ beforeEach(() => {
 describe("a chain that started public may not arrive at loopback", () => {
   it("refuses a public → loopback redirect even with the opt-in set", async () => {
     transport.executeOAuthProxy.mockResolvedValueOnce(
-      respond(302, { location: "http://127.0.0.1:11434/steal" })
+      respond(302, { location: "http://127.0.0.1:11434/steal" }, false)
     );
 
     await expect(
-      createPinnedFetch({ allowLoopback: true, timeoutMs: 2_000 })(
-        "https://public.example/mcp"
-      )
+      createPinnedFetch({
+        allowLoopback: true,
+        allowPrivateNetwork: false,
+        timeoutMs: 2_000,
+      })("https://public.example/mcp")
     ).rejects.toBeInstanceOf(BlockedEgressTargetError);
 
     // The loopback hop was refused BEFORE the transport was asked to dial it.
     expect(transport.executeOAuthProxy).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps every hop of a public chain httpsOnly, opt-in or not", async () => {
-    transport.executeOAuthProxy.mockResolvedValueOnce(respond(200));
+  it("narrows a chain to httpsOnly once the first hop lands public", async () => {
+    // Hop 0 carries the caller's permission, because nothing here can tell a
+    // public hostname from one that answers loopback. The transport reports
+    // that it landed public, and every hop after it is held to the strict
+    // policy — which is what keeps a public chain from wandering onto the
+    // caller's own network two hops later.
+    transport.executeOAuthProxy
+      .mockResolvedValueOnce(
+        respond(302, { location: "https://public.example/next" }, false)
+      )
+      .mockResolvedValueOnce(respond(200, {}, false));
 
     await createPinnedFetch({ allowLoopback: true, timeoutMs: 2_000 })(
       "https://public.example/mcp"
     );
 
-    expect(transport.executeOAuthProxy).toHaveBeenCalledWith(
-      expect.objectContaining({ httpsOnly: true })
+    const calls = transport.executeOAuthProxy.mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(calls[0][0]).toMatchObject({ allowPrivateNetwork: true });
+    expect(calls[1][0]).toMatchObject({
+      httpsOnly: true,
+      allowPrivateNetwork: false,
+    });
+  });
+
+  it("refuses a public-landing chain that then redirects to a private host", async () => {
+    // The same rule seen from the attack: a public server answering
+    // `302 Location: http://10.0.0.1/…` cannot make the local inspector
+    // fetch it, because hop 0 reported that it landed public.
+    transport.executeOAuthProxy.mockResolvedValueOnce(
+      respond(302, { location: "http://10.0.0.1/steal" }, false)
     );
+
+    await expect(
+      createPinnedFetch({ timeoutMs: 2_000 })("https://public.example/mcp")
+    ).rejects.toBeInstanceOf(BlockedEgressTargetError);
+
+    expect(transport.executeOAuthProxy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the allowance for a chain whose first hop landed private", async () => {
+    // The counterpart, and the case a hostname test refuses by mistake: the
+    // start URL reads as public and answers loopback, so hop 0 reports
+    // private and the redirect to another private port is followed.
+    transport.executeOAuthProxy
+      .mockResolvedValueOnce(
+        respond(302, { location: "http://auth.localtest.me:9401/token" }, true)
+      )
+      .mockResolvedValueOnce(respond(200, {}, true));
+
+    const res = await createPinnedFetch({ timeoutMs: 2_000 })(
+      "http://auth.localtest.me:9400/token"
+    );
+
+    expect(res.status).toBe(200);
+    const calls = transport.executeOAuthProxy.mock.calls;
+    expect(calls).toHaveLength(2);
+    for (const call of calls) {
+      expect(call[0]).toMatchObject({ allowPrivateNetwork: true });
+    }
   });
 });
 
@@ -80,9 +140,9 @@ describe("a chain that started loopback keeps its allowance", () => {
     // development, and the chain rule must not break it.
     transport.executeOAuthProxy
       .mockResolvedValueOnce(
-        respond(302, { location: "http://127.0.0.1:6060/authorize" })
+        respond(302, { location: "http://127.0.0.1:6060/authorize" }, true)
       )
-      .mockResolvedValueOnce(respond(200));
+      .mockResolvedValueOnce(respond(200, {}, true));
 
     const res = await createPinnedFetch({
       allowLoopback: true,

--- a/mcpjam-inspector/server/utils/__tests__/pinned-fetch.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/pinned-fetch.test.ts
@@ -15,6 +15,12 @@
  * and that is what these are: they call `createPinnedFetch` at real reserved
  * addresses and assert the class that comes back, so a reworded SDK message
  * fails here instead of silently downgrading a refusal.
+ *
+ * `allowPrivateNetwork: false` is passed EXPLICITLY throughout the strict
+ * suites below. The option now defaults to `!HOSTED_MODE`, so a bare
+ * `createPinnedFetch()` in a test process is a LOCAL inspector and reaches
+ * private addresses on purpose — which is the subject of the last describe
+ * block, not of these. Naming it here keeps each suite testing one policy.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -26,7 +32,10 @@ import {
   EgressResolutionError,
 } from "../hosted-egress-guard.js";
 
-const pinnedFetch = createPinnedFetch({ timeoutMs: 2_000 });
+const pinnedFetch = createPinnedFetch({
+  allowPrivateNetwork: false,
+  timeoutMs: 2_000,
+});
 
 describe("refusals keep their class", () => {
   it("refuses a literal loopback address as a blocked target", async () => {
@@ -83,7 +92,9 @@ describe("the loopback opt-in is real in both directions", () => {
 
   it("refuses loopback by default", async () => {
     await expect(
-      createPinnedFetch({ timeoutMs: 2_000 })("http://127.0.0.1:9/mcp")
+      createPinnedFetch({ allowPrivateNetwork: false, timeoutMs: 2_000 })(
+        "http://127.0.0.1:9/mcp"
+      )
     ).rejects.toBeInstanceOf(BlockedEgressTargetError);
   });
 
@@ -95,6 +106,7 @@ describe("the loopback opt-in is real in both directions", () => {
     // a connection error would fail for a reason unrelated to what it proves.
     const outcome = await createPinnedFetch({
       allowLoopback: true,
+      allowPrivateNetwork: false,
       timeoutMs: 2_000,
     })("http://127.0.0.1:9/mcp").catch((e: unknown) => e);
 
@@ -104,7 +116,11 @@ describe("the loopback opt-in is real in both directions", () => {
   it("still refuses non-loopback private addresses even with the opt-in", async () => {
     // The carve-out is for loopback ONLY. It never relaxes the guard for LAN,
     // link-local, CGNAT, multicast, documentation, or NAT64-private targets.
-    const pinned = createPinnedFetch({ allowLoopback: true, timeoutMs: 2_000 });
+    const pinned = createPinnedFetch({
+      allowLoopback: true,
+      allowPrivateNetwork: false,
+      timeoutMs: 2_000,
+    });
 
     await expect(pinned("http://169.254.169.254/")).rejects.toBeInstanceOf(
       BlockedEgressTargetError
@@ -432,5 +448,59 @@ describe("the caller's AbortSignal actually ends the request", () => {
     );
 
     expect((outcome as Error).name).toBe("AbortError");
+  });
+});
+
+/**
+ * The local inspector's side of the same transport.
+ *
+ * `allowPrivateNetwork` defaults to `!HOSTED_MODE`, so a bare
+ * `createPinnedFetch()` in a local process reaches the developer's own
+ * network. These assert the two halves of that: what it now permits, and the
+ * floor it still will not cross.
+ */
+describe("the private-network allowance follows the deployment", () => {
+  it("dials a loopback server by default, because that IS the local product", async () => {
+    // As above, reaching the socket layer is the proof: assert the guard did
+    // not refuse, not that the connection succeeded.
+    const outcome = await createPinnedFetch({ timeoutMs: 2_000 })(
+      "http://127.0.0.1:9/mcp"
+    ).catch((e: unknown) => e);
+
+    expect(outcome).not.toBeInstanceOf(BlockedEgressTargetError);
+  });
+
+  it("dials a LAN address by default", async () => {
+    const outcome = await createPinnedFetch({ timeoutMs: 2_000 })(
+      "http://10.0.0.1/mcp"
+    ).catch((e: unknown) => e);
+
+    expect(outcome).not.toBeInstanceOf(BlockedEgressTargetError);
+  });
+
+  it("still refuses cloud metadata, which no local server ever needs", async () => {
+    await expect(
+      createPinnedFetch({ timeoutMs: 2_000 })(
+        "http://169.254.169.254/latest/meta-data/"
+      )
+    ).rejects.toBeInstanceOf(BlockedEgressTargetError);
+  });
+
+  it("still refuses a non-http scheme and a credentialed URL", async () => {
+    const pinned = createPinnedFetch({ timeoutMs: 2_000 });
+    await expect(pinned("file:///etc/passwd")).rejects.toBeInstanceOf(
+      BlockedEgressTargetError
+    );
+    await expect(
+      pinned("https://user:pass@example.com/mcp")
+    ).rejects.toBeInstanceOf(BlockedEgressTargetError);
+  });
+
+  it("keeps refusing private targets when the caller opts out", async () => {
+    await expect(
+      createPinnedFetch({ allowPrivateNetwork: false, timeoutMs: 2_000 })(
+        "http://10.0.0.1/mcp"
+      )
+    ).rejects.toBeInstanceOf(BlockedEgressTargetError);
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/pinned-fetch.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/pinned-fetch.test.ts
@@ -180,9 +180,14 @@ describe("every hop's scheme is checked, not just the last one", () => {
     // The carve-out is for reaching `http://127.0.0.1:3000/mcp` in local
     // development. A dev-mode probe that leaves loopback for a public http host
     // is refused exactly like a hosted one would be.
+    //
+    // `example.com` rather than a `.example` name that cannot resolve: the
+    // refusal is now made on the RESOLVED address, so a host that never
+    // resolves fails as a resolution error — a different, retryable class —
+    // and would prove nothing about the plaintext rule.
     await expect(
-      createPinnedFetch({ allowLoopback: true, timeoutMs: 2_000 })(
-        "http://public.example/mcp"
+      createPinnedFetch({ allowLoopback: true, timeoutMs: 5_000 })(
+        "http://example.com/mcp"
       )
     ).rejects.toBeInstanceOf(BlockedEgressTargetError);
   });
@@ -497,10 +502,27 @@ describe("the private-network allowance follows the deployment", () => {
   });
 
   it("keeps refusing private targets when the caller opts out", async () => {
+    // HTTPS on purpose: over `http://` the scheme check refuses first and the
+    // address classifier never runs, so the assertion would pass for a reason
+    // that has nothing to do with the address and would survive a regression
+    // that let private targets through.
     await expect(
       createPinnedFetch({ allowPrivateNetwork: false, timeoutMs: 2_000 })(
-        "http://10.0.0.1/mcp"
+        "https://10.0.0.1/mcp"
       )
     ).rejects.toBeInstanceOf(BlockedEgressTargetError);
+  });
+
+  it("dials a plaintext host that only DNS knows is private", async () => {
+    // The case the whole change exists for, and the one a hostname-based chain
+    // rule silently refused: a name that reads as public, answers loopback, and
+    // is served over http. Nothing about the string says "private" — only the
+    // resolver does — so this is the regression test for deciding the chain's
+    // character from where the first hop landed.
+    const outcome = await createPinnedFetch({ timeoutMs: 2_000 })(
+      "http://localtest.me:9/mcp"
+    ).catch((e: unknown) => e);
+
+    expect(outcome).not.toBeInstanceOf(BlockedEgressTargetError);
   });
 });

--- a/mcpjam-inspector/server/utils/pinned-fetch.ts
+++ b/mcpjam-inspector/server/utils/pinned-fetch.ts
@@ -31,7 +31,6 @@ import {
   createPinnedStreamingFetch,
   executeOAuthProxy,
   isLoopbackOAuthUrl,
-  isPrivateHost,
   OAuthProxyError,
 } from "@mcpjam/sdk/oauth/node";
 import { HOSTED_MODE } from "../config.js";
@@ -227,9 +226,21 @@ function assertSchemeAllowed(
 ): void {
   if (isHttps(url)) return;
   if (allowLoopback && isLoopbackOAuthUrl(url)) return;
-  // A private hop on a private chain may be plaintext for the same reason a
-  // loopback hop may: the developer's own LAN server is routinely http.
-  if (allowPrivateNetwork && isPrivateHost(new URL(url).hostname)) return;
+  // A hop the caller is allowed to reach privately may be plaintext, for the
+  // same reason a loopback hop may: the developer's own LAN server is
+  // routinely http, and on their machine this request is one their shell could
+  // make anyway.
+  //
+  // Note what this does NOT test: whether the host is private. It cannot —
+  // `auth.local` reads as public and answers 127.0.0.1, which is exactly the
+  // case being served, so classifying the string here would refuse it. The
+  // address decision belongs to the resolver, which makes it once and pins it;
+  // this check is only about the scheme. The cost is that a LOCAL caller may
+  // also speak plaintext to a genuinely public host on the first hop. Callers
+  // that must not (the discovery preflight) refuse that by URL shape before
+  // reaching the transport, and after the first hop the chain rule has the
+  // resolver's answer and applies it.
+  if (allowPrivateNetwork) return;
   throw new BlockedEgressTargetError(
     `Refusing a plaintext connection to "${safeHost(url)}".`
   );
@@ -328,10 +339,15 @@ export function createPinnedFetch(
     // started public may not arrive there.
     const chainAllowsLoopback =
       options.allowLoopback === true && isLoopbackOAuthUrl(url);
-    // Same chain rule for the wider allowance: a chain that started public may
-    // not redirect onto the caller's LAN, even in local mode.
-    const chainAllowsPrivate =
-      allowPrivateNetwork && isPrivateHost(new URL(url).hostname);
+    // Same chain rule for the wider allowance, with one difference that
+    // matters: it CANNOT be decided from the hostname. `auth.local` and
+    // `auth.localtest.me` look public and answer 127.0.0.1 — the case this
+    // allowance exists to serve — so a name-based test refuses the very thing
+    // it is meant to permit. The first hop therefore carries the caller's
+    // permission, and the transport reports back where it actually landed;
+    // `chainAllowsPrivate` is fixed from that answer for every hop after it.
+    let chainAllowsPrivate = allowPrivateNetwork;
+    let chainCharacterKnown = false;
 
     try {
       // REDIRECTS ARE FOLLOWED HERE, ONE HOP AT A TIME, so every hop's scheme
@@ -368,9 +384,11 @@ export function createPinnedFetch(
         signal?.throwIfAborted();
         const hopAllowsLoopback =
           chainAllowsLoopback && isLoopbackOAuthUrl(currentUrl);
-        const hopAllowsPrivate =
-          chainAllowsPrivate && isPrivateHost(new URL(currentUrl).hostname);
-        assertSchemeAllowed(currentUrl, chainAllowsLoopback, chainAllowsPrivate);
+        // Before the chain's character is known (hop 0) the caller's
+        // permission stands, so a plaintext hostname that resolves privately
+        // is dialled rather than refused on the strength of how it reads.
+        const hopAllowsPrivate = chainAllowsPrivate;
+        assertSchemeAllowed(currentUrl, chainAllowsLoopback, hopAllowsPrivate);
 
         result = await executeOAuthProxy({
           url: currentUrl,
@@ -391,6 +409,14 @@ export function createPinnedFetch(
           timeoutMs: remainingTimeout(options.timeoutMs, startedAt),
           signal,
         });
+
+        // Fix the chain's character from the hop that actually dialled. After
+        // this, a chain that landed public may not redirect onto the caller's
+        // private network, and one that landed private may keep going there.
+        if (!chainCharacterKnown) {
+          chainAllowsPrivate = chainAllowsPrivate && result.targetIsPrivate;
+          chainCharacterKnown = true;
+        }
 
         const location = result.headers["location"] ?? result.headers["Location"];
         if (!isRedirectStatus(result.status) || !location) break;

--- a/mcpjam-inspector/server/utils/pinned-fetch.ts
+++ b/mcpjam-inspector/server/utils/pinned-fetch.ts
@@ -31,6 +31,7 @@ import {
   createPinnedStreamingFetch,
   executeOAuthProxy,
   isLoopbackOAuthUrl,
+  isPrivateHost,
   OAuthProxyError,
 } from "@mcpjam/sdk/oauth/node";
 import { HOSTED_MODE } from "../config.js";
@@ -46,6 +47,21 @@ export interface PinnedFetchOptions {
    * documentation, NAT64-private, or IPv4-mapped-private addresses.
    */
   allowLoopback?: boolean;
+  /**
+   * Permit private destinations for the whole chain: loopback, RFC 1918,
+   * CGNAT, unique-local, and any hostname resolving to one.
+   *
+   * DEFAULTS TO `!HOSTED_MODE`, mirroring the `hosted ?? HOSTED_MODE` gate on
+   * this module's streaming sibling. On a developer's machine reaching their
+   * own network is the product; on our nodes it is the thing this guard
+   * exists to stop. Callers that must never reach a private target whatever
+   * the deployment (registry derive, benchmark scorecards) pass `false`
+   * explicitly.
+   *
+   * Link-local and cloud-metadata addresses stay refused either way — the SDK
+   * enforces that floor and no option here can lift it.
+   */
+  allowPrivateNetwork?: boolean;
   /** Bounds DNS, connection setup, redirects, and the body read together. */
   timeoutMs?: number;
 }
@@ -84,6 +100,10 @@ const REFUSAL_PATTERNS: readonly RegExp[] = [
   // because in hosted mode "loopback" and "not publicly routable" are the same
   // statement; the refusals below are not.
   /refusing a connection to loopback/i,
+  // The floor under the local-network allowance: link-local and cloud metadata
+  // are refused in every mode, so their refusal must classify as a verdict
+  // about the target rather than as a retryable outage.
+  /link-local or cloud-metadata/i,
 ];
 
 /**
@@ -200,9 +220,16 @@ function remainingTimeout(
  * It is not a blanket permission to speak plaintext, so a dev-mode probe that
  * redirects off to a public http host is refused exactly like a hosted one.
  */
-function assertSchemeAllowed(url: string, allowLoopback: boolean): void {
+function assertSchemeAllowed(
+  url: string,
+  allowLoopback: boolean,
+  allowPrivateNetwork: boolean
+): void {
   if (isHttps(url)) return;
   if (allowLoopback && isLoopbackOAuthUrl(url)) return;
+  // A private hop on a private chain may be plaintext for the same reason a
+  // loopback hop may: the developer's own LAN server is routinely http.
+  if (allowPrivateNetwork && isPrivateHost(new URL(url).hostname)) return;
   throw new BlockedEgressTargetError(
     `Refusing a plaintext connection to "${safeHost(url)}".`
   );
@@ -244,6 +271,7 @@ function toBodyInit(status: number, body: unknown): string | null {
 export function createPinnedFetch(
   options: PinnedFetchOptions = {}
 ): typeof fetch {
+  const allowPrivateNetwork = options.allowPrivateNetwork ?? !HOSTED_MODE;
   const pinnedFetch = async (
     input: RequestInfo | URL,
     init?: RequestInit
@@ -279,7 +307,11 @@ export function createPinnedFetch(
     // loopback dev target is plaintext by nature, and that alone made
     // `http://127.0.0.1:…` reachable in production: the `allowLoopback` option
     // below was declared, documented, and enforced by nobody.
-    if (options.allowLoopback !== true && isLoopbackOAuthUrl(url)) {
+    if (
+      !allowPrivateNetwork &&
+      options.allowLoopback !== true &&
+      isLoopbackOAuthUrl(url)
+    ) {
       throw new BlockedEgressTargetError(
         `Refusing a connection to loopback address "${new URL(url).hostname}".`
       );
@@ -296,6 +328,10 @@ export function createPinnedFetch(
     // started public may not arrive there.
     const chainAllowsLoopback =
       options.allowLoopback === true && isLoopbackOAuthUrl(url);
+    // Same chain rule for the wider allowance: a chain that started public may
+    // not redirect onto the caller's LAN, even in local mode.
+    const chainAllowsPrivate =
+      allowPrivateNetwork && isPrivateHost(new URL(url).hostname);
 
     try {
       // REDIRECTS ARE FOLLOWED HERE, ONE HOP AT A TIME, so every hop's scheme
@@ -332,7 +368,9 @@ export function createPinnedFetch(
         signal?.throwIfAborted();
         const hopAllowsLoopback =
           chainAllowsLoopback && isLoopbackOAuthUrl(currentUrl);
-        assertSchemeAllowed(currentUrl, chainAllowsLoopback);
+        const hopAllowsPrivate =
+          chainAllowsPrivate && isPrivateHost(new URL(currentUrl).hostname);
+        assertSchemeAllowed(currentUrl, chainAllowsLoopback, chainAllowsPrivate);
 
         result = await executeOAuthProxy({
           url: currentUrl,
@@ -347,7 +385,8 @@ export function createPinnedFetch(
           // transport permit it because that HOP is loopback. The permission
           // is the CHAIN's (see `chainAllowsLoopback` above) re-checked
           // against the hop being dialled.
-          httpsOnly: !hopAllowsLoopback,
+          httpsOnly: !hopAllowsLoopback && !hopAllowsPrivate,
+          allowPrivateNetwork: hopAllowsPrivate,
           redirect: "manual",
           timeoutMs: remainingTimeout(options.timeoutMs, startedAt),
           signal,

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -511,6 +511,7 @@ export {
   isPrivateHost,
   isDisallowedIpAddress,
   isLoopbackOAuthUrl,
+  isNeverDialableHost,
   OAuthOutboundUrlBlockedError,
 } from "./oauth/ssrf-guard.js";
 // RFC 9207 authorization-response `iss` validation. The comparison itself is

--- a/sdk/src/oauth-conformance/runner.ts
+++ b/sdk/src/oauth-conformance/runner.ts
@@ -6,6 +6,7 @@ import {
   getConformanceClientCredentialsDynamicRegistrationMetadata,
 } from "../oauth/client-identity.js";
 import { createOAuthStateMachine } from "../oauth/state-machines/factory.js";
+import { isLoopbackOAuthUrl } from "../oauth/ssrf-guard.js";
 import {
   getStepInfo,
   type OAuthStepInfo,
@@ -586,6 +587,12 @@ export class OAuthConformanceTest {
         serverUrl: this.config.serverUrl,
         serverName: this.config.serverName,
         redirectUrl,
+        // The executor below is the caller's `fetchFn`, so the factory's
+        // pre-flight guard is the only address check on this path: it has to
+        // learn about the local allowance or a loopback server under test is
+        // refused before its first well-known fetch.
+        allowLoopbackMetadataFetch: isLoopbackOAuthUrl(this.config.serverUrl),
+        allowPrivateMetadataFetch: this.config.allowPrivateNetwork,
         requestExecutor: (request) => trackedRequest(request),
         loadPreregisteredCredentials: async () => ({
           clientId: this.config.client.preregistered?.clientId,

--- a/sdk/src/oauth-conformance/types.ts
+++ b/sdk/src/oauth-conformance/types.ts
@@ -150,6 +150,13 @@ export interface OAuthConformanceConfig {
   customHeaders?: Record<string, string>;
   redirectUrl?: string;
   fetchFn?: typeof fetch;
+  /**
+   * Permit private destinations (loopback, RFC 1918, CGNAT, unique-local) for
+   * the outbound metadata fetches this flow makes. Set by the local inspector
+   * and the CLI, where the server under test is routinely on the developer's
+   * own machine. Link-local and cloud-metadata destinations stay refused.
+   */
+  allowPrivateNetwork?: boolean;
   stepTimeout?: number;
   verification?: OAuthVerificationConfig;
   oauthConformanceChecks?: boolean;
@@ -255,6 +262,7 @@ export interface NormalizedOAuthConformanceConfig {
   customHeaders?: Record<string, string>;
   redirectUrl?: string;
   fetchFn: typeof fetch;
+  allowPrivateNetwork: boolean;
   stepTimeout: number;
   verification: OAuthVerificationConfig;
   oauthConformanceChecks: boolean;

--- a/sdk/src/oauth-conformance/validation.ts
+++ b/sdk/src/oauth-conformance/validation.ts
@@ -116,6 +116,7 @@ export function normalizeOAuthConformanceConfig(
     customHeaders: config.customHeaders,
     redirectUrl: config.redirectUrl,
     fetchFn: config.fetchFn ?? fetch,
+    allowPrivateNetwork: config.allowPrivateNetwork ?? false,
     stepTimeout: config.stepTimeout ?? 30_000,
     verification: {
       listTools: config.verification?.listTools ?? !!config.verification?.callTool,

--- a/sdk/src/oauth-login.ts
+++ b/sdk/src/oauth-login.ts
@@ -11,6 +11,7 @@ import {
   type ResolvedAuthorizationPlan,
 } from "./oauth/authorization-plan.js";
 import { createOAuthStateMachine } from "./oauth/state-machines/factory.js";
+import { isLoopbackOAuthUrl } from "./oauth/ssrf-guard.js";
 import { runOAuthStateMachine } from "./oauth/state-machines/runner.js";
 import {
   EMPTY_OAUTH_FLOW_STATE,
@@ -235,6 +236,7 @@ async function resolveOAuthLoginAuthorizationPlan(
     headers: input.customHeaders,
     timeoutMs: input.stepTimeout ?? DEFAULT_OAUTH_LOGIN_STEP_TIMEOUT_MS,
     fetchFn: input.fetchFn,
+    allowPrivateNetwork: input.allowPrivateNetwork,
   });
 
   return resolveAuthorizationPlan({
@@ -513,6 +515,11 @@ export async function runOAuthLogin(
       serverUrl: config.serverUrl,
       serverName: config.serverName,
       redirectUrl,
+      // See the conformance runner: `trackedRequest` wraps the caller's
+      // `fetchFn`, so this pre-flight is the only destination check the login
+      // flow gets.
+      allowLoopbackMetadataFetch: isLoopbackOAuthUrl(config.serverUrl),
+      allowPrivateMetadataFetch: config.allowPrivateNetwork,
       requestExecutor: (request: OAuthHttpRequest) => trackedRequest(request),
       loadPreregisteredCredentials: async () => ({
         clientId: config.client.preregistered?.clientId,

--- a/sdk/src/oauth-proxy.ts
+++ b/sdk/src/oauth-proxy.ts
@@ -16,6 +16,13 @@ export interface OAuthProxyRequest {
   body?: unknown;
   headers?: Record<string, string>;
   httpsOnly?: boolean;
+  /**
+   * Permit private destinations (loopback, RFC 1918, CGNAT, unique-local, and
+   * any hostname resolving to one). The LOCAL inspector sets this; hosted
+   * callers never do, and `httpsOnly` overrides it if both are set.
+   * Link-local and cloud-metadata addresses stay refused either way.
+   */
+  allowPrivateNetwork?: boolean;
   /** Redirect handling. httpsOnly always forces "manual" (cannot be
    * weakened); otherwise an explicit value is honored and omission preserves
    * the historical "follow". */
@@ -40,7 +47,6 @@ export interface OAuthProxyResponse {
 // stays here. Re-exported to preserve the public `isDisallowedIpAddress` symbol.
 import {
   isDisallowedIpAddress,
-  isLoopbackOAuthUrl,
   isPrivateHost,
 } from "./oauth/ssrf-guard.js";
 // The DNS half — resolve once, classify, pin — lives in its own node-only
@@ -48,8 +54,10 @@ import {
 // this exact implementation rather than forking a second one.
 import {
   createPinnedLookup,
+  resolveEgressPolicy,
   resolvePinnedAddresses,
 } from "./oauth/pinned-dns.js";
+import type { EgressPolicy } from "./oauth/pinned-dns.js";
 export { isDisallowedIpAddress };
 
 interface ValidatedUrl {
@@ -87,19 +95,35 @@ function parseAndValidateUrl(url: string, httpsOnly = false): URL {
   return targetUrl;
 }
 
+/**
+ * Options for the destination checks. The boolean form is the historical
+ * `httpsOnly` positional and stays supported so existing callers (including
+ * consumers of the published package) need no change.
+ */
+export interface ValidateUrlOptions {
+  httpsOnly?: boolean;
+  allowPrivateNetwork?: boolean;
+}
+
+function toValidateOptions(
+  options: boolean | ValidateUrlOptions | undefined,
+): ValidateUrlOptions {
+  if (typeof options === "boolean") return { httpsOnly: options };
+  return options ?? {};
+}
+
 export async function validateUrl(
   url: string,
-  httpsOnly = false,
+  options: boolean | ValidateUrlOptions = false,
 ): Promise<ValidatedUrl> {
+  const { httpsOnly = false, allowPrivateNetwork } = toValidateOptions(options);
   const targetUrl = parseAndValidateUrl(url, httpsOnly);
-  const allowLoopbackFlow =
-    !httpsOnly && isLoopbackOAuthUrl(targetUrl.toString());
-  await resolvePinnedAddresses(
-    targetUrl,
-    allowLoopbackFlow,
-    undefined,
-    "OAuth target",
-  );
+  const policy = resolveEgressPolicy({
+    httpsOnly,
+    allowPrivateNetwork,
+    startUrl: targetUrl.toString(),
+  });
+  await resolvePinnedAddresses(targetUrl, policy, undefined, "OAuth target");
 
   return { url: targetUrl };
 }
@@ -454,12 +478,12 @@ function updateRequestForRedirect(
 async function requestPinnedOAuthHop(
   targetUrl: URL,
   requestInit: PreparedOAuthRequest,
-  allowLoopbackFlow: boolean,
+  policy: EgressPolicy,
   signal: AbortSignal | undefined
 ): Promise<RawPinnedOAuthResponse> {
   const pinnedAddresses = await resolvePinnedAddresses(
     targetUrl,
-    allowLoopbackFlow,
+    policy,
     signal,
     "OAuth proxy target"
   );
@@ -504,8 +528,11 @@ async function executePinnedOAuthRequest(req: OAuthProxyRequest): Promise<{
   signal: AbortSignal | undefined;
 }> {
   const initialUrl = parseAndValidateUrl(req.url, req.httpsOnly);
-  const allowLoopbackFlow =
-    !req.httpsOnly && isLoopbackOAuthUrl(initialUrl.toString());
+  const policy = resolveEgressPolicy({
+    httpsOnly: req.httpsOnly,
+    allowPrivateNetwork: req.allowPrivateNetwork,
+    startUrl: initialUrl.toString(),
+  });
   const redirectMode = req.httpsOnly ? "manual" : req.redirect ?? "follow";
   const signal = requestTimeoutSignal(req.timeoutMs, req.signal);
   let currentUrl = initialUrl;
@@ -516,7 +543,7 @@ async function executePinnedOAuthRequest(req: OAuthProxyRequest): Promise<{
       const response = await requestPinnedOAuthHop(
         currentUrl,
         requestInit,
-        allowLoopbackFlow,
+        policy,
         signal
       );
 
@@ -830,12 +857,12 @@ interface RawOAuthMetadataResponse {
 
 async function requestPinnedOAuthMetadata(
   targetUrl: URL,
-  allowLoopbackFlow: boolean,
+  policy: EgressPolicy,
   signal: AbortSignal | undefined
 ): Promise<RawOAuthMetadataResponse> {
   const pinnedAddresses = await resolvePinnedAddresses(
     targetUrl,
-    allowLoopbackFlow,
+    policy,
     signal
   );
   const transport = targetUrl.protocol === "https:" ? https : http;
@@ -911,7 +938,7 @@ async function requestPinnedOAuthMetadata(
 
 export async function fetchOAuthMetadata(
   url: string,
-  httpsOnly = false,
+  options: boolean | ValidateUrlOptions = false,
   timeoutMs?: number
 ): Promise<
   | {
@@ -921,9 +948,13 @@ export async function fetchOAuthMetadata(
     }
   | { status: number; statusText: string }
 > {
+  const { httpsOnly = false, allowPrivateNetwork } = toValidateOptions(options);
   const metadataUrl = parseAndValidateUrl(url, httpsOnly);
-  const allowLoopbackFlow =
-    !httpsOnly && isLoopbackOAuthUrl(metadataUrl.toString());
+  const policy = resolveEgressPolicy({
+    httpsOnly,
+    allowPrivateNetwork,
+    startUrl: metadataUrl.toString(),
+  });
   const signal = requestTimeoutSignal(timeoutMs);
   let currentUrl = metadataUrl;
   let response: RawOAuthMetadataResponse | undefined;
@@ -943,11 +974,7 @@ export async function fetchOAuthMetadata(
     }
 
     try {
-      response = await requestPinnedOAuthMetadata(
-        currentUrl,
-        allowLoopbackFlow,
-        signal
-      );
+      response = await requestPinnedOAuthMetadata(currentUrl, policy, signal);
     } catch (error) {
       if (signal?.aborted) {
         throw new OAuthProxyError(

--- a/sdk/src/oauth-proxy.ts
+++ b/sdk/src/oauth-proxy.ts
@@ -40,6 +40,17 @@ export interface OAuthProxyResponse {
   headers: Record<string, string>;
   body: unknown;
   finalUrl: string;
+  /**
+   * Whether the hop this call dialed landed on a private address.
+   *
+   * Reported because a caller that drives redirects ITSELF — one
+   * `redirect: "manual"` call per hop, which is how the inspector's pinned
+   * fetch bounds each hop's scheme — cannot otherwise apply the chain rule.
+   * Every such call looks like a first hop from in here, so the caller has to
+   * carry "did this chain start private" across them, and the only honest
+   * answer comes from the resolver that already looked.
+   */
+  targetIsPrivate: boolean;
 }
 
 // SSRF IP classifier + host check moved to the browser-safe `oauth/ssrf-guard`
@@ -336,6 +347,9 @@ export async function fetchPinnedPublicDocument(
             headers,
             body,
             finalUrl: url.toString(),
+            // `fetchPinnedPublicDocument` refuses every private destination by
+            // construction, so the document it returns came from a public one.
+            targetIsPrivate: false,
           });
         });
         res.on("error", reject);
@@ -371,6 +385,7 @@ interface RawPinnedOAuthResponse {
   statusText: string;
   headers: Record<string, string>;
   finalUrl: string;
+  targetIsPrivate: boolean;
   stream?: IncomingMessage;
 }
 
@@ -514,6 +529,7 @@ async function requestPinnedOAuthHop(
           statusText: response.statusMessage ?? "",
           headers: normalizeResponseHeaders(response),
           finalUrl: targetUrl.toString(),
+          targetIsPrivate,
           stream: response,
         });
       }
@@ -794,6 +810,7 @@ export async function executeOAuthProxy(
       headers: response.headers,
       body: parseBufferedResponseBody(body),
       finalUrl: response.finalUrl,
+      targetIsPrivate: response.targetIsPrivate,
     };
   } catch (error) {
     if (signal?.aborted) {
@@ -859,6 +876,7 @@ export async function executeDebugOAuthProxy(
     headers: response.headers,
     body: responseBody,
     finalUrl: response.finalUrl,
+    targetIsPrivate: response.targetIsPrivate,
   };
 }
 

--- a/sdk/src/oauth-proxy.ts
+++ b/sdk/src/oauth-proxy.ts
@@ -479,14 +479,17 @@ async function requestPinnedOAuthHop(
   targetUrl: URL,
   requestInit: PreparedOAuthRequest,
   policy: EgressPolicy,
-  signal: AbortSignal | undefined
+  signal: AbortSignal | undefined,
+  onResolved?: (targetIsPrivate: boolean) => void
 ): Promise<RawPinnedOAuthResponse> {
-  const pinnedAddresses = await resolvePinnedAddresses(
-    targetUrl,
-    policy,
-    signal,
-    "OAuth proxy target"
-  );
+  const { addresses: pinnedAddresses, targetIsPrivate } =
+    await resolvePinnedAddresses(
+      targetUrl,
+      policy,
+      signal,
+      "OAuth proxy target"
+    );
+  onResolved?.(targetIsPrivate);
   const transport = targetUrl.protocol === "https:" ? https : http;
 
   return await new Promise<RawPinnedOAuthResponse>((resolve, reject) => {
@@ -537,14 +540,28 @@ async function executePinnedOAuthRequest(req: OAuthProxyRequest): Promise<{
   const signal = requestTimeoutSignal(req.timeoutMs, req.signal);
   let currentUrl = initialUrl;
   let requestInit = prepareOAuthRequest(req);
+  // THE PRIVATE ALLOWANCE BELONGS TO THE CHAIN, and the chain's character is
+  // decided by where its FIRST hop actually landed — not by how the hostname
+  // looked, because a name that looks public and answers 127.0.0.1 is the case
+  // this allowance exists to serve. So: hop 1 may go anywhere the policy
+  // permits; a later hop may be private only if hop 1 was. Without this a
+  // public authorization server could answer `302 Location: http://192.168…`
+  // and have the local inspector fetch it.
+  let hopPolicy = policy;
+  const narrowAfterFirstHop = (targetIsPrivate: boolean) => {
+    hopPolicy = targetIsPrivate
+      ? hopPolicy
+      : { ...hopPolicy, allowPrivateNetwork: false };
+  };
 
   try {
     for (let redirectCount = 0; ; redirectCount += 1) {
       const response = await requestPinnedOAuthHop(
         currentUrl,
         requestInit,
-        policy,
-        signal
+        hopPolicy,
+        signal,
+        redirectCount === 0 ? narrowAfterFirstHop : undefined
       );
 
       if (!isFetchRedirectStatus(response.status)) {
@@ -858,13 +875,12 @@ interface RawOAuthMetadataResponse {
 async function requestPinnedOAuthMetadata(
   targetUrl: URL,
   policy: EgressPolicy,
-  signal: AbortSignal | undefined
+  signal: AbortSignal | undefined,
+  onResolved?: (targetIsPrivate: boolean) => void
 ): Promise<RawOAuthMetadataResponse> {
-  const pinnedAddresses = await resolvePinnedAddresses(
-    targetUrl,
-    policy,
-    signal
-  );
+  const { addresses: pinnedAddresses, targetIsPrivate } =
+    await resolvePinnedAddresses(targetUrl, policy, signal);
+  onResolved?.(targetIsPrivate);
   const transport = targetUrl.protocol === "https:" ? https : http;
 
   return await new Promise<RawOAuthMetadataResponse>((resolve, reject) => {
@@ -958,6 +974,19 @@ export async function fetchOAuthMetadata(
   const signal = requestTimeoutSignal(timeoutMs);
   let currentUrl = metadataUrl;
   let response: RawOAuthMetadataResponse | undefined;
+  // THE PRIVATE ALLOWANCE BELONGS TO THE CHAIN, and the chain's character is
+  // decided by where its FIRST hop actually landed — not by how the hostname
+  // looked, because a name that looks public and answers 127.0.0.1 is the case
+  // this allowance exists to serve. So: hop 1 may go anywhere the policy
+  // permits; a later hop may be private only if hop 1 was. Without this a
+  // public authorization server could answer `302 Location: http://192.168…`
+  // and have the local inspector fetch it.
+  let hopPolicy = policy;
+  const narrowAfterFirstHop = (targetIsPrivate: boolean) => {
+    hopPolicy = targetIsPrivate
+      ? hopPolicy
+      : { ...hopPolicy, allowPrivateNetwork: false };
+  };
 
   for (let redirectCount = 0; ; redirectCount += 1) {
     if (currentUrl.protocol !== "https:" && currentUrl.protocol !== "http:") {
@@ -974,7 +1003,12 @@ export async function fetchOAuthMetadata(
     }
 
     try {
-      response = await requestPinnedOAuthMetadata(currentUrl, policy, signal);
+      response = await requestPinnedOAuthMetadata(
+        currentUrl,
+        hopPolicy,
+        signal,
+        redirectCount === 0 ? narrowAfterFirstHop : undefined
+      );
     } catch (error) {
       if (signal?.aborted) {
         throw new OAuthProxyError(

--- a/sdk/src/oauth/emulation/preflight.ts
+++ b/sdk/src/oauth/emulation/preflight.ts
@@ -121,6 +121,12 @@ export interface EmulatedOAuthPreflightConfig {
   requestExecutor?: OAuthRequestExecutor;
   allowLoopbackMetadataFetch?: boolean;
   /**
+   * Permit private destinations (loopback, RFC 1918, CGNAT, unique-local).
+   * The LOCAL inspector's default; hosted surfaces leave it unset. Link-local
+   * and cloud-metadata destinations stay refused either way.
+   */
+  allowPrivateMetadataFetch?: boolean;
+  /**
    * Defaults to "warn": emulation is an observational surface, and rejecting
    * an odd resource indicator would hide the very server behavior the run
    * exists to expose.
@@ -190,7 +196,10 @@ export interface EmulatedOAuthPreflightResult {
  * The hardened default executor. Runs every OAuth and MCP request through the
  * SSRF-hardened proxy path rather than a bare `fetch`.
  */
-function createHardenedExecutor(timeoutMs: number): OAuthRequestExecutor {
+function createHardenedExecutor(
+  timeoutMs: number,
+  allowPrivateNetwork: boolean
+): OAuthRequestExecutor {
   return async (request: OAuthHttpRequest): Promise<OAuthRequestResult> => {
     const response = await executeOAuthProxy({
       url: request.url,
@@ -199,6 +208,7 @@ function createHardenedExecutor(timeoutMs: number): OAuthRequestExecutor {
       headers: request.headers,
       redirect: request.redirect,
       timeoutMs,
+      allowPrivateNetwork,
     });
     return {
       status: response.status,
@@ -357,11 +367,13 @@ export async function runEmulatedOAuthPreflight(
     maxSteps = DEFAULT_MAX_STEPS,
     completeAuthorization,
     allowLoopbackMetadataFetch,
+    allowPrivateMetadataFetch,
     resourceIndicatorEnforcement = "warn",
   } = config;
 
   const executor =
-    config.requestExecutor ?? createHardenedExecutor(timeoutMs);
+    config.requestExecutor ??
+    createHardenedExecutor(timeoutMs, allowPrivateMetadataFetch ?? false);
   const protocolVersion = derived.protocolVersion;
   const divergences: OAuthEmulationDivergence[] = [...derived.divergences];
   const attempts: EmulatedAuthAttemptResult[] = [];
@@ -387,6 +399,7 @@ export async function runEmulatedOAuthPreflight(
   ): Promise<OAuthRequestResult> => {
     assertOutboundOAuthUrlAllowed(serverUrl, {
       allowLoopback: allowLoopbackMetadataFetch ?? false,
+      allowPrivateNetwork: allowPrivateMetadataFetch ?? false,
     });
     const mcpVersion = resolveEmulatedMcpVersion(
       derived.emulation,
@@ -527,6 +540,7 @@ export async function runEmulatedOAuthPreflight(
           customHeaders,
           resourceIndicatorEnforcement,
           allowLoopbackMetadataFetch,
+          allowPrivateMetadataFetch,
           maxSteps,
           loadPreregisteredCredentials: preregistered
             ? () => ({

--- a/sdk/src/oauth/pinned-dns.ts
+++ b/sdk/src/oauth/pinned-dns.ts
@@ -26,11 +26,61 @@ import { lookup as dnsLookupCb } from "node:dns";
 import type { LookupFunction } from "node:net";
 
 import { OAuthProxyError } from "../oauth-proxy-error.js";
-import { isDisallowedIpAddress, isLoopbackOAuthUrl, isPrivateHost } from "./ssrf-guard.js";
+import {
+  isDisallowedIpAddress,
+  isLoopbackOAuthUrl,
+  isNeverDialableHost,
+  isNeverDialableIpAddress,
+  isPrivateHost,
+} from "./ssrf-guard.js";
 
 export interface PinnedAddress {
   address: string;
   family: number;
+}
+
+/**
+ * What a chain is allowed to reach. Computed ONCE per chain by
+ * {@link resolveEgressPolicy} and handed to every hop, so the three buffered
+ * entry points and the streaming transport cannot drift apart on the question
+ * of what "local" means.
+ */
+export interface EgressPolicy {
+  /**
+   * The chain started at a loopback target and the caller opted in, so
+   * loopback answers are permitted (and, for a loopback target, required).
+   */
+  allowLoopbackFlow: boolean;
+  /**
+   * The caller is a local inspector: every private destination is permitted,
+   * and only {@link isNeverDialableHost} stays refused.
+   */
+  allowPrivateNetwork: boolean;
+}
+
+/**
+ * Derive the chain policy from a caller's options.
+ *
+ * `httpsOnly` is the hosted switch and always wins: a hosted deployment fetches
+ * on OUR infrastructure, where a private destination means our own network, so
+ * neither opt-in survives it.
+ */
+export function resolveEgressPolicy(options: {
+  httpsOnly?: boolean;
+  allowPrivateNetwork?: boolean;
+  startUrl: string;
+}): EgressPolicy {
+  if (options.httpsOnly === true) {
+    return { allowLoopbackFlow: false, allowPrivateNetwork: false };
+  }
+  const allowPrivateNetwork = options.allowPrivateNetwork === true;
+  return {
+    // Private-network callers get loopback as a subset, so a chain that starts
+    // on a private host is not held to the loopback-only rule below.
+    allowLoopbackFlow:
+      !allowPrivateNetwork && isLoopbackOAuthUrl(options.startUrl),
+    allowPrivateNetwork,
+  };
 }
 
 function isLoopbackAddress(address: string): boolean {
@@ -45,20 +95,33 @@ function isLoopbackAddress(address: string): boolean {
  * `null` when the host is a numeric literal: there is no name to re-resolve,
  * so there is nothing a rebind could change.
  *
- * `allowLoopbackFlow` is narrow on purpose — it permits a loopback TARGET, and
- * then still requires every resolved address to be loopback, so a name that
- * looks local but answers publicly is refused rather than dialled.
+ * `policy.allowLoopbackFlow` is narrow on purpose — it permits a loopback
+ * TARGET, and then still requires every resolved address to be loopback, so a
+ * name that looks local but answers publicly is refused rather than dialled.
+ *
+ * `policy.allowPrivateNetwork` is the local inspector's wider allowance: any
+ * private answer is fine, so the rebinding question becomes "did it land on
+ * something never-dialable", not "did it land off loopback". Resolution is
+ * still done ONCE and still pinned, so the address that was classified is the
+ * address that gets dialled.
  */
 export async function resolvePinnedAddresses(
   targetUrl: URL,
-  allowLoopbackFlow: boolean,
+  policy: EgressPolicy,
   signal: AbortSignal | undefined,
   targetLabel = "OAuth metadata target",
 ): Promise<PinnedAddress[] | null> {
   const targetIsLoopback = isLoopbackOAuthUrl(targetUrl.toString());
 
-  if (isPrivateHost(targetUrl.hostname)) {
-    if (!(allowLoopbackFlow && targetIsLoopback)) {
+  if (isNeverDialableHost(targetUrl.hostname)) {
+    throw new OAuthProxyError(
+      400,
+      `${targetLabel} is a link-local or cloud-metadata host (${targetUrl.hostname})`,
+    );
+  }
+
+  if (!policy.allowPrivateNetwork && isPrivateHost(targetUrl.hostname)) {
+    if (!(policy.allowLoopbackFlow && targetIsLoopback)) {
       throw new OAuthProxyError(
         400,
         `${targetLabel} is a private/reserved host (${targetUrl.hostname})`,
@@ -117,6 +180,17 @@ export async function resolvePinnedAddresses(
   }
 
   for (const { address } of addresses) {
+    if (isNeverDialableIpAddress(address)) {
+      throw new OAuthProxyError(
+        400,
+        `${targetLabel} resolves to a link-local or cloud-metadata address (${address})`,
+      );
+    }
+    if (policy.allowPrivateNetwork) {
+      // Every remaining answer is dialable for a local caller; the pin below
+      // still binds the socket to exactly what was classified here.
+      continue;
+    }
     if (targetIsLoopback) {
       if (!isLoopbackAddress(address)) {
         throw new OAuthProxyError(

--- a/sdk/src/oauth/pinned-dns.ts
+++ b/sdk/src/oauth/pinned-dns.ts
@@ -40,6 +40,20 @@ export interface PinnedAddress {
 }
 
 /**
+ * What one hop's resolution concluded.
+ *
+ * `addresses` is `null` for a numeric literal — there is no name to re-resolve,
+ * so there is nothing to pin. `targetIsPrivate` reports where the hop actually
+ * LANDED, which is the only honest basis for the chain rule below: a hostname
+ * that looks public and answers 127.0.0.1 is exactly the case this whole change
+ * exists to serve, so "did the chain start private" cannot be asked of the name.
+ */
+export interface ResolvedTarget {
+  addresses: PinnedAddress[] | null;
+  targetIsPrivate: boolean;
+}
+
+/**
  * What a chain is allowed to reach. Computed ONCE per chain by
  * {@link resolveEgressPolicy} and handed to every hop, so the three buffered
  * entry points and the streaming transport cannot drift apart on the question
@@ -110,7 +124,7 @@ export async function resolvePinnedAddresses(
   policy: EgressPolicy,
   signal: AbortSignal | undefined,
   targetLabel = "OAuth metadata target",
-): Promise<PinnedAddress[] | null> {
+): Promise<ResolvedTarget> {
   const targetIsLoopback = isLoopbackOAuthUrl(targetUrl.toString());
 
   if (isNeverDialableHost(targetUrl.hostname)) {
@@ -135,7 +149,10 @@ export async function resolvePinnedAddresses(
     /^\d+\.\d+\.\d+\.\d+$/.test(targetUrl.hostname) ||
     targetUrl.hostname.includes(":")
   ) {
-    return null;
+    return {
+      addresses: null,
+      targetIsPrivate: isPrivateHost(targetUrl.hostname),
+    };
   }
 
   const addresses = await new Promise<PinnedAddress[]>((resolve, reject) => {
@@ -179,7 +196,13 @@ export async function resolvePinnedAddresses(
     );
   }
 
+  let targetIsPrivate = isPrivateHost(targetUrl.hostname);
   for (const { address } of addresses) {
+    if (isDisallowedIpAddress(address)) {
+      // Reported for the chain rule whatever the policy decides below: the
+      // question "may a later hop be private" is about where THIS one landed.
+      targetIsPrivate = true;
+    }
     if (isNeverDialableIpAddress(address)) {
       throw new OAuthProxyError(
         400,
@@ -206,7 +229,7 @@ export async function resolvePinnedAddresses(
     }
   }
 
-  return addresses;
+  return { addresses, targetIsPrivate };
 }
 
 /**

--- a/sdk/src/oauth/pinned-dns.ts
+++ b/sdk/src/oauth/pinned-dns.ts
@@ -196,13 +196,33 @@ export async function resolvePinnedAddresses(
     );
   }
 
-  let targetIsPrivate = isPrivateHost(targetUrl.hostname);
+  // EVERY answer must be private for the hop to count as private, not just one.
+  // A mixed `[public, private]` answer is pinned as a set and the socket may
+  // pick either, so "one of them was private" would hand a chain that can dial
+  // a public address the permission meant for one that cannot.
+  const landedPrivate = addresses.every(({ address }) =>
+    isDisallowedIpAddress(address),
+  );
+  const targetIsPrivate = isPrivateHost(targetUrl.hostname) || landedPrivate;
+
+  // PLAINTEXT IS FOR PRIVATE DESTINATIONS, and now the resolver knows which
+  // those are. `allowPrivateNetwork` exists so a local developer can reach
+  // their own http server; it is not a reason to put a request to a PUBLIC
+  // host on the wire in the clear, where anyone on the path can read a bearer
+  // token or rewrite a redirect. The scheme gate upstream cannot make this
+  // call — `auth.local` reads as public and answers loopback — so it defers
+  // to here, which is still before any socket opens.
+  if (
+    policy.allowPrivateNetwork &&
+    targetUrl.protocol === "http:" &&
+    !targetIsPrivate
+  ) {
+    throw new OAuthProxyError(
+      400,
+      `Refusing a plaintext connection to "${targetUrl.hostname}": it is a public host, so the target must be served over https.`,
+    );
+  }
   for (const { address } of addresses) {
-    if (isDisallowedIpAddress(address)) {
-      // Reported for the chain rule whatever the policy decides below: the
-      // question "may a later hop be private" is about where THIS one landed.
-      targetIsPrivate = true;
-    }
     if (isNeverDialableIpAddress(address)) {
       throw new OAuthProxyError(
         400,

--- a/sdk/src/oauth/pinned-stream-fetch.ts
+++ b/sdk/src/oauth/pinned-stream-fetch.ts
@@ -45,8 +45,13 @@ import type { IncomingMessage } from "node:http";
 import { createBrotliDecompress, createGunzip, createInflate } from "node:zlib";
 
 import { OAuthProxyError } from "../oauth-proxy-error.js";
-import { isLoopbackOAuthUrl } from "./ssrf-guard.js";
-import { createPinnedLookup, resolvePinnedAddresses } from "./pinned-dns.js";
+import { isLoopbackOAuthUrl, isPrivateHost } from "./ssrf-guard.js";
+import {
+  createPinnedLookup,
+  resolveEgressPolicy,
+  resolvePinnedAddresses,
+} from "./pinned-dns.js";
+import type { EgressPolicy } from "./pinned-dns.js";
 
 export interface PinnedStreamingFetchOptions {
   /**
@@ -55,6 +60,18 @@ export interface PinnedStreamingFetchOptions {
    * at loopback, however many redirects it takes to try.
    */
   allowLoopback?: boolean;
+  /**
+   * Permit private destinations for the whole chain: loopback, RFC 1918,
+   * CGNAT, unique-local, and any hostname resolving to one. This is what the
+   * LOCAL inspector sets, where reaching a developer's own network is the
+   * product. It supersedes {@link allowLoopback} (loopback is a subset), and
+   * it never permits a link-local or cloud-metadata destination.
+   *
+   * Like the loopback opt-in it is a property of the CHAIN: the allowance is
+   * decided by where the chain started, so a public target cannot redirect its
+   * way onto the caller's LAN.
+   */
+  allowPrivateNetwork?: boolean;
   /**
    * Budget for DNS + connect + response headers, summed across every hop of
    * the redirect chain. An established body stream is outside it — see the
@@ -268,13 +285,13 @@ async function openPinnedHop(
   method: string,
   headers: Record<string, string>,
   body: Buffer | undefined,
-  hopAllowsLoopback: boolean,
+  policy: EgressPolicy,
   signal: AbortSignal,
   targetLabel: string,
 ): Promise<HopResult> {
   const pinnedAddresses = await resolvePinnedAddresses(
     targetUrl,
-    hopAllowsLoopback,
+    policy,
     signal,
     targetLabel,
   );
@@ -491,7 +508,12 @@ export function createPinnedStreamingFetch(
     // the opt-in set but derived per hop, a PUBLIC target could answer
     // `302 Location: http://127.0.0.1:11434/…` and have that hop dialled:
     // attacker-chosen path, plaintext, on the user's own machine.
-    if (options.allowLoopback !== true && isLoopbackOAuthUrl(startUrl)) {
+    const allowPrivateNetwork = options.allowPrivateNetwork === true;
+    if (
+      !allowPrivateNetwork &&
+      options.allowLoopback !== true &&
+      isLoopbackOAuthUrl(startUrl)
+    ) {
       throw new OAuthProxyError(
         400,
         `Refusing a connection to loopback address "${safeHost(startUrl)}".`,
@@ -499,6 +521,10 @@ export function createPinnedStreamingFetch(
     }
     const chainAllowsLoopback =
       options.allowLoopback === true && isLoopbackOAuthUrl(startUrl);
+    // The private allowance is likewise the chain's: a chain that started
+    // public may not redirect onto the caller's LAN even in local mode.
+    const chainAllowsPrivate =
+      allowPrivateNetwork && isPrivateHost(new URL(startUrl).hostname);
 
     // ONE deadline for the whole chain's DNS/connect/header phases. Handing
     // each hop the full budget would let a five-hop chain outlive five of them.
@@ -587,7 +613,14 @@ export function createPinnedStreamingFetch(
 
         const parsed = new URL(currentUrl);
         const hopIsLoopback = isLoopbackOAuthUrl(currentUrl);
-        if (parsed.protocol !== "https:" && !(chainAllowsLoopback && hopIsLoopback)) {
+        const hopIsPrivate = isPrivateHost(parsed.hostname);
+        // Plaintext is a property of the DESTINATION, not of the mode: a
+        // private hop on a private chain may be http, exactly as a loopback
+        // hop on a loopback chain may. A public host still must serve https.
+        const hopMayBePlaintext =
+          (chainAllowsLoopback && hopIsLoopback) ||
+          (chainAllowsPrivate && hopIsPrivate);
+        if (parsed.protocol !== "https:" && !hopMayBePlaintext) {
           throw new OAuthProxyError(
             400,
             // Name the fix. This refusal is about the SCHEME, and a message
@@ -602,7 +635,10 @@ export function createPinnedStreamingFetch(
           currentMethod,
           currentHeaders,
           currentBody,
-          chainAllowsLoopback && hopIsLoopback,
+          resolveEgressPolicy({
+            allowPrivateNetwork: chainAllowsPrivate,
+            startUrl,
+          }),
           socketController.signal,
           targetLabel,
         );

--- a/sdk/src/oauth/pinned-stream-fetch.ts
+++ b/sdk/src/oauth/pinned-stream-fetch.ts
@@ -289,7 +289,7 @@ async function openPinnedHop(
   signal: AbortSignal,
   targetLabel: string,
 ): Promise<HopResult> {
-  const pinnedAddresses = await resolvePinnedAddresses(
+  const { addresses: pinnedAddresses } = await resolvePinnedAddresses(
     targetUrl,
     policy,
     signal,

--- a/sdk/src/oauth/ssrf-guard.ts
+++ b/sdk/src/oauth/ssrf-guard.ts
@@ -144,6 +144,122 @@ export function isPrivateHost(hostname: string): boolean {
 }
 
 /**
+ * The subset of {@link isDisallowedIpAddress} that stays refused even for a
+ * caller that has opted into private networks (`allowPrivateNetwork`, the
+ * LOCAL inspector's default).
+ *
+ * The reasoning behind the split: a developer running the inspector on their
+ * own machine can already reach their LAN with `curl`, so refusing 10/8 or a
+ * name that answers 127.0.0.1 buys nothing and blocks the product's whole
+ * purpose. These addresses are different — none of them is ever a legitimate
+ * OAuth destination, and each is a known credential-bearing or
+ * traffic-amplifying target:
+ *
+ *   - `0/8` — "this host". Reachable as loopback on Linux/macOS, so it is an
+ *     alias that bypasses an operator's mental model of what is exposed.
+ *   - `169.254/16` / `fe80::/10` — link-local, which is where every cloud
+ *     instance-metadata service lives (`169.254.169.254` on AWS/GCP/Azure/
+ *     DigitalOcean, `169.254.170.2` for ECS task credentials). A developer
+ *     running this on a cloud VM is exactly who this protects.
+ *   - `100.100.100.200` — Alibaba Cloud's IMDS, which sits INSIDE the CGNAT
+ *     range that corporate VPNs legitimately use, so it needs naming
+ *     individually rather than blocking all of 100.64/10.
+ *   - `fd00:ec2::254` — the same problem in IPv6: AWS's IMDS inside the ULA
+ *     range that IPv6 LANs legitimately use.
+ *   - multicast / reserved / discard — not unicast destinations at all.
+ */
+export function isNeverDialableIpAddress(ip: string): boolean {
+  const addr = ip
+    .replace(/^\[|\]$/g, "")
+    .trim()
+    .toLowerCase();
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(addr)) return isNeverDialableIpv4(addr);
+  if (addr.includes(":")) return isNeverDialableIpv6(addr);
+  return false;
+}
+
+function isNeverDialableIpv4(ip: string): boolean {
+  const parts = ip.split(".").map((o) => parseInt(o, 10));
+  if (
+    parts.length !== 4 ||
+    parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)
+  ) {
+    return true; // malformed → reject
+  }
+  const [a, b, c, d] = parts;
+  if (a === 0) return true; // 0.0.0.0/8 "this host"
+  if (a === 169 && b === 254) return true; // 169.254/16 link-local (cloud IMDS)
+  // Alibaba Cloud IMDS, inside the CGNAT range this policy otherwise allows.
+  if (a === 100 && b === 100 && c === 100 && d === 200) return true;
+  if (a >= 224 && a <= 239) return true; // 224/4 multicast
+  if (a >= 240) return true; // 240/4 reserved (incl. 255.255.255.255)
+  return false;
+}
+
+function isNeverDialableEmbeddedIpv4(h6: number, h7: number): boolean {
+  return isNeverDialableIpv4(
+    `${h6 >> 8}.${h6 & 0xff}.${h7 >> 8}.${h7 & 0xff}`,
+  );
+}
+
+function isNeverDialableIpv6(input: string): boolean {
+  const h = ipv6ToHextets(input);
+  if (!h) return true; // unparseable → reject
+  const topZero = h.slice(0, 6).every((x) => x === 0);
+  // `::` is the unspecified address; `::1` is loopback and stays dialable.
+  // Both must be decided HERE: the IPv4-compatible branch at the bottom would
+  // otherwise read `::1` as the embedded address `0.0.0.1` and refuse it.
+  if (topZero && h[6] === 0 && (h[7] === 0 || h[7] === 1)) return h[7] === 0;
+  if (h[0] >= 0xfe80 && h[0] <= 0xfebf) return true; // fe80::/10 link-local
+  if (h[0] >> 8 === 0xff) return true; // ff00::/8 multicast
+  if (h[0] === 0x0100 && h[1] === 0 && h[2] === 0 && h[3] === 0) return true; // 100::/64 discard
+  // AWS IPv6 IMDS, inside the ULA range this policy otherwise allows.
+  if (
+    h[0] === 0xfd00 &&
+    h[1] === 0x0ec2 &&
+    h[2] === 0 &&
+    h[3] === 0 &&
+    h[4] === 0 &&
+    h[5] === 0 &&
+    h[6] === 0 &&
+    h[7] === 0x0254
+  ) {
+    return true;
+  }
+  // NAT64 and IPv4-mapped/compatible: the embedded IPv4 decides, so a
+  // translator cannot carry a link-local address in through the back door.
+  if (h[0] === 0x0064 && h[1] === 0xff9b) {
+    return isNeverDialableEmbeddedIpv4(h[6], h[7]);
+  }
+  if (h[0] === 0 && h[1] === 0 && h[2] === 0 && h[3] === 0 && h[4] === 0) {
+    if (h[5] === 0xffff || h[5] === 0)
+      return isNeverDialableEmbeddedIpv4(h[6], h[7]);
+  }
+  return false;
+}
+
+/**
+ * Hostnames that resolve to instance metadata by convention. `isNeverDialable`
+ * is an ADDRESS check, and the pinned resolver applies it to every answer, so
+ * this is belt-and-braces for the pre-flight (browser-safe) path where no
+ * resolution happens.
+ */
+const NEVER_DIALABLE_HOSTNAMES = new Set([
+  "metadata.google.internal",
+  "metadata.goog",
+]);
+
+/**
+ * True for a host that stays refused even under `allowPrivateNetwork`.
+ * See {@link isNeverDialableIpAddress} for what qualifies and why.
+ */
+export function isNeverDialableHost(hostname: string): boolean {
+  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (NEVER_DIALABLE_HOSTNAMES.has(host)) return true;
+  return isNeverDialableIpAddress(host);
+}
+
+/**
  * True for an IPv4-mapped/compatible IPv6 literal whose embedded address is
  * loopback (127.0.0.0/8), e.g. `::ffff:127.0.0.1` or `::ffff:7f00:1`. Used so
  * the loopback opt-in treats a mapped-loopback host consistently with a plain
@@ -196,12 +312,23 @@ export class OAuthOutboundUrlBlockedError extends Error {
 
 /**
  * Refuse an outbound OAuth metadata fetch to a private/reserved destination
- * before it runs. `allowLoopback` (local-dev opt-in) carves out loopback hosts
- * only — it never relaxes the guard for a LAN/link-local/reserved address.
+ * before it runs.
+ *
+ * Two opt-ins, deliberately different in width:
+ *
+ *   - `allowLoopback` carves out loopback hosts ONLY, and callers derive it
+ *     per-target from the user-configured server URL. It never relaxes the
+ *     guard for a LAN/link-local/reserved address. This is what a HOSTED
+ *     deployment uses when it has an exact-origin reason to permit one.
+ *   - `allowPrivateNetwork` is the LOCAL inspector's default. It permits every
+ *     private destination — loopback, RFC 1918, CGNAT, unique-local, and any
+ *     hostname that resolves to one — because a developer's own machine can
+ *     already reach them. It still refuses {@link isNeverDialableHost}: the
+ *     link-local/metadata addresses that are never a real OAuth endpoint.
  */
 export function assertOutboundOAuthUrlAllowed(
   rawUrl: string,
-  options: { allowLoopback?: boolean } = {},
+  options: { allowLoopback?: boolean; allowPrivateNetwork?: boolean } = {},
 ): URL {
   let url: URL;
   try {
@@ -223,6 +350,21 @@ export function assertOutboundOAuthUrlAllowed(
   }
 
   const host = url.hostname;
+
+  // The never-dialable set is checked FIRST and answers to no opt-in, so a
+  // caller cannot reach cloud metadata by asking for private networks.
+  if (isNeverDialableHost(host)) {
+    throw new OAuthOutboundUrlBlockedError(
+      rawUrl,
+      "private-host",
+      `Refusing outbound OAuth fetch to link-local or cloud-metadata host "${host}"`,
+    );
+  }
+
+  if (options.allowPrivateNetwork === true) {
+    return url;
+  }
+
   if (isLoopbackHost(host) || isMappedLoopbackHost(host)) {
     if (options.allowLoopback === true) {
       return url;

--- a/sdk/src/oauth/ssrf-guard.ts
+++ b/sdk/src/oauth/ssrf-guard.ts
@@ -20,6 +20,22 @@
 
 import { isLoopbackHost } from "./state-machines/shared/client-id-metadata.js";
 
+/**
+ * One spelling of a host, so every classifier below judges the same string.
+ *
+ * The trailing dot matters: `metadata.google.internal.` is the fully-qualified
+ * form of `metadata.google.internal` and resolves identically, so a set lookup
+ * that keeps the dot would let the absolute form walk past a floor the relative
+ * form is refused by. Brackets come off IPv6 literals for the same reason.
+ */
+function normalizeHost(value: string): string {
+  return value
+    .replace(/^\[|\]$/g, "")
+    .trim()
+    .toLowerCase()
+    .replace(/\.+$/, "");
+}
+
 function isDisallowedIpv4(ip: string): boolean {
   const parts = ip.split(".").map((o) => parseInt(o, 10));
   if (
@@ -126,7 +142,7 @@ function isDisallowedIpv6(input: string): boolean {
  * false — the caller resolves it first.
  */
 export function isDisallowedIpAddress(ip: string): boolean {
-  const addr = ip.replace(/^\[|\]$/g, "").trim().toLowerCase();
+  const addr = normalizeHost(ip);
   if (/^\d+\.\d+\.\d+\.\d+$/.test(addr)) return isDisallowedIpv4(addr);
   if (addr.includes(":")) return isDisallowedIpv6(addr);
   return false;
@@ -138,7 +154,7 @@ export function isDisallowedIpAddress(ip: string): boolean {
  * DNS resolution is validated separately in the Node proxy path).
  */
 export function isPrivateHost(hostname: string): boolean {
-  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  const host = normalizeHost(hostname);
   if (host === "localhost" || host.endsWith(".localhost")) return true;
   return isDisallowedIpAddress(host);
 }
@@ -169,10 +185,7 @@ export function isPrivateHost(hostname: string): boolean {
  *   - multicast / reserved / discard — not unicast destinations at all.
  */
 export function isNeverDialableIpAddress(ip: string): boolean {
-  const addr = ip
-    .replace(/^\[|\]$/g, "")
-    .trim()
-    .toLowerCase();
+  const addr = normalizeHost(ip);
   if (/^\d+\.\d+\.\d+\.\d+$/.test(addr)) return isNeverDialableIpv4(addr);
   if (addr.includes(":")) return isNeverDialableIpv6(addr);
   return false;
@@ -254,7 +267,7 @@ const NEVER_DIALABLE_HOSTNAMES = new Set([
  * See {@link isNeverDialableIpAddress} for what qualifies and why.
  */
 export function isNeverDialableHost(hostname: string): boolean {
-  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  const host = normalizeHost(hostname);
   if (NEVER_DIALABLE_HOSTNAMES.has(host)) return true;
   return isNeverDialableIpAddress(host);
 }

--- a/sdk/src/oauth/state-machines/factory.ts
+++ b/sdk/src/oauth/state-machines/factory.ts
@@ -152,6 +152,17 @@ export interface OAuthStateMachineFactoryConfig extends BaseOAuthStateMachineCon
    * LAN/link-local/reserved destinations regardless of this flag.
    */
   allowLoopbackMetadataFetch?: boolean;
+  /**
+   * Permit outbound OAuth metadata fetches to any private destination —
+   * loopback, RFC 1918, CGNAT, unique-local. This is the LOCAL inspector's
+   * default: on a developer's own machine, reaching their own network is the
+   * product, and the browser could not be steered anywhere the developer's
+   * shell cannot already reach. Hosted surfaces must never set it.
+   *
+   * Supersedes {@link allowLoopbackMetadataFetch}. Link-local and
+   * cloud-metadata destinations stay refused either way.
+   */
+  allowPrivateMetadataFetch?: boolean;
 }
 
 /**
@@ -189,6 +200,7 @@ export function createOAuthStateMachine(
   const {
     protocolVersion,
     allowLoopbackMetadataFetch,
+    allowPrivateMetadataFetch,
     ...rest
   } = config;
 
@@ -197,12 +209,16 @@ export function createOAuthStateMachine(
   // Validate the destination before the fetch runs — blocking private/reserved
   // hosts — with an explicit loopback opt-in for local dev.
   const allowLoopback = allowLoopbackMetadataFetch ?? false;
+  const allowPrivateNetwork = allowPrivateMetadataFetch ?? false;
   const guardedExecutor: OAuthRequestExecutor = async (request) => {
     // Validate the request URL (initial hop) for every machine request. The
     // executor is responsible for re-validating the FINAL URL after any
     // redirects (see the client executor / DNS-pinning proxy) — a URL-string
     // check here cannot catch a 3xx or DNS-rebind to a private host.
-    assertOutboundOAuthUrlAllowed(request.url, { allowLoopback });
+    assertOutboundOAuthUrlAllowed(request.url, {
+      allowLoopback,
+      allowPrivateNetwork,
+    });
     const result = await rest.requestExecutor(request);
     // Second cross-cutting guard at the same seam: catch a trace redactor that
     // was applied to live data before the sentinel is spent as a credential.

--- a/sdk/src/server-probe.ts
+++ b/sdk/src/server-probe.ts
@@ -27,6 +27,13 @@ export interface ProbeMcpServerConfig {
   clientName?: string;
   clientVersion?: string;
   retryPolicy?: RetryPolicy;
+  /**
+   * Permit private destinations (loopback, RFC 1918, CGNAT, unique-local) for
+   * the metadata pointers this probe follows. The LOCAL inspector and CLI set
+   * it; hosted callers leave it unset. Link-local and cloud-metadata
+   * destinations stay refused either way.
+   */
+  allowPrivateNetwork?: boolean;
 }
 
 export interface ProbeHttpAttempt {
@@ -243,7 +250,8 @@ function buildAuthServerMetadataUrls(
  */
 function assertMetadataDestinationAllowed(
   candidate: string,
-  serverUrl: string
+  serverUrl: string,
+  allowPrivateNetwork = false
 ): void {
   try {
     const target = new URL(candidate);
@@ -267,6 +275,7 @@ function assertMetadataDestinationAllowed(
 
   assertOutboundOAuthUrlAllowed(candidate, {
     allowLoopback: isLoopbackOAuthUrl(serverUrl),
+    allowPrivateNetwork,
   });
 }
 
@@ -582,7 +591,8 @@ async function discoverOAuthDetails(
     if (resourceMetadataUrlFromHeader) {
       assertMetadataDestinationAllowed(
         resourceMetadataUrlFromHeader,
-        config.url
+        config.url,
+        config.allowPrivateNetwork
       );
     }
     attempts.push(resourceMetadataAttempt);
@@ -616,7 +626,12 @@ async function discoverOAuthDetails(
         config.fetchFn ?? fetch,
         attempt,
         config.timeoutMs,
-        (landingUrl) => assertMetadataDestinationAllowed(landingUrl, config.url)
+        (landingUrl) =>
+          assertMetadataDestinationAllowed(
+            landingUrl,
+            config.url,
+            config.allowPrivateNetwork
+          )
       );
 
       return new Response(
@@ -652,7 +667,11 @@ async function discoverOAuthDetails(
       // loopback server discovering its own metadata. This also keeps a
       // malformed entry from aborting discovery inside `new URL()` below.
       if (advertisedAuthServer) {
-        assertMetadataDestinationAllowed(advertisedAuthServer, config.url);
+        assertMetadataDestinationAllowed(
+          advertisedAuthServer,
+          config.url,
+          config.allowPrivateNetwork
+        );
       }
       authMetadataUrls = buildAuthServerMetadataUrls(
         protocolVersion,
@@ -680,7 +699,11 @@ async function discoverOAuthDetails(
           authAttempt,
           config.timeoutMs,
           (landingUrl) =>
-            assertMetadataDestinationAllowed(landingUrl, config.url)
+            assertMetadataDestinationAllowed(
+              landingUrl,
+              config.url,
+              config.allowPrivateNetwork
+            )
         );
 
         if (

--- a/sdk/src/xaa/in-process-executor.ts
+++ b/sdk/src/xaa/in-process-executor.ts
@@ -40,6 +40,11 @@ export interface InProcessXaaExecutorOptions {
   issuerBaseUrl: string;
   /** Reject non-HTTPS / private targets. Default false (local dev). */
   httpsOnly?: boolean;
+  /**
+   * Permit private destinations on the outbound proxy calls. Default false.
+   * Never relaxes `enforcePublicHost` below, which is about the CIMD document.
+   */
+  allowPrivateNetwork?: boolean;
   /** Per-request timeout (ms) applied to every outbound proxy request. */
   timeoutMs?: number;
   /** Node-side confidential-CIMD credential capability. Defaults to the local
@@ -115,6 +120,7 @@ export function createInProcessXaaExecutor(
   options: InProcessXaaExecutorOptions
 ): XAARequestExecutor {
   const httpsOnly = options.httpsOnly ?? false;
+  const allowPrivateNetwork = options.allowPrivateNetwork ?? false;
   const timeoutMs = options.timeoutMs;
   const confidentialCimdProvider =
     options.confidentialCimdProvider ?? getLocalConfidentialCimdProvider();
@@ -297,6 +303,7 @@ export function createInProcessXaaExecutor(
         },
         body: form,
         httpsOnly,
+        allowPrivateNetwork,
         timeoutMs,
       });
       return jsonResult(200, { status: upstream.status, body: upstream.body });
@@ -343,6 +350,7 @@ export function createInProcessXaaExecutor(
       headers: normalizeHeaders(init?.headers),
       body: init?.body ?? undefined,
       httpsOnly,
+      allowPrivateNetwork,
       ...(redirect ? { redirect } : {}),
       timeoutMs,
     });

--- a/sdk/src/xaa/run-xaa-flow.ts
+++ b/sdk/src/xaa/run-xaa-flow.ts
@@ -84,6 +84,14 @@ export interface XaaFlowConfig {
   timeoutMs?: number;
   /** Reject non-HTTPS / private targets. Default false for local development. */
   httpsOnly?: boolean;
+  /**
+   * Permit private destinations (loopback, RFC 1918, CGNAT, unique-local) on
+   * the outbound issuer/JWKS/token fetches. The CLI derives it from the
+   * inverse of {@link httpsOnly}; link-local and cloud-metadata destinations
+   * stay refused either way. The CIMD document is validated strictly
+   * regardless — see the `validateUrl(..., true)` call below.
+   */
+  allowPrivateNetwork?: boolean;
   onProgress?: (message: string) => void;
 }
 export interface XaaFlowStep {
@@ -167,11 +175,16 @@ function publicJwkMatches(local: JsonWebKey, published: JsonWebKey): boolean {
 async function verifyIssuerPublication(
   issuer: string,
   httpsOnly: boolean,
+  allowPrivateNetwork: boolean,
   timeoutMs: number | undefined
 ): Promise<{ ok: boolean; detail: string }> {
   let metadata: Record<string, unknown> | undefined;
   for (const url of buildIssuerPublicationCandidates(issuer)) {
-    const response = await fetchOAuthMetadata(url, httpsOnly, timeoutMs);
+    const response = await fetchOAuthMetadata(
+      url,
+      { httpsOnly, allowPrivateNetwork },
+      timeoutMs
+    );
     if (!("status" in response) && response.metadata.issuer === issuer) {
       metadata = response.metadata;
       break;
@@ -194,6 +207,7 @@ async function verifyIssuerPublication(
     url: jwksUri,
     headers: { Accept: "application/json" },
     httpsOnly,
+    allowPrivateNetwork,
     timeoutMs,
   });
   const rawKeys =
@@ -462,6 +476,7 @@ async function runSharedAttempt(
   const executor = createInProcessXaaExecutor({
     issuerBaseUrl: config.issuerBaseUrl,
     httpsOnly: config.httpsOnly ?? false,
+    allowPrivateNetwork: config.allowPrivateNetwork ?? false,
     timeoutMs: config.timeoutMs,
   });
   const reportedSteps = new Set<string>();
@@ -523,6 +538,7 @@ export async function runXaaFlow(
   config: XaaFlowConfig
 ): Promise<XaaFlowResult> {
   const httpsOnly = config.httpsOnly ?? false;
+  const allowPrivateNetwork = config.allowPrivateNetwork ?? false;
   const progress = (message: string) => config.onProgress?.(message);
   const issuer = getXAAIssuerUrl(config.issuerBaseUrl);
   const publicationStep: XaaFlowStep[] = [];
@@ -634,6 +650,7 @@ export async function runXaaFlow(
     const issuerPublication = await verifyIssuerPublication(
       issuer,
       httpsOnly,
+      allowPrivateNetwork,
       config.timeoutMs
     );
     publicationStep.push({

--- a/sdk/tests/oauth-proxy.test.ts
+++ b/sdk/tests/oauth-proxy.test.ts
@@ -1166,6 +1166,68 @@ describe("allowPrivateNetwork (local inspector)", () => {
     expect(httpRequestMock).not.toHaveBeenCalled();
   });
 
+  it("refuses a private redirect on a chain that started public", async () => {
+    // The one attack the local allowance must still stop: a public server
+    // answering `302 Location: http://10.0.0.5/…` to make the developer's own
+    // inspector fetch something on their LAN. The chain's character is decided
+    // by where hop 1 LANDED, so hop 2 is held to the strict policy.
+    dnsLookupMock
+      .mockImplementationOnce(
+        (
+          _hostname: string,
+          _options: unknown,
+          callback: (error: Error | null, addresses: unknown) => void
+        ) => callback(null, [{ address: "93.184.216.34", family: 4 }])
+      )
+      .mockImplementation(
+        (
+          _hostname: string,
+          _options: unknown,
+          callback: (error: Error | null, addresses: unknown) => void
+        ) => callback(null, [{ address: "10.0.0.5", family: 4 }])
+      );
+    queueMetadataResponses(httpsRequestMock, [
+      {
+        status: 302,
+        statusText: "Found",
+        headers: { location: "http://internal.example/secrets" },
+      },
+    ]);
+
+    await expect(
+      executeOAuthProxy({
+        url: "https://auth.example.com/oauth/token",
+        allowPrivateNetwork: true,
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("private/reserved IP address"),
+    });
+    expect(httpRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("follows a private redirect on a chain that started private", async () => {
+    // The legitimate counterpart: a local authorization server bouncing
+    // between its own ports, reached through a hostname that answers 127.0.0.1.
+    resolveTo("127.0.0.1");
+    queueMetadataResponses(httpRequestMock, [
+      {
+        status: 302,
+        statusText: "Found",
+        headers: { location: "http://auth.localtest.me:9401/token" },
+      },
+      { body: JSON.stringify({ access_token: "ok" }) },
+    ]);
+
+    const result = await executeOAuthProxy({
+      url: "http://auth.localtest.me:9400/token",
+      allowPrivateNetwork: true,
+    });
+
+    expect(result).toMatchObject({ status: 200 });
+    expect(httpRequestMock).toHaveBeenCalledTimes(2);
+  });
+
   it("is overridden by httpsOnly, so hosted mode cannot be talked out of it", async () => {
     await expect(
       executeOAuthProxy({

--- a/sdk/tests/oauth-proxy.test.ts
+++ b/sdk/tests/oauth-proxy.test.ts
@@ -1228,6 +1228,75 @@ describe("allowPrivateNetwork (local inspector)", () => {
     expect(httpRequestMock).toHaveBeenCalledTimes(2);
   });
 
+  it("refuses plaintext to a host that resolves publicly", async () => {
+    // `allowPrivateNetwork` is permission to reach a private network, not
+    // permission to shout a bearer token across a public one. The decision is
+    // made on the resolved address, after the name is looked up and before any
+    // socket opens, because the hostname alone cannot answer it.
+    resolveTo("93.184.216.34");
+
+    await expect(
+      executeOAuthProxy({
+        url: "http://auth.example.com/token",
+        allowPrivateNetwork: true,
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("public host"),
+    });
+    expect(httpRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("still allows https to a public host, and plaintext to a private one", async () => {
+    resolveTo("127.0.0.1");
+    queueMetadataResponses(httpRequestMock, [{ body: "{}" }]);
+
+    await expect(
+      executeOAuthProxy({
+        url: "http://auth.localtest.me:9400/token",
+        allowPrivateNetwork: true,
+      })
+    ).resolves.toMatchObject({ status: 200, targetIsPrivate: true });
+  });
+
+  it("reports a public landing so a caller driving its own redirects can narrow", async () => {
+    resolveTo("93.184.216.34");
+    queueMetadataResponses(httpsRequestMock, [{ body: "{}" }]);
+
+    const result = await executeOAuthProxy({
+      url: "https://auth.example.com/token",
+      allowPrivateNetwork: true,
+    });
+
+    expect(result).toMatchObject({ status: 200, targetIsPrivate: false });
+  });
+
+  it("treats a mixed public/private DNS answer as public for the chain rule", async () => {
+    // The socket picks from the pinned set, so "one of the answers was
+    // private" is not a promise that the connection landed there. Anything
+    // less than all-private has to read as public, or a chain that can reach
+    // the open internet keeps a permission meant for one that cannot.
+    dnsLookupMock.mockImplementation(
+      (
+        _hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void
+      ) =>
+        callback(null, [
+          { address: "93.184.216.34", family: 4 },
+          { address: "10.0.0.5", family: 4 },
+        ])
+    );
+    queueMetadataResponses(httpsRequestMock, [{ body: "{}" }]);
+
+    const result = await executeOAuthProxy({
+      url: "https://mixed.example/token",
+      allowPrivateNetwork: true,
+    });
+
+    expect(result).toMatchObject({ targetIsPrivate: false });
+  });
+
   it("is overridden by httpsOnly, so hosted mode cannot be talked out of it", async () => {
     await expect(
       executeOAuthProxy({

--- a/sdk/tests/oauth-proxy.test.ts
+++ b/sdk/tests/oauth-proxy.test.ts
@@ -204,6 +204,30 @@ describe("oauth-proxy helpers", () => {
       executeOAuthProxy({ url: "https://attacker.example/oauth/token" })
     ).rejects.toMatchObject({
       status: 400,
+      message: expect.stringContaining(
+        "link-local or cloud-metadata address"
+      ),
+    });
+    expect(httpsRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a mixed DNS answer whose private member is a LAN address", async () => {
+    dnsLookupMock.mockImplementation(
+      (
+        _hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void
+      ) =>
+        callback(null, [
+          { address: "93.184.216.34", family: 4 },
+          { address: "10.0.0.5", family: 4 },
+        ])
+    );
+
+    await expect(
+      executeOAuthProxy({ url: "https://attacker.example/oauth/token" })
+    ).rejects.toMatchObject({
+      status: 400,
       message: expect.stringContaining("private/reserved IP address"),
     });
     expect(httpsRequestMock).not.toHaveBeenCalled();
@@ -241,12 +265,16 @@ describe("oauth-proxy helpers", () => {
   });
 
   it.each([
-    ["loopback", "http://127.0.0.1:8787/oauth/token"],
-    ["LAN", "http://192.168.1.10/oauth/token"],
-    ["link-local metadata service", "http://169.254.169.254/latest/meta-data"],
+    ["loopback", "http://127.0.0.1:8787/oauth/token", "private/reserved host"],
+    ["LAN", "http://192.168.1.10/oauth/token", "private/reserved host"],
+    [
+      "link-local metadata service",
+      "http://169.254.169.254/latest/meta-data",
+      "link-local or cloud-metadata host",
+    ],
   ])(
     "rejects a generic public request redirected to %s before connecting",
-    async (_destinationType, location) => {
+    async (_destinationType, location, expectedRefusal) => {
       queueMetadataResponses(httpsRequestMock, [
         {
           status: 302,
@@ -259,7 +287,7 @@ describe("oauth-proxy helpers", () => {
         executeOAuthProxy({ url: "https://auth.example.com/oauth/token" })
       ).rejects.toMatchObject({
         status: 400,
-        message: expect.stringContaining("private/reserved host"),
+        message: expect.stringContaining(expectedRefusal),
       });
       expect(httpsRequestMock).toHaveBeenCalledTimes(1);
       expect(httpRequestMock).not.toHaveBeenCalled();
@@ -1030,5 +1058,139 @@ describe("fetchPinnedPublicDocument guards", () => {
     await expect(
       fetchPinnedPublicDocument("https://127.0.0.1/meta.json")
     ).rejects.toThrow(/private or reserved/i);
+  });
+});
+
+/**
+ * The LOCAL inspector's policy. A developer running on their own machine can
+ * already reach their LAN with `curl`, so the address guard yields — but only
+ * for addresses that can host a real authorization server. The pin is still
+ * taken, and the never-dialable set still answers to nobody.
+ */
+describe("allowPrivateNetwork (local inspector)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requestWriteMocks.length = 0;
+  });
+
+  function resolveTo(address: string, family = 4) {
+    dnsLookupMock.mockImplementation(
+      (
+        _hostname: string,
+        _options: unknown,
+        callback: (error: Error | null, addresses: unknown) => void
+      ) => callback(null, [{ address, family }])
+    );
+  }
+
+  it("reaches a public hostname that resolves to loopback", async () => {
+    // The reported case: an authorization server named `auth.local` or
+    // `auth.localtest.me` that answers 127.0.0.1. Strict mode reads this as
+    // DNS rebinding; for a local developer it is just their own machine.
+    resolveTo("127.0.0.1");
+    queueMetadataResponses(httpRequestMock, [
+      { body: JSON.stringify({ issuer: "http://auth.localtest.me:9400" }) },
+    ]);
+
+    const result = await fetchOAuthMetadata(
+      "http://auth.localtest.me:9400/.well-known/oauth-authorization-server",
+      { allowPrivateNetwork: true }
+    );
+
+    expect(result).toMatchObject({
+      metadata: { issuer: "http://auth.localtest.me:9400" },
+    });
+    expect(httpRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("pins the resolved address it validated", async () => {
+    resolveTo("10.0.0.5");
+    queueMetadataResponses(httpRequestMock, [{ body: "{}" }]);
+
+    await fetchOAuthMetadata("http://mcp.corp.internal/.well-known/oauth", {
+      allowPrivateNetwork: true,
+    });
+
+    const options = httpRequestMock.mock.calls[0][1];
+    expect(options.lookup).toBeTypeOf("function");
+    const pinned = await new Promise((resolve) =>
+      options.lookup("mcp.corp.internal", { all: true }, (_e: unknown, a: unknown) =>
+        resolve(a)
+      )
+    );
+    expect(pinned).toEqual([{ address: "10.0.0.5", family: 4 }]);
+  });
+
+  it("reaches a LAN literal over plaintext", async () => {
+    resolveTo("192.168.1.10");
+    queueMetadataResponses(httpRequestMock, [{ body: "{}" }]);
+
+    await expect(
+      executeOAuthProxy({
+        url: "http://192.168.1.10:8080/oauth/token",
+        method: "POST",
+        allowPrivateNetwork: true,
+      })
+    ).resolves.toMatchObject({ status: 200 });
+  });
+
+  it.each([
+    ["cloud metadata", "http://169.254.169.254/latest/meta-data"],
+    ["Alibaba cloud metadata inside CGNAT", "http://100.100.100.200/latest"],
+    ["the unspecified address", "http://0.0.0.0:9000/oauth"],
+    ["IPv6 link-local", "http://[fe80::1]/oauth"],
+    ["AWS IPv6 metadata inside the ULA range", "http://[fd00:ec2::254]/latest"],
+  ])("still refuses %s", async (_label, url) => {
+    await expect(
+      executeOAuthProxy({ url, allowPrivateNetwork: true })
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("link-local or cloud-metadata"),
+    });
+    expect(httpRequestMock).not.toHaveBeenCalled();
+    expect(httpsRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("still refuses a name that resolves to cloud metadata", async () => {
+    resolveTo("169.254.169.254");
+
+    await expect(
+      executeOAuthProxy({
+        url: "http://harmless.example/oauth/token",
+        allowPrivateNetwork: true,
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("link-local or cloud-metadata address"),
+    });
+    expect(httpRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("is overridden by httpsOnly, so hosted mode cannot be talked out of it", async () => {
+    await expect(
+      executeOAuthProxy({
+        url: "https://127.0.0.1/oauth/token",
+        httpsOnly: true,
+        allowPrivateNetwork: true,
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("private/reserved host"),
+    });
+    expect(httpsRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps refusing private targets when it is not set", async () => {
+    resolveTo("127.0.0.1");
+
+    await expect(
+      fetchOAuthMetadata(
+        "http://auth.localtest.me:9400/.well-known/oauth-authorization-server"
+      )
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("private/reserved IP address"),
+    });
+    expect(httpRequestMock).not.toHaveBeenCalled();
   });
 });

--- a/sdk/tests/oauth/ssrf-guard.test.ts
+++ b/sdk/tests/oauth/ssrf-guard.test.ts
@@ -2,6 +2,8 @@ import {
   assertOutboundOAuthUrlAllowed,
   isDisallowedIpAddress,
   isLoopbackOAuthUrl,
+  isNeverDialableHost,
+  isNeverDialableIpAddress,
   isPrivateHost,
   OAuthOutboundUrlBlockedError,
 } from "../../src/oauth/ssrf-guard.js";
@@ -232,5 +234,96 @@ describe("factory wraps every machine's executor with the SSRF guard", () => {
     await advance(machine);
     const urls = inner.mock.calls.map((c) => c[0].url);
     expect(urls).toContain("http://127.0.0.1:8080/register");
+  });
+});
+
+/**
+ * The never-dialable set is the floor under `allowPrivateNetwork`: the
+ * addresses that are never a real OAuth endpoint, and that a local developer
+ * therefore gains nothing by reaching.
+ */
+describe("isNeverDialableIpAddress / isNeverDialableHost", () => {
+  it("flags link-local, metadata, unspecified, multicast and reserved", () => {
+    for (const ip of [
+      "169.254.169.254", // AWS/GCP/Azure IMDS
+      "169.254.170.2", // ECS task credentials
+      "100.100.100.200", // Alibaba IMDS, inside CGNAT
+      "0.0.0.0",
+      "0.1.2.3",
+      "224.0.0.1",
+      "255.255.255.255",
+      "fe80::1",
+      "ff02::1",
+      "::",
+      "100::1",
+      "fd00:ec2::254", // AWS IPv6 IMDS, inside the ULA range
+      "::ffff:169.254.169.254", // mapped form of the same
+      "64:ff9b::a9fe:a9fe", // NAT64-embedded link-local
+      "not-an-ip-at-all:::",
+    ]) {
+      expect(isNeverDialableIpAddress(ip), ip).toBe(true);
+    }
+  });
+
+  it("leaves the private ranges a developer legitimately uses alone", () => {
+    for (const ip of [
+      "127.0.0.1",
+      "::1",
+      "::ffff:127.0.0.1",
+      "10.0.0.5",
+      "192.168.1.10",
+      "172.16.5.5",
+      "100.64.0.1", // CGNAT, minus the Alibaba IMDS address
+      "fc00::1", // unique-local, minus the AWS IMDS address
+      "93.184.216.34",
+    ]) {
+      expect(isNeverDialableIpAddress(ip), ip).toBe(false);
+      // …and every one of them is still "private" to the strict classifier,
+      // which is what keeps hosted mode unchanged.
+      if (ip !== "93.184.216.34") expect(isPrivateHost(ip), ip).toBe(true);
+    }
+  });
+
+  it("names the metadata hostnames, which resolve nowhere useful to check", () => {
+    expect(isNeverDialableHost("metadata.google.internal")).toBe(true);
+    expect(isNeverDialableHost("localhost")).toBe(false);
+    expect(isNeverDialableHost("auth.local")).toBe(false);
+  });
+});
+
+describe("assertOutboundOAuthUrlAllowed with allowPrivateNetwork", () => {
+  it("permits loopback, LAN and localhost names", () => {
+    for (const url of [
+      "http://127.0.0.1:9000/.well-known/oauth-authorization-server",
+      "http://localhost:9000/register",
+      "http://auth.localhost:9000/register",
+      "http://10.0.0.5/token",
+      "http://[fc00::1]/token",
+    ]) {
+      expect(() =>
+        assertOutboundOAuthUrlAllowed(url, { allowPrivateNetwork: true }),
+      ).not.toThrow();
+    }
+  });
+
+  it("refuses the never-dialable set regardless of the opt-in", () => {
+    for (const url of [
+      "http://169.254.169.254/latest/meta-data",
+      "http://100.100.100.200/latest",
+      "http://metadata.google.internal/computeMetadata/v1/",
+      "http://0.0.0.0:9000/oauth",
+    ]) {
+      expect(() =>
+        assertOutboundOAuthUrlAllowed(url, { allowPrivateNetwork: true }),
+      ).toThrow(/link-local or cloud-metadata/i);
+    }
+  });
+
+  it("still refuses a non-http scheme", () => {
+    expect(() =>
+      assertOutboundOAuthUrlAllowed("file:///etc/passwd", {
+        allowPrivateNetwork: true,
+      }),
+    ).toThrow(/http\(s\)/i);
   });
 });

--- a/sdk/tests/oauth/ssrf-guard.test.ts
+++ b/sdk/tests/oauth/ssrf-guard.test.ts
@@ -289,6 +289,16 @@ describe("isNeverDialableIpAddress / isNeverDialableHost", () => {
     expect(isNeverDialableHost("localhost")).toBe(false);
     expect(isNeverDialableHost("auth.local")).toBe(false);
   });
+
+  it("sees through the fully-qualified form of a name or address", () => {
+    // The trailing dot is the DNS root: `metadata.google.internal.` resolves
+    // exactly where `metadata.google.internal` does, so a floor that compares
+    // the string without normalising it lets the absolute form walk past.
+    expect(isNeverDialableHost("metadata.google.internal.")).toBe(true);
+    expect(isNeverDialableHost("169.254.169.254.")).toBe(true);
+    expect(isPrivateHost("localhost.")).toBe(true);
+    expect(isPrivateHost("127.0.0.1.")).toBe(true);
+  });
 });
 
 describe("assertOutboundOAuthUrlAllowed with allowPrivateNetwork", () => {
@@ -311,6 +321,7 @@ describe("assertOutboundOAuthUrlAllowed with allowPrivateNetwork", () => {
       "http://169.254.169.254/latest/meta-data",
       "http://100.100.100.200/latest",
       "http://metadata.google.internal/computeMetadata/v1/",
+      "http://metadata.google.internal./computeMetadata/v1/",
       "http://0.0.0.0:9000/oauth",
     ]) {
       expect(() =>

--- a/sdk/tests/pinned-stream-fetch.test.ts
+++ b/sdk/tests/pinned-stream-fetch.test.ts
@@ -157,7 +157,7 @@ describe("a redirect is re-validated at the hop that names it", () => {
     });
 
     await expect(loopbackFetch()(`${origin}/start`)).rejects.toThrow(
-      /private\/reserved/i,
+      /link-local or cloud-metadata/i,
     );
     // The target answered once; the metadata hop was refused before a socket
     // to it existed.

--- a/sdk/tests/server-probe.test.ts
+++ b/sdk/tests/server-probe.test.ts
@@ -477,7 +477,7 @@ describe("probeMcpServer", () => {
       const result = await probeMcpServer({ url: serverUrl, fetchFn });
 
       expect(result.status).toBe("oauth_required");
-      expect(result.oauth.discoveryError).toMatch(/private\/reserved/);
+      expect(result.oauth.discoveryError).toMatch(/link-local or cloud-metadata/);
       expect(requestedUrls(fetchFn)).not.toContain(internal);
     });
 
@@ -603,7 +603,7 @@ describe("probeMcpServer", () => {
 
       const result = await probeMcpServer({ url: serverUrl, fetchFn });
 
-      expect(result.oauth.discoveryError).toMatch(/private\/reserved/);
+      expect(result.oauth.discoveryError).toMatch(/link-local or cloud-metadata/);
       expect(bodyWasRead).toBe(false);
     });
 


### PR DESCRIPTION
## The report

A user testing a fully local OAuth-protected MCP server hit this, on every registration strategy:

```
Backend debug proxy error: 400 Bad Request:
OAuth proxy target resolves to a private/reserved IP address (127.0.0.1)
```

Their authorization server had a hostname of its own that resolved to loopback. Protected-resource discovery succeeded; authorization-server discovery did not. The official MCP Inspector, which has no outbound address guard at all, worked where we did not. Issue #4364 is the same guard reached from the CGNAT side, for internal corporate servers.

## Why it happened

`resolvePinnedAddresses` asked one question — is this private? — and the loopback carve-out was keyed on the literal hostname (`localhost`, `*.localhost`, `127/8`, `::1`). A name that looks public and answers `127.0.0.1` is indistinguishable from DNS rebinding by that test, so it was refused. Correct on our infrastructure. Wrong on a laptop, where reaching your own network is the entire product and your shell can already do it.

## The change

The guard now asks two questions instead of one.

| | private target | link-local / cloud metadata | plaintext http |
|---|---|---|---|
| **Hosted** (`httpsOnly`) | refused, unchanged | refused, unchanged | refused, unchanged |
| **Local** | **allowed** | refused | allowed to private hops |

`isNeverDialableIpAddress` is the new floor: link-local and every cloud metadata service, including the two that hide *inside* ranges corporate networks legitimately use (Alibaba's `100.100.100.200` inside CGNAT, AWS's `fd00:ec2::254` inside the unique-local range), plus the unspecified address, multicast and reserved space. None of those is ever an OAuth endpoint, so keeping them shut costs nothing.

**No env vars and no knobs**, per the product decision. The only switch is `HOSTED_MODE`, which is our deployment constant. This follows a convention the server already had: `hosted-egress-guard.ts` no-ops outside hosted mode, `createStreamingPinnedFetch` returns plain `fetch` locally, `local-server-resolver.ts` already gates on `!HOSTED_MODE`. The buffered half of that same transport was the one the OAuth flow used, and it had the opposite default.

## What is still refused locally

The allowance belongs to the **chain**, and the chain's character is decided by where its first hop actually *landed* — not by how the hostname looked, since a name that looks public and answers `127.0.0.1` is the case this exists to serve. A public authorization server answering `302 Location: http://192.168.1.1/…` still cannot make a local inspector fetch it. DNS is resolved once and pinned into the socket, so rebinding stays closed, and cross-origin redirects still drop credentials.

I found this gap mid-implementation: the buffered proxy handed one policy to every hop, so the third commit closes it and pins both directions with tests.

## SDK compatibility

`allowPrivateNetwork` is additive and defaults to `false`, so consumers of the published package — `mcpjam-backend` among them — keep today's behaviour without changing a line, and `httpsOnly` still overrides it. Verified directly against both builds:

```
BEFORE (main, httpsOnly false)  REFUSED  resolves to a private/reserved IP address (127.0.0.1)
AFTER  (this branch, local)     OK       {"issuer":"http://auth.localtest.me:9400", …}
AFTER  (hosted)                 REFUSED  Only HTTPS targets are allowed in hosted mode
AFTER  (old boolean call)       REFUSED  identical to BEFORE
```

The one visible difference for an unchanged caller is wording: a link-local destination now says so rather than reporting as "private/reserved". `@mcpjam/sdk/oauth/node` gains no new exports, so its frozen-surface test is untouched.

## Also fixed

The CLI's `oauth metadata` / `proxy` / `debug-proxy` hardcoded `httpsOnly: true` with no flag, so `mcpjam oauth metadata --url http://localhost:…` was impossible — a local-first tool refusing local servers. They now default to the local policy and gain `--https-only`, matching what `xaa run` already had. `oauth login` and the conformance runner passed **no** opt-in at all: both hand the state machine a caller-supplied `fetchFn`, which makes the factory pre-flight their only address check, so a loopback server under test was refused at its first well-known fetch.

## Verification

End-to-end against a local MCP server on `localtest.me:9300` with its AS on `auth.localtest.me:9400` (public DNS names that resolve to 127.0.0.1 — the reporter's exact shape), through the real running inspector:

| check | result |
|---|---|
| `/api/mcp/oauth/metadata` for the AS | 200, metadata returned |
| `/api/mcp/oauth/debug/proxy` (the surface in the report) | 200 |
| same route for `169.254.169.254` | 400, link-local refusal |
| `mcpjam server probe` full discovery | `oauth_required`, no discovery error, AS issuer and token endpoint found |
| `mcpjam oauth metadata --https-only` | refused, as the hosted app would |

Tests: SDK 7050 passed; CLI 1218 passed; inspector 22937 passed. The inspector's 3 failing files (`score-run-resume`, `scenario-chat-transcript`, `runtime-install`) fail identically on clean `main` and are unrelated. Strict suites now name `allowPrivateNetwork: false` explicitly rather than leaning on a default that moved, so each suite states which policy it tests.

## Follow-up

This also unblocks #4364. That reporter hit a second wall behind this one — the resource-indicator origin check rejecting a loopback reverse proxy — which is a separate policy and not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuRkWRQmB5XJzAbQVAPEH2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes SSRF egress policy, redirect chain narrowing, and defaults for local vs hosted OAuth/metadata fetches—security-sensitive networking behavior across SDK, inspector, and CLI.
> 
> **Overview**
> Fixes local OAuth discovery failing when an authorization server uses a hostname that resolves to loopback or LAN (e.g. `auth.local` → `127.0.0.1`), which the hosted SSRF policy incorrectly applied on the developer’s machine.
> 
> The SDK splits **hosted** policy (still block all private targets) from **local** policy via opt-in `allowPrivateNetwork` / `allowPrivateMetadataFetch` (default **false** for published consumers; `httpsOnly` still wins). Locally, loopback, RFC 1918, CGNAT, and unique-local targets are allowed after DNS pin; **link-local, cloud metadata, and related “never dialable” addresses stay blocked everywhere**, with clearer error text for those cases.
> 
> **Chain safety:** redirect permission is fixed from where the **first hop actually landed** (`targetIsPrivate` on proxy responses), so a public server cannot `302` the local inspector onto the user’s LAN while still permitting private-to-private redirects (e.g. `auth.localtest.me` → another loopback port).
> 
> **Surfaces:** local inspector OAuth routes, discovery preflight, and `createPinnedFetch` default to private-network access when `!HOSTED_MODE`; registry derive and benchmark probes stay strict. CLI `oauth metadata` / `proxy` / `debug-proxy` flip from hardcoded hosted mode to local defaults and add **`--https-only`**; login, conformance, server probe, and XAA wire the same opt-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd68ecafe5c4ed3ddab81d40ac70f1c02d80d66d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Local inspector and CLI flows now reach OAuth servers on the developer's private network, including hostnames that resolve to loopback. Previously, the egress guard rejected these targets as private or reserved; hosted behavior remains strict.

**Details**

- Local flows allow loopback, LAN, CGNAT, and unique-local addresses. Plaintext HTTP is permitted only to destinations that resolve private; public hosts never receive unencrypted requests.
- Private access is decided by where hop 1 actually landed, not by how the hostname reads, so `auth.local` resolving to 127.0.0.1 counts as private. A public server cannot redirect onto the caller's network; DNS pinning and credential protections remain unchanged.
- Link-local, cloud-metadata, unspecified, multicast, and reserved addresses remain blocked everywhere, including fully-qualified hostnames with a trailing dot. A mixed public/private DNS answer counts as public.
- The CLI's OAuth metadata and proxy commands default to local access and add `--https-only` to reproduce hosted policy.
- SDK options default to the existing strict behavior for consumers, while local inspector, login, conformance, probing, and XAA flows opt into private access; registry and benchmark flows remain strict, and hosted mode cannot be overridden.
- This unblocks the egress portion of #4364; resource-indicator origin validation remains unchanged.

<sup>Written for commit cd68ecafe5c4ed3ddab81d40ac70f1c02d80d66d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

