### PR TITLE
mcp apps: host-origin pinning, ui.domain surfacing, and per-server view origins

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -77,6 +77,7 @@
               "inspector/playground",
               "inspector/evals",
               "inspector/compatibility",
+              "inspector/view-origins",
               "inspector/host-templates"
             ]
           },

--- a/docs/guides/first-chatgpt-app-react.mdx
+++ b/docs/guides/first-chatgpt-app-react.mdx
@@ -184,7 +184,7 @@ Without declaring a domain in your CSP, the sandbox will block the request. Only
 
 #### Third-party APIs with referrer or origin restrictions
 
-Some APIs (such as Google Maps with a referrer-restricted key) validate the page URL before serving a response. Widgets run at a real sandbox URL — `http://localhost:*` locally and `https://sandbox.mcpjam.com` when hosted — so you can allowlist those origins in your API provider's dashboard.
+Some APIs (such as Google Maps with a referrer-restricted key) validate the page URL before serving a response. Widgets run at a real sandbox URL, so you can allowlist it in your API provider's dashboard. Locally that is `http://localhost:*` **and** `http://127.0.0.1:*` — the sandbox uses whichever of the two you did not open the Inspector with — and `https://sandbox.mcpjam.com` when hosted. See [View origins](/inspector/view-origins) for how to read the exact value.
 
 You still need to declare the API's domains in `_meta.ui.csp`:
 - Add script and asset CDN domains to `resourceDomains`

--- a/docs/inspector/view-origins.mdx
+++ b/docs/inspector/view-origins.mdx
@@ -17,6 +17,7 @@ Your app's view runs in a sandboxed iframe at a **real URL**, on an origin separ
     http://localhost:*
     http://127.0.0.1:*
     ```
+
   </Tab>
   <Tab title="Hosted">
     ```
@@ -28,12 +29,15 @@ Your app's view runs in a sandboxed iframe at a **real URL**, on an origin separ
 To read the exact value rather than infer it, open a tool result, expand the CSP Workbench, and look at **Sandbox Stack → View origin**. It has a copy button.
 
 <Note>
-  Cross-origin requests carry the **origin**, not the full path — MCPJam sends `Referrer-Policy: strict-origin-when-cross-origin`. So a third party sees `http://127.0.0.1:6274/`, and an allowlist pattern keyed on the origin matches. A pattern keyed on a path will not.
+  Cross-origin requests carry the **origin**, not the full path — MCPJam sends
+  `Referrer-Policy: strict-origin-when-cross-origin`. So a third party sees
+  `http://127.0.0.1:6274/`, and an allowlist pattern keyed on the origin
+  matches. A pattern keyed on a path will not.
 </Note>
 
 ## CSP is a separate gate
 
-Allowlisting your origin tells the third party to *accept* your requests. It does not let your widget *make* them — MCPJam's default policy denies everything not declared. Both have to pass.
+Allowlisting your origin tells the third party to _accept_ your requests. It does not let your widget _make_ them — MCPJam's default policy denies everything not declared. Both have to pass.
 
 Declare what the API needs in the UI resource's `_meta.ui.csp`:
 
@@ -42,7 +46,10 @@ Declare what the API needs in the UI resource's `_meta.ui.csp`:
   "_meta": {
     "ui": {
       "csp": {
-        "resourceDomains": ["https://maps.googleapis.com", "https://*.gstatic.com"],
+        "resourceDomains": [
+          "https://maps.googleapis.com",
+          "https://*.gstatic.com"
+        ],
         "connectDomains": ["https://maps.googleapis.com"]
       }
     }

--- a/docs/inspector/view-origins.mdx
+++ b/docs/inspector/view-origins.mdx
@@ -1,0 +1,67 @@
+---
+title: "View origins"
+description: "Which origin your MCP App's view runs at, and how to allowlist it with a third-party API"
+---
+
+Your app's view runs in a sandboxed iframe at a **real URL**, on an origin separate from the Inspector itself. That matters whenever something outside MCPJam checks where a request came from — a referrer-restricted Google Maps key, an OAuth redirect URI, a CORS allowlist.
+
+## Which origin to allowlist
+
+<Tabs>
+  <Tab title="Local">
+    The view runs on the Inspector's scheme and port with the hostname swapped between `localhost` and `127.0.0.1`. The swap is what keeps the sandbox on a different origin from the app.
+
+    Because the swap depends on which one you open the Inspector with, **allowlist both**:
+
+    ```
+    http://localhost:*
+    http://127.0.0.1:*
+    ```
+  </Tab>
+  <Tab title="Hosted">
+    ```
+    https://sandbox.mcpjam.com
+    ```
+  </Tab>
+</Tabs>
+
+To read the exact value rather than infer it, open a tool result, expand the CSP Workbench, and look at **Sandbox Stack → View origin**. It has a copy button.
+
+<Note>
+  Cross-origin requests carry the **origin**, not the full path — MCPJam sends `Referrer-Policy: strict-origin-when-cross-origin`. So a third party sees `http://127.0.0.1:6274/`, and an allowlist pattern keyed on the origin matches. A pattern keyed on a path will not.
+</Note>
+
+## CSP is a separate gate
+
+Allowlisting your origin tells the third party to *accept* your requests. It does not let your widget *make* them — MCPJam's default policy denies everything not declared. Both have to pass.
+
+Declare what the API needs in the UI resource's `_meta.ui.csp`:
+
+```json
+{
+  "_meta": {
+    "ui": {
+      "csp": {
+        "resourceDomains": ["https://maps.googleapis.com", "https://*.gstatic.com"],
+        "connectDomains": ["https://maps.googleapis.com"]
+      }
+    }
+  }
+}
+```
+
+`resourceDomains` covers scripts, images, styles and fonts; `connectDomains` covers `fetch`/XHR/WebSocket. A JavaScript SDK usually needs both. `frameDomains` is only for APIs you embed as a nested iframe — an embed widget, not a JS SDK.
+
+Anything still blocked shows up in the Workbench's **Findings** tab with the directive that refused it.
+
+## `_meta.ui.domain`
+
+SEP-1865 lets a server request a dedicated origin with `_meta.ui.domain`. The format is host-specific and each host derives its own — Claude uses `sha256(<connector URL>)[:32] + ".claudemcpcontent.com"`, ChatGPT a per-plugin label — so one declared string cannot match every host.
+
+MCPJam **derives** the origin it serves your view from rather than routing on what you declare; a server-chosen string would otherwise let one server claim another's origin, and with it that origin's cookies and storage. If you declare a domain, the Workbench's Findings tab reports whether it matches what MCPJam serves. A mismatch is informational — it is the normal state for a server already targeting Claude or ChatGPT — and simply means an allowlist keyed on that value will not match requests coming from MCPJam.
+
+## Rendering mode
+
+MCPJam mounts a view by writing its HTML into a blank document, the same way Claude does. A document written that way **without a doctype is parsed in quirks mode**, where the box model and percentage heights differ from what you probably tested against.
+
+Start your resource HTML with `<!DOCTYPE html>`. The readiness report flags this as `claude.apps.design.doctype`.

--- a/mcpjam-inspector/Dockerfile
+++ b/mcpjam-inspector/Dockerfile
@@ -42,6 +42,7 @@ ARG VITE_CONVEX_URL
 ARG VITE_WORKOS_CLIENT_ID
 ARG VITE_MCPJAM_SANDBOX_ORIGIN
 ARG VITE_MCPJAM_VIEW_MOUNT
+ARG VITE_MCPJAM_VIEW_SUBDOMAINS
 # Not a VITE_ var — it is never bundled. `sentryVitePlugin` in
 # client/vite.config.ts reads it at BUILD time to upload source maps for the
 # release, and without it every hosted prod stack trace stays minified
@@ -121,6 +122,7 @@ RUN if [ -n "$VITE_MCPJAM_HOSTED_MODE" ]; then export VITE_MCPJAM_HOSTED_MODE; f
     if [ -n "$VITE_WORKOS_CLIENT_ID" ]; then export VITE_WORKOS_CLIENT_ID; fi; \
     if [ -n "$VITE_MCPJAM_SANDBOX_ORIGIN" ]; then export VITE_MCPJAM_SANDBOX_ORIGIN; fi; \
     if [ -n "$VITE_MCPJAM_VIEW_MOUNT" ]; then export VITE_MCPJAM_VIEW_MOUNT; fi; \
+    if [ -n "$VITE_MCPJAM_VIEW_SUBDOMAINS" ]; then export VITE_MCPJAM_VIEW_SUBDOMAINS; fi; \
     if [ -n "$SENTRY_AUTH_TOKEN" ]; then export SENTRY_AUTH_TOKEN; fi; \
     MCPJAM_BUILD_SURFACE=web npm run build:client -w @mcpjam/inspector
 

--- a/mcpjam-inspector/HOSTED_DEPLOYMENT.md
+++ b/mcpjam-inspector/HOSTED_DEPLOYMENT.md
@@ -59,6 +59,34 @@ configured sandbox origin are equal by definition. No page can tell that apart
 from a deploy that pointed its sandbox at itself. Only the server knows which
 hostname it was supposed to answer as, which is why the check lives there.
 
+### Per-server view origins (optional)
+
+Each MCP server's views can be served from their own origin,
+`<label>.sandbox.example.com`, so apps do not share cookies or storage with
+each other and each gets an origin stable enough to name in an OAuth redirect
+URI or a third-party API-key allowlist. Off unless the deploy opts in:
+
+```bash
+# Client build time. Requires the DNS and certificate below.
+VITE_MCPJAM_VIEW_SUBDOMAINS=true
+```
+
+Before enabling it:
+
+- wildcard DNS for `*.sandbox.example.com` pointing at the same backend;
+- a certificate covering that wildcard. A one-level wildcard for the apex does
+  NOT cover `*.sandbox.example.com`, so this is usually a separate certificate;
+- if an access proxy fronts the sandbox host, its bypass must cover the
+  wildcard too, or the proxy document loads a login page instead.
+
+Enable it on staging first. With the DNS or certificate missing, a labelled
+host does not resolve and widgets fail to load rather than degrading — there is
+no fallback, by design, because silently sharing an origin is the failure this
+is meant to remove.
+
+`SANDBOX_HOSTS` needs no change: a label under a listed host is recognised
+automatically, and answers the sandbox proxy path only — not `/health`.
+
 ### DNS / routing
 
 Point the sandbox hostname at the same backend that serves the host app.

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/CspWorkbench.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/CspWorkbench.tsx
@@ -99,6 +99,8 @@ export function CspWorkbench({ sandboxInfo, protocol }: CspWorkbenchProps) {
           <FindingsTab
             diagnoses={diagnoses}
             onViewPolicyDiff={handleViewPolicyDiff}
+            declaredDomain={sandboxInfo.declaredDomain}
+            assignedOrigin={sandboxInfo.applied?.assignedOrigin}
           />
         </TabsContent>
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/FindingsTab.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/FindingsTab.tsx
@@ -3,10 +3,15 @@ import { CheckCircle2 } from "lucide-react";
 import type { Diagnosis } from "./types";
 import { summarize } from "./classify";
 import { BlockedRequestCard } from "./BlockedRequestCard";
+import { OriginCard } from "./OriginCard";
 
 interface FindingsTabProps {
   diagnoses: Diagnosis[];
   onViewPolicyDiff: (host: string) => void;
+  /** `_meta.ui.domain`, when the server declared one. */
+  declaredDomain?: string | null;
+  /** The origin MCPJam actually serves the view from. */
+  assignedOrigin?: string;
 }
 
 interface MeterPart {
@@ -15,18 +20,36 @@ interface MeterPart {
   cls: string;
 }
 
-export function FindingsTab({ diagnoses, onViewPolicyDiff }: FindingsTabProps) {
+export function FindingsTab({
+  diagnoses,
+  onViewPolicyDiff,
+  declaredDomain,
+  assignedOrigin,
+}: FindingsTabProps) {
   const summary = useMemo(() => summarize(diagnoses), [diagnoses]);
+
+  // Rendered above the empty-state early return: a widget can declare a
+  // domain that does not match and still trip no CSP violation at all, which
+  // is exactly the case a developer needs told.
+  const originCard = (
+    <OriginCard
+      declaredDomain={declaredDomain}
+      assignedOrigin={assignedOrigin}
+    />
+  );
 
   if (diagnoses.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-12 text-center gap-3">
-        <CheckCircle2 className="size-8 text-emerald-500/70" />
-        <div className="text-sm font-medium">No CSP violations recorded.</div>
-        <div className="text-[11.5px] text-muted-foreground max-w-md">
-          The widget loaded without tripping any{" "}
-          <span className="font-mono">securitypolicyviolation</span> events.
-          Check Policy Diff to inspect the declared / effective allowlists.
+      <div className="space-y-3">
+        {originCard}
+        <div className="flex flex-col items-center justify-center py-12 text-center gap-3">
+          <CheckCircle2 className="size-8 text-emerald-500/70" />
+          <div className="text-sm font-medium">No CSP violations recorded.</div>
+          <div className="text-[11.5px] text-muted-foreground max-w-md">
+            The widget loaded without tripping any{" "}
+            <span className="font-mono">securitypolicyviolation</span> events.
+            Check Policy Diff to inspect the declared / effective allowlists.
+          </div>
         </div>
       </div>
     );

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/OriginCard.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/OriginCard.tsx
@@ -1,0 +1,73 @@
+import { classifyDeclaredDomain } from "./origin-finding";
+
+interface OriginCardProps {
+  declaredDomain?: string | null;
+  assignedOrigin?: string;
+}
+
+/**
+ * The `_meta.ui.domain` reading, rendered outside the blocked-request list.
+ *
+ * It is not a `Diagnosis`: that type means "the browser refused a request",
+ * and the surfaces built on it (the blocked-requests meter, the Policy Diff
+ * "observed" column, the copy-a-CSP-patch button) would all misdescribe a
+ * declaration mismatch.
+ */
+export function OriginCard({
+  declaredDomain,
+  assignedOrigin,
+}: OriginCardProps) {
+  const kind = classifyDeclaredDomain(declaredDomain, assignedOrigin);
+  if (!kind) return null;
+
+  const tone =
+    kind === "malformed"
+      ? "border-amber-500/40 bg-amber-500/5"
+      : "border-border/40 bg-card";
+
+  return (
+    <div className={`rounded-md border p-3.5 ${tone}`}>
+      <div className="flex items-baseline justify-between mb-2">
+        <span className="text-[12.5px] font-medium">Declared view domain</span>
+        <span className="font-mono text-[10.5px] text-muted-foreground">
+          _meta.ui.domain
+        </span>
+      </div>
+      <div className="font-mono text-[11.5px] break-all mb-2">
+        {declaredDomain}
+      </div>
+      <p className="text-[11.5px] text-muted-foreground leading-relaxed">
+        {kind === "malformed" ? (
+          <>
+            This is not a bare hostname. Hosts expect a domain like{" "}
+            <code className="font-mono">abc123.claudemcpcontent.com</code> — no
+            scheme, path or port.
+          </>
+        ) : kind === "match" ? (
+          <>
+            Matches the origin MCPJam serves this view from
+            {assignedOrigin ? (
+              <>
+                {" "}
+                (<code className="font-mono">{assignedOrigin}</code>)
+              </>
+            ) : null}
+            .
+          </>
+        ) : (
+          <>
+            MCPJam serves this view from{" "}
+            <code className="font-mono">
+              {assignedOrigin ?? "a different origin"}
+            </code>
+            , so an allowlist keyed on the declared domain — an API key
+            restriction, an OAuth redirect URI — will not match requests from
+            here. That is expected if the value targets another host: MCPJam
+            assigns one origin per server, like Claude, while ChatGPT assigns
+            one per plugin.
+          </>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/__tests__/origin-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/__tests__/origin-card.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * The declared-domain card in the Findings tab.
+ *
+ * It lives outside the blocked-request list on purpose: a `Diagnosis` means
+ * "the browser refused a request", and the surfaces built on that type would
+ * misdescribe a declaration mismatch. These tests pin that it renders on its
+ * own terms, including when there are no violations at all.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { OriginCard } from "../OriginCard";
+import { FindingsTab } from "../FindingsTab";
+
+describe("OriginCard", () => {
+  it("renders nothing without a declaration", () => {
+    const { container } = render(
+      <OriginCard assignedOrigin="https://x.test" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("confirms a match", () => {
+    render(
+      <OriginCard
+        declaredDomain="sandbox.mcpjam.com"
+        assignedOrigin="https://sandbox.mcpjam.com"
+      />,
+    );
+    expect(screen.getByText(/Matches the origin/)).toBeTruthy();
+  });
+
+  it("names the served origin and the consequence on a mismatch", () => {
+    render(
+      <OriginCard
+        declaredDomain="abc.claudemcpcontent.com"
+        assignedOrigin="https://sandbox.mcpjam.com"
+      />,
+    );
+    expect(screen.getByText("abc.claudemcpcontent.com")).toBeTruthy();
+    expect(screen.getByText("https://sandbox.mcpjam.com")).toBeTruthy();
+    // The actionable part: what will not work, not merely that it differs.
+    expect(screen.getByText(/will not match requests from/)).toBeTruthy();
+  });
+
+  it("calls out a value that is not a bare hostname", () => {
+    render(
+      <OriginCard
+        declaredDomain="https://sandbox.mcpjam.com"
+        assignedOrigin="https://sandbox.mcpjam.com"
+      />,
+    );
+    expect(screen.getByText(/not a bare hostname/)).toBeTruthy();
+  });
+});
+
+describe("FindingsTab — origin card placement", () => {
+  it("shows the card even when there are no CSP violations", () => {
+    // A widget can declare a mismatched domain and trip no violation at all.
+    // If the card sat below the empty-state early return, that developer
+    // would never see it.
+    render(
+      <FindingsTab
+        diagnoses={[]}
+        onViewPolicyDiff={() => {}}
+        declaredDomain="abc.claudemcpcontent.com"
+        assignedOrigin="https://sandbox.mcpjam.com"
+      />,
+    );
+    expect(screen.getByText("Declared view domain")).toBeTruthy();
+    expect(screen.getByText("No CSP violations recorded.")).toBeTruthy();
+  });
+
+  it("keeps the empty state clean when nothing was declared", () => {
+    render(<FindingsTab diagnoses={[]} onViewPolicyDiff={() => {}} />);
+    expect(screen.queryByText("Declared view domain")).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/__tests__/origin-finding.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/__tests__/origin-finding.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Classifying a declared `_meta.ui.domain` against the origin MCPJam serves.
+ *
+ * The stakes are in the copy this drives: a mismatch tells a developer their
+ * API-key or OAuth allowlist will not match requests from MCPJam. Calling a
+ * match a mismatch (or vice versa) sends them to edit the wrong allowlist.
+ */
+import { describe, it, expect } from "vitest";
+import { classifyDeclaredDomain } from "../origin-finding";
+
+const ORIGIN = "https://sandbox.mcpjam.com";
+
+describe("classifyDeclaredDomain", () => {
+  it("returns nothing when the server declared no domain", () => {
+    // The overwhelmingly common case — the card must not render.
+    expect(classifyDeclaredDomain(undefined, ORIGIN)).toBeNull();
+    expect(classifyDeclaredDomain(null, ORIGIN)).toBeNull();
+    expect(classifyDeclaredDomain("", ORIGIN)).toBeNull();
+  });
+
+  it("matches a declaration equal to the served host", () => {
+    expect(classifyDeclaredDomain("sandbox.mcpjam.com", ORIGIN)).toBe("match");
+  });
+
+  it("compares hosts case-insensitively and ignores surrounding space", () => {
+    expect(classifyDeclaredDomain("  Sandbox.McpJam.Com  ", ORIGIN)).toBe(
+      "match",
+    );
+  });
+
+  it("reports a mismatch for another host's domain", () => {
+    // The normal state for a server already shipping to Claude or ChatGPT.
+    expect(
+      classifyDeclaredDomain("abc123def456.claudemcpcontent.com", ORIGIN),
+    ).toBe("mismatch");
+    expect(
+      classifyDeclaredDomain("my-app.web-sandbox.oaiusercontent.com", ORIGIN),
+    ).toBe("mismatch");
+  });
+
+  it("does not treat a suffix as a match", () => {
+    expect(classifyDeclaredDomain("evil-sandbox.mcpjam.com", ORIGIN)).toBe(
+      "mismatch",
+    );
+    expect(classifyDeclaredDomain("mcpjam.com", ORIGIN)).toBe("mismatch");
+  });
+
+  it("flags anything that is not a bare hostname", () => {
+    // The mistakes that actually get made: a URL, a path, a port.
+    expect(classifyDeclaredDomain("https://sandbox.mcpjam.com", ORIGIN)).toBe(
+      "malformed",
+    );
+    expect(classifyDeclaredDomain("sandbox.mcpjam.com/widget", ORIGIN)).toBe(
+      "malformed",
+    );
+    expect(classifyDeclaredDomain("sandbox.mcpjam.com:443", ORIGIN)).toBe(
+      "malformed",
+    );
+    expect(classifyDeclaredDomain("*.mcpjam.com", ORIGIN)).toBe("malformed");
+  });
+
+  it("checks the shape before the comparison", () => {
+    // A malformed value is malformed regardless of what we serve, and saying
+    // "does not match" would send the developer to fix the wrong thing.
+    expect(
+      classifyDeclaredDomain("https://sandbox.mcpjam.com", undefined),
+    ).toBe("malformed");
+  });
+
+  it("treats an unknown assigned origin as a mismatch, not a match", () => {
+    // Before the proxy reports its mount there is nothing to match against;
+    // claiming a match would be an unearned reassurance.
+    expect(classifyDeclaredDomain("sandbox.mcpjam.com", undefined)).toBe(
+      "mismatch",
+    );
+    expect(classifyDeclaredDomain("sandbox.mcpjam.com", "not-a-url")).toBe(
+      "mismatch",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/origin-finding.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/origin-finding.ts
@@ -1,0 +1,44 @@
+/**
+ * Does the origin a server ASKED for match the one MCPJam actually serves its
+ * view from?
+ *
+ * Deliberately informational rather than a violation. `_meta.ui.domain` is
+ * host-specific by design — Claude wants
+ * `<sha256(connectorUrl)[:32]>.claudemcpcontent.com`, ChatGPT a
+ * `*.web-sandbox.oaiusercontent.com` label — and a server can only declare
+ * ONE string. So a value that does not match here is the normal case for any
+ * server already shipping to a production host, not a defect. What is worth
+ * saying is the consequence: an allowlist keyed on that string will not match
+ * requests coming from MCPJam.
+ */
+export type OriginFindingKind =
+  | "match"
+  | "mismatch"
+  /** Not a hostname at all — a scheme, a path, or a port crept in. */
+  | "malformed";
+
+/**
+ * A bare hostname: dot-separated labels of letters, digits and hyphens.
+ * Mirrors what `_meta.ui.domain` is specified to carry (Claude's
+ * `{hash}.claudemcpcontent.com`), and rejects the mistakes that actually get
+ * made — a full URL, a trailing path, an explicit port.
+ */
+const BARE_HOSTNAME =
+  /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
+
+export function classifyDeclaredDomain(
+  declared: string | null | undefined,
+  assignedOrigin: string | undefined,
+): OriginFindingKind | null {
+  if (!declared) return null;
+  const value = declared.trim().toLowerCase();
+  if (!BARE_HOSTNAME.test(value)) return "malformed";
+  if (!assignedOrigin) return "mismatch";
+  let assignedHost: string;
+  try {
+    assignedHost = new URL(assignedOrigin).hostname.toLowerCase();
+  } catch {
+    return "mismatch";
+  }
+  return value === assignedHost ? "match" : "mismatch";
+}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -2662,6 +2662,39 @@ describe("MCPAppsRenderer tool input streaming", () => {
     });
   });
 
+  it("publishes a declared ui.domain into the debug store", async () => {
+    // The Workbench's origin card is the only place a developer learns their
+    // `_meta.ui.domain` will not match what MCPJam serves, so the declaration
+    // has to survive the trip from the widget-content response into the store.
+    vi.mocked(authFetch).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          html: "<html><body>live-widget</body></html>",
+          permissive: true,
+          mimeTypeValid: true,
+          declaredDomain: "abc123.claudemcpcontent.com",
+        }),
+      status: 200,
+      headers: new Headers(),
+    } as Response);
+
+    render(<HostedRenderer {...baseProps} />);
+
+    await vi.waitFor(() => {
+      expect(stableStoreFns.setWidgetCsp).toHaveBeenCalledWith(
+        "call-1",
+        expect.objectContaining({
+          declaredDomain: "abc123.claudemcpcontent.com",
+          // Permissive, no csp, no permissions: without the declared domain
+          // widening the guard, this record would never be written and the
+          // panel would not render at all.
+          mode: "permissive",
+        }),
+      );
+    });
+  });
+
   it("sends partial tool input during input-streaming", async () => {
     const partialInput = { elements: '[{"type":"rectangle"' };
     render(

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/use-widget-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/use-widget-host.test.tsx
@@ -12,7 +12,15 @@ import { useWidgetHost } from "../use-widget-host";
 
 // Pin HOSTED_MODE off so the listResourceTemplates guard is exercised purely via
 // the web-managed-servers context (the security-sensitive boundary concern).
-vi.mock("@/lib/config", () => ({ HOSTED_MODE: false, SANDBOX_ORIGIN: "" }));
+// Every config export the hook reads has to appear here: vitest throws on a
+// missing one rather than returning undefined, so a new read is a hard break
+// in this suite. (VIEW_MOUNT_MODE was added without it and landed red.)
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: false,
+  SANDBOX_ORIGIN: "",
+  VIEW_MOUNT_MODE: "write",
+  VIEW_SUBDOMAINS_ENABLED: false,
+}));
 
 // Isolate the hook from the api/network layer.
 const listResourceTemplatesMock = vi.fn();

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/fetch-widget-content.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/fetch-widget-content.ts
@@ -78,6 +78,13 @@ export interface FetchMcpAppsWidgetContentResponse {
    */
   declaredDomain?: string;
   /**
+   * Subdomain label for this server's dedicated view origin
+   * (`<label>.sandbox.mcpjam.com`), derived from the server's identity. Absent
+   * when the server identifies nothing to derive from; the view then renders
+   * on the default sandbox origin.
+   */
+  viewOriginLabel?: string;
+  /**
    * Server-confirmed compat-runtime flag — echoes what the route
    * decided after applying its `injectOpenAiCompat === true` gate.
    * Caller can persist this alongside cached HTML to remove ambiguity

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/fetch-widget-content.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/fetch-widget-content.ts
@@ -72,6 +72,12 @@ export interface FetchMcpAppsWidgetContentResponse {
   mimeTypeValid?: boolean;
   prefersBorder?: boolean;
   /**
+   * `_meta.ui.domain` — the dedicated origin the server ASKED for. Advisory:
+   * MCPJam derives the origin it serves the view from, and reports this only
+   * so the Workbench can say whether the declaration matches.
+   */
+  declaredDomain?: string;
+  /**
    * Server-confirmed compat-runtime flag — echoes what the route
    * decided after applying its `injectOpenAiCompat === true` gate.
    * Caller can persist this alongside cached HTML to remove ambiguity

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/use-widget-host.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/use-widget-host.tsx
@@ -16,7 +16,12 @@
 // pre-resolving them into `WidgetHost.resolveEnvironment` is the Phase-3 target.
 
 import { useMemo, useRef, type ReactNode } from "react";
-import { HOSTED_MODE, SANDBOX_ORIGIN, VIEW_MOUNT_MODE } from "@/lib/config";
+import {
+  HOSTED_MODE,
+  SANDBOX_ORIGIN,
+  VIEW_MOUNT_MODE,
+  VIEW_SUBDOMAINS_ENABLED,
+} from "@/lib/config";
 import { authFetch } from "@/lib/session-token";
 import { useIsScenarioSurface } from "@/contexts/scenario-surface-context";
 import { useWebManagedServers } from "@/contexts/web-managed-servers-context";
@@ -190,6 +195,7 @@ export function useWidgetHost(): WidgetHostImpl {
       hostedMode: HOSTED_MODE,
       sandboxOrigin: SANDBOX_ORIGIN ?? "",
       viewMountMode: VIEW_MOUNT_MODE,
+      viewSubdomainsEnabled: VIEW_SUBDOMAINS_ENABLED,
       playgroundCspMode,
     }),
     [kind, persistentSurfaceHost, webManagedServers, playgroundCspMode],

--- a/mcpjam-inspector/client/src/lib/config.ts
+++ b/mcpjam-inspector/client/src/lib/config.ts
@@ -68,6 +68,23 @@ export const VIEW_MOUNT_MODE: "write" | "srcdoc" =
   import.meta.env.VITE_MCPJAM_VIEW_MOUNT === "srcdoc" ? "srcdoc" : "write";
 
 /**
+ * Whether each MCP server's views get their own origin
+ * (`<label>.sandbox.mcpjam.com`) instead of sharing the sandbox origin.
+ *
+ * What it buys: cookie and storage isolation BETWEEN apps, and a stable
+ * per-server origin for an OAuth redirect URI or a third-party API-key
+ * allowlist — the same shape Claude and ChatGPT use.
+ *
+ * Off by default because it is an infrastructure commitment, not a code one:
+ * it needs wildcard DNS and a certificate covering `*.sandbox.mcpjam.com`,
+ * and with those absent every widget would fail to load rather than degrade.
+ * Set via `VITE_MCPJAM_VIEW_SUBDOMAINS` at build time (see the Dockerfile ARG
+ * — a service variable alone never reaches the bundle).
+ */
+export const VIEW_SUBDOMAINS_ENABLED =
+  import.meta.env.VITE_MCPJAM_VIEW_SUBDOMAINS === "true";
+
+/**
  * The Discord application the agent bot runs as, used to build the "add to
  * server" URL on the Integrations page.
  *

--- a/mcpjam-inspector/client/src/stores/widget-debug-store.ts
+++ b/mcpjam-inspector/client/src/stores/widget-debug-store.ts
@@ -203,6 +203,13 @@ export interface WidgetSandboxInfo {
     frameDomains?: string[];
     baseUriDomains?: string[];
   } | null;
+  /**
+   * `_meta.ui.domain` as declared by the server, or null when it declared
+   * none. Compared against the origin MCPJam actually serves the view from;
+   * a mismatch is informational, since each host's domain format differs and
+   * a server can only declare one string.
+   */
+  declaredDomain?: string | null;
 }
 
 export interface WidgetGlobals {

--- a/mcpjam-inspector/client/src/vite-env.d.ts
+++ b/mcpjam-inspector/client/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_MCPJAM_HOSTED_MODE?: string;
   readonly VITE_MCPJAM_SANDBOX_ORIGIN?: string;
   readonly VITE_MCPJAM_VIEW_MOUNT?: string;
+  readonly VITE_MCPJAM_VIEW_SUBDOMAINS?: string;
   readonly VITE_ENVIRONMENT?: string;
   // more env variables...
 }

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-mount.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-mount.test.ts
@@ -56,6 +56,8 @@ const applyColorSchemeSrc = extract("applyColorScheme");
 const createInnerFrameSrc = extract("createInnerFrame");
 const mountInnerSrc = extract("mountInner");
 const remountLastSrc = extract("remountLast");
+const parseOriginPatternSrc = extract("parseOriginPattern");
+const hostOriginAllowedSrc = extract("hostOriginAllowed");
 
 interface MountHarness {
   mountInner: (
@@ -103,6 +105,8 @@ function harness(): { dom: JSDOM; h: MountHarness } {
     const INNER_STYLE = "width:100%; height:100%; border:none;";
     let inner = null;
     let lastMount = null;
+    // Pinning is off in this harness; the view-mode post falls back to "*".
+    let hostOrigin = null;
     ${applyColorSchemeSrc}
     ${createInnerFrameSrc}
     ${mountInnerSrc}
@@ -356,5 +360,97 @@ describe("sandbox-proxy nested sandbox-proxy-ready guard", () => {
     expect(guard).toContain("remountLast();");
     expect(guard).toContain("return;");
     expect(guard).not.toContain("window.parent.postMessage");
+  });
+});
+
+describe("sandbox-proxy host-origin allowlist", () => {
+  // The proxy loads untrusted HTML on request and relays that widget's
+  // messages back out, so "who may post to this document" is a real gate,
+  // not bookkeeping. Everything ambiguous has to fail closed.
+  const allowed = new Function(
+    "origin",
+    "patterns",
+    `${parseOriginPatternSrc}\n${hostOriginAllowedSrc}\nreturn hostOriginAllowed(origin, patterns);`,
+  ) as (origin: string, patterns: string[] | null) => boolean;
+
+  const parse = new Function(
+    "pattern",
+    `${parseOriginPatternSrc}\nreturn parseOriginPattern(pattern);`,
+  ) as (pattern: string) => unknown;
+
+  const HOSTED = ["https://app.mcpjam.com", "http://localhost:*"];
+
+  it("accepts an exact origin", () => {
+    expect(allowed("https://app.mcpjam.com", HOSTED)).toBe(true);
+  });
+
+  it("accepts any port when the pattern wildcards it", () => {
+    expect(allowed("http://localhost:5173", HOSTED)).toBe(true);
+    expect(allowed("http://localhost:6274", HOSTED)).toBe(true);
+  });
+
+  it("rejects a different scheme, host, or port", () => {
+    expect(allowed("http://app.mcpjam.com", HOSTED)).toBe(false);
+    expect(allowed("https://evil.com", HOSTED)).toBe(false);
+    expect(allowed("https://app.mcpjam.com:8443", HOSTED)).toBe(false);
+  });
+
+  it("does not let a wildcard span a dot in the host", () => {
+    // The danger a host wildcard would introduce: a pattern for mcpjam.com
+    // matching an attacker-registered lookalike.
+    expect(parse("https://*.mcpjam.com")).toBeNull();
+    expect(allowed("https://evil-mcpjam.com", ["https://*mcpjam.com"])).toBe(
+      false,
+    );
+  });
+
+  it("treats a suffix or prefix of an allowed host as a different host", () => {
+    expect(allowed("https://app.mcpjam.com.evil.test", HOSTED)).toBe(false);
+    expect(allowed("https://notapp.mcpjam.com", HOSTED)).toBe(false);
+  });
+
+  it("matches a default port against a pattern that names none", () => {
+    expect(allowed("https://app.mcpjam.com:443", HOSTED)).toBe(true);
+  });
+
+  it("fails closed on an opaque origin and on an empty list", () => {
+    // A sandboxed document without allow-same-origin posts "null".
+    expect(allowed("null", HOSTED)).toBe(false);
+    expect(allowed("https://app.mcpjam.com", [])).toBe(false);
+    expect(allowed("https://app.mcpjam.com", null)).toBe(false);
+  });
+
+  it("ignores unparsable patterns rather than widening on them", () => {
+    expect(allowed("https://app.mcpjam.com", ["not-an-origin", "*"])).toBe(
+      false,
+    );
+  });
+});
+
+describe("sandbox-proxy host-origin pinning (source contract)", () => {
+  // The lock lives inline in the message listener rather than in a named
+  // function, so pin its shape where it is: the gate must precede any
+  // handling, and the inner→host relay must answer the locked origin.
+  it("gates the parent branch before handling and locks the origin", () => {
+    const branch = html.slice(
+      html.indexOf("if (event.source === window.parent)"),
+      html.indexOf(
+        'event.data.method === "ui/notifications/sandbox-resource-ready"',
+      ),
+    );
+    expect(branch).toContain(
+      "hostOriginAllowed(event.origin, hostOriginPatterns)",
+    );
+    expect(branch).toContain("hostOrigin = event.origin");
+    expect(branch).toContain("event.origin !== hostOrigin");
+  });
+
+  it("relays to the locked origin rather than any window", () => {
+    expect(html).toContain(
+      'window.parent.postMessage(data, hostOrigin || "*")',
+    );
+    // And the boot handshake, which happens before any host message, is the
+    // only postMessage that can still be unaddressed.
+    expect(html).not.toContain('window.parent.postMessage(data, "*")');
   });
 });

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy.test.ts
@@ -1,105 +1,68 @@
 /**
- * Sandbox Proxy CSP Tests
+ * Sandbox proxy response headers, against the REAL router.
  *
- * Tests for the MCP Apps sandbox-proxy endpoint (SEP-1865).
- * Verifies that CSP headers are correctly configured to allow
- * cross-origin framing in the double-iframe architecture.
+ * This file previously re-declared a look-alike route inline, so it asserted
+ * the shape of its own fixture and would have stayed green through any change
+ * to what the app actually serves. It now mounts the real router behind the
+ * real security middleware, which is the only arrangement that can catch the
+ * two failures that matter: `frame-ancestors` drifting away from the origins
+ * the proxy pins against, and the global `X-Frame-Options: SAMEORIGIN`
+ * surviving to override it (the header does not support multiple origins, so
+ * leaving it on would break the cross-origin sandbox everywhere at once).
  */
-
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { Hono } from "hono";
+import mcpAppsRoutes from "../routes/apps/mcp-apps/index.js";
 import { securityHeadersMiddleware } from "../middleware/security-headers.js";
+import {
+  SANDBOX_PROXY_LOCALHOST_PATTERNS,
+  sandboxProxyHostOriginPatterns,
+} from "../routes/apps/mcp-apps/sandbox-proxy-html.js";
 
-// Mock fs to avoid file system dependency
-vi.mock("fs", () => ({
-  default: {
-    readFileSync: vi.fn(() => "<html><body>Sandbox Proxy</body></html>"),
-  },
-}));
+const PROXY_PATH = "/api/apps/mcp-apps/sandbox-proxy";
 
-/**
- * Creates a test app that mimics the sandbox-proxy route setup.
- * Includes the security middleware to verify header override behavior.
- */
-function createSandboxProxyTestApp(): Hono {
+function createApp(): Hono {
   const app = new Hono();
-
-  // Apply security middleware (sets X-Frame-Options: SAMEORIGIN)
   app.use("*", securityHeadersMiddleware);
-
-  // Sandbox proxy route (mirrors server/routes/mcp/index.ts)
-  app.get("/api/apps/mcp-apps/sandbox-proxy", (c) => {
-    c.header("Content-Type", "text/html; charset=utf-8");
-    c.header("Cache-Control", "no-cache, no-store, must-revalidate");
-    // Allow cross-origin framing between localhost and 127.0.0.1 for double-iframe architecture
-    c.header(
-      "Content-Security-Policy",
-      "frame-ancestors 'self' http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*",
-    );
-    // Remove X-Frame-Options as it doesn't support multiple origins (CSP frame-ancestors takes precedence)
-    c.res.headers.delete("X-Frame-Options");
-    return c.body("<html><body>Sandbox Proxy</body></html>");
-  });
-
-  // Regular route for comparison (should keep X-Frame-Options)
+  app.route("/api/apps/mcp-apps", mcpAppsRoutes);
   app.get("/api/mcp/health", (c) => c.json({ status: "ok" }));
-
   return app;
 }
 
-describe("Sandbox Proxy CSP Headers", () => {
-  let app: Hono;
-
-  beforeEach(() => {
-    app = createSandboxProxyTestApp();
+describe("sandbox proxy response headers", () => {
+  it("serves HTML that must not be cached", async () => {
+    const res = await createApp().request(PROXY_PATH);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+    // The document carries the host-origin allowlist for THIS deploy, so a
+    // cached copy could outlive the configuration it was templated from.
+    expect(res.headers.get("Cache-Control")).toBe(
+      "no-cache, no-store, must-revalidate",
+    );
   });
 
-  describe("GET /api/apps/mcp-apps/sandbox-proxy", () => {
-    it("sets Content-Security-Policy with frame-ancestors for localhost origins", async () => {
-      const res = await app.request("/api/apps/mcp-apps/sandbox-proxy");
-
-      const csp = res.headers.get("Content-Security-Policy");
-      expect(csp).toBe(
-        "frame-ancestors 'self' http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*",
-      );
-    });
-
-    it("removes X-Frame-Options header to avoid conflict with CSP", async () => {
-      const res = await app.request("/api/apps/mcp-apps/sandbox-proxy");
-
-      // X-Frame-Options should be removed (CSP frame-ancestors takes precedence)
-      expect(res.headers.get("X-Frame-Options")).toBeNull();
-    });
-
-    it("sets correct Content-Type for HTML", async () => {
-      const res = await app.request("/api/apps/mcp-apps/sandbox-proxy");
-
-      expect(res.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
-    });
-
-    it("sets Cache-Control to prevent caching", async () => {
-      const res = await app.request("/api/apps/mcp-apps/sandbox-proxy");
-
-      expect(res.headers.get("Cache-Control")).toBe(
-        "no-cache, no-store, must-revalidate",
-      );
-    });
-
-    it("returns HTML content", async () => {
-      const res = await app.request("/api/apps/mcp-apps/sandbox-proxy");
-
-      expect(res.status).toBe(200);
-      const body = await res.text();
-      expect(body).toContain("<html>");
-    });
+  it("allows the app origins to frame it, and drops X-Frame-Options", async () => {
+    const res = await createApp().request(PROXY_PATH);
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toContain("frame-ancestors 'self'");
+    for (const pattern of SANDBOX_PROXY_LOCALHOST_PATTERNS) {
+      expect(csp).toContain(pattern);
+    }
+    expect(res.headers.get("X-Frame-Options")).toBeNull();
   });
 
-  describe("other routes retain X-Frame-Options", () => {
-    it("health endpoint keeps X-Frame-Options from middleware", async () => {
-      const res = await app.request("/api/mcp/health");
+  it("frames-ancestors matches the origins the proxy pins against", async () => {
+    // One source of truth: an origin allowed to frame the proxy but not to
+    // talk to it renders a widget that then silently does nothing.
+    const res = await createApp().request(PROXY_PATH);
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    for (const pattern of sandboxProxyHostOriginPatterns()) {
+      expect(csp).toContain(pattern);
+    }
+  });
 
-      // Regular routes should still have X-Frame-Options set by middleware
-      expect(res.headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
-    });
+  it("leaves X-Frame-Options in place on ordinary routes", async () => {
+    const res = await createApp().request("/api/mcp/health");
+    expect(res.headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
   });
 });

--- a/mcpjam-inspector/server/middleware/__tests__/sandbox-host-partition.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/sandbox-host-partition.test.ts
@@ -21,9 +21,8 @@ const PROXY_PATH = "/api/web/apps/mcp-apps/sandbox-proxy";
  */
 async function buildApp() {
   vi.resetModules();
-  const { applySandboxHostPartition, SANDBOX_HOST_OPEN_PATHS } = await import(
-    "../sandbox-host-partition.js"
-  );
+  const { applySandboxHostPartition, SANDBOX_HOST_OPEN_PATHS } =
+    await import("../sandbox-host-partition.js");
 
   // Adding a third path to an origin that exists to hold untrusted content is
   // a decision, not a detail. Make it fail here first.
@@ -61,7 +60,7 @@ describe("sandbox host", () => {
 
   it("serves the proxy with the renderer's cache-buster attached", async () => {
     expect(
-      await status(app, `${PROXY_PATH}?v=1750000000000`, SANDBOX_HOST)
+      await status(app, `${PROXY_PATH}?v=1750000000000`, SANDBOX_HOST),
     ).toBe(200);
   });
 
@@ -82,6 +81,50 @@ describe("sandbox host", () => {
   it("matches the host regardless of port or case", async () => {
     expect(await status(app, "/", `${SANDBOX_HOST}:6274`)).toBe(404);
     expect(await status(app, "/", SANDBOX_HOST.toUpperCase())).toBe(404);
+  });
+});
+
+describe("per-server view host", () => {
+  // `<label>.<sandbox host>` is minted per MCP server so one server's views
+  // get their own origin — cookie and storage isolation between apps.
+  const LABEL_HOST = `0123456789abcdef.${SANDBOX_HOST}`;
+  let app: Hono;
+
+  beforeAll(async () => {
+    vi.stubEnv("SANDBOX_HOSTS", SANDBOX_HOST);
+    app = await buildApp();
+  });
+  afterAll(() => vi.unstubAllEnvs());
+
+  it("serves the sandbox proxy", async () => {
+    expect(await status(app, PROXY_PATH, LABEL_HOST)).toBe(200);
+  });
+
+  it("does not serve /health", async () => {
+    // Nothing derived from a server id has business describing this service's
+    // infrastructure, and no operator probes such a name.
+    expect(await status(app, "/health", LABEL_HOST)).toBe(404);
+  });
+
+  it("404s everything else, as the parent host does", async () => {
+    expect(await status(app, "/", LABEL_HOST)).toBe(404);
+    expect(await status(app, "/api/web/projects", LABEL_HOST)).toBe(404);
+    expect(await status(app, "/assets/index.js", LABEL_HOST)).toBe(404);
+  });
+
+  it("only matches a label this service would actually mint", async () => {
+    // Not hex, wrong length, nested, or under a host that is not ours — none
+    // are names the deriver produces, so they are not partitioned at all and
+    // fall through to the ordinary app.
+    for (const host of [
+      `zzzzzzzzzzzzzzzz.${SANDBOX_HOST}`,
+      `0123456789abcde.${SANDBOX_HOST}`,
+      `0123456789abcdef0.${SANDBOX_HOST}`,
+      `a.0123456789abcdef.${SANDBOX_HOST}`,
+      "0123456789abcdef.evil.example",
+    ]) {
+      expect(await status(app, "/api/web/projects", host), host).toBe(200);
+    }
   });
 });
 
@@ -173,9 +216,8 @@ async function bootWith(env: {
     logged.push(message);
   });
 
-  const { assertSandboxIsolation } = await import(
-    "../sandbox-host-partition.js"
-  );
+  const { assertSandboxIsolation } =
+    await import("../sandbox-host-partition.js");
   const { buildHealthMeta } = await import("../../utils/health-payload.js");
 
   assertSandboxIsolation();

--- a/mcpjam-inspector/server/middleware/sandbox-host-partition.ts
+++ b/mcpjam-inspector/server/middleware/sandbox-host-partition.ts
@@ -49,6 +49,18 @@ export const SANDBOX_HOST_OPEN_PATHS = new Set<string>([
 ]);
 
 /**
+ * What a PER-SERVER view hostname (`<label>.<sandbox host>`) may answer.
+ *
+ * The proxy and nothing else — not `/health`. These names are minted per MCP
+ * server to hold one server's untrusted view; a health probe there would
+ * describe infrastructure the origin has no business knowing about, and there
+ * is no operator reason to probe a name derived from a server id.
+ */
+export const SANDBOX_VIEW_HOST_OPEN_PATHS = new Set<string>([
+  "/api/web/apps/mcp-apps/sandbox-proxy",
+]);
+
+/**
  * Host header without its port, lowercased.
  *
  * The same read the caniuse/score vanity-domain gates in server/index.ts use,
@@ -65,12 +77,43 @@ function requestHost(c: Context): string {
   return (c.req.header("Host") ?? "").toLowerCase().split(":")[0];
 }
 
+/** A per-server view label, as `view-origin-label.ts` derives them. */
+const VIEW_ORIGIN_LABEL = /^[a-f0-9]{16}$/;
+
+/**
+ * How a hostname relates to the sandbox.
+ *
+ *   "exact"  — a configured sandbox host. Serves the proxy and /health.
+ *   "view"   — a single per-server label under one. Serves ONLY the proxy:
+ *              these hostnames are minted per MCP server and exist to hold
+ *              that server's untrusted view, so there is nothing else for
+ *              them to answer — not even the health probe, which would
+ *              report on infrastructure the origin has no business
+ *              describing.
+ *   null     — not a sandbox host at all.
+ *
+ * One label only. A nested subdomain is not a name this service mints, and
+ * matching it would extend the partition to hostnames nobody derived.
+ */
+function sandboxHostKind(host: string): "exact" | "view" | null {
+  if (SANDBOX_HOSTS.has(host)) return "exact";
+  const dot = host.indexOf(".");
+  if (dot === -1) return null;
+  const label = host.slice(0, dot);
+  const parent = host.slice(dot + 1);
+  if (!VIEW_ORIGIN_LABEL.test(label)) return null;
+  return SANDBOX_HOSTS.has(parent) ? "view" : null;
+}
+
 const sandboxHostPartition: MiddlewareHandler = async (c, next) => {
-  if (!SANDBOX_HOSTS.has(requestHost(c))) {
+  const kind = sandboxHostKind(requestHost(c));
+  if (kind === null) {
     await next();
     return;
   }
-  if (SANDBOX_HOST_OPEN_PATHS.has(c.req.path)) {
+  const openPaths =
+    kind === "view" ? SANDBOX_VIEW_HOST_OPEN_PATHS : SANDBOX_HOST_OPEN_PATHS;
+  if (openPaths.has(c.req.path)) {
     await next();
     return;
   }

--- a/mcpjam-inspector/server/routes/apps/__tests__/sandbox-proxy-routes.test.ts
+++ b/mcpjam-inspector/server/routes/apps/__tests__/sandbox-proxy-routes.test.ts
@@ -39,7 +39,7 @@ describe("Sandbox proxy routes", () => {
     // pre-pinning behavior rather than render nothing). This assertion is what
     // keeps a real build from shipping that way.
     expect(body).not.toContain(
-      'const HOST_ORIGIN_PATTERNS = "__MCPJAM_HOST_ORIGINS__";'
+      'const HOST_ORIGIN_PATTERNS = "__MCPJAM_HOST_ORIGINS__";',
     );
     expect(body).toContain('"http://127.0.0.1:*"');
     expect(body).toContain("function hostOriginAllowed");

--- a/mcpjam-inspector/server/routes/apps/__tests__/sandbox-proxy-routes.test.ts
+++ b/mcpjam-inspector/server/routes/apps/__tests__/sandbox-proxy-routes.test.ts
@@ -34,5 +34,14 @@ describe("Sandbox proxy routes", () => {
     expect(body).not.toContain(
       'const RECORDER_SHIM = "__MCPJAM_RECORDER_SHIM__";'
     );
+    // Load-bearing: an unreplaced host-origin placeholder makes the proxy
+    // accept a message from ANY parent (it fails open on purpose, to preserve
+    // pre-pinning behavior rather than render nothing). This assertion is what
+    // keeps a real build from shipping that way.
+    expect(body).not.toContain(
+      'const HOST_ORIGIN_PATTERNS = "__MCPJAM_HOST_ORIGINS__";'
+    );
+    expect(body).toContain('"http://127.0.0.1:*"');
+    expect(body).toContain("function hostOriginAllowed");
   });
 });

--- a/mcpjam-inspector/server/routes/apps/__tests__/widget-content-metadata.test.ts
+++ b/mcpjam-inspector/server/routes/apps/__tests__/widget-content-metadata.test.ts
@@ -104,6 +104,7 @@ describe("/widget-content — SEP-1865 metadata precedence", () => {
       csp: "content",
       permissions: "content",
       prefersBorder: "content",
+      domain: "none",
     });
   });
 
@@ -120,6 +121,7 @@ describe("/widget-content — SEP-1865 metadata precedence", () => {
       csp: "listing",
       permissions: "listing",
       prefersBorder: "listing",
+      domain: "none",
     });
   });
 
@@ -141,6 +143,7 @@ describe("/widget-content — SEP-1865 metadata precedence", () => {
       csp: "listing",
       permissions: "none",
       prefersBorder: "content",
+      domain: "none",
     });
     expect(body.prefersBorder).toBe(true);
     expect(body.csp).toEqual({ connectDomains: ["https://api.example.com"] });
@@ -273,6 +276,7 @@ describe("/widget-content — SEP-1865 metadata precedence", () => {
       csp: "none",
       permissions: "none",
       prefersBorder: "none",
+      domain: "none",
     });
   });
 });

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/__tests__/sandbox-proxy-html.test.ts
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/__tests__/sandbox-proxy-html.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The serving helper that templates the sandbox proxy document.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../../config.js", () => ({
+  CORS_ORIGINS: [
+    "http://localhost:5173",
+    "https://app.mcpjam.test",
+    "http://insecure.mcpjam.test",
+  ],
+  MCPJAM_HOSTED_ORIGIN: "https://app.mcpjam.test",
+}));
+
+const {
+  SANDBOX_PROXY_LOCALHOST_PATTERNS,
+  buildSandboxProxyFrameAncestors,
+  renderSandboxProxyHtml,
+  resetSandboxProxyHtmlForTests,
+  sandboxProxyHostOriginPatterns,
+} = await import("../sandbox-proxy-html.js");
+
+describe("sandboxProxyHostOriginPatterns", () => {
+  it("always includes the loopback patterns", () => {
+    const patterns = sandboxProxyHostOriginPatterns();
+    for (const pattern of SANDBOX_PROXY_LOCALHOST_PATTERNS) {
+      expect(patterns).toContain(pattern);
+    }
+  });
+
+  it("includes the hosted origin and https CORS origins", () => {
+    expect(sandboxProxyHostOriginPatterns()).toContain(
+      "https://app.mcpjam.test",
+    );
+  });
+
+  it("drops non-https CORS entries", () => {
+    // A plaintext origin in the list would let anything that can MITM the
+    // network pose as the host to every widget.
+    const patterns = sandboxProxyHostOriginPatterns();
+    expect(patterns).not.toContain("http://insecure.mcpjam.test");
+    // ...except the loopback patterns, which are the local app itself.
+    expect(patterns).not.toContain("http://localhost:5173");
+  });
+
+  it("does not repeat an origin that is both hosted and a CORS entry", () => {
+    const patterns = sandboxProxyHostOriginPatterns();
+    expect(
+      patterns.filter((p) => p === "https://app.mcpjam.test"),
+    ).toHaveLength(1);
+  });
+});
+
+describe("buildSandboxProxyFrameAncestors", () => {
+  it("keeps 'self' for the documented same-origin fallback deploy", () => {
+    // 'self' belongs in frame-ancestors but NOT in the message-sender list —
+    // see sandbox-proxy-html.ts.
+    expect(buildSandboxProxyFrameAncestors(["https://app.mcpjam.test"])).toBe(
+      "frame-ancestors 'self' https://app.mcpjam.test",
+    );
+  });
+});
+
+describe("renderSandboxProxyHtml", () => {
+  beforeEach(() => resetSandboxProxyHtmlForTests());
+
+  it("replaces both placeholders", () => {
+    const html = renderSandboxProxyHtml();
+    // Only the ASSIGNMENTS are replaced. `buildRecorderScript` compares
+    // RECORDER_SHIM against its own placeholder to detect "recording
+    // unavailable", so those two occurrences must survive.
+    expect(html).not.toContain(
+      'const RECORDER_SHIM = "__MCPJAM_RECORDER_SHIM__";',
+    );
+    expect(html).not.toContain(
+      'const HOST_ORIGIN_PATTERNS = "__MCPJAM_HOST_ORIGINS__";',
+    );
+    expect(html).toContain('const RECORDER_SHIM = "(function(){');
+    expect(html).toContain('"https://app.mcpjam.test"');
+  });
+
+  it("memoizes", () => {
+    expect(renderSandboxProxyHtml()).toBe(renderSandboxProxyHtml());
+  });
+});

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
@@ -253,7 +253,14 @@ apps.post("/widget-content", async (c) => {
             })
         );
 
-    const { csp, permissions, prefersBorder, metadataSources, metadataSource } =
+    const {
+      csp,
+      permissions,
+      prefersBorder,
+      domain: declaredDomain,
+      metadataSources,
+      metadataSource,
+    } =
       resolveUiResourceMeta({ contentMeta: resourceMeta, listingMeta });
 
     // Log CSP and permissions configuration for security review (SEP-1865)
@@ -340,6 +347,7 @@ apps.post("/widget-content", async (c) => {
       permissive: isPermissive, // Tell sandbox-proxy to skip CSP injection entirely
       cspMode: effectiveCspMode,
       prefersBorder,
+      declaredDomain,
       // Echoed for trace clarity. The renderer's reload-key already
       // uses the flag it sent (not this echoed value), but persisting
       // the server-confirmed value alongside cached HTML makes saved

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
@@ -12,8 +12,10 @@ import { logger } from "../../../utils/logger";
 import { getRequestLogger } from "../../../utils/request-logger";
 import { classifyWidgetError } from "../../../utils/error-classify";
 import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/app-bridge";
-import { MCP_APPS_SANDBOX_PROXY_HTML } from "../SandboxProxyHtml.bundled";
-import { RECORDER_SHIM_JS } from "./recorder-shim";
+import {
+  buildSandboxProxyFrameAncestors,
+  renderSandboxProxyHtml,
+} from "./sandbox-proxy-html";
 import { injectOpenAICompat } from "../../../utils/widget-helpers";
 import {
   canSkipListingLookup,
@@ -378,23 +380,14 @@ apps.post("/widget-content", async (c) => {
   }
 });
 
-// Inject the Tier 2 recorder shim (a JS string from recorder-shim.ts) into the
-// proxy's `RECORDER_SHIM` placeholder at serve time, so the heavy, unit-tested
-// shim source lives in one TS module and never drifts from a copy in the HTML.
-const SANDBOX_PROXY_HTML_WITH_RECORDER = MCP_APPS_SANDBOX_PROXY_HTML.replace(
-  '"__MCPJAM_RECORDER_SHIM__"',
-  () => JSON.stringify(RECORDER_SHIM_JS)
-);
-
 apps.get("/sandbox-proxy", (c) => {
   c.header("Content-Type", "text/html; charset=utf-8");
   c.header("Cache-Control", "no-cache, no-store, must-revalidate");
-  c.header(
-    "Content-Security-Policy",
-    "frame-ancestors 'self' http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*"
-  );
+  // Same list the proxy pins its host origin against — see
+  // sandbox-proxy-html.ts for why these two must not drift.
+  c.header("Content-Security-Policy", buildSandboxProxyFrameAncestors());
   c.res.headers.delete("X-Frame-Options");
-  return c.body(SANDBOX_PROXY_HTML_WITH_RECORDER);
+  return c.body(renderSandboxProxyHtml());
 });
 
 export default apps;

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
@@ -22,6 +22,7 @@ import {
   findListingMetaForUri,
   resolveUiResourceMeta,
 } from "../../../utils/ui-resource-meta";
+import { viewOriginLabelForConfig } from "../../../utils/view-origin-label";
 
 const apps = new Hono();
 
@@ -348,6 +349,12 @@ apps.post("/widget-content", async (c) => {
       cspMode: effectiveCspMode,
       prefersBorder,
       declaredDomain,
+      // The subdomain this server's views get once per-app origins are on.
+      // Optional-called: the route tests stand up managers that expose no
+      // config accessor, and an absent label just means the default origin.
+      viewOriginLabel: viewOriginLabelForConfig(
+        mcpClientManager.getServerConfig?.(serverId)
+      ),
       // Echoed for trace clarity. The renderer's reload-key already
       // uses the flag it sent (not this echoed value), but persisting
       // the server-confirmed value alongside cached HTML makes saved

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
@@ -261,8 +261,7 @@ apps.post("/widget-content", async (c) => {
       domain: declaredDomain,
       metadataSources,
       metadataSource,
-    } =
-      resolveUiResourceMeta({ contentMeta: resourceMeta, listingMeta });
+    } = resolveUiResourceMeta({ contentMeta: resourceMeta, listingMeta });
 
     // Log CSP and permissions configuration for security review (SEP-1865)
     logger.debug("[MCP Apps] Security configuration", {
@@ -353,7 +352,7 @@ apps.post("/widget-content", async (c) => {
       // Optional-called: the route tests stand up managers that expose no
       // config accessor, and an absent label just means the default origin.
       viewOriginLabel: viewOriginLabelForConfig(
-        mcpClientManager.getServerConfig?.(serverId)
+        mcpClientManager.getServerConfig?.(serverId),
       ),
       // Echoed for trace clarity. The renderer's reload-key already
       // uses the flag it sent (not this echoed value), but persisting

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy-html.ts
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy-html.ts
@@ -1,0 +1,94 @@
+/**
+ * One place that renders the MCP Apps sandbox-proxy document, for both the
+ * local (`/api/apps/...`) and hosted (`/api/web/apps/...`) routes.
+ *
+ * Two things get templated into the HTML at serve time, and both must agree
+ * with the `frame-ancestors` the route sends:
+ *
+ *   - the recorder shim, so the heavy unit-tested source lives in one TS
+ *     module rather than a copy inside the HTML;
+ *   - the host origins the proxy will accept messages from. The proxy is a
+ *     document that receives untrusted widget HTML over `postMessage` and
+ *     relays the widget's messages back out, so it has to know who the host
+ *     legitimately is. Only the process knows which origins this deploy
+ *     answers as, which is why the list is templated rather than inferred in
+ *     the browser.
+ */
+import { CORS_ORIGINS, MCPJAM_HOSTED_ORIGIN } from "../../../config.js";
+import { MCP_APPS_SANDBOX_PROXY_HTML } from "../SandboxProxyHtml.bundled.js";
+import { RECORDER_SHIM_JS } from "./recorder-shim.js";
+
+/**
+ * Loopback origins that may frame the proxy and post to it.
+ *
+ * A port wildcard rather than a fixed port: the Vite dev server, the Hono
+ * server and the Electron renderer each pick their own (the renderer's is
+ * assigned at runtime), and all three are the host app on the same machine.
+ */
+export const SANDBOX_PROXY_LOCALHOST_PATTERNS = [
+  "http://localhost:*",
+  "http://127.0.0.1:*",
+  "https://localhost:*",
+  "https://127.0.0.1:*",
+];
+
+/**
+ * Origins the proxy accepts as the host, and the same list the route allows to
+ * frame it. One source of truth on purpose: an origin that may frame the proxy
+ * but may not talk to it produces a widget that renders and then silently does
+ * nothing, which is the least debuggable of the possible mismatches.
+ *
+ * `'self'` is deliberately NOT here. It belongs in `frame-ancestors` (a
+ * same-origin fallback deploy is documented), but as a message-sender rule it
+ * would admit `location.origin` — and once views get their own per-app
+ * subdomains the widget is same-origin with its proxy, so `'self'` would let
+ * widget content pose as the host.
+ */
+export function sandboxProxyHostOriginPatterns(): string[] {
+  const patterns = new Set<string>(SANDBOX_PROXY_LOCALHOST_PATTERNS);
+  if (MCPJAM_HOSTED_ORIGIN.startsWith("https://")) {
+    patterns.add(MCPJAM_HOSTED_ORIGIN);
+  }
+  for (const origin of CORS_ORIGINS) {
+    if (origin.startsWith("https://")) {
+      patterns.add(origin);
+    }
+  }
+  return Array.from(patterns);
+}
+
+/** The `Content-Security-Policy` the proxy route sends. */
+export function buildSandboxProxyFrameAncestors(
+  patterns: string[] = sandboxProxyHostOriginPatterns(),
+): string {
+  return `frame-ancestors 'self' ${patterns.join(" ")}`;
+}
+
+let rendered: string | null = null;
+
+/**
+ * The proxy document with both placeholders replaced.
+ *
+ * Memoized because the inputs are process constants and the HTML is ~40KB.
+ * The replacements use replacer FUNCTIONS so a `$&` or `$1` inside the shim
+ * source or an origin can never be interpreted as a substitution pattern.
+ *
+ * Deliberately does not assert the placeholders exist: two route tests stub
+ * the bundled module with `"<html></html>"`, and a serving helper that threw
+ * on that would turn an unrelated test's fixture into a failure here.
+ */
+export function renderSandboxProxyHtml(): string {
+  if (rendered !== null) return rendered;
+  rendered = MCP_APPS_SANDBOX_PROXY_HTML.replace(
+    '"__MCPJAM_RECORDER_SHIM__"',
+    () => JSON.stringify(RECORDER_SHIM_JS),
+  ).replace('"__MCPJAM_HOST_ORIGINS__"', () =>
+    JSON.stringify(sandboxProxyHostOriginPatterns()),
+  );
+  return rendered;
+}
+
+/** Test-only: drop the memo so a `vi.mock` of the config is observable. */
+export function resetSandboxProxyHtmlForTests(): void {
+  rendered = null;
+}

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -717,7 +717,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
         typeof HOST_ORIGIN_PATTERNS === "string" ? null : HOST_ORIGIN_PATTERNS;
       if (!hostOriginPatterns) {
         console.warn(
-          "[MCP Apps] sandbox proxy has no host-origin allowlist; accepting any parent."
+          "[MCP Apps] sandbox proxy has no host-origin allowlist; accepting any parent.",
         );
       }
       /** The host origin locked in at the first accepted message. */

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -702,6 +702,71 @@ document.addEventListener('securitypolicyviolation', function(e) {
       // Tier 2 recorder shim source, injected at serve time (see index.ts).
       // Stays the placeholder string when recording is unavailable.
       const RECORDER_SHIM = "__MCPJAM_RECORDER_SHIM__";
+
+      /**
+       * Origins this deploy will accept as the host, templated at serve time
+       * (see sandbox-proxy-html.ts). An unreplaced placeholder is still the
+       * string literal, and is treated as "no list" — which preserves the
+       * behavior this document had before pinning existed rather than making
+       * an un-templated build fail closed and render nothing. The route test
+       * that asserts the placeholder IS replaced is what keeps production
+       * honest, so it is load-bearing.
+       */
+      const HOST_ORIGIN_PATTERNS = "__MCPJAM_HOST_ORIGINS__";
+      const hostOriginPatterns =
+        typeof HOST_ORIGIN_PATTERNS === "string" ? null : HOST_ORIGIN_PATTERNS;
+      if (!hostOriginPatterns) {
+        console.warn(
+          "[MCP Apps] sandbox proxy has no host-origin allowlist; accepting any parent."
+        );
+      }
+      /** The host origin locked in at the first accepted message. */
+      let hostOrigin = null;
+
+      /**
+       * Parse an origin pattern into its parts, or null when it is not one.
+       * `*` is allowed only as the whole port, never inside the host: a
+       * wildcard that could span a dot would make `https://evil-mcpjam.com`
+       * match a pattern meant for `https://mcpjam.com`.
+       * @param {string} pattern
+       * @returns {{scheme: string, host: string, port: string | null} | null}
+       */
+      function parseOriginPattern(pattern) {
+        if (typeof pattern !== "string") return null;
+        const m = /^(https?):\/\/([^/:*]+)(?::(\*|\d+))?$/.exec(pattern.trim());
+        if (!m) return null;
+        return { scheme: m[1], host: m[2].toLowerCase(), port: m[3] ?? null };
+      }
+
+      /**
+       * Whether `origin` matches any pattern. Fails closed on everything
+       * ambiguous: no list, an empty list, and the opaque `"null"` origin a
+       * sandboxed document sends (which `new URL` rejects anyway).
+       * @param {string} origin
+       * @param {string[] | null} patterns
+       * @returns {boolean}
+       */
+      function hostOriginAllowed(origin, patterns) {
+        if (!patterns || patterns.length === 0) return false;
+        let parsed;
+        try {
+          parsed = new URL(origin);
+        } catch (error) {
+          return false;
+        }
+        const scheme = parsed.protocol.slice(0, -1).toLowerCase();
+        const host = parsed.hostname.toLowerCase();
+        // An origin on its scheme's default port reports an empty port, and a
+        // pattern that names no port means exactly that default.
+        const port = parsed.port === "" ? null : parsed.port;
+        for (const pattern of patterns) {
+          const p = parseOriginPattern(pattern);
+          if (!p) continue;
+          if (p.scheme !== scheme || p.host !== host) continue;
+          if (p.port === "*" || p.port === port) return true;
+        }
+        return false;
+      }
       let recorderDebugEnabled = false;
       function recorderDebug(message, details) {
         try {
@@ -917,7 +982,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
             mode,
             url: mode === "url" ? document.URL : "about:srcdoc",
           },
-          "*",
+          hostOrigin || "*",
         );
         return mode;
       }
@@ -956,7 +1021,26 @@ document.addEventListener('securitypolicyviolation', function(e) {
       // Handle messages from parent (host) and inner (guest UI)
       window.addEventListener("message", async (event) => {
         if (event.source === window.parent) {
-          // Message from host
+          // Message from host.
+          //
+          // Anyone who can frame this document can post to it, and what it
+          // does with a message is load untrusted HTML and relay the widget's
+          // traffic back out — so the sender has to be an origin this deploy
+          // actually serves the app from. The first accepted origin is locked
+          // in: a page that framed us legitimately cannot later be joined by
+          // a second sender, and the relay below has one unambiguous address
+          // to answer instead of "*".
+          if (
+            hostOriginPatterns &&
+            !hostOriginAllowed(event.origin, hostOriginPatterns)
+          ) {
+            return;
+          }
+          if (hostOrigin === null) {
+            hostOrigin = event.origin;
+          } else if (event.origin !== hostOrigin) {
+            return;
+          }
           if (
             event.data &&
             event.data.method === "ui/notifications/sandbox-resource-ready"
@@ -1175,7 +1259,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
               ) {
                 recorderDebug("forward " + data.type);
               }
-              window.parent.postMessage(data, "*");
+              window.parent.postMessage(data, hostOrigin || "*");
             }
           }
         }

--- a/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
@@ -471,6 +471,7 @@ describe("hosted /widget-content — SEP-1865 metadata precedence", () => {
       csp: "listing",
       permissions: "listing",
       prefersBorder: "listing",
+      domain: "none",
     });
   });
 
@@ -499,6 +500,7 @@ describe("hosted /widget-content — SEP-1865 metadata precedence", () => {
       csp: "listing",
       permissions: "none",
       prefersBorder: "content",
+      domain: "none",
     });
   });
 

--- a/mcpjam-inspector/server/routes/web/apps.ts
+++ b/mcpjam-inspector/server/routes/web/apps.ts
@@ -1,9 +1,10 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/app-bridge";
-import { CORS_ORIGINS } from "../../config.js";
-import { MCP_APPS_SANDBOX_PROXY_HTML } from "../apps/SandboxProxyHtml.bundled.js";
-import { RECORDER_SHIM_JS } from "../apps/mcp-apps/recorder-shim.js";
+import {
+  buildSandboxProxyFrameAncestors,
+  renderSandboxProxyHtml,
+} from "../apps/mcp-apps/sandbox-proxy-html.js";
 import { injectOpenAICompat } from "../../utils/widget-helpers.js";
 import { logger } from "../../utils/logger.js";
 import {
@@ -23,11 +24,6 @@ import {
 const apps = new Hono();
 
 const MCP_APPS_MIMETYPE = RESOURCE_MIME_TYPE;
-const SANDBOX_PROXY_HTML_WITH_RECORDER = MCP_APPS_SANDBOX_PROXY_HTML.replace(
-  '"__MCPJAM_RECORDER_SHIM__"',
-  () => JSON.stringify(RECORDER_SHIM_JS),
-);
-
 // Mimetypes accepted by the hosted-mode widget-content route. Mirrors
 // the local route in routes/apps/mcp-apps/index.ts — see the long-form
 // comment there for rationale (SEP-1865 canonical + two legacy Apps SDK
@@ -39,23 +35,6 @@ const ACCEPTED_WIDGET_MIMETYPES = new Set<string>([
   SKYBRIDGE_MIMETYPE,
   PLAIN_HTML_MIMETYPE,
 ]);
-
-const LOCALHOST_FRAME_SOURCES = [
-  "http://localhost:*",
-  "http://127.0.0.1:*",
-  "https://localhost:*",
-  "https://127.0.0.1:*",
-];
-
-export function buildFrameAncestors(): string {
-  const origins = new Set<string>(["'self'", ...LOCALHOST_FRAME_SOURCES]);
-  for (const origin of CORS_ORIGINS) {
-    if (origin.startsWith("https://")) {
-      origins.add(origin);
-    }
-  }
-  return `frame-ancestors ${Array.from(origins).join(" ")}`;
-}
 
 function extractHtmlFromResourceContent(content: unknown): string {
   if (!content || typeof content !== "object") return "";
@@ -108,9 +87,11 @@ const mcpAppsWidgetContentSchema = projectServerSchema.extend({
 apps.get("/mcp-apps/sandbox-proxy", (c) => {
   c.header("Content-Type", "text/html; charset=utf-8");
   c.header("Cache-Control", "no-cache, no-store, must-revalidate");
-  c.header("Content-Security-Policy", buildFrameAncestors());
+  // Same list the proxy pins its host origin against — see
+  // sandbox-proxy-html.ts for why these two must not drift.
+  c.header("Content-Security-Policy", buildSandboxProxyFrameAncestors());
   c.res.headers.delete("X-Frame-Options");
-  return c.body(SANDBOX_PROXY_HTML_WITH_RECORDER);
+  return c.body(renderSandboxProxyHtml());
 });
 
 // ── MCP Apps Widget Content ──────────────────────────────────────────

--- a/mcpjam-inspector/server/routes/web/apps.ts
+++ b/mcpjam-inspector/server/routes/web/apps.ts
@@ -12,6 +12,7 @@ import {
   findListingMetaForUri,
   resolveUiResourceMeta,
 } from "../../utils/ui-resource-meta.js";
+import { viewOriginLabelForConfig } from "../../utils/view-origin-label.js";
 import {
   projectServerSchema,
   withEphemeralConnection,
@@ -221,6 +222,9 @@ apps.post("/mcp-apps/widget-content", async (c) =>
         cspMode: effectiveCspMode,
         prefersBorder: prefersBorderFromMeta,
         declaredDomain,
+        viewOriginLabel: viewOriginLabelForConfig(
+          manager.getServerConfig?.(body.serverId),
+        ),
         injectedOpenAiCompat: shouldInjectOpenAiCompat,
         injectedOpenAiCompatCapabilities:
           shouldInjectOpenAiCompat &&

--- a/mcpjam-inspector/server/routes/web/apps.ts
+++ b/mcpjam-inspector/server/routes/web/apps.ts
@@ -178,6 +178,7 @@ apps.post("/mcp-apps/widget-content", async (c) =>
         csp: cspFromMeta,
         permissions: permissionsFromMeta,
         prefersBorder: prefersBorderFromMeta,
+        domain: declaredDomain,
         metadataSource,
         metadataSources,
       } = resolveUiResourceMeta({
@@ -219,6 +220,7 @@ apps.post("/mcp-apps/widget-content", async (c) =>
         permissive: effectiveCspMode === "permissive",
         cspMode: effectiveCspMode,
         prefersBorder: prefersBorderFromMeta,
+        declaredDomain,
         injectedOpenAiCompat: shouldInjectOpenAiCompat,
         injectedOpenAiCompatCapabilities:
           shouldInjectOpenAiCompat &&

--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -77,10 +77,6 @@ import {
 } from "@mcpjam/sdk";
 import { isMCPAuthError } from "@mcpjam/sdk";
 import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/app-bridge";
-import type {
-  McpUiResourceCsp,
-  McpUiResourcePermissions,
-} from "@modelcontextprotocol/ext-apps";
 import { HOSTED_MODE, WEB_STREAM_TIMEOUT_MS } from "../../config.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
 import { streamWebChatTurn } from "../../utils/web-chat-turn.js";
@@ -91,6 +87,7 @@ import {
 import { WEB_SEARCH_TOOL_NAME } from "../../utils/built-in-tools/exa-web-search.js";
 import { resolveHostTools } from "../../utils/built-in-tools/registry.js";
 import { injectOpenAICompat } from "../../utils/widget-helpers.js";
+import { resolveUiResourceMeta } from "../../utils/ui-resource-meta.js";
 import { logger } from "../../utils/logger.js";
 import { resolvePlatformMcpUrl } from "../../utils/platform-mcp-url.js";
 import { MCPJAM_PLATFORM_SERVER_ID } from "../../../shared/mcpjam-agent-widgets";
@@ -612,13 +609,12 @@ mcpjamAgent.post("/widget-content", async (c) => {
       }
 
       const resourceMeta = record._meta as Record<string, unknown> | undefined;
-      const uiMeta = (resourceMeta as { ui?: unknown } | undefined)?.ui as
-        | {
-            csp?: McpUiResourceCsp;
-            permissions?: McpUiResourcePermissions;
-            prefersBorder?: boolean;
-          }
-        | undefined;
+      // The shared resolver rather than a local cast, so this route reports
+      // the same normalized fields (and the same `domain`) as the other two
+      // widget-content routes. No listing lookup: these resources come from
+      // MCPJam's own MCP server and a fixed table, so there is no second
+      // source a lower-precedence declaration could arrive from.
+      const uiMeta = resolveUiResourceMeta({ contentMeta: resourceMeta });
       const effectiveCspMode = body.cspMode ?? "permissive";
 
       if (body.injectOpenAiCompat === true) {
@@ -640,11 +636,12 @@ mcpjamAgent.post("/widget-content", async (c) => {
 
       return c.json({
         html,
-        csp: effectiveCspMode === "permissive" ? undefined : uiMeta?.csp,
-        permissions: uiMeta?.permissions,
+        csp: effectiveCspMode === "permissive" ? undefined : uiMeta.csp,
+        permissions: uiMeta.permissions,
         permissive: effectiveCspMode === "permissive",
         cspMode: effectiveCspMode,
-        prefersBorder: uiMeta?.prefersBorder,
+        prefersBorder: uiMeta.prefersBorder,
+        declaredDomain: uiMeta.domain,
         injectedOpenAiCompat: body.injectOpenAiCompat === true,
         injectedOpenAiCompatCapabilities:
           body.injectOpenAiCompat === true &&

--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -88,6 +88,7 @@ import { WEB_SEARCH_TOOL_NAME } from "../../utils/built-in-tools/exa-web-search.
 import { resolveHostTools } from "../../utils/built-in-tools/registry.js";
 import { injectOpenAICompat } from "../../utils/widget-helpers.js";
 import { resolveUiResourceMeta } from "../../utils/ui-resource-meta.js";
+import { viewOriginLabel } from "../../utils/view-origin-label.js";
 import { logger } from "../../utils/logger.js";
 import { resolvePlatformMcpUrl } from "../../utils/platform-mcp-url.js";
 import { MCPJAM_PLATFORM_SERVER_ID } from "../../../shared/mcpjam-agent-widgets";
@@ -642,6 +643,10 @@ mcpjamAgent.post("/widget-content", async (c) => {
         cspMode: effectiveCspMode,
         prefersBorder: uiMeta.prefersBorder,
         declaredDomain: uiMeta.domain,
+        // A fixed label of its own rather than none: with per-app origins on,
+        // "no label" means the bare sandbox origin, and MCPJam's own widgets
+        // should not be the one thing still rendering there.
+        viewOriginLabel: viewOriginLabel("mcpjam:platform"),
         injectedOpenAiCompat: body.injectOpenAiCompat === true,
         injectedOpenAiCompatCapabilities:
           body.injectOpenAiCompat === true &&

--- a/mcpjam-inspector/server/utils/__tests__/ui-resource-meta.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/ui-resource-meta.test.ts
@@ -1,0 +1,171 @@
+/**
+ * `_meta.ui` resolution (SEP-1865 precedence).
+ *
+ * The spec allows a server to publish UI metadata on the `resources/list`
+ * entry, on the `resources/read` content item, or both, and requires the
+ * content item to win. The fields resolve INDEPENDENTLY — a server may
+ * publish csp at read time and prefersBorder at list time — which is why the
+ * resolver reports a per-field breakdown rather than one source.
+ *
+ * No test file existed for this module until the `domain` field landed.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  canSkipListingLookup,
+  resolveUiResourceMeta,
+} from "../ui-resource-meta.js";
+
+const CSP_A = { connectDomains: ["https://a.example"] };
+const CSP_B = { connectDomains: ["https://b.example"] };
+
+function uiMeta(ui: Record<string, unknown>): Record<string, unknown> {
+  return { ui };
+}
+
+describe("resolveUiResourceMeta — precedence", () => {
+  it("prefers the content item over the listing, per field", () => {
+    const resolved = resolveUiResourceMeta({
+      contentMeta: uiMeta({ csp: CSP_A }),
+      listingMeta: uiMeta({ csp: CSP_B, prefersBorder: false }),
+    });
+    expect(resolved.csp).toEqual(CSP_A);
+    expect(resolved.prefersBorder).toBe(false);
+    expect(resolved.metadataSources.csp).toBe("content");
+    expect(resolved.metadataSources.prefersBorder).toBe("listing");
+    // Two sources actually contributed, which is what "mixed" is for.
+    expect(resolved.metadataSource).toBe("mixed");
+  });
+
+  it("reports a single source when only one contributed", () => {
+    const resolved = resolveUiResourceMeta({
+      contentMeta: uiMeta({ csp: CSP_A, prefersBorder: true }),
+    });
+    expect(resolved.metadataSource).toBe("content");
+  });
+
+  it("reports none when nothing was declared", () => {
+    const resolved = resolveUiResourceMeta({});
+    expect(resolved.metadataSource).toBe("none");
+    expect(resolved.metadataSources).toEqual({
+      csp: "none",
+      permissions: "none",
+      prefersBorder: "none",
+      domain: "none",
+    });
+  });
+
+  it("ranks legacy openai keys below the listing's canonical block", () => {
+    const resolved = resolveUiResourceMeta({
+      contentMeta: {
+        "openai/widgetCSP": { connect_domains: ["https://legacy"] },
+      },
+      listingMeta: uiMeta({ csp: CSP_B }),
+    });
+    expect(resolved.csp).toEqual(CSP_B);
+    expect(resolved.metadataSources.csp).toBe("listing");
+  });
+
+  it("treats an explicit prefersBorder:false as a declaration, not an absence", () => {
+    const resolved = resolveUiResourceMeta({
+      contentMeta: uiMeta({ prefersBorder: false }),
+      listingMeta: uiMeta({ prefersBorder: true }),
+    });
+    expect(resolved.prefersBorder).toBe(false);
+  });
+
+  it("ignores a malformed prefersBorder rather than coercing it", () => {
+    const resolved = resolveUiResourceMeta({
+      contentMeta: uiMeta({ prefersBorder: "yes" }),
+    });
+    expect(resolved.prefersBorder).toBeUndefined();
+    expect(resolved.metadataSources.prefersBorder).toBe("none");
+  });
+});
+
+describe("resolveUiResourceMeta — domain", () => {
+  it("resolves a declared domain and records its source", () => {
+    const resolved = resolveUiResourceMeta({
+      contentMeta: uiMeta({ domain: "abc123.claudemcpcontent.com" }),
+    });
+    expect(resolved.domain).toBe("abc123.claudemcpcontent.com");
+    expect(resolved.metadataSources.domain).toBe("content");
+  });
+
+  it("falls back to the listing", () => {
+    const resolved = resolveUiResourceMeta({
+      contentMeta: uiMeta({ csp: CSP_A }),
+      listingMeta: uiMeta({ domain: "listed.example.com" }),
+    });
+    expect(resolved.domain).toBe("listed.example.com");
+    expect(resolved.metadataSources.domain).toBe("listing");
+  });
+
+  it("lets the content item win", () => {
+    const resolved = resolveUiResourceMeta({
+      contentMeta: uiMeta({ domain: "content.example.com" }),
+      listingMeta: uiMeta({ domain: "listing.example.com" }),
+    });
+    expect(resolved.domain).toBe("content.example.com");
+  });
+
+  it("trims, and treats an empty declaration as none", () => {
+    // It is compared against a hostname downstream, and reporting `""` would
+    // render a mismatch finding against a value the server never made.
+    expect(
+      resolveUiResourceMeta({ contentMeta: uiMeta({ domain: "  x.test  " }) })
+        .domain,
+    ).toBe("x.test");
+    expect(
+      resolveUiResourceMeta({ contentMeta: uiMeta({ domain: "   " }) }).domain,
+    ).toBeUndefined();
+    expect(
+      resolveUiResourceMeta({ contentMeta: uiMeta({ domain: 42 }) }).domain,
+    ).toBeUndefined();
+  });
+
+  it("has no legacy source", () => {
+    // `_meta.ui.domain` is SEP-1865 only; the Apps SDK never shipped an
+    // `openai/widget*` equivalent, so there is nothing to fall back to.
+    const resolved = resolveUiResourceMeta({
+      contentMeta: { "openai/widgetDomain": "nope.example.com" },
+    });
+    expect(resolved.domain).toBeUndefined();
+    expect(resolved.metadataSources.domain).toBe("none");
+  });
+});
+
+describe("canSkipListingLookup", () => {
+  const complete = uiMeta({
+    csp: CSP_A,
+    permissions: { camera: {} },
+    prefersBorder: true,
+  });
+
+  it("skips when the content item supplies every resolved field", () => {
+    expect(canSkipListingLookup(complete)).toBe(true);
+  });
+
+  it("does not skip when a field is missing", () => {
+    expect(canSkipListingLookup(uiMeta({ csp: CSP_A }))).toBe(false);
+    expect(canSkipListingLookup(undefined)).toBe(false);
+  });
+
+  it("does not skip on legacy-only metadata", () => {
+    // Legacy keys rank below the listing, so the listing can still change the
+    // outcome and must be fetched.
+    expect(
+      canSkipListingLookup({
+        "openai/widgetCSP": { connect_domains: ["https://legacy"] },
+      }),
+    ).toBe(false);
+  });
+
+  it("still skips when only `domain` is absent, by design", () => {
+    // `domain` is advisory. Requiring it would make every render of a
+    // resource that declares the other three pay a resources/list round-trip
+    // forever. The narrow cost: a listing-only domain is not seen here.
+    expect(canSkipListingLookup(complete)).toBe(true);
+    const resolved = resolveUiResourceMeta({ contentMeta: complete });
+    expect(resolved.domain).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/view-origin-label.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/view-origin-label.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Deriving the per-server view origin label.
+ *
+ * An origin is where OAuth redirect URIs point and what third-party API-key
+ * allowlists name, so the property that matters is stability: the same server
+ * must always produce the same label, and two different servers must not
+ * collide.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  canonicalServerKey,
+  VIEW_ORIGIN_LABEL_PATTERN,
+  viewOriginLabel,
+  viewOriginLabelForConfig,
+} from "../view-origin-label.js";
+
+describe("canonicalServerKey", () => {
+  it("keys an HTTP server on its URL", () => {
+    expect(canonicalServerKey({ url: "https://example.com/mcp" })).toBe(
+      "http:https://example.com/mcp",
+    );
+  });
+
+  it("strips query and fragment", () => {
+    // A hosted server URL can carry a resolved token in its query. Hashing
+    // that would key the origin on a secret and rotate it whenever the secret
+    // did — invalidating every allowlist a developer had configured.
+    expect(
+      canonicalServerKey({ url: "https://example.com/mcp?token=s3cret#x" }),
+    ).toBe(canonicalServerKey({ url: "https://example.com/mcp" }));
+  });
+
+  it("keeps a trailing slash significant, as the URL itself is", () => {
+    expect(canonicalServerKey({ url: "https://example.com/mcp/" })).not.toBe(
+      canonicalServerKey({ url: "https://example.com/mcp" }),
+    );
+  });
+
+  it("keys a STDIO server on its command and args", () => {
+    expect(
+      canonicalServerKey({ command: "npx", args: ["-y", "server"] }),
+    ).toBe("stdio:npx -y server");
+    expect(canonicalServerKey({ command: "npx" })).toBe("stdio:npx");
+  });
+
+  it("prefers the URL when a config somehow carries both", () => {
+    expect(
+      canonicalServerKey({ url: "https://example.com/mcp", command: "npx" }),
+    ).toBe("http:https://example.com/mcp");
+  });
+
+  it("keeps an unparseable URL rather than dropping the identity", () => {
+    expect(canonicalServerKey({ url: "not a url" })).toBe("http:not a url");
+  });
+
+  it("identifies nothing when the config has neither", () => {
+    expect(canonicalServerKey({})).toBeUndefined();
+    expect(canonicalServerKey(undefined)).toBeUndefined();
+    expect(canonicalServerKey({ url: "", command: "" })).toBeUndefined();
+  });
+});
+
+describe("viewOriginLabel", () => {
+  it("is a 16-character hex label usable as a DNS label", () => {
+    const label = viewOriginLabel("http:https://example.com/mcp");
+    expect(label).toMatch(VIEW_ORIGIN_LABEL_PATTERN);
+  });
+
+  it("is stable for the same key", () => {
+    // Pinned rather than recomputed: a test that derived the expected value
+    // the same way the code does would agree with any change to either.
+    // Verified independently:
+    //   printf '%s' 'http:https://example.com/mcp' | shasum -a 256
+    expect(viewOriginLabel("http:https://example.com/mcp")).toBe(
+      "4c17a6ac61e19736",
+    );
+  });
+
+  it("differs for different servers", () => {
+    expect(viewOriginLabel("http:https://a.example/mcp")).not.toBe(
+      viewOriginLabel("http:https://b.example/mcp"),
+    );
+    expect(viewOriginLabel("stdio:npx -y a")).not.toBe(
+      viewOriginLabel("stdio:npx -y b"),
+    );
+  });
+
+  it("does not collide across transports", () => {
+    expect(viewOriginLabelForConfig({ url: "x" })).not.toBe(
+      viewOriginLabelForConfig({ command: "x" }),
+    );
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/view-origin-label.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/view-origin-label.test.ts
@@ -37,9 +37,9 @@ describe("canonicalServerKey", () => {
   });
 
   it("keys a STDIO server on its command and args", () => {
-    expect(
-      canonicalServerKey({ command: "npx", args: ["-y", "server"] }),
-    ).toBe("stdio:npx -y server");
+    expect(canonicalServerKey({ command: "npx", args: ["-y", "server"] })).toBe(
+      "stdio:npx -y server",
+    );
     expect(canonicalServerKey({ command: "npx" })).toBe("stdio:npx");
   });
 

--- a/mcpjam-inspector/server/utils/ui-resource-meta.ts
+++ b/mcpjam-inspector/server/utils/ui-resource-meta.ts
@@ -42,12 +42,24 @@ export interface UiResourceMetaSources {
   csp: MetadataFieldSource;
   permissions: MetadataFieldSource;
   prefersBorder: MetadataFieldSource;
+  domain: MetadataFieldSource;
 }
 
 export interface ResolvedUiResourceMeta {
   csp?: McpUiResourceCsp;
   permissions?: McpUiResourcePermissions;
   prefersBorder?: boolean;
+  /**
+   * `_meta.ui.domain` — the dedicated origin the SERVER asked for.
+   *
+   * Advisory only. MCPJam derives the origin it actually serves a view from,
+   * the way Claude and ChatGPT do; a server-chosen string is never used for
+   * routing, because keying an origin on it would let one server claim
+   * another's storage. It travels to the client so the CSP Workbench can say
+   * whether the declaration matches what a developer will really need to
+   * allowlist here.
+   */
+  domain?: string;
   /** Per-field breakdown of which source won. */
   metadataSources: UiResourceMetaSources;
   /** Summary of `metadataSources` — `"mixed"` when they disagree. */
@@ -270,6 +282,7 @@ interface NormalizedUiMeta {
   csp?: McpUiResourceCsp;
   permissions?: McpUiResourcePermissions;
   prefersBorder?: boolean;
+  domain?: string;
 }
 
 function readUiMeta(
@@ -283,6 +296,13 @@ function readUiMeta(
     // Anything non-boolean is a malformed declaration, not a `false`.
     prefersBorder:
       typeof ui.prefersBorder === "boolean" ? ui.prefersBorder : undefined,
+    // Trimmed because it is compared against a hostname downstream, and an
+    // empty declaration is no declaration — reporting `""` would render a
+    // mismatch finding against a value the server never made.
+    domain:
+      typeof ui.domain === "string" && ui.domain.trim().length > 0
+        ? ui.domain.trim()
+        : undefined,
   };
 }
 
@@ -302,6 +322,7 @@ export function resolveUiResourceMeta(
     csp: "none",
     permissions: "none",
     prefersBorder: "none",
+    domain: "none",
   };
 
   // ── csp ──────────────────────────────────────────────────────────────
@@ -352,6 +373,18 @@ export function resolveUiResourceMeta(
     metadataSources.prefersBorder = "legacy";
   }
 
+  // ── domain ───────────────────────────────────────────────────────────
+  // Two-source chain: `_meta.ui.domain` is a SEP-1865 field with no legacy
+  // `openai/widget*` equivalent.
+  let domain: string | undefined;
+  if (contentUiMeta?.domain !== undefined) {
+    domain = contentUiMeta.domain;
+    metadataSources.domain = "content";
+  } else if (listingUiMeta?.domain !== undefined) {
+    domain = listingUiMeta.domain;
+    metadataSources.domain = "listing";
+  }
+
   const usedMetadataSources = new Set(
     Object.values(metadataSources).filter((source) => source !== "none")
   );
@@ -362,7 +395,14 @@ export function resolveUiResourceMeta(
       ? (Array.from(usedMetadataSources)[0] as MetadataFieldSource)
       : "mixed";
 
-  return { csp, permissions, prefersBorder, metadataSources, metadataSource };
+  return {
+    csp,
+    permissions,
+    prefersBorder,
+    domain,
+    metadataSources,
+    metadataSource,
+  };
 }
 
 /**
@@ -403,6 +443,12 @@ export function canSkipListingLookup(
   contentMeta: Record<string, unknown> | undefined
 ): boolean {
   const ui = readUiMeta(contentMeta);
+  // `domain` is deliberately NOT part of this predicate. It is an advisory
+  // field the Workbench reports on, and requiring it would make every render
+  // of a resource that declares csp/permissions/prefersBorder but no domain
+  // pay a `resources/list` round-trip forever. The cost of leaving it out is
+  // narrow and worth naming: a listing-only `domain` is not seen when the
+  // content item already supplies the other three.
   return (
     ui.csp !== undefined &&
     ui.permissions !== undefined &&

--- a/mcpjam-inspector/server/utils/view-origin-label.ts
+++ b/mcpjam-inspector/server/utils/view-origin-label.ts
@@ -1,0 +1,83 @@
+import { createHash } from "node:crypto";
+
+/**
+ * The label MCPJam serves a server's MCP App views from:
+ * `<label>.sandbox.mcpjam.com`.
+ *
+ * Derived, never declared. `_meta.ui.domain` is a string the SERVER chooses,
+ * and routing on it would let one server claim another's origin — and with it
+ * that origin's cookies and storage. Claude derives its label the same way, as
+ * `sha256(<connector URL>)[:32] + ".claudemcpcontent.com"`.
+ *
+ * What a stable label buys is the reason to be careful about the input: an
+ * origin is where OAuth redirect URIs point and what third-party API-key
+ * allowlists name, so a label that changes when nothing meaningful changed
+ * silently invalidates a developer's configuration.
+ */
+
+/** Hex characters of the digest that go into the label. */
+export const VIEW_ORIGIN_LABEL_LENGTH = 16;
+
+/** A label as it may appear in a hostname. */
+export const VIEW_ORIGIN_LABEL_PATTERN = /^[a-f0-9]{16}$/;
+
+export interface ViewOriginServerConfig {
+  /** HTTP/SSE servers. */
+  url?: string;
+  /** STDIO servers. */
+  command?: string;
+  args?: string[];
+}
+
+/**
+ * The canonical string a label is derived from, or `undefined` when the config
+ * identifies nothing.
+ *
+ * Query and fragment are stripped from a URL. This is a deliberate divergence
+ * from Claude, which hashes the connector URL exactly as entered: MCPJam's
+ * suffix differs anyway so the digests were never going to agree, and a URL
+ * here can carry a resolved token in its query. Hashing that would key an
+ * origin on a secret and rotate it whenever the secret did.
+ *
+ * The shapes mirror `computeServerKey` on the client
+ * (`components/ui-playground/hooks/useServerKey.ts`), so the two never
+ * disagree about what counts as "the same server".
+ */
+export function canonicalServerKey(
+  config: ViewOriginServerConfig | undefined,
+): string | undefined {
+  if (!config) return undefined;
+  if (typeof config.url === "string" && config.url.length > 0) {
+    try {
+      const url = new URL(config.url);
+      url.search = "";
+      url.hash = "";
+      return `http:${url.toString()}`;
+    } catch {
+      // Not parseable as a URL: hash it verbatim rather than dropping the
+      // server's identity entirely.
+      return `http:${config.url}`;
+    }
+  }
+  if (typeof config.command === "string" && config.command.length > 0) {
+    const args = (config.args ?? []).join(" ");
+    return `stdio:${config.command} ${args}`.trim();
+  }
+  return undefined;
+}
+
+/** The subdomain label for a canonical key. */
+export function viewOriginLabel(key: string): string {
+  return createHash("sha256")
+    .update(key, "utf8")
+    .digest("hex")
+    .slice(0, VIEW_ORIGIN_LABEL_LENGTH);
+}
+
+/** Convenience: config → label, or `undefined` when it identifies nothing. */
+export function viewOriginLabelForConfig(
+  config: ViewOriginServerConfig | undefined,
+): string | undefined {
+  const key = canonicalServerKey(config);
+  return key === undefined ? undefined : viewOriginLabel(key);
+}

--- a/sdk/src/claude-readiness/checks/apps.ts
+++ b/sdk/src/claude-readiness/checks/apps.ts
@@ -120,7 +120,10 @@ const HTML_MIME_PROFILE: ClaudeCheckDefinition = {
   title: `Widget resources are served as \`${CLAUDE_APP_HTML_MIME}\``,
   lane: "runtime-compatibility",
   class: "required",
-  source: claudePolicySource("mcp-apps/cross-compatibility", "§Resource mime type"),
+  source: claudePolicySource(
+    "mcp-apps/cross-compatibility",
+    "§Resource mime type"
+  ),
   provenance: "wire",
 };
 
@@ -159,7 +162,10 @@ const CSP_SHAPE: ClaudeCheckDefinition = {
   title: "A declared CSP names only hosts the widget actually needs",
   lane: "experience-insights",
   class: "recommended",
-  source: claudePolicySource("mcp-apps/external-links", "§Content security policy"),
+  source: claudePolicySource(
+    "mcp-apps/external-links",
+    "§Content security policy"
+  ),
   provenance: "static",
   intrusiveness: "passive",
 };
@@ -208,10 +214,12 @@ const INSTANCE_SUPERSESSION: ClaudeCheckDefinition = {
  */
 function declaresMinimumTouchTarget(styleText: string): boolean {
   const declarations = styleText.matchAll(
-    /min-(?:height|block-size)\s*:\s*([\d.]+)px/gi,
+    /min-(?:height|block-size)\s*:\s*([\d.]+)px/gi
   );
   for (const [, value] of declarations) {
-    if (Number.parseFloat(value) >= CLAUDE_APP_DESIGN_BUDGETS.minTouchTargetPx) {
+    if (
+      Number.parseFloat(value) >= CLAUDE_APP_DESIGN_BUDGETS.minTouchTargetPx
+    ) {
       return true;
     }
   }
@@ -226,9 +234,19 @@ const DESIGN_LINTS: Array<{
 }> = [
   {
     definition: designLint(
+      "doctype",
+      "Widget HTML declares no `<!DOCTYPE html>`",
+      "§Rendering"
+    ),
+    detect: (scanned) => !scanned.hasDoctype,
+    remediation:
+      "Claude mounts a view by writing its HTML into a blank document, and a written document with no doctype is parsed in QUIRKS mode — the box model and percentage heights differ from what you tested. Start the resource with `<!DOCTYPE html>`. (The same markup can render correctly in a host that mounts via `srcdoc`, which is never quirks mode, so this will not reproduce everywhere.)",
+  },
+  {
+    definition: designLint(
       "responsive-320",
       "Widget appears to have no narrow-viewport handling",
-      "§Responsiveness",
+      "§Responsiveness"
     ),
     detect: (scanned) =>
       !/@media[^{]*\(\s*max-width/i.test(scanned.styleText) &&
@@ -240,7 +258,7 @@ const DESIGN_LINTS: Array<{
     definition: designLint(
       "touch-targets",
       `Interactive elements may be below the ${CLAUDE_APP_DESIGN_BUDGETS.minTouchTargetPx}×${CLAUDE_APP_DESIGN_BUDGETS.minTouchTargetPx}px touch target`,
-      "§Touch targets",
+      "§Touch targets"
     ),
     // Read the declared minimums and COMPARE them, rather than pattern-matching
     // the digits of one particular number: a regex spelling out `4[4-9]|[5-9]\d`
@@ -256,7 +274,7 @@ const DESIGN_LINTS: Array<{
     definition: designLint(
       "safe-area",
       "Widget does not account for the device safe area",
-      "§Safe areas",
+      "§Safe areas"
     ),
     detect: (scanned) => !/safe-area-inset/i.test(scanned.styleText),
     remediation:
@@ -266,7 +284,7 @@ const DESIGN_LINTS: Array<{
     definition: designLint(
       "theming",
       "Widget appears not to follow the host's light/dark theme",
-      "§Theming",
+      "§Theming"
     ),
     detect: (scanned) =>
       !/prefers-color-scheme/i.test(scanned.styleText) &&
@@ -279,11 +297,11 @@ const DESIGN_LINTS: Array<{
     definition: designLint(
       "transparent-background",
       "Widget paints an opaque background over the host surface",
-      "§Backgrounds",
+      "§Backgrounds"
     ),
     detect: (scanned) =>
       /body\s*{[^}]*background(-color)?\s*:\s*(#|rgb|hsl|white|black)/i.test(
-        scanned.styleText,
+        scanned.styleText
       ),
     remediation:
       "The widget paints its own body background; Claude's surface shows through a transparent one.",
@@ -292,7 +310,7 @@ const DESIGN_LINTS: Array<{
     definition: designLint(
       "nested-scrolling",
       "Widget introduces its own scroll container",
-      "§Scrolling",
+      "§Scrolling"
     ),
     detect: (scanned) =>
       /overflow(-y)?\s*:\s*(auto|scroll)/i.test(scanned.styleText),
@@ -303,7 +321,7 @@ const DESIGN_LINTS: Array<{
     definition: designLint(
       "accessibility",
       "Widget shows few accessibility affordances",
-      "§Accessibility",
+      "§Accessibility"
     ),
     detect: (scanned) =>
       hasInteractiveElement(scanned) && !hasAccessibilityAffordance(scanned),
@@ -313,7 +331,7 @@ const DESIGN_LINTS: Array<{
     definition: designLint(
       "display-mode",
       "Widget does not react to the host's display mode",
-      "§Display modes",
+      "§Display modes"
     ),
     detect: (scanned) =>
       !/displayMode/i.test(scanned.scriptText) &&
@@ -327,7 +345,7 @@ const DESIGN_LINTS: Array<{
 function designLint(
   slug: string,
   title: string,
-  section: string,
+  section: string
 ): ClaudeCheckDefinition {
   return {
     id: `claude.apps.design.${slug}`,
@@ -355,7 +373,7 @@ function designLint(
 export function claudeAppContentDomain(enteredUrl: string): string {
   const digest = sha256Hex(enteredUrl).slice(
     0,
-    CLAUDE_APP_CONTENT_DOMAIN_HASH_LENGTH,
+    CLAUDE_APP_CONTENT_DOMAIN_HASH_LENGTH
   );
   return `${digest}${CLAUDE_APP_CONTENT_DOMAIN_SUFFIX}`;
 }
@@ -364,7 +382,7 @@ export function claudeAppContentDomain(enteredUrl: string): string {
 
 export function runClaudeAppsChecks(
   evidence: ClaudeAppsEvidence,
-  stamp: ClaudeCheckStamp,
+  stamp: ClaudeCheckStamp
 ): ClaudeReadinessFinding[] {
   const findings: ClaudeReadinessFinding[] = [];
   const tools = evidence.tools ?? [];
@@ -401,9 +419,11 @@ export function runClaudeAppsChecks(
     const reason =
       "no MCP Apps conformance result was available, so nothing app-specific was evaluated";
     for (const definition of everyDefinition) {
-      findings.push(notEvaluated(definition, stamp, reason, {
-        missingInput: CLAUDE_APPS_RESULT_INPUT,
-      }));
+      findings.push(
+        notEvaluated(definition, stamp, reason, {
+          missingInput: CLAUDE_APPS_RESULT_INPUT,
+        })
+      );
     }
     return findings;
   }
@@ -421,40 +441,41 @@ export function runClaudeAppsChecks(
   // the deprecated field and nothing else is a problem — an earlier reading
   // that warned whenever the legacy field was absent had it exactly backwards.
   const legacyOnly = tools.filter(
-    (tool) => tool.hasLegacyField && !tool.hasNestedField,
+    (tool) => tool.hasLegacyField && !tool.hasNestedField
   );
   findings.push(
     derivedFrom(
       legacyOnly.length === 0
         ? satisfied(RESOURCE_URI_MODERNITY, stamp, {
             tools: tools.length,
-            modernOnly: tools.filter((t) => t.hasNestedField && !t.hasLegacyField)
-              .length,
+            modernOnly: tools.filter(
+              (t) => t.hasNestedField && !t.hasLegacyField
+            ).length,
           })
         : violated(
             RESOURCE_URI_MODERNITY,
             stamp,
             "Declare `_meta.ui.resourceUri`. These tools use only the deprecated `ui/resourceUri` field, which Claude does not read.",
-            { tools: legacyOnly.map((tool) => tool.name) },
+            { tools: legacyOnly.map((tool) => tool.name) }
           ),
-      "apps-conformance:ui-tool-metadata-valid",
-    ),
+      "apps-conformance:ui-tool-metadata-valid"
+    )
   );
 
   // ── MIME profile ─────────────────────────────────────────────────────
   const wrongMime = resources.filter(
     (resource) =>
-      resource.mimeType !== undefined && !isClaudeAppMime(resource.mimeType),
+      resource.mimeType !== undefined && !isClaudeAppMime(resource.mimeType)
   );
   const unknownMime = resources.filter(
-    (resource) => resource.mimeType === undefined,
+    (resource) => resource.mimeType === undefined
   );
   findings.push(
     resources.length === 0
       ? notEvaluated(
           HTML_MIME_PROFILE,
           stamp,
-          "no widget resources were read, so their mime types are unknown",
+          "no widget resources were read, so their mime types are unknown"
         )
       : wrongMime.length === 0 && unknownMime.length === 0
         ? satisfied(HTML_MIME_PROFILE, stamp, { resources: resources.length })
@@ -463,10 +484,13 @@ export function runClaudeAppsChecks(
             stamp,
             `Serve widget resources as \`${CLAUDE_APP_HTML_MIME}\`. Plain \`text/html\` does not tell the host the payload is an app.`,
             {
-              wrong: wrongMime.map((r) => ({ uri: r.uri, mimeType: r.mimeType })),
+              wrong: wrongMime.map((r) => ({
+                uri: r.uri,
+                mimeType: r.mimeType,
+              })),
               missing: unknownMime.map((r) => r.uri),
-            },
-          ),
+            }
+          )
   );
 
   // ── OpenAI-only widgets ──────────────────────────────────────────────
@@ -474,7 +498,8 @@ export function runClaudeAppsChecks(
   // textual fallback still works in Claude — degraded, not broken — and
   // failing it would tell a submitter their working connector is unusable.
   const openAiTools = tools.filter(
-    (tool) => tool.hasOpenAiWidget && !tool.hasNestedField && !tool.hasLegacyField,
+    (tool) =>
+      tool.hasOpenAiWidget && !tool.hasNestedField && !tool.hasLegacyField
   );
   const blocking = openAiTools.filter((tool) => isAppOnly(tool));
   const degraded = openAiTools.filter((tool) => !isAppOnly(tool));
@@ -489,7 +514,7 @@ export function runClaudeAppsChecks(
             {
               blocking: blocking.map((tool) => tool.name),
               degraded: degraded.map((tool) => tool.name),
-            },
+            }
           )
         : satisfied(OPENAI_ONLY_WIDGET, stamp, {
             // Named rather than silent: the connector works, and the reviewer
@@ -498,21 +523,23 @@ export function runClaudeAppsChecks(
               name: tool.name,
               hasTextualFallback: tool.hasTextualFallback ?? false,
             })),
-          }),
+          })
   );
 
   // ── ui.domain ────────────────────────────────────────────────────────
   const expectedDomain = claudeAppContentDomain(evidence.enteredUrl);
-  const withDomain = resources.filter((resource) => resource.domain !== undefined);
+  const withDomain = resources.filter(
+    (resource) => resource.domain !== undefined
+  );
   const mismatched = withDomain.filter(
-    (resource) => resource.domain !== expectedDomain,
+    (resource) => resource.domain !== expectedDomain
   );
   findings.push(
     withDomain.length === 0
       ? notApplicable(
           UI_DOMAIN_DERIVATION,
           stamp,
-          "`ui.domain` is optional and no resource set one",
+          "`ui.domain` is optional and no resource set one"
         )
       : mismatched.length === 0
         ? satisfied(UI_DOMAIN_DERIVATION, stamp, { domain: expectedDomain })
@@ -524,8 +551,8 @@ export function runClaudeAppsChecks(
               expected: expectedDomain,
               found: mismatched.map((r) => ({ uri: r.uri, domain: r.domain })),
               hashedInput: evidence.enteredUrl,
-            },
-          ),
+            }
+          )
   );
 
   findings.push(
@@ -533,16 +560,16 @@ export function runClaudeAppsChecks(
       ? notApplicable(
           UI_DOMAIN_ADVISED,
           stamp,
-          "the widget already declares a content domain",
+          "the widget already declares a content domain"
         )
       : evidence.appOwnedOAuth
         ? violated(
             UI_DOMAIN_ADVISED,
             stamp,
             "This widget owns its own OAuth but declares no `ui.domain`, so its origin changes with the connector URL and stored credentials will not survive.",
-            { suggested: expectedDomain },
+            { suggested: expectedDomain }
           )
-        : satisfied(UI_DOMAIN_ADVISED, stamp),
+        : satisfied(UI_DOMAIN_ADVISED, stamp)
   );
 
   // ── CSP ──────────────────────────────────────────────────────────────
@@ -552,21 +579,25 @@ export function runClaudeAppsChecks(
       // wildcard hidden in that form is the same wildcard.
       const entries = Array.isArray(value) ? value : [value];
       return entries.some(
-        (entry) => typeof entry === "string" && entry.includes("*"),
+        (entry) => typeof entry === "string" && entry.includes("*")
       );
-    }),
+    })
   );
   findings.push(
     resources.every((resource) => resource.csp === undefined)
-      ? notApplicable(CSP_SHAPE, stamp, "no widget declares a content security policy")
+      ? notApplicable(
+          CSP_SHAPE,
+          stamp,
+          "no widget declares a content security policy"
+        )
       : wildcardCsp.length === 0
         ? satisfied(CSP_SHAPE, stamp)
         : violated(
             CSP_SHAPE,
             stamp,
             "A wildcard in `_meta.ui.csp` grants the widget more reach than it needs; name the hosts it actually calls.",
-            { resources: wildcardCsp.map((r) => r.uri) },
-          ),
+            { resources: wildcardCsp.map((r) => r.uri) }
+          )
   );
 
   // ── Call-specific and browser-only observations ──────────────────────
@@ -574,26 +605,26 @@ export function runClaudeAppsChecks(
     notEvaluated(
       RESULT_SIZE,
       stamp,
-      "the result-size budget is per CALL, so it depends on the arguments a caller passes and has no static verdict; it is observed by a functional run",
-    ),
+      "the result-size budget is per CALL, so it depends on the arguments a caller passes and has no static verdict; it is observed by a functional run"
+    )
   );
 
   const singleInstance = resources.filter(
-    (resource) => resource.claimsSingleActiveInstance,
+    (resource) => resource.claimsSingleActiveInstance
   );
   findings.push(
     singleInstance.length === 0
       ? notApplicable(
           INSTANCE_SUPERSESSION,
           stamp,
-          "no widget claims a single active instance, so there is no supersession contract to test",
+          "no widget claims a single active instance, so there is no supersession contract to test"
         )
       : notEvaluated(
           INSTANCE_SUPERSESSION,
           stamp,
           "verifying supersession requires rendering two instances in a browser harness",
-          { resources: singleInstance.map((r) => r.uri) },
-        ),
+          { resources: singleInstance.map((r) => r.uri) }
+        )
   );
 
   // ── Design guideline lints ───────────────────────────────────────────
@@ -605,11 +636,11 @@ export function runClaudeAppsChecks(
 function runDesignLints(
   evidence: ClaudeAppsEvidence,
   resources: ClaudeAppResourceEvidence[],
-  stamp: ClaudeCheckStamp,
+  stamp: ClaudeCheckStamp
 ): ClaudeReadinessFinding[] {
   const withHtml = resources.filter(
     (resource): resource is ClaudeAppResourceEvidence & { html: string } =>
-      typeof resource.html === "string" && resource.html.length > 0,
+      typeof resource.html === "string" && resource.html.length > 0
   );
 
   if (withHtml.length === 0) {
@@ -617,8 +648,8 @@ function runDesignLints(
       notEvaluated(
         lint.definition,
         stamp,
-        "no widget HTML was captured, so the static design lints could not run",
-      ),
+        "no widget HTML was captured, so the static design lints could not run"
+      )
     );
   }
 
@@ -718,7 +749,9 @@ export function claudeAppToolEvidenceFrom(tool: {
   _meta?: unknown;
 }): ClaudeAppToolEvidence | undefined {
   const meta =
-    typeof tool._meta === "object" && tool._meta !== null && !Array.isArray(tool._meta)
+    typeof tool._meta === "object" &&
+    tool._meta !== null &&
+    !Array.isArray(tool._meta)
       ? (tool._meta as Record<string, unknown>)
       : undefined;
   const ui =
@@ -726,7 +759,8 @@ export function claudeAppToolEvidenceFrom(tool: {
       ? (meta.ui as Record<string, unknown>)
       : undefined;
 
-  const nested = typeof ui?.resourceUri === "string" ? ui.resourceUri : undefined;
+  const nested =
+    typeof ui?.resourceUri === "string" ? ui.resourceUri : undefined;
   const legacy =
     typeof meta?.["ui/resourceUri"] === "string"
       ? (meta["ui/resourceUri"] as string)

--- a/sdk/src/claude-readiness/html-scan.ts
+++ b/sdk/src/claude-readiness/html-scan.ts
@@ -35,6 +35,17 @@ export interface ScannedHtml {
   styleText: string;
   /** Concatenated contents of every `<script>` element. */
   scriptText: string;
+  /**
+   * Whether the document opens with a doctype.
+   *
+   * Load-bearing for how the widget RENDERS, not just for tidiness: Claude
+   * mounts a view by writing its HTML into a blank document, and a written
+   * document with no doctype is parsed in quirks mode — where the box model
+   * and percentage heights differ from every other context the author tested
+   * in. A srcdoc-mounted view never had this problem, so the same markup can
+   * look correct locally and wrong in Claude.
+   */
+  hasDoctype: boolean;
 }
 
 const RAW_TEXT_ELEMENTS = new Set(["script", "style"]);
@@ -56,7 +67,13 @@ function isNameChar(char: string): boolean {
 }
 
 function isSpace(char: string): boolean {
-  return char === " " || char === "\t" || char === "\n" || char === "\r" || char === "\f";
+  return (
+    char === " " ||
+    char === "\t" ||
+    char === "\n" ||
+    char === "\r" ||
+    char === "\f"
+  );
 }
 
 /**
@@ -72,6 +89,7 @@ export function scanHtml(html: string): ScannedHtml {
   const attributes = new Set<string>();
   const styleParts: string[] = [];
   const scriptParts: string[] = [];
+  let hasDoctype = false;
 
   let index = 0;
   while (index < html.length) {
@@ -84,6 +102,10 @@ export function scanHtml(html: string): ScannedHtml {
       continue;
     }
     if (isDoctypeAt(html, lt)) {
+      // Only a doctype that precedes every element counts. One written after
+      // the document has started is ignored by the parser, so recording it
+      // would report quirks-mode safety the browser will not deliver.
+      if (tags.size === 0) hasDoctype = true;
       const end = html.indexOf(">", lt + 2);
       index = end === -1 ? html.length : end + 1;
       continue;
@@ -118,10 +140,16 @@ export function scanHtml(html: string): ScannedHtml {
         cursor += 1;
         break;
       } else if (!closing) {
-        if (attributeStart === -1 && isNameChar(char) && isSpace(html[cursor - 1])) {
+        if (
+          attributeStart === -1 &&
+          isNameChar(char) &&
+          isSpace(html[cursor - 1])
+        ) {
           attributeStart = cursor;
         } else if (attributeStart !== -1 && !isNameChar(char)) {
-          const attributeName = html.slice(attributeStart, cursor).toLowerCase();
+          const attributeName = html
+            .slice(attributeStart, cursor)
+            .toLowerCase();
           attributes.add(attributeName);
           if (attributeName === "style") {
             const value = readAttributeValue(html, cursor);
@@ -171,6 +199,7 @@ export function scanHtml(html: string): ScannedHtml {
     attributes,
     styleText: styleParts.join("\n"),
     scriptText: scriptParts.join("\n"),
+    hasDoctype,
   };
 }
 

--- a/sdk/tests/claude-readiness/apps-checks.test.ts
+++ b/sdk/tests/claude-readiness/apps-checks.test.ts
@@ -32,7 +32,7 @@ const URL_UNDER_TEST = "https://mcp.example.com/mcp";
 function run(evidence: Partial<ClaudeAppsEvidence>) {
   return runClaudeAppsChecks(
     { enteredUrl: URL_UNDER_TEST, appsSuiteRan: true, ...evidence },
-    STAMP,
+    STAMP
   );
 }
 
@@ -58,7 +58,7 @@ describe("no apps evidence versus no apps", () => {
     // "We have no result" is not "this server has no widgets".
     const findings = runClaudeAppsChecks(
       { enteredUrl: URL_UNDER_TEST, appsSuiteRan: false },
-      STAMP,
+      STAMP
     );
     expect(findings.every((f) => f.status === "not-evaluated")).toBe(true);
   });
@@ -81,8 +81,8 @@ describe("no apps evidence versus no apps", () => {
           tools: [MODERN_TOOL],
           resources: [GOOD_RESOURCE],
         },
-        STAMP,
-      ).map((finding) => finding.id),
+        STAMP
+      ).map((finding) => finding.id)
     );
 
     for (const evidence of [
@@ -90,7 +90,7 @@ describe("no apps evidence versus no apps", () => {
       { enteredUrl: URL_UNDER_TEST, appsSuiteRan: true, tools: [] },
     ]) {
       const reported = new Set(
-        runClaudeAppsChecks(evidence, STAMP).map((finding) => finding.id),
+        runClaudeAppsChecks(evidence, STAMP).map((finding) => finding.id)
       );
       expect(reported).toEqual(everyId);
     }
@@ -100,8 +100,10 @@ describe("no apps evidence versus no apps", () => {
 describe("resourceUri modernity", () => {
   it("passes a tool that declares only the modern field", () => {
     expect(
-      byId(run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE] }), "claude.apps.resource-uri-modern")
-        .status,
+      byId(
+        run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE] }),
+        "claude.apps.resource-uri-modern"
+      ).status
     ).toBe("satisfied");
   });
 
@@ -112,18 +114,20 @@ describe("resourceUri modernity", () => {
           tools: [{ ...MODERN_TOOL, hasLegacyField: true }],
           resources: [GOOD_RESOURCE],
         }),
-        "claude.apps.resource-uri-modern",
-      ).status,
+        "claude.apps.resource-uri-modern"
+      ).status
     ).toBe("satisfied");
   });
 
   it("fails only a tool that declares the legacy field alone", () => {
     const finding = byId(
       run({
-        tools: [{ ...MODERN_TOOL, hasNestedField: false, hasLegacyField: true }],
+        tools: [
+          { ...MODERN_TOOL, hasNestedField: false, hasLegacyField: true },
+        ],
         resources: [GOOD_RESOURCE],
       }),
-      "claude.apps.resource-uri-modern",
+      "claude.apps.resource-uri-modern"
     );
     expect(finding.status).toBe("violated");
     expect(finding.details).toMatchObject({ tools: ["show_order"] });
@@ -131,8 +135,10 @@ describe("resourceUri modernity", () => {
 
   it("cites the apps-suite check it composes rather than re-running it", () => {
     expect(
-      byId(run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE] }), "claude.apps.resource-uri-modern")
-        .derivedFrom,
+      byId(
+        run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE] }),
+        "claude.apps.resource-uri-modern"
+      ).derivedFrom
     ).toContain("apps-conformance:ui-tool-metadata-valid");
   });
 });
@@ -144,7 +150,7 @@ describe("the html mime profile", () => {
         tools: [MODERN_TOOL],
         resources: [{ uri: "ui://order", mimeType: "text/html" }],
       }),
-      "claude.apps.html-mime-profile",
+      "claude.apps.html-mime-profile"
     );
     // A failure, not a warning: without the profile the host does not know the
     // payload is an app.
@@ -166,8 +172,8 @@ describe("the html mime profile", () => {
             },
           ],
         }),
-        "claude.apps.html-mime-profile",
-      ).status,
+        "claude.apps.html-mime-profile"
+      ).status
     ).toBe("satisfied");
   });
 
@@ -180,8 +186,8 @@ describe("the html mime profile", () => {
             { uri: "ui://order", mimeType: 'text/html;profile="mcp-app"' },
           ],
         }),
-        "claude.apps.html-mime-profile",
-      ).status,
+        "claude.apps.html-mime-profile"
+      ).status
     ).toBe("satisfied");
   });
 
@@ -190,10 +196,12 @@ describe("the html mime profile", () => {
       byId(
         run({
           tools: [MODERN_TOOL],
-          resources: [{ uri: "ui://order", mimeType: "text/html; charset=utf-8" }],
+          resources: [
+            { uri: "ui://order", mimeType: "text/html; charset=utf-8" },
+          ],
         }),
-        "claude.apps.html-mime-profile",
-      ).status,
+        "claude.apps.html-mime-profile"
+      ).status
     ).toBe("violated");
   });
 
@@ -202,10 +210,12 @@ describe("the html mime profile", () => {
       byId(
         run({
           tools: [MODERN_TOOL],
-          resources: [{ uri: "ui://order", mimeType: "Text/HTML; profile=mcp-app" }],
+          resources: [
+            { uri: "ui://order", mimeType: "Text/HTML; profile=mcp-app" },
+          ],
         }),
-        "claude.apps.html-mime-profile",
-      ).status,
+        "claude.apps.html-mime-profile"
+      ).status
     ).toBe("satisfied");
   });
 });
@@ -225,7 +235,7 @@ describe("OpenAI-only widgets", () => {
         tools: [{ ...openAiTool, toolMeta: { ui: { visibility: ["app"] } } }],
         resources: [],
       }),
-      "claude.apps.openai-only-widget",
+      "claude.apps.openai-only-widget"
     );
     expect(finding.status).toBe("violated");
     expect(finding.class).toBe("runtime-blocker");
@@ -237,7 +247,7 @@ describe("OpenAI-only widgets", () => {
         tools: [{ ...openAiTool, hasTextualFallback: true }],
         resources: [],
       }),
-      "claude.apps.openai-only-widget",
+      "claude.apps.openai-only-widget"
     );
     expect(finding.status).toBe("satisfied");
     // …and still names it, so a reviewer knows the UI is lost in Claude.
@@ -253,13 +263,13 @@ describe("ui.domain", () => {
     // check that canonicalized first would pass a value that fails in
     // production.
     expect(claudeAppContentDomain(URL_UNDER_TEST)).not.toBe(
-      claudeAppContentDomain(`${URL_UNDER_TEST}/`),
+      claudeAppContentDomain(`${URL_UNDER_TEST}/`)
     );
   });
 
   it("produces a 32-hex label under the Claude content host", () => {
     expect(claudeAppContentDomain(URL_UNDER_TEST)).toMatch(
-      /^[0-9a-f]{32}\.claudemcpcontent\.com$/,
+      /^[0-9a-f]{32}\.claudemcpcontent\.com$/
     );
   });
 
@@ -279,8 +289,8 @@ describe("ui.domain", () => {
     expect(
       byId(
         run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE] }),
-        "claude.apps.ui-domain-derivation",
-      ).status,
+        "claude.apps.ui-domain-derivation"
+      ).status
     ).toBe("not-applicable");
   });
 
@@ -290,11 +300,14 @@ describe("ui.domain", () => {
         run({
           tools: [MODERN_TOOL],
           resources: [
-            { ...GOOD_RESOURCE, domain: claudeAppContentDomain(URL_UNDER_TEST) },
+            {
+              ...GOOD_RESOURCE,
+              domain: claudeAppContentDomain(URL_UNDER_TEST),
+            },
           ],
         }),
-        "claude.apps.ui-domain-derivation",
-      ).status,
+        "claude.apps.ui-domain-derivation"
+      ).status
     ).toBe("satisfied");
   });
 
@@ -303,10 +316,13 @@ describe("ui.domain", () => {
       run({
         tools: [MODERN_TOOL],
         resources: [
-          { ...GOOD_RESOURCE, domain: claudeAppContentDomain(`${URL_UNDER_TEST}/`) },
+          {
+            ...GOOD_RESOURCE,
+            domain: claudeAppContentDomain(`${URL_UNDER_TEST}/`),
+          },
         ],
       }),
-      "claude.apps.ui-domain-derivation",
+      "claude.apps.ui-domain-derivation"
     );
     expect(finding.status).toBe("violated");
     expect(finding.remediation).toMatch(/trailing slash/);
@@ -317,12 +333,16 @@ describe("ui.domain", () => {
     expect(
       byId(
         run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE] }),
-        "claude.apps.ui-domain-recommended-for-app-oauth",
-      ).status,
+        "claude.apps.ui-domain-recommended-for-app-oauth"
+      ).status
     ).toBe("satisfied");
     const advised = byId(
-      run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE], appOwnedOAuth: true }),
-      "claude.apps.ui-domain-recommended-for-app-oauth",
+      run({
+        tools: [MODERN_TOOL],
+        resources: [GOOD_RESOURCE],
+        appOwnedOAuth: true,
+      }),
+      "claude.apps.ui-domain-recommended-for-app-oauth"
     );
     expect(advised.status).toBe("violated");
     // An advisory, so it can never fail the lane.
@@ -334,7 +354,7 @@ describe("the result-size budget is not a static check", () => {
   it("is reported as an unevaluated functional observation", () => {
     const finding = byId(
       run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE] }),
-      "claude.apps.result-size-budget",
+      "claude.apps.result-size-budget"
     );
     expect(finding.status).toBe("not-evaluated");
     expect(finding.notEvaluatedReason).toMatch(/per CALL/);
@@ -343,7 +363,9 @@ describe("the result-size budget is not a static check", () => {
 
 describe("design-guideline lints", () => {
   const bareHtml = "<html><body><button>Go</button></body></html>";
-  const carefulHtml = `<html><head><style>
+  // Declares a doctype: a careful widget is one Claude renders in standards
+  // mode, and Claude writes the view into a blank document.
+  const carefulHtml = `<!DOCTYPE html><html><head><style>
     @media (max-width: 320px) { body { padding: 0 } }
     button { min-height: 44px }
     body { padding: env(safe-area-inset-bottom) }
@@ -356,7 +378,9 @@ describe("design-guideline lints", () => {
       resources: [{ ...GOOD_RESOURCE, html: bareHtml }],
     }).filter((finding) => finding.id.startsWith("claude.apps.design."));
     expect(findings.length).toBeGreaterThan(0);
-    expect(findings.every((finding) => finding.class === "heuristic")).toBe(true);
+    expect(findings.every((finding) => finding.class === "heuristic")).toBe(
+      true
+    );
     expect(decideLaneStatus(findings)).toBe("incomplete");
   });
 
@@ -366,17 +390,59 @@ describe("design-guideline lints", () => {
       resources: [{ ...GOOD_RESOURCE, html: bareHtml }],
     }).filter(
       (finding) =>
-        finding.id.startsWith("claude.apps.design.") && finding.status === "violated",
+        finding.id.startsWith("claude.apps.design.") &&
+        finding.status === "violated"
     );
     expect(flagged.map((f) => f.id)).toEqual(
       expect.arrayContaining([
+        "claude.apps.design.doctype",
         "claude.apps.design.responsive-320",
         "claude.apps.design.touch-targets",
         "claude.apps.design.safe-area",
         "claude.apps.design.theming",
         "claude.apps.design.accessibility",
-      ]),
+      ])
     );
+  });
+
+  describe("doctype", () => {
+    // Claude mounts a view by writing its HTML into a blank document, and a
+    // written document with no doctype is parsed in quirks mode. A host that
+    // mounts via `srcdoc` is never in quirks mode, so the same markup can
+    // look right in one host and wrong in Claude — which is exactly the class
+    // of bug a static lint should catch before submission.
+    const doctypeStatus = (html: string) =>
+      run({
+        tools: [MODERN_TOOL],
+        resources: [{ ...GOOD_RESOURCE, html }],
+      }).find((f) => f.id === "claude.apps.design.doctype")!.status;
+
+    it("flags markup that declares none", () => {
+      expect(doctypeStatus(bareHtml)).toBe("violated");
+    });
+
+    it("accepts a declared doctype, in any case and with leading space", () => {
+      expect(doctypeStatus(`<!DOCTYPE html>${bareHtml}`)).toBe("satisfied");
+      expect(doctypeStatus(`<!doctype html>${bareHtml}`)).toBe("satisfied");
+      expect(doctypeStatus(`\n  <!DOCTYPE html>\n${bareHtml}`)).toBe(
+        "satisfied"
+      );
+    });
+
+    it("accepts a doctype behind a leading comment", () => {
+      expect(doctypeStatus(`<!-- build: 1 --><!DOCTYPE html>${bareHtml}`)).toBe(
+        "satisfied"
+      );
+    });
+
+    it("does not count a doctype the parser would ignore", () => {
+      // Written after the document has started, it has no effect on the
+      // rendering mode — reporting it as satisfied would promise quirks-mode
+      // safety the browser does not deliver.
+      expect(doctypeStatus("<html><body><!DOCTYPE html></body></html>")).toBe(
+        "violated"
+      );
+    });
   });
 
   it("counts inline style declarations, not only <style> blocks", () => {
@@ -391,7 +457,7 @@ describe("design-guideline lints", () => {
     }).filter(
       (finding) =>
         finding.id === "claude.apps.design.touch-targets" &&
-        finding.status === "violated",
+        finding.status === "violated"
     );
     expect(flagged).toEqual([]);
   });
@@ -407,24 +473,24 @@ describe("design-guideline lints", () => {
     // old regex accepted at ANY value, including ones far below the minimum.
     expect(
       touchTarget(
-        `<html><body><button style="min-height: ${CLAUDE_APP_DESIGN_BUDGETS.minTouchTargetPx}px" aria-label="Go">Go</button></body></html>`,
-      ),
+        `<html><body><button style="min-height: ${CLAUDE_APP_DESIGN_BUDGETS.minTouchTargetPx}px" aria-label="Go">Go</button></body></html>`
+      )
     ).toBe("satisfied");
     expect(
       touchTarget(
-        '<html><body><button style="min-block-size: 48px" aria-label="Go">Go</button></body></html>',
-      ),
+        '<html><body><button style="min-block-size: 48px" aria-label="Go">Go</button></body></html>'
+      )
     ).toBe("satisfied");
     expect(
       touchTarget(
-        '<html><body><button style="min-block-size: 8px" aria-label="Go">Go</button></body></html>',
-      ),
+        '<html><body><button style="min-block-size: 8px" aria-label="Go">Go</button></body></html>'
+      )
     ).toBe("violated");
     // A fractional value below the budget is still below it.
     expect(
       touchTarget(
-        '<html><body><button style="min-height: 43.5px" aria-label="Go">Go</button></body></html>',
-      ),
+        '<html><body><button style="min-height: 43.5px" aria-label="Go">Go</button></body></html>'
+      )
     ).toBe("violated");
   });
 
@@ -441,7 +507,7 @@ describe("design-guideline lints", () => {
       (finding) =>
         (finding.id === "claude.apps.design.accessibility" ||
           finding.id === "claude.apps.design.touch-targets") &&
-        finding.status === "violated",
+        finding.status === "violated"
     );
     expect(flagged).toEqual([]);
   });
@@ -452,7 +518,8 @@ describe("design-guideline lints", () => {
       resources: [{ ...GOOD_RESOURCE, html: carefulHtml }],
     }).filter(
       (finding) =>
-        finding.id.startsWith("claude.apps.design.") && finding.status === "violated",
+        finding.id.startsWith("claude.apps.design.") &&
+        finding.status === "violated"
     );
     expect(flagged).toEqual([]);
   });
@@ -486,8 +553,8 @@ describe("instance supersession", () => {
     expect(
       byId(
         run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE] }),
-        "claude.apps.instance-supersession",
-      ).status,
+        "claude.apps.instance-supersession"
+      ).status
     ).toBe("not-applicable");
     expect(
       byId(
@@ -495,8 +562,8 @@ describe("instance supersession", () => {
           tools: [MODERN_TOOL],
           resources: [{ ...GOOD_RESOURCE, claimsSingleActiveInstance: true }],
         }),
-        "claude.apps.instance-supersession",
-      ).status,
+        "claude.apps.instance-supersession"
+      ).status
     ).toBe("not-evaluated");
   });
 });
@@ -507,16 +574,19 @@ describe("composition helpers", () => {
       claudeAppToolEvidenceFrom({
         name: "a",
         _meta: { ui: { resourceUri: "ui://a" } },
-      }),
+      })
     ).toMatchObject({ hasNestedField: true, hasLegacyField: false });
     expect(
-      claudeAppToolEvidenceFrom({ name: "b", _meta: { "ui/resourceUri": "ui://b" } }),
+      claudeAppToolEvidenceFrom({
+        name: "b",
+        _meta: { "ui/resourceUri": "ui://b" },
+      })
     ).toMatchObject({ hasNestedField: false, hasLegacyField: true });
     expect(
       claudeAppToolEvidenceFrom({
         name: "c",
         _meta: { "openai/outputTemplate": "ui://c" },
-      }),
+      })
     ).toMatchObject({ hasOpenAiWidget: true, hasNestedField: false });
   });
 
@@ -530,14 +600,14 @@ describe("composition helpers", () => {
         uri: "ui://a",
         mimeType: "application/json",
         text: '{"not":"html"}',
-      }).html,
+      }).html
     ).toBeUndefined();
     expect(
       claudeAppResourceEvidenceFrom({
         uri: "ui://a",
         mimeType: "text/html;profile=mcp-app",
         text: "<html></html>",
-      }).html,
+      }).html
     ).toBe("<html></html>");
   });
 
@@ -546,8 +616,13 @@ describe("composition helpers", () => {
       claudeAppResourceEvidenceFrom({
         uri: "ui://a",
         mimeType: "text/html;profile=mcp-app",
-        _meta: { ui: { domain: "abc.claudemcpcontent.com", csp: { "connect-src": ["*"] } } },
-      }),
+        _meta: {
+          ui: {
+            domain: "abc.claudemcpcontent.com",
+            csp: { "connect-src": ["*"] },
+          },
+        },
+      })
     ).toMatchObject({
       domain: "abc.claudemcpcontent.com",
       csp: { "connect-src": ["*"] },
@@ -561,10 +636,12 @@ describe("CSP shape", () => {
       byId(
         run({
           tools: [MODERN_TOOL],
-          resources: [{ ...GOOD_RESOURCE, csp: { "connect-src": ["https://*"] } }],
+          resources: [
+            { ...GOOD_RESOURCE, csp: { "connect-src": ["https://*"] } },
+          ],
         }),
-        "claude.apps.csp-shape",
-      ).status,
+        "claude.apps.csp-shape"
+      ).status
     ).toBe("violated");
   });
 
@@ -574,11 +651,14 @@ describe("CSP shape", () => {
         run({
           tools: [MODERN_TOOL],
           resources: [
-            { ...GOOD_RESOURCE, csp: { "connect-src": "https://*.example.com" } },
+            {
+              ...GOOD_RESOURCE,
+              csp: { "connect-src": "https://*.example.com" },
+            },
           ],
         }),
-        "claude.apps.csp-shape",
-      ).status,
+        "claude.apps.csp-shape"
+      ).status
     ).toBe("violated");
   });
 
@@ -588,11 +668,14 @@ describe("CSP shape", () => {
         run({
           tools: [MODERN_TOOL],
           resources: [
-            { ...GOOD_RESOURCE, csp: { "connect-src": ["https://api.example.com"] } },
+            {
+              ...GOOD_RESOURCE,
+              csp: { "connect-src": ["https://api.example.com"] },
+            },
           ],
         }),
-        "claude.apps.csp-shape",
-      ).status,
+        "claude.apps.csp-shape"
+      ).status
     ).toBe("satisfied");
   });
 });

--- a/widget-react/src/__tests__/sandbox-proxy-url.test.ts
+++ b/widget-react/src/__tests__/sandbox-proxy-url.test.ts
@@ -93,3 +93,107 @@ describe("resolveSandboxProxyUrl — local dev", () => {
     expect(url.pathname).toBe("/api/apps/mcp-apps/sandbox-proxy");
   });
 });
+
+describe("resolveSandboxProxyUrl — per-server view origins", () => {
+  const LABEL = "0123456789abcdef";
+  const CHROME =
+    "Mozilla/5.0 (Macintosh) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36";
+  const SAFARI =
+    "Mozilla/5.0 (Macintosh) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+
+  function hosted(overrides: Record<string, unknown> = {}) {
+    return new URL(
+      resolveSandboxProxyUrl({
+        hostedMode: true,
+        sandboxOrigin: "https://sandbox.mcpjam.test",
+        location: locationOf(APP_ORIGIN),
+        viewOriginLabel: LABEL,
+        viewSubdomainsEnabled: true,
+        userAgent: CHROME,
+        ...overrides,
+      })
+    ).origin;
+  }
+
+  it("prefixes the sandbox host with the label", () => {
+    expect(hosted()).toBe(`https://${LABEL}.sandbox.mcpjam.test`);
+  });
+
+  it("stays on the shared origin when the deploy has not enabled it", () => {
+    // Off means off: without wildcard DNS and a certificate, a labelled host
+    // does not resolve and every widget would fail to load.
+    expect(hosted({ viewSubdomainsEnabled: false })).toBe(
+      "https://sandbox.mcpjam.test"
+    );
+  });
+
+  it("stays on the shared origin without a label", () => {
+    expect(hosted({ viewOriginLabel: undefined })).toBe(
+      "https://sandbox.mcpjam.test"
+    );
+  });
+
+  it("ignores a label this code did not derive", () => {
+    // The label reaches the browser through a server response. Anything but
+    // the exact derived shape could name a host we do not control.
+    for (const bogus of [
+      "evil.example.com",
+      "0123456789ABCDEF",
+      "0123456789abcde",
+      "0123456789abcdef0",
+      "../etc",
+      "",
+    ]) {
+      expect(hosted({ viewOriginLabel: bogus })).toBe(
+        "https://sandbox.mcpjam.test"
+      );
+    }
+  });
+
+  it("labels *.localhost in local dev, keeping the port", () => {
+    const url = new URL(
+      resolveSandboxProxyUrl({
+        hostedMode: false,
+        sandboxOrigin: "",
+        location: locationOf("http://localhost:5173"),
+        viewOriginLabel: LABEL,
+        viewSubdomainsEnabled: true,
+        userAgent: CHROME,
+      })
+    );
+    // The local swap lands on 127.0.0.1, which has no subdomains — so the
+    // label goes on `localhost`, which Chromium resolves to loopback.
+    expect(url.origin).toBe(`http://${LABEL}.localhost:5173`);
+  });
+
+  it("keeps the plain host on a browser that will not resolve *.localhost", () => {
+    // Safari does not. A view that simply fails to load is worse than one
+    // sharing an origin, so local dev degrades instead.
+    const url = new URL(
+      resolveSandboxProxyUrl({
+        hostedMode: false,
+        sandboxOrigin: "",
+        location: locationOf("http://localhost:5173"),
+        viewOriginLabel: LABEL,
+        viewSubdomainsEnabled: true,
+        userAgent: SAFARI,
+      })
+    );
+    expect(url.origin).toBe("http://127.0.0.1:5173");
+  });
+
+  it("still points at the proxy path", () => {
+    const url = new URL(
+      resolveSandboxProxyUrl({
+        hostedMode: true,
+        sandboxOrigin: "https://sandbox.mcpjam.test",
+        location: locationOf(APP_ORIGIN),
+        viewOriginLabel: LABEL,
+        viewSubdomainsEnabled: true,
+        userAgent: CHROME,
+      })
+    );
+    expect(url.pathname).toBe(PROXY_PATH);
+    expect(url.searchParams.get("v")).toBeTruthy();
+  });
+});

--- a/widget-react/src/mcp-apps-modal.tsx
+++ b/widget-react/src/mcp-apps-modal.tsx
@@ -474,6 +474,7 @@ export function McpAppsModal({
             hostedMode={host.surface.hostedMode}
             sandboxOrigin={host.surface.sandboxOrigin}
             mountMode={host.surface.viewMountMode}
+            viewSubdomainsEnabled={host.surface.viewSubdomainsEnabled}
             className="min-w-full border-0 rounded-md bg-transparent overflow-hidden"
             style={{
               height: "100%",

--- a/widget-react/src/mcp-apps-renderer.tsx
+++ b/widget-react/src/mcp-apps-renderer.tsx
@@ -1322,6 +1322,12 @@ export function MCPAppsRendererSurface({
   const [widgetPermissive, setWidgetPermissive] = useState<boolean>(
     isCachedReplay ? true : initialWidgetPermissive ?? false
   );
+  // Per-server label for a dedicated view origin, from the widget-content
+  // response. Changing it re-navigates the sandbox iframe, so it is state
+  // rather than a ref.
+  const [viewOriginLabel, setViewOriginLabel] = useState<string | undefined>(
+    undefined
+  );
   const [prefersBorder, setPrefersBorder] = useState<boolean>(
     initialPrefersBorder ?? true
   );
@@ -1770,6 +1776,7 @@ export function MCPAppsRendererSurface({
         mimeTypeValid: valid,
         prefersBorder,
         declaredDomain: serverDeclaredDomain,
+        viewOriginLabel: serverViewOriginLabel,
         injectedOpenAiCompat: serverInjectedOpenAiCompat,
         injectedOpenAiCompatCapabilities:
           serverInjectedOpenAiCompatCapabilities,
@@ -1878,6 +1885,8 @@ export function MCPAppsRendererSurface({
         resolvedInjectedOpenAiCompatCapabilities
       );
 
+
+      setViewOriginLabel(serverViewOriginLabel);
 
       // Update the widget debug store with CSP and permissions info. A
       // declared domain alone is enough to open the Workbench: the origin
@@ -4265,6 +4274,8 @@ export function MCPAppsRendererSurface({
       hostedMode={host.surface.hostedMode}
       sandboxOrigin={host.surface.sandboxOrigin}
       mountMode={host.surface.viewMountMode}
+      viewOriginLabel={viewOriginLabel}
+      viewSubdomainsEnabled={host.surface.viewSubdomainsEnabled}
       className={`bg-transparent overflow-hidden ${
         isFullscreen
           ? "flex-1 border-0 rounded-none"

--- a/widget-react/src/mcp-apps-renderer.tsx
+++ b/widget-react/src/mcp-apps-renderer.tsx
@@ -1885,7 +1885,6 @@ export function MCPAppsRendererSurface({
         resolvedInjectedOpenAiCompatCapabilities
       );
 
-
       setViewOriginLabel(serverViewOriginLabel);
 
       // Update the widget debug store with CSP and permissions info. A

--- a/widget-react/src/mcp-apps-renderer.tsx
+++ b/widget-react/src/mcp-apps-renderer.tsx
@@ -1769,6 +1769,7 @@ export function MCPAppsRendererSurface({
         mimeTypeWarning: warning,
         mimeTypeValid: valid,
         prefersBorder,
+        declaredDomain: serverDeclaredDomain,
         injectedOpenAiCompat: serverInjectedOpenAiCompat,
         injectedOpenAiCompatCapabilities:
           serverInjectedOpenAiCompatCapabilities,
@@ -1877,9 +1878,15 @@ export function MCPAppsRendererSurface({
         resolvedInjectedOpenAiCompatCapabilities
       );
 
-      // Update the widget debug store with CSP and permissions info
-      if (csp || permissions || !permissive) {
+
+      // Update the widget debug store with CSP and permissions info. A
+      // declared domain alone is enough to open the Workbench: the origin
+      // card is the only place a developer learns their declaration does not
+      // match what MCPJam serves, and a permissive widget would otherwise
+      // never render the panel at all.
+      if (csp || permissions || !permissive || serverDeclaredDomain) {
         setWidgetCspStore(toolCallIdRef.current, {
+          declaredDomain: serverDeclaredDomain ?? null,
           mode: permissive ? "permissive" : "widget-declared",
           connectDomains: csp?.connectDomains || [],
           resourceDomains: csp?.resourceDomains || [],

--- a/widget-react/src/sandboxed-iframe.tsx
+++ b/widget-react/src/sandboxed-iframe.tsx
@@ -380,8 +380,7 @@ export const SandboxedIframe = forwardRef<
         location: window.location,
         viewOriginLabel,
         viewSubdomainsEnabled,
-        userAgent:
-          typeof navigator === "undefined" ? "" : navigator.userAgent,
+        userAgent: typeof navigator === "undefined" ? "" : navigator.userAgent,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [hostedMode, sandboxOrigin, viewOriginLabel, viewSubdomainsEnabled]

--- a/widget-react/src/sandboxed-iframe.tsx
+++ b/widget-react/src/sandboxed-iframe.tsx
@@ -109,24 +109,80 @@ function parseSandboxOrigin(value: string): string | null {
  * Same-origin fallback exists only as a soft-fail for misconfigured hosted
  * deploys; it emits a loud security warning.
  */
+/** A DNS label MCPJam derives for a server's dedicated view origin. */
+const VIEW_ORIGIN_LABEL = /^[a-f0-9]{16}$/;
+
+/**
+ * Prefix `origin`'s host with a per-server label, or return null when this
+ * browser would not resolve the result.
+ *
+ * Locally the label goes on `localhost`, which Chromium and Firefox resolve to
+ * loopback for any subdomain. Safari does not, and a page that simply fails to
+ * load is a worse outcome than sharing an origin, so it keeps the plain host.
+ */
+function labelledOrigin(
+  origin: string,
+  label: string,
+  userAgent: string
+): string | null {
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    return null;
+  }
+  const isLoopback =
+    url.hostname === "localhost" || url.hostname === "127.0.0.1";
+  if (isLoopback) {
+    const chromiumOrFirefox =
+      /Chrome\/|Chromium\/|Firefox\//.test(userAgent) &&
+      !/^((?!Chrome|Chromium).)*Safari/.test(userAgent);
+    if (!chromiumOrFirefox) return null;
+    // 127.0.0.1 has no subdomains; *.localhost does.
+    url.hostname = `${label}.localhost`;
+  } else {
+    url.hostname = `${label}.${url.hostname}`;
+  }
+  return url.origin;
+}
+
 export function resolveSandboxProxyUrl({
   hostedMode,
   sandboxOrigin,
   location,
+  viewOriginLabel,
+  viewSubdomainsEnabled,
+  userAgent,
 }: {
   hostedMode: boolean;
   sandboxOrigin: string;
   location: SandboxProxyLocation;
+  /** Per-server label; views share the sandbox origin without one. */
+  viewOriginLabel?: string;
+  viewSubdomainsEnabled?: boolean;
+  userAgent?: string;
 }): string {
   const proxyPath = hostedMode
     ? "/api/web/apps/mcp-apps/sandbox-proxy"
     : "/api/apps/mcp-apps/sandbox-proxy";
 
+  // Only a label this code derived. Anything else — including a string a
+  // server supplied — could name a host we do not control.
+  const label =
+    viewSubdomainsEnabled &&
+    typeof viewOriginLabel === "string" &&
+    VIEW_ORIGIN_LABEL.test(viewOriginLabel)
+      ? viewOriginLabel
+      : null;
+
   const configuredOrigin = hostedMode
     ? parseSandboxOrigin(sandboxOrigin)
     : null;
   if (configuredOrigin && configuredOrigin !== location.origin) {
-    return `${configuredOrigin}${proxyPath}?v=${Date.now()}`;
+    const perApp = label
+      ? labelledOrigin(configuredOrigin, label, userAgent ?? "")
+      : null;
+    return `${perApp ?? configuredOrigin}${proxyPath}?v=${Date.now()}`;
   }
 
   const currentHost = location.hostname;
@@ -158,7 +214,11 @@ export function resolveSandboxProxyUrl({
   }
 
   const portSuffix = currentPort ? `:${currentPort}` : "";
-  return `${protocol}//${sandboxHost}${portSuffix}${proxyPath}?v=${Date.now()}`;
+  const baseOrigin = `${protocol}//${sandboxHost}${portSuffix}`;
+  const perApp = label
+    ? labelledOrigin(baseOrigin, label, userAgent ?? "")
+    : null;
+  return `${perApp ?? baseOrigin}${proxyPath}?v=${Date.now()}`;
 }
 
 export interface SandboxedIframeHandle {
@@ -250,6 +310,13 @@ interface SandboxedIframeProps {
    * behaviour at runtime.
    */
   mountMode?: "write" | "srcdoc";
+  /**
+   * Per-server label for a dedicated view origin, and whether this deploy
+   * serves one. Supplied by the host; without both the view renders on the
+   * shared sandbox origin.
+   */
+  viewOriginLabel?: string;
+  viewSubdomainsEnabled?: boolean;
 }
 
 /**
@@ -285,6 +352,8 @@ export const SandboxedIframe = forwardRef<
     hostedMode = false,
     sandboxOrigin = "",
     mountMode,
+    viewOriginLabel,
+    viewSubdomainsEnabled,
   },
   ref
 ) {
@@ -296,12 +365,26 @@ export const SandboxedIframe = forwardRef<
   onMessageRef.current = onMessage;
   onProxyReadyRef.current = onProxyReady;
 
-  const [sandboxProxyUrl] = useState(() =>
-    resolveSandboxProxyUrl({
-      hostedMode,
-      sandboxOrigin,
-      location: window.location,
-    })
+  // Recomputed only when an input that changes the ORIGIN changes. It cannot
+  // be a plain derivation: the URL carries a `?v=` cache-buster, so
+  // recomputing every render would hand the iframe a new `src` each time and
+  // reload the widget continuously. And it cannot be a one-shot initializer
+  // either: `viewOriginLabel` arrives with the widget-content response, after
+  // this component has already mounted, so a one-shot value would leave every
+  // view on the shared origin forever.
+  const sandboxProxyUrl = useMemo(
+    () =>
+      resolveSandboxProxyUrl({
+        hostedMode,
+        sandboxOrigin,
+        location: window.location,
+        viewOriginLabel,
+        viewSubdomainsEnabled,
+        userAgent:
+          typeof navigator === "undefined" ? "" : navigator.userAgent,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [hostedMode, sandboxOrigin, viewOriginLabel, viewSubdomainsEnabled]
   );
 
   const sandboxProxyOrigin = useMemo(() => {
@@ -568,11 +651,14 @@ export const SandboxedIframe = forwardRef<
   // to the new proxy).
   useEffect(() => {
     setProxyReady(false);
-  }, [outerSandboxAttribute]);
+  }, [outerSandboxAttribute, sandboxProxyOrigin]);
 
   return (
     <iframe
-      key={outerSandboxAttribute}
+      // Remount on a changed origin as well as changed sandbox flags: an
+      // <iframe> whose `src` changes navigates in place, and the proxy would
+      // keep the state of whichever origin it loaded first.
+      key={`${sandboxProxyOrigin}\u0000${outerSandboxAttribute}`}
       ref={outerRef}
       src={sandboxProxyUrl}
       sandbox={outerSandboxAttribute}

--- a/widget-react/src/widget-host.ts
+++ b/widget-react/src/widget-host.ts
@@ -217,6 +217,12 @@ export interface WidgetSurfaceInfo {
    */
   viewMountMode?: "write" | "srcdoc";
   /**
+   * VIEW_SUBDOMAINS_ENABLED (VITE_MCPJAM_VIEW_SUBDOMAINS) — serve each
+   * server's views from their own origin. Requires wildcard DNS and a
+   * certificate for the sandbox apex, so it is off unless a deploy has them.
+   */
+  viewSubdomainsEnabled?: boolean;
+  /**
    * Playground CSP-mode selection (useUIPlaygroundStore.mcpAppsCspMode) — an
    * INPUT, not the effective mode. The renderer derives the effective sandbox
    * CSP mode from `kind` + this + the per-widget `minimalMode` prop (kept as an
@@ -624,6 +630,13 @@ export interface FetchWidgetContentResponse {
    * so the Workbench can say whether the declaration matches.
    */
   declaredDomain?: string;
+  /**
+   * Subdomain label for this server's dedicated view origin
+   * (`<label>.sandbox.mcpjam.com`), derived from the server's identity. Absent
+   * when the server identifies nothing to derive from; the view then renders
+   * on the default sandbox origin.
+   */
+  viewOriginLabel?: string;
   injectedOpenAiCompat?: boolean;
   injectedOpenAiCompatCapabilities?: ResolvedOpenAiAppsCapabilities;
 }

--- a/widget-react/src/widget-host.ts
+++ b/widget-react/src/widget-host.ts
@@ -324,6 +324,13 @@ export interface WidgetSandboxInfo {
     frameDomains?: string[];
     baseUriDomains?: string[];
   } | null;
+  /**
+   * `_meta.ui.domain` as declared by the server, or null when it declared
+   * none. Compared against the origin MCPJam actually serves the view from;
+   * a mismatch is informational, since each host's domain format differs and
+   * a server can only declare one string.
+   */
+  declaredDomain?: string | null;
 }
 
 export interface WidgetGlobals {
@@ -611,6 +618,12 @@ export interface FetchWidgetContentResponse {
   mimeTypeWarning?: string;
   mimeTypeValid?: boolean;
   prefersBorder?: boolean;
+  /**
+   * `_meta.ui.domain` — the dedicated origin the server ASKED for. Advisory:
+   * MCPJam derives the origin it serves the view from, and reports this only
+   * so the Workbench can say whether the declaration matches.
+   */
+  declaredDomain?: string;
   injectedOpenAiCompat?: boolean;
   injectedOpenAiCompatCapabilities?: ResolvedOpenAiAppsCapabilities;
 }


### PR DESCRIPTION
## Why

Finishes the view-origins plan after #4661 (real-URL views) and #4665 (the origin chip). Six commits, each a self-contained step — reviewable commit by commit.

One PR rather than a stack: stacked PRs here get vacuous CI (a base other than `main` never schedules the test workflows), and steps 1B and 3A touch the same partition and route files.

**Not included: 3B.** Turning per-server origins *on* needs wildcard DNS, a wildcard certificate, and an access-proxy bypass — dashboard work I can't do. 3A ships inert behind a flag; `HOSTED_DEPLOYMENT.md` documents exactly what the deploy needs first.

## The commits

**`25e77e3` — pin the host origin, serve the proxy from one place.** The proxy loads untrusted HTML on request and relays that widget's messages back out, but accepted a `sandbox-resource-ready` from any parent that could frame it, and answered `postMessage(..., "*")`. It now rejects origins off a templated allowlist, locks the first accepted one, and relays to that address. `'self'` stays in `frame-ancestors` (the same-origin fallback deploy is documented) but is deliberately not a *sender*: it would admit `location.origin`, and once views get per-app subdomains the widget is same-origin with its proxy and could pose as the host. An unreplaced placeholder means "no list" and keeps the old permissive behaviour, so **the route test asserting the placeholder is replaced is load-bearing** — it says so in a comment. Also replaces two duplicated `SANDBOX_PROXY_HTML_WITH_RECORDER` constants and the local route's hardcoded directive with one helper, and rewrites `sandbox-proxy.test.ts`, which re-declared a look-alike route inline and therefore asserted the shape of its own fixture.

**`5578d3d` — resolve `_meta.ui.domain`.** Joins the existing per-field precedence chain (content over listing, no legacy equivalent). Deliberately *not* added to `canSkipListingLookup`: an advisory field should not make every render of a resource that declares the other three pay a `resources/list` round-trip. The narrow cost is commented and pinned. First test file for that module. The platform-widget route drops a hand-rolled cast for the shared resolver.

**`b13a190` — surface it.** A card in Findings saying whether the declaration matches the origin we serve, and what it costs when it doesn't. **Not a `Diagnosis`**: that type means "the browser refused a request", and the blocked-request meter, Policy Diff's observed column and the copy-a-CSP-patch button would all misdescribe a declaration mismatch. It renders *above* the empty-state early return, because a widget can declare a mismatched domain and trip no violation at all — the developer who most needs this sees no findings.

**`16df2e3` — doctype readiness lint.** Claude writes the view into a blank document, so doctype-less HTML renders in quirks mode; a `srcdoc` host never does, so it reproduces nowhere the author looks. The lint immediately flagged the suite's own "careful widget" fixture, which is the lint working.

**`1667b62` — per-server origins, flag-gated.** `sha256(canonical key)[:16]`. Query and fragment are stripped from a URL — a deliberate divergence from Claude's hash-as-entered, because a hosted server URL can carry a resolved token, and keying an origin on a secret rotates the origin whenever the secret does, silently invalidating a developer's allowlist. `resolveSandboxProxyUrl` accepts only a label matching the derived shape (it arrives through a server response) and **stopped being a one-shot initializer** — the label arrives *after* mount, so a one-shot value would have left every view on the shared origin forever; the iframe is keyed on the resolved origin so a change re-navigates. Local dev labels `*.localhost` on Chromium/Firefox only; Safari won't resolve it, and a view that fails to load is worse than one sharing an origin. The partition admits `<label>.<sandbox host>` for the proxy path and **not** `/health`.

**`dcccec1` — docs.** A `View origins` page, plus the operator half in `HOSTED_DEPLOYMENT.md`.

## Two things to know

**I broke a test in #4665 and didn't catch it.** `use-widget-host.test.tsx` mocks `@/lib/config`, and vitest throws on an export the mock doesn't declare — `VIEW_MOUNT_MODE` was added without it, so that suite has been red on `main` since #4665 merged. Fixed here in `1667b62`, with a comment on the mock. Cause: I ran the suites I expected to be affected rather than the full client suite. I ran the full suites this time.

**Pre-existing failures I did not touch**, all outside this diff: `server/utils/harness/local/runtime-install` (macOS BSD `tar` lacks GNU `--sort`), `scenario-chat-transcript` (storage-quota stub), `permalink-routes` ("no app route for `eval_iteration`" — likely the worktree resolving `@mcpjam/sdk` to the main checkout's build). CI will say definitively.

## Verification

Full suites: server 10214 passed (1 env failure above), client 12003 passed (3 above), sdk 7034 passed, widget-react 25 passed. `typecheck:client` and `build:server` clean. Prettier: only my own lines are formatted — verified by intersecting prettier's hunks with the diff's line ranges, since these files carry a lot of pre-existing v3 drift.

Not re-run here: the browser e2e in #4667, which is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox `postMessage` trust boundaries and optional per-host DNS routing; misconfiguration could break widget loading, though defaults stay backward-compatible and subdomains are opt-in.
> 
> **Overview**
> **MCP App views** get clearer origin guidance and tighter sandbox messaging: the proxy now **pins the host origin** (templated allowlist, first accepted origin locked, `postMessage` targets that origin instead of `"*"`), with **`frame-ancestors` and the allowlist kept in sync** via a shared `sandbox-proxy-html` helper.
> 
> **Widget metadata and debugging:** `_meta.ui.domain` is resolved like other SEP-1865 UI fields and returned as `declaredDomain` (plus a derived `viewOriginLabel`). The CSP Workbench **Findings** tab adds an **Declared view domain** card that compares the declaration to the origin MCPJam actually serves—even when there are no CSP violations.
> 
> **Optional per-server origins** (`VITE_MCPJAM_VIEW_SUBDOMAINS`): stable `<label>.sandbox…` hosts for isolation and allowlists, with partition routing for labelled sandbox hosts (proxy only, no `/health`), client URL resolution that waits for the label after fetch, and Safari-friendly local degradation.
> 
> **Docs and readiness:** new **View origins** inspector page, hosted deploy notes, guide tweaks for localhost vs `127.0.0.1`, and a Claude readiness **doctype** lint for document-write quirks mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 598092ed68998235e22d338afba699539bd37396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures the sandbox proxy and gives each MCP app a stable, per-server origin so third-party allowlists (OAuth redirect URIs, API-key restrictions) can name where a view runs. The proxy previously accepted `sandbox-resource-ready` from any parent and relayed to `*`; it now rejects origins off a templated allowlist, locks the first accepted one, and relays only to it. An unreplaced placeholder keeps the old accept-anything behavior, so the route test asserting the placeholder is replaced is load-bearing.

The server now resolves `_meta.ui.domain` (content-over-listing precedence) and the Workbench's Findings tab shows whether the declaration matches the origin actually served. It's informational rather than a `Diagnosis` and renders above the empty-state, so a widget with no CSP violations still surfaces a mismatched domain. A new Claude-readiness lint flags HTML without a doctype, which renders in quirks mode when Claude writes the view into a blank document.

Per-server view origins derive `sha256(canonical server key)[:16]` and serve from `<label>.<sandbox host>`, off by default behind `VITE_MCPJAM_VIEW_SUBDOMAINS`. Query and fragment are stripped from the hashed URL so a resolved token doesn't rotate the origin. The label arrives after mount, so the sandbox iframe is keyed on the resolved origin and re-navigates when it changes. Local dev labels `*.localhost` on Chromium and Firefox only — Safari doesn't resolve it, and a failing view is worse than a shared origin. The partition admits only the proxy path on labelled hosts, not `/health`.

Also fixes a red suite on `main`: the `@/lib/config` mock in `use-widget-host.test.tsx` threw on the undeclared `VIEW_MOUNT_MODE` export.

**Migration**
- `VITE_MCPJAM_VIEW_SUBDOMAINS=true` requires wildcard DNS for `*.sandbox.example.com`, a certificate covering that wildcard (a one-level apex wildcard does not), and an access-proxy bypass for the labelled hosts. The feature ships inert until a deploy provides these.

<sup>Written for commit 598092ed68998235e22d338afba699539bd37396. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

