### PR TITLE
Fix false unavailable project routes

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -206,6 +206,7 @@ import {
 import {
   captureAppSignInReturnPath,
   consumeAppSignInReturnPath,
+  readAppSignInReturnPath,
 } from "./lib/app-signin-return-path";
 import {
   trackSignInReturnRestored,
@@ -2513,8 +2514,15 @@ export default function App() {
   const [oauthServerModalNonce, setOauthServerModalNonce] = useState(0);
   const [callbackCompleted, setCallbackCompleted] = useState(false);
   const [callbackRecoveryExpired, setCallbackRecoveryExpired] = useState(false);
-  const pendingProjectReturnRecoveryRef =
-    useRef<ProjectSignInReturnRecoveryIntent | null>(null);
+  const [pendingProjectReturnRecovery, setPendingProjectReturnRecovery] =
+    useState<ProjectSignInReturnRecoveryIntent | null>(() => {
+      if (window.location.pathname === routePaths.callback) return null;
+      const restoredPath = readAppSignInReturnPath();
+      const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      return restoredPath === currentPath
+        ? createProjectSignInReturnRecoveryIntent(restoredPath)
+        : null;
+    });
   const billingDeepLinkNavRef = useRef(false);
   /** True after we read valid plan/interval from the URL and stripped query params; avoids clearing session on the next /billing tick. */
   const billingCheckoutQueryConsumedRef = useRef(false);
@@ -2529,6 +2537,25 @@ export default function App() {
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
   const compatibilityEnabled = useFeatureFlagEnabled("mcpjam-compatibility");
   const xaaEnabled = useFeatureFlagEnabled("xaa");
+
+  // AuthKit can restore a permalink from `main.tsx` before the callback route
+  // ever renders. Consume the generic return path on that restored page so it
+  // can still arm stale-project recovery. Layout timing prevents the generic
+  // unavailable boundary from painting first.
+  useLayoutEffect(() => {
+    if (window.location.pathname === routePaths.callback) return;
+    const restoredPath = consumeAppSignInReturnPath();
+    if (!restoredPath) return;
+    const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    if (restoredPath !== currentPath) {
+      trackSignInReturnRestored("superseded");
+      return;
+    }
+    trackSignInReturnRestored("restored");
+    setPendingProjectReturnRecovery(
+      createProjectSignInReturnRecoveryIntent(restoredPath),
+    );
+  }, []);
 
   // Per-tab "hide from this header" list for the OAuth / XAA debugger chip strip.
   // View-only (localStorage) — the x on a chip dismisses it from this header
@@ -2956,8 +2983,9 @@ export default function App() {
             ? "restored"
             : "superseded",
       );
-      pendingProjectReturnRecoveryRef.current =
-        createProjectSignInReturnRecoveryIntent(restoredPath);
+      setPendingProjectReturnRecovery(
+        createProjectSignInReturnRecoveryIntent(restoredPath),
+      );
       // `navigateApp`, not `history.replaceState`: a raw history write leaves
       // the ROUTER matched on `/callback` while the address bar says
       // `/p/<id>/evals/...`, so the project boundary never mounts and the URL
@@ -4508,7 +4536,6 @@ export default function App() {
         : undefined,
     [allMembershipProjects],
   );
-  const pendingProjectReturnRecovery = pendingProjectReturnRecoveryRef.current;
   const currentLocation = useCurrentLocationParts();
   const currentProjectPath = `${currentLocation.pathname}${currentLocation.search}${currentLocation.hash}`;
   const confirmedStaleReturnProjectId =
@@ -4566,12 +4593,7 @@ export default function App() {
   // fallback can show the normal error but can never loop.
   useLayoutEffect(() => {
     if (projectReturnRecoveryDecision.kind === "none") return;
-    if (
-      pendingProjectReturnRecoveryRef.current !== pendingProjectReturnRecovery
-    ) {
-      return;
-    }
-    pendingProjectReturnRecoveryRef.current = null;
+    setPendingProjectReturnRecovery(null);
 
     if (projectReturnRecoveryDecision.kind === "clear") return;
     if (projectReturnRecoveryDecision.kind === "home") {

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -199,10 +199,18 @@ import {
 } from "./lib/project-route";
 import { useProjectRouteCoordinator } from "./hooks/use-project-route-coordinator";
 import {
+  createProjectSignInReturnRecoveryIntent,
+  resolveProjectSignInReturnRecovery,
+  type ProjectSignInReturnRecoveryIntent,
+} from "./lib/project-route-recovery";
+import {
   captureAppSignInReturnPath,
   consumeAppSignInReturnPath,
 } from "./lib/app-signin-return-path";
-import { trackSignInReturnRestored } from "./lib/project-route-telemetry";
+import {
+  trackSignInReturnRestored,
+  trackStaleProjectReturnRecovered,
+} from "./lib/project-route-telemetry";
 import { isHostedTabBlocked } from "./lib/hosted-tab-policy";
 import { buildOAuthTokensByServerId } from "./lib/oauth/oauth-tokens";
 import type { OAuthTrace } from "./lib/oauth/oauth-trace";
@@ -2505,6 +2513,8 @@ export default function App() {
   const [oauthServerModalNonce, setOauthServerModalNonce] = useState(0);
   const [callbackCompleted, setCallbackCompleted] = useState(false);
   const [callbackRecoveryExpired, setCallbackRecoveryExpired] = useState(false);
+  const pendingProjectReturnRecoveryRef =
+    useRef<ProjectSignInReturnRecoveryIntent | null>(null);
   const billingDeepLinkNavRef = useRef(false);
   /** True after we read valid plan/interval from the URL and stripped query params; avoids clearing session on the next /billing tick. */
   const billingCheckoutQueryConsumedRef = useRef(false);
@@ -2946,6 +2956,8 @@ export default function App() {
             ? "restored"
             : "superseded",
       );
+      pendingProjectReturnRecoveryRef.current =
+        createProjectSignInReturnRecoveryIntent(restoredPath);
       // `navigateApp`, not `history.replaceState`: a raw history write leaves
       // the ROUTER matched on `/callback` while the address bar says
       // `/p/<id>/evals/...`, so the project boundary never mounts and the URL
@@ -3684,8 +3696,10 @@ export default function App() {
     // connection negotiates, which an unpinned host only learns at connect.
     const cancellationLeaves = Object.fromEntries(
       (["legacy", "modern"] as const)
-        .filter((key) => activeMcpProfile?.toolCallCancellation?.[key] === false)
-        .map((key) => [key, false])
+        .filter(
+          (key) => activeMcpProfile?.toolCallCancellation?.[key] === false,
+        )
+        .map((key) => [key, false]),
     );
     const toolCallCancellation =
       Object.keys(cancellationLeaves).length > 0
@@ -4487,6 +4501,23 @@ export default function App() {
   const { allProjects: allMembershipProjects } = useProjectQueries({
     isAuthenticated,
   });
+  const allMembershipProjectIds = useMemo(
+    () =>
+      allMembershipProjects
+        ? new Set(allMembershipProjects.map((project) => project._id))
+        : undefined,
+    [allMembershipProjects],
+  );
+  const pendingProjectReturnRecovery = pendingProjectReturnRecoveryRef.current;
+  const confirmedStaleReturnProjectId =
+    pendingProjectReturnRecovery &&
+    isProjectIdShape(pendingProjectReturnRecovery.requestedProjectId) &&
+    allMembershipProjectIds !== undefined &&
+    !allMembershipProjectIds.has(
+      pendingProjectReturnRecovery.requestedProjectId,
+    )
+      ? pendingProjectReturnRecovery.requestedProjectId
+      : null;
   // Silent: the URL already told the user which project they are in, so a
   // toast on every cold open of a shared link would be narrating the address
   // bar back at them.
@@ -4504,7 +4535,52 @@ export default function App() {
     activeOrganizationId,
     setActiveOrganizationId,
     switchProject: switchProjectForRoute,
+    suppressInaccessibleTelemetryFor: confirmedStaleReturnProjectId,
   });
+
+  const fallbackProjectForStaleReturn =
+    activeProject && allMembershipProjectIds?.has(activeProjectId)
+      ? { id: activeProjectId, name: activeProject.name }
+      : null;
+  const projectReturnRecoveryDecision = resolveProjectSignInReturnRecovery({
+    intent: pendingProjectReturnRecovery,
+    routeState: projectRouteState,
+    membershipProjectIds: allMembershipProjectIds,
+    fallbackProject: fallbackProjectForStaleReturn,
+  });
+  const projectRouteStateForBoundary =
+    projectReturnRecoveryDecision.kind === "switch" ||
+    projectReturnRecoveryDecision.kind === "home"
+      ? {
+          status: "resolving" as const,
+          requestedProjectId:
+            pendingProjectReturnRecovery?.requestedProjectId ?? "",
+        }
+      : projectRouteState;
+
+  // Layout timing keeps the generic unavailable screen from painting for a
+  // stale sign-in return. The intent is cleared before navigation so a bad
+  // fallback can show the normal error but can never loop.
+  useLayoutEffect(() => {
+    if (projectReturnRecoveryDecision.kind === "none") return;
+    if (
+      pendingProjectReturnRecoveryRef.current !== pendingProjectReturnRecovery
+    ) {
+      return;
+    }
+    pendingProjectReturnRecoveryRef.current = null;
+
+    if (projectReturnRecoveryDecision.kind === "clear") return;
+    if (projectReturnRecoveryDecision.kind === "home") {
+      trackStaleProjectReturnRecovered("no-fallback");
+      navigateApp(routePaths.root, { replace: true, unscoped: true });
+      return;
+    }
+
+    trackStaleProjectReturnRecovered("switched");
+    navigateApp(projectReturnRecoveryDecision.path, { replace: true });
+    toast.error(projectReturnRecoveryDecision.message);
+  }, [pendingProjectReturnRecovery, projectReturnRecoveryDecision]);
 
   /**
    * Picking another project in the switcher NAVIGATES. It does not switch
@@ -4890,7 +4966,7 @@ export default function App() {
     // What the URL's project segment resolved to. `ProjectRouteBoundary`
     // renders on it, and the legacy normalizer reads the rest of this bag to
     // decide which project an old link should adopt.
-    projectRouteState,
+    projectRouteState: projectRouteStateForBoundary,
     activeMcpProfile,
     activeOrganizationId,
     activeOrganizationName,

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -4509,6 +4509,8 @@ export default function App() {
     [allMembershipProjects],
   );
   const pendingProjectReturnRecovery = pendingProjectReturnRecoveryRef.current;
+  const currentLocation = useCurrentLocationParts();
+  const currentProjectPath = `${currentLocation.pathname}${currentLocation.search}${currentLocation.hash}`;
   const confirmedStaleReturnProjectId =
     pendingProjectReturnRecovery &&
     isProjectIdShape(pendingProjectReturnRecovery.requestedProjectId) &&
@@ -4545,6 +4547,7 @@ export default function App() {
   const projectReturnRecoveryDecision = resolveProjectSignInReturnRecovery({
     intent: pendingProjectReturnRecovery,
     routeState: projectRouteState,
+    currentPath: currentProjectPath,
     membershipProjectIds: allMembershipProjectIds,
     fallbackProject: fallbackProjectForStaleReturn,
   });

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -7,6 +7,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toast as sonnerToast } from "sonner";
 import App from "../App";
 import {
   clearHostedOAuthPendingState,
@@ -28,6 +29,7 @@ import {
   writeScenarioSignInReturnPath,
   writeScenarioSession,
 } from "../lib/scenario-session";
+import { writeAppSignInReturnPath } from "../lib/app-signin-return-path";
 
 const existingConvexUser = {
   _id: "user-1",
@@ -121,10 +123,7 @@ const {
     mockHandleOAuthCallback: vi.fn(),
     mockHostedShellGateState: {
       value: "ready" as
-        | "ready"
-        | "auth-loading"
-        | "project-loading"
-        | "logged-out",
+        "ready" | "auth-loading" | "project-loading" | "logged-out",
     },
     mockMCPSidebar: vi.fn(() => <div />),
     mockOAuthFlowTabState: {
@@ -181,7 +180,7 @@ function mockFreshGuestUser() {
           // Fresh guest cookie/user rows have not seen first-run NUX yet.
           hasSeenOnboarding: false,
         }
-      : undefined
+      : undefined,
   );
 }
 
@@ -196,7 +195,7 @@ function mockSeenGuestUser() {
           isAnonymous: true,
           hasSeenOnboarding: true,
         }
-      : undefined
+      : undefined,
   );
 }
 
@@ -489,7 +488,7 @@ describe("App hosted OAuth callback handling", () => {
     localStorage.clear();
     localStorage.setItem(
       "mcp-onboarding-state",
-      JSON.stringify({ status: "completed", completedAt: Date.now() })
+      JSON.stringify({ status: "completed", completedAt: Date.now() }),
     );
     sessionStorage.clear();
     vi.stubGlobal("__APP_VERSION__", "test");
@@ -507,7 +506,7 @@ describe("App hosted OAuth callback handling", () => {
     mockUseFeatureFlagEnabled.mockReturnValue(false);
     mockUseQuery.mockReset();
     mockUseQuery.mockImplementation((ref: string) =>
-      ref === "users:getCurrentUser" ? existingConvexUser : undefined
+      ref === "users:getCurrentUser" ? existingConvexUser : undefined,
     );
     mockHostedShellGateState.value = "ready";
     mockConvexAuthState.isAuthenticated = true;
@@ -535,13 +534,14 @@ describe("App hosted OAuth callback handling", () => {
     mockOAuthFlowTabState.lastProps = undefined;
     mockPosthogCapture.mockReset();
     mockTrack.mockReset();
+    vi.mocked(sonnerToast.error).mockReset();
     mockPlaygroundTabMounts.mockReset();
     mockPlaygroundTabProps.mockReset();
     mockCompleteHostedOAuthCallback.mockImplementation(
-      () => new Promise<never>(() => {})
+      () => new Promise<never>(() => {}),
     );
     mockHandleOAuthCallback.mockImplementation(
-      () => new Promise<never>(() => {})
+      () => new Promise<never>(() => {}),
     );
 
     writeScenarioSession({
@@ -597,7 +597,7 @@ describe("App hosted OAuth callback handling", () => {
 
     expect(screen.getByTestId("hosted-oauth-loading")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Authorize" })
+      screen.queryByRole("button", { name: "Authorize" }),
     ).not.toBeInTheDocument();
     await waitFor(() => {
       expect(mockCompleteHostedOAuthCallback).toHaveBeenCalledWith(
@@ -608,7 +608,7 @@ describe("App hosted OAuth callback handling", () => {
         "oauth-code",
         expect.objectContaining({
           onTraceUpdate: expect.any(Function),
-        })
+        }),
       );
     });
   });
@@ -621,7 +621,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/oauth-flow");
     mockOAuthFlowTabState.shouldThrow = true;
     mockOAuthFlowTabState.error = new Error(
-      "token exchange failed client_secret=super-secret Bearer access-token"
+      "token exchange failed client_secret=super-secret Bearer access-token",
     );
     const writeText = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("navigator", {
@@ -632,13 +632,13 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     expect(
-      await screen.findByText("OAuth Debugger crashed")
+      await screen.findByText("OAuth Debugger crashed"),
     ).toBeInTheDocument();
     expect(mockTrack).toHaveBeenCalledWith(
       "oauth_debugger_error_boundary",
       expect.objectContaining({
         message: expect.stringContaining("[redacted]"),
-      })
+      }),
     );
     expect(JSON.stringify(mockTrack.mock.calls)).not.toContain("super-secret");
 
@@ -646,7 +646,7 @@ describe("App hosted OAuth callback handling", () => {
 
     await waitFor(() => {
       expect(writeText).toHaveBeenCalledWith(
-        expect.not.stringContaining("super-secret")
+        expect.not.stringContaining("super-secret"),
       );
     });
     expect(writeText.mock.calls[0]?.[0]).toContain("[redacted]");
@@ -671,7 +671,7 @@ describe("App hosted OAuth callback handling", () => {
         expect.objectContaining({
           authorizationHeader: "Bearer guest-bearer",
           onTraceUpdate: expect.any(Function),
-        })
+        }),
       );
     });
   });
@@ -708,7 +708,7 @@ describe("App hosted OAuth callback handling", () => {
         expect.objectContaining({
           authorizationHeader: undefined,
           onTraceUpdate: expect.any(Function),
-        })
+        }),
       );
     });
   });
@@ -721,7 +721,7 @@ describe("App hosted OAuth callback handling", () => {
 
     await waitFor(() => {
       expect(readHostedOAuthResumeMarker("scenario")?.errorMessage).toBe(
-        "Your guest session expired. Reopen the swarm link and try again."
+        "Your guest session expired. Reopen the swarm link and try again.",
       );
     });
     expect(mockCompleteHostedOAuthCallback).not.toHaveBeenCalled();
@@ -751,7 +751,7 @@ describe("App hosted OAuth callback handling", () => {
         expect.objectContaining({
           authorizationHeader: "Bearer workos-token",
           onTraceUpdate: expect.any(Function),
-        })
+        }),
       );
     });
     expect(mockGetGuestBearerToken).not.toHaveBeenCalled();
@@ -775,7 +775,7 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     expect(
-      screen.queryByTestId("hosted-oauth-loading")
+      screen.queryByTestId("hosted-oauth-loading"),
     ).not.toBeInTheDocument();
     expect(screen.getByTestId("hosts-tab")).toBeInTheDocument();
     expect(screen.getByText("Servers Tab")).toBeInTheDocument();
@@ -804,11 +804,11 @@ describe("App hosted OAuth callback handling", () => {
     });
 
     expect(
-      screen.queryByTestId("callback-auth-timeout")
+      screen.queryByTestId("callback-auth-timeout"),
     ).not.toBeInTheDocument();
     expect(mockWorkOsAuthState.signIn).not.toHaveBeenCalled();
     expect(readScenarioSignInReturnPath()).toBe(
-      "/user-testing/asana/token-123"
+      "/user-testing/asana/token-123",
     );
   });
 
@@ -836,7 +836,7 @@ describe("App hosted OAuth callback handling", () => {
           guestId: "guest_123",
           token: "guest-token",
           expiresAt: Date.now() + 60_000,
-        })
+        }),
       );
       writeHostedOAuthPendingMarker({
         surface: "project",
@@ -863,7 +863,7 @@ describe("App hosted OAuth callback handling", () => {
       expect(screen.getByTestId("callback-auth-timeout")).toBeInTheDocument();
 
       fireEvent.click(
-        screen.getByRole("button", { name: "Try sign in again" })
+        screen.getByRole("button", { name: "Try sign in again" }),
       );
 
       await act(async () => {
@@ -894,13 +894,13 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     const entitlementsCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getOrganizationEntitlements"
+      ([name]) => name === "billing:getOrganizationEntitlements",
     );
     const orgPremiumnessCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getOrganizationPremiumness"
+      ([name]) => name === "billing:getOrganizationPremiumness",
     );
     const wsPremiumnessCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getProjectPremiumness"
+      ([name]) => name === "billing:getProjectPremiumness",
     );
 
     expect(entitlementsCall?.[1]).toBe("skip");
@@ -926,13 +926,13 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     const entitlementsCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getOrganizationEntitlements"
+      ([name]) => name === "billing:getOrganizationEntitlements",
     );
     const orgPremiumnessCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getOrganizationPremiumness"
+      ([name]) => name === "billing:getOrganizationPremiumness",
     );
     const wsPremiumnessCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getProjectPremiumness"
+      ([name]) => name === "billing:getProjectPremiumness",
     );
 
     expect(entitlementsCall?.[1]).toBe("skip");
@@ -973,7 +973,7 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     const wsPremiumnessCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getProjectPremiumness"
+      ([name]) => name === "billing:getProjectPremiumness",
     );
 
     expect(wsPremiumnessCall?.[1]).toBe("skip");
@@ -1033,7 +1033,7 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     const wsPremiumnessCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getProjectPremiumness"
+      ([name]) => name === "billing:getProjectPremiumness",
     );
 
     expect(wsPremiumnessCall?.[1]).toBe("skip");
@@ -1093,7 +1093,7 @@ describe("App hosted OAuth callback handling", () => {
         "oauth-code",
         expect.objectContaining({
           onTraceUpdate: expect.any(Function),
-        })
+        }),
       );
     });
 
@@ -1407,7 +1407,7 @@ describe("App hosted OAuth callback handling", () => {
     clearScenarioSession();
     window.history.replaceState({}, "", "/organizations/org-3");
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      (flag: string) => flag === "billing-entitlements-ui",
     );
     mockUseAppState.mockImplementation(() => ({
       ...createAppStateMock(),
@@ -1543,7 +1543,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/callback?code=oauth-code");
 
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      (flag: string) => flag === "billing-entitlements-ui",
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "organizations:getMyOrganizations") {
@@ -1595,6 +1595,71 @@ describe("App hosted OAuth callback handling", () => {
     expect(readBillingSignInReturnPath()).toBeNull();
   });
 
+  it("recovers a stale scoped sign-in return without painting the unavailable screen", async () => {
+    clearScenarioSession();
+    const staleProjectId = "k5700000000000000000000000a";
+    const currentProjectId = "k5700000000000000000000000b";
+    const stalePath = `/p/${staleProjectId}/evals?view=runs#case-3`;
+    writeAppSignInReturnPath(stalePath);
+    window.history.replaceState({}, "", "/callback?code=oauth-code");
+    mockUseAppState.mockImplementation(() => ({
+      ...createAppStateMock(),
+      activeProjectId: currentProjectId,
+      projects: {
+        [currentProjectId]: {
+          id: currentProjectId,
+          name: "Default Project",
+          sharedProjectId: currentProjectId,
+          organizationId: "org-1",
+          servers: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      },
+    }));
+    mockUseQuery.mockImplementation((name: string) => {
+      if (name === "users:getCurrentUser") return existingConvexUser;
+      if (name === "projects:getMyProjects") {
+        return [
+          {
+            _id: currentProjectId,
+            name: "Default Project",
+            organizationId: "org-1",
+            ownerId: "user-1",
+            servers: {},
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ];
+      }
+      return undefined;
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(`${window.location.pathname}${window.location.search}`).toBe(
+        `/p/${currentProjectId}/evals?view=runs`,
+      );
+      expect(window.location.hash).toBe("#case-3");
+    });
+    expect(
+      screen.queryByTestId("project-route-inaccessible"),
+    ).not.toBeInTheDocument();
+    expect(sonnerToast.error).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(sonnerToast.error).mock.calls[0]?.[0]).toMatchObject({
+      props: { text: "Project not found. Switched to Default Project." },
+    });
+    expect(mockTrack).toHaveBeenCalledWith(
+      "project_route_stale_return_recovered",
+      { location: "signin-return", outcome: "switched" },
+    );
+    expect(mockTrack).not.toHaveBeenCalledWith(
+      "project_route_inaccessible",
+      expect.anything(),
+    );
+  });
+
   it("keeps a persisted billing resume alive when /billing returns without query params", async () => {
     clearHostedOAuthPendingState();
     clearScenarioSession();
@@ -1603,7 +1668,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/billing");
 
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      (flag: string) => flag === "billing-entitlements-ui",
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "organizations:getMyOrganizations") {
@@ -1648,8 +1713,8 @@ describe("App hosted OAuth callback handling", () => {
           (props as { checkoutIntent?: { plan?: string } }).checkoutIntent
             ?.plan === "team" &&
           (props as { checkoutIntent?: { interval?: string } }).checkoutIntent
-            ?.interval === "annual"
-      )
+            ?.interval === "annual",
+      ),
     ).toBe(true);
   });
 
@@ -1670,7 +1735,7 @@ describe("App hosted OAuth callback handling", () => {
       expect(replaceStateSpy).toHaveBeenCalledWith(
         {},
         "",
-        "/user-testing/demo/token-123"
+        "/user-testing/demo/token-123",
       );
     });
   });
@@ -1681,7 +1746,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
 
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      (flag: string) => flag === "billing-entitlements-ui",
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "organizations:getMyOrganizations") {
@@ -1728,8 +1793,8 @@ describe("App hosted OAuth callback handling", () => {
           (props as { checkoutIntent?: { plan?: string } }).checkoutIntent
             ?.plan === "team" &&
           (props as { checkoutIntent?: { interval?: string } }).checkoutIntent
-            ?.interval === "annual"
-      )
+            ?.interval === "annual",
+      ),
     ).toBe(true);
   });
 
@@ -1739,7 +1804,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
 
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      (flag: string) => flag === "billing-entitlements-ui",
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "organizations:getMyOrganizations") {
@@ -1766,7 +1831,7 @@ describe("App hosted OAuth callback handling", () => {
         >
           Consume checkout intent
         </button>
-      )
+      ),
     );
 
     render(<App />);
@@ -1780,7 +1845,7 @@ describe("App hosted OAuth callback handling", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByTestId("billing-handoff-overlay")
+        screen.queryByTestId("billing-handoff-overlay"),
       ).not.toBeInTheDocument();
     });
   });
@@ -1791,7 +1856,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
 
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      (flag: string) => flag === "billing-entitlements-ui",
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "organizations:getMyOrganizations") {
@@ -1818,7 +1883,7 @@ describe("App hosted OAuth callback handling", () => {
         >
           Start checkout navigation
         </button>
-      )
+      ),
     );
 
     render(<App />);
@@ -1826,7 +1891,7 @@ describe("App hosted OAuth callback handling", () => {
     await waitFor(() => {
       expect(screen.getByTestId("billing-handoff-overlay")).toBeInTheDocument();
       expect(
-        screen.getByTestId("start-checkout-navigation")
+        screen.getByTestId("start-checkout-navigation"),
       ).toBeInTheDocument();
     });
 
@@ -1834,7 +1899,7 @@ describe("App hosted OAuth callback handling", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByTestId("billing-handoff-overlay")
+        screen.queryByTestId("billing-handoff-overlay"),
       ).not.toBeInTheDocument();
     });
     expect(readPersistedCheckoutIntent()).toBeNull();
@@ -1846,7 +1911,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
 
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      (flag: string) => flag === "billing-entitlements-ui",
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "organizations:getMyOrganizations") {
@@ -1863,10 +1928,10 @@ describe("App hosted OAuth callback handling", () => {
     });
 
     expect(
-      screen.queryByTestId("billing-handoff-loading")
+      screen.queryByTestId("billing-handoff-loading"),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId("billing-handoff-overlay")
+      screen.queryByTestId("billing-handoff-overlay"),
     ).not.toBeInTheDocument();
     expect(mockOrganizationsTab).not.toHaveBeenCalled();
   });
@@ -1983,7 +2048,7 @@ describe("App hosted OAuth callback handling", () => {
         >
           Delete org
         </button>
-      )
+      ),
     );
 
     render(<App />);
@@ -1997,7 +2062,7 @@ describe("App hosted OAuth callback handling", () => {
     expect(clearConvexActiveProjectSelection).toHaveBeenCalled();
     expect(clearLocalFallbackProjectSelection).toHaveBeenCalledWith(
       "org-deleted",
-      "org-owned"
+      "org-owned",
     );
     expect(window.location.pathname).toBe("/servers");
   });
@@ -2058,7 +2123,7 @@ describe("App hosted OAuth callback handling", () => {
         >
           Delete org with no owner fallback
         </button>
-      )
+      ),
     );
 
     render(<App />);
@@ -2143,7 +2208,7 @@ describe("App hosted OAuth callback handling", () => {
         >
           Delete non-current org
         </button>
-      )
+      ),
     );
 
     render(<App />);
@@ -2155,12 +2220,12 @@ describe("App hosted OAuth callback handling", () => {
     await waitFor(() => {
       expect(clearLocalFallbackProjectSelection).toHaveBeenCalledWith(
         "org-deleted",
-        "org-owner"
+        "org-owner",
       );
     });
 
     const postDeleteCalls = setActiveOrganizationId.mock.calls.slice(
-      activeOrgCallsBeforeDelete
+      activeOrgCallsBeforeDelete,
     );
     expect(postDeleteCalls).not.toContainEqual(["org-owner"]);
     expect(clearConvexActiveProjectSelection).not.toHaveBeenCalled();
@@ -2222,7 +2287,7 @@ describe("App hosted OAuth callback handling", () => {
         >
           Delete last org
         </button>
-      )
+      ),
     );
 
     render(<App />);
@@ -2236,7 +2301,7 @@ describe("App hosted OAuth callback handling", () => {
     expect(clearConvexActiveProjectSelection).toHaveBeenCalled();
     expect(clearLocalFallbackProjectSelection).toHaveBeenCalledWith(
       "org-deleted",
-      undefined
+      undefined,
     );
     expect(window.location.pathname).toBe("/servers");
   });
@@ -2266,7 +2331,7 @@ describe("App hosted OAuth callback handling", () => {
     // User Testing is flag-gated at the route, not just in the sidebar — the
     // callback can only land back on it for a user who has the flag.
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "sandboxes-enabled"
+      (flag: string) => flag === "sandboxes-enabled",
     );
     mockCompleteHostedOAuthCallback.mockResolvedValue({
       success: true,
@@ -2294,7 +2359,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/playground");
     mockHandleOAuthCallback.mockReset();
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "playground-enabled"
+      (flag: string) => flag === "playground-enabled",
     );
 
     render(<App />);
@@ -2324,7 +2389,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/playground");
     mockHandleOAuthCallback.mockReset();
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "playground-enabled"
+      (flag: string) => flag === "playground-enabled",
     );
 
     render(<App />);
@@ -2373,7 +2438,7 @@ describe("App hosted OAuth callback handling", () => {
         isWorkOsAuthLoading: false,
         isConvexAuthenticated: true,
         hasSeenFirstRunOnboarding: false,
-      })
+      }),
     );
   });
 
@@ -2680,7 +2745,7 @@ describe("App hosted OAuth callback handling", () => {
     clearScenarioSession();
     localStorage.setItem(
       "mcp-onboarding-state",
-      JSON.stringify({ status: "seen", shownAt: Date.now() })
+      JSON.stringify({ status: "seen", shownAt: Date.now() }),
     );
     window.history.replaceState({}, "", "/servers");
     mockHandleOAuthCallback.mockReset();
@@ -2721,7 +2786,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/evals");
     mockHandleOAuthCallback.mockReset();
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "playground-enabled" || flag === "evaluate-ui"
+      (flag: string) => flag === "playground-enabled" || flag === "evaluate-ui",
     );
 
     render(<App />);
@@ -2743,7 +2808,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/evals/runs");
     mockHandleOAuthCallback.mockReset();
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "playground-enabled" || flag === "evaluate-ui"
+      (flag: string) => flag === "playground-enabled" || flag === "evaluate-ui",
     );
 
     render(<App />);
@@ -2819,22 +2884,22 @@ describe("App hosted OAuth callback handling", () => {
       ref === "users:getCurrentUser"
         ? existingConvexUser
         : ref === "hosts:listHosts"
-        ? [
-            {
-              hostId: "m17b6q9xw2tv4kz8p3r5s0dc",
-              name: "Slack",
-              hostConfigId: "host-config-slack",
-              modelId: "claude-sonnet-4",
-              serverCount: 0,
-              createdAt: 0,
-              updatedAt: 0,
-            },
-          ]
-        : undefined
+          ? [
+              {
+                hostId: "m17b6q9xw2tv4kz8p3r5s0dc",
+                name: "Slack",
+                hostConfigId: "host-config-slack",
+                modelId: "claude-sonnet-4",
+                serverCount: 0,
+                createdAt: 0,
+                updatedAt: 0,
+              },
+            ]
+          : undefined,
     );
     localStorage.setItem(
       "mcp-previewed-host-id",
-      JSON.stringify({ project_shared: "kd7n2m5xq9b3tv6yz1r4s0hc" })
+      JSON.stringify({ project_shared: "kd7n2m5xq9b3tv6yz1r4s0hc" }),
     );
     window.history.replaceState({}, "", "/hosts/m17b6q9xw2tv4kz8p3r5s0dc");
 
@@ -2842,7 +2907,7 @@ describe("App hosted OAuth callback handling", () => {
 
     await waitFor(() => {
       expect(
-        JSON.parse(localStorage.getItem("mcp-previewed-host-id") ?? "{}")
+        JSON.parse(localStorage.getItem("mcp-previewed-host-id") ?? "{}"),
       ).toEqual({
         project_shared: "m17b6q9xw2tv4kz8p3r5s0dc",
       });
@@ -2872,7 +2937,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/xaa-flow");
     mockHandleOAuthCallback.mockReset();
     mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
-      flag === "xaa" ? true : false
+      flag === "xaa" ? true : false,
     );
 
     render(<App />);
@@ -2891,7 +2956,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/xaa-flow");
     mockHandleOAuthCallback.mockReset();
     mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
-      flag === "xaa" ? true : false
+      flag === "xaa" ? true : false,
     );
     const appStateMock = createAppStateMock();
     const currentProjectServers = {
@@ -2929,7 +2994,7 @@ describe("App hosted OAuth callback handling", () => {
             showOnlyOAuthServers: true,
             autoSelectFilteredServer: "when-empty",
           }),
-        })
+        }),
       );
     });
 
@@ -2937,7 +3002,7 @@ describe("App hosted OAuth callback handling", () => {
       activeServerSelectorProps?: { serverConfigs?: unknown };
     };
     expect(latestProps.activeServerSelectorProps?.serverConfigs).toBe(
-      currentProjectServers
+      currentProjectServers,
     );
   });
 
@@ -2983,7 +3048,7 @@ describe("App hosted OAuth callback handling", () => {
             showOnlyOAuthServers: true,
             autoSelectFilteredServer: "when-empty",
           }),
-        })
+        }),
       );
     });
 
@@ -2991,11 +3056,11 @@ describe("App hosted OAuth callback handling", () => {
       activeServerSelectorProps?: { serverConfigs?: unknown };
     };
     expect(latestProps.activeServerSelectorProps?.serverConfigs).toBe(
-      currentProjectServers
+      currentProjectServers,
     );
     expect(
       (mockOAuthFlowTabState.lastProps as { serverConfigs?: unknown })
-        .serverConfigs
+        .serverConfigs,
     ).toBe(currentProjectServers);
   });
 
@@ -3014,7 +3079,7 @@ describe("App hosted OAuth callback handling", () => {
             showOnlyOAuthServers: false,
             autoSelectFilteredServer: true,
           }),
-        })
+        }),
       );
     });
   });
@@ -3042,7 +3107,7 @@ describe("App hosted OAuth callback handling", () => {
       },
     }));
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      (flag: string) => flag === "billing-entitlements-ui",
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "users:getCurrentUser") {
@@ -3090,7 +3155,7 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     const wsPremiumnessCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getProjectPremiumness"
+      ([name]) => name === "billing:getProjectPremiumness",
     );
 
     expect(wsPremiumnessCall?.[1]).toEqual({

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -1660,6 +1660,70 @@ describe("App hosted OAuth callback handling", () => {
     );
   });
 
+  it("recovers when AuthKit restores the project URL before App sees the callback", async () => {
+    clearScenarioSession();
+    const staleProjectId = "k5700000000000000000000000a";
+    const currentProjectId = "k5700000000000000000000000b";
+    const stalePath = `/p/${staleProjectId}/servers?view=grid#tools`;
+    writeAppSignInReturnPath(stalePath);
+    window.history.replaceState({}, "", stalePath);
+    mockUseAppState.mockImplementation(() => ({
+      ...createAppStateMock(),
+      activeProjectId: currentProjectId,
+      projects: {
+        [currentProjectId]: {
+          id: currentProjectId,
+          name: "Default Project",
+          sharedProjectId: currentProjectId,
+          organizationId: "org-1",
+          servers: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      },
+    }));
+    mockUseQuery.mockImplementation((name: string) => {
+      if (name === "users:getCurrentUser") return existingConvexUser;
+      if (name === "projects:getMyProjects") {
+        return [
+          {
+            _id: currentProjectId,
+            name: "Default Project",
+            organizationId: "org-1",
+            ownerId: "user-1",
+            servers: {},
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ];
+      }
+      return undefined;
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(
+        `${window.location.pathname}${window.location.search}${window.location.hash}`,
+      ).toBe(`/p/${currentProjectId}/servers?view=grid#tools`);
+    });
+    expect(
+      screen.queryByTestId("project-route-inaccessible"),
+    ).not.toBeInTheDocument();
+    expect(mockTrack).toHaveBeenCalledWith("app_signin_return_restored", {
+      location: "signin-return",
+      outcome: "restored",
+    });
+    expect(mockTrack).toHaveBeenCalledWith(
+      "project_route_stale_return_recovered",
+      { location: "signin-return", outcome: "switched" },
+    );
+    expect(mockTrack).not.toHaveBeenCalledWith(
+      "project_route_inaccessible",
+      expect.anything(),
+    );
+  });
+
   it("returns a no-project account home without claiming it switched projects", async () => {
     clearScenarioSession();
     const staleProjectId = "k5700000000000000000000000a";

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -1660,6 +1660,42 @@ describe("App hosted OAuth callback handling", () => {
     );
   });
 
+  it("returns a no-project account home without claiming it switched projects", async () => {
+    clearScenarioSession();
+    const staleProjectId = "k5700000000000000000000000a";
+    writeAppSignInReturnPath(`/p/${staleProjectId}/playground?model=test#chat`);
+    window.history.replaceState({}, "", "/callback?code=oauth-code");
+    mockWorkOsAuthState.user = { id: "workos-user-1" };
+    mockUseAppState.mockImplementation(() => ({
+      ...createAppStateMock(),
+      activeProjectId: "none",
+      projects: {},
+    }));
+    mockUseQuery.mockImplementation((name: string) => {
+      if (name === "users:getCurrentUser") return existingConvexUser;
+      if (name === "projects:getMyProjects") return [];
+      return undefined;
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(window.location.pathname).toBe("/"));
+    expect(window.location.search).toBe("");
+    expect(window.location.hash).toBe("");
+    expect(
+      screen.queryByTestId("project-route-inaccessible"),
+    ).not.toBeInTheDocument();
+    expect(sonnerToast.error).not.toHaveBeenCalled();
+    expect(mockTrack).toHaveBeenCalledWith(
+      "project_route_stale_return_recovered",
+      { location: "signin-return", outcome: "no-fallback" },
+    );
+    expect(mockTrack).not.toHaveBeenCalledWith(
+      "project_route_inaccessible",
+      expect.anything(),
+    );
+  });
+
   it("keeps a persisted billing resume alive when /billing returns without query params", async () => {
     clearHostedOAuthPendingState();
     clearScenarioSession();

--- a/mcpjam-inspector/client/src/components/routing/__tests__/project-route-boundary.test.tsx
+++ b/mcpjam-inspector/client/src/components/routing/__tests__/project-route-boundary.test.tsx
@@ -27,7 +27,7 @@ function renderBoundary(projectRouteState: ProjectRouteState | undefined) {
         ],
       },
     ],
-    { initialEntries: [`/p/${A}`] }
+    { initialEntries: [`/p/${A}`] },
   );
   render(<RouterProvider router={router} />);
   return router;
@@ -58,9 +58,13 @@ describe("ProjectRouteBoundary", () => {
   it("shows one generic message for an unavailable project", () => {
     // Deleted, never existed, and not yours are deliberately the same
     // message: distinguishing them would leak which project ids are real.
-    renderBoundary({ status: "inaccessible", requestedProjectId: A });
+    renderBoundary({
+      status: "inaccessible",
+      requestedProjectId: A,
+      reason: "not-a-member",
+    });
     expect(
-      screen.getByTestId("project-route-inaccessible")
+      screen.getByTestId("project-route-inaccessible"),
     ).toBeInTheDocument();
     expect(screen.queryByTestId("project-screen")).toBeNull();
   });
@@ -72,6 +76,7 @@ describe("ProjectRouteBoundary", () => {
     const router = renderBoundary({
       status: "inaccessible",
       requestedProjectId: A,
+      reason: "not-a-member",
     });
     expect(router.state.location.pathname).toBe(`/p/${A}`);
   });
@@ -83,11 +88,12 @@ describe("ProjectRouteBoundary", () => {
     const router = renderBoundary({
       status: "inaccessible",
       requestedProjectId: A,
+      reason: "not-a-member",
     });
     fireEvent.click(screen.getByRole("button", { name: /projects/i }));
     await waitFor(
       () => expect(router.state.location.pathname).toBe("/"),
-      NAVIGATION_TIMEOUT
+      NAVIGATION_TIMEOUT,
     );
   });
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-route-coordinator.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-route-coordinator.test.tsx
@@ -168,6 +168,7 @@ describe("useProjectRouteCoordinator", () => {
     expect(result.current).toEqual({
       status: "inaccessible",
       requestedProjectId: B,
+      reason: "not-a-member",
     });
     expect(switchProject).not.toHaveBeenCalled();
   });
@@ -225,6 +226,7 @@ describe("useProjectRouteCoordinator", () => {
     expect(result.current).toEqual({
       status: "inaccessible",
       requestedProjectId: "none",
+      reason: "malformed",
     });
   });
 
@@ -323,7 +325,13 @@ describe("useProjectRouteCoordinator", () => {
     // without waiting out the 15s resolve budget first.
     const switchProject = vi.fn().mockRejectedValue(new Error("persistent"));
     const { result } = renderHook(
-      () => useProjectRouteCoordinator(inputFor({ switchProject })),
+      () =>
+        useProjectRouteCoordinator(
+          inputFor({
+            switchProject,
+            suppressInaccessibleTelemetryFor: B,
+          }),
+        ),
       { wrapper: wrapperFor(`/p/${B}/servers`) },
     );
     await waitFor(
@@ -331,8 +339,13 @@ describe("useProjectRouteCoordinator", () => {
         expect(result.current).toEqual({
           status: "inaccessible",
           requestedProjectId: B,
+          reason: "timed-out",
         }),
       RESOLUTION_TIMEOUT,
+    );
+    expect(vi.mocked(track)).toHaveBeenCalledWith(
+      "project_route_inaccessible",
+      expect.objectContaining({ reason: "timed-out" }),
     );
     // Bounded: the cap, not an unbounded retry loop.
     expect(switchProject.mock.calls.length).toBeLessThanOrEqual(4);

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-route-coordinator.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-route-coordinator.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
 import { useProjectRouteCoordinator } from "../use-project-route-coordinator";
+import { track } from "@/lib/analytics";
 
 vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 
@@ -57,7 +58,7 @@ describe("useProjectRouteCoordinator", () => {
       () => useProjectRouteCoordinator(inputFor()),
       {
         wrapper: wrapperFor("/settings"),
-      }
+      },
     );
     expect(result.current).toEqual({ status: "unscoped" });
   });
@@ -67,7 +68,7 @@ describe("useProjectRouteCoordinator", () => {
       () => useProjectRouteCoordinator(inputFor()),
       {
         wrapper: wrapperFor(`/p/${A}/servers`),
-      }
+      },
     );
     expect(result.current).toEqual({ status: "ready", projectId: A });
   });
@@ -76,12 +77,12 @@ describe("useProjectRouteCoordinator", () => {
     const switchProject = vi.fn().mockResolvedValue(undefined);
     const { result } = renderHook(
       () => useProjectRouteCoordinator(inputFor({ switchProject })),
-      { wrapper: wrapperFor(`/p/${B}/servers`) }
+      { wrapper: wrapperFor(`/p/${B}/servers`) },
     );
     expect(result.current.status).toBe("resolving");
     await waitFor(
       () => expect(switchProject).toHaveBeenCalledWith(B),
-      RESOLUTION_TIMEOUT
+      RESOLUTION_TIMEOUT,
     );
   });
 
@@ -97,7 +98,7 @@ describe("useProjectRouteCoordinator", () => {
     rerender();
     await waitFor(
       () => expect(switchProject).toHaveBeenCalledTimes(1),
-      RESOLUTION_TIMEOUT
+      RESOLUTION_TIMEOUT,
     );
   });
 
@@ -116,9 +117,9 @@ describe("useProjectRouteCoordinator", () => {
             switchProject: async (id: string) => {
               calls.push(id);
             },
-          })
+          }),
         ),
-      { wrapper: wrapperFor(`/p/${B}/servers`) }
+      { wrapper: wrapperFor(`/p/${B}/servers`) },
     );
     for (let i = 0; i < 5; i += 1) rerender();
     await waitFor(() => expect(calls).toEqual([B]), RESOLUTION_TIMEOUT);
@@ -139,13 +140,13 @@ describe("useProjectRouteCoordinator", () => {
             ],
             setActiveOrganizationId,
             switchProject,
-          })
+          }),
         ),
-      { wrapper: wrapperFor(`/p/${B}/servers`) }
+      { wrapper: wrapperFor(`/p/${B}/servers`) },
     );
     await waitFor(
       () => expect(setActiveOrganizationId).toHaveBeenCalledWith("org_b"),
-      RESOLUTION_TIMEOUT
+      RESOLUTION_TIMEOUT,
     );
     // The project switch waits for the organization-filtered list to catch up.
     expect(switchProject).not.toHaveBeenCalled();
@@ -160,9 +161,9 @@ describe("useProjectRouteCoordinator", () => {
             projects: { [A]: {} },
             allProjects: [{ _id: A, organizationId: "org_a" }],
             switchProject,
-          })
+          }),
         ),
-      { wrapper: wrapperFor(`/p/${B}/servers`) }
+      { wrapper: wrapperFor(`/p/${B}/servers`) },
     );
     expect(result.current).toEqual({
       status: "inaccessible",
@@ -171,10 +172,55 @@ describe("useProjectRouteCoordinator", () => {
     expect(switchProject).not.toHaveBeenCalled();
   });
 
+  it("does not report an inaccessible event for a confirmed stale sign-in return", () => {
+    renderHook(
+      () =>
+        useProjectRouteCoordinator(
+          inputFor({
+            projects: { [A]: {} },
+            allProjects: [{ _id: A, organizationId: "org_a" }],
+            suppressInaccessibleTelemetryFor: B,
+          }),
+        ),
+      { wrapper: wrapperFor(`/p/${B}/servers`) },
+    );
+
+    expect(vi.mocked(track)).not.toHaveBeenCalledWith(
+      "project_route_inaccessible",
+      expect.anything(),
+    );
+  });
+
+  it("records when an inaccessible route unexpectedly becomes ready", async () => {
+    let input = inputFor({
+      projects: { [A]: {} },
+      allProjects: [{ _id: A, organizationId: "org_a" }],
+    });
+    const { rerender } = renderHook(() => useProjectRouteCoordinator(input), {
+      wrapper: wrapperFor(`/p/${B}/servers`),
+    });
+    await waitFor(() =>
+      expect(vi.mocked(track)).toHaveBeenCalledWith(
+        "project_route_inaccessible",
+        expect.objectContaining({ reason: "not-a-member" }),
+      ),
+    );
+
+    input = inputFor({ activeProjectId: B });
+    rerender();
+
+    await waitFor(() =>
+      expect(vi.mocked(track)).toHaveBeenCalledWith("project_route_recovered", {
+        location: "project-route",
+        cause: "late-ready",
+      }),
+    );
+  });
+
   it("answers a malformed project id without waiting", () => {
     const { result } = renderHook(
       () => useProjectRouteCoordinator(inputFor({ isAuthLoading: true })),
-      { wrapper: wrapperFor("/p/none/servers") }
+      { wrapper: wrapperFor("/p/none/servers") },
     );
     expect(result.current).toEqual({
       status: "inaccessible",
@@ -194,7 +240,7 @@ describe("useProjectRouteCoordinator", () => {
         window.history.replaceState({}, "", pathname);
         return useProjectRouteCoordinator(inputFor({ switchProject }));
       },
-      { initialProps: { pathname: path } }
+      { initialProps: { pathname: path } },
     );
     expect(result.current).toEqual({ status: "ready", projectId: A });
 
@@ -208,7 +254,7 @@ describe("useProjectRouteCoordinator", () => {
     rerender({ pathname: path });
     await waitFor(
       () => expect(switchProject).toHaveBeenCalledWith(B),
-      RESOLUTION_TIMEOUT
+      RESOLUTION_TIMEOUT,
     );
     expect(result.current.status).toBe("resolving");
   });
@@ -219,15 +265,15 @@ describe("useProjectRouteCoordinator", () => {
     // make one tab's project decide the other's.
     const tabA = renderHook(
       () => useProjectRouteCoordinator(inputFor({ activeProjectId: A })),
-      { wrapper: wrapperFor(`/p/${A}/servers`) }
+      { wrapper: wrapperFor(`/p/${A}/servers`) },
     );
     const switchProject = vi.fn().mockResolvedValue(undefined);
     const tabB = renderHook(
       () =>
         useProjectRouteCoordinator(
-          inputFor({ activeProjectId: B, switchProject })
+          inputFor({ activeProjectId: B, switchProject }),
         ),
-      { wrapper: wrapperFor(`/p/${B}/evals`) }
+      { wrapper: wrapperFor(`/p/${B}/evals`) },
     );
 
     expect(tabA.result.current).toEqual({ status: "ready", projectId: A });
@@ -244,11 +290,11 @@ describe("useProjectRouteCoordinator", () => {
     const switchProject = vi.fn().mockRejectedValue(new Error("nope"));
     const { result } = renderHook(
       () => useProjectRouteCoordinator(inputFor({ switchProject })),
-      { wrapper: wrapperFor(`/p/${B}/servers`) }
+      { wrapper: wrapperFor(`/p/${B}/servers`) },
     );
     await waitFor(
       () => expect(switchProject).toHaveBeenCalled(),
-      RESOLUTION_TIMEOUT
+      RESOLUTION_TIMEOUT,
     );
     expect(result.current.status).toBe("resolving");
   });
@@ -267,7 +313,7 @@ describe("useProjectRouteCoordinator", () => {
     });
     await waitFor(
       () => expect(switchProject).toHaveBeenCalledTimes(2),
-      RESOLUTION_TIMEOUT
+      RESOLUTION_TIMEOUT,
     );
   });
 
@@ -278,7 +324,7 @@ describe("useProjectRouteCoordinator", () => {
     const switchProject = vi.fn().mockRejectedValue(new Error("persistent"));
     const { result } = renderHook(
       () => useProjectRouteCoordinator(inputFor({ switchProject })),
-      { wrapper: wrapperFor(`/p/${B}/servers`) }
+      { wrapper: wrapperFor(`/p/${B}/servers`) },
     );
     await waitFor(
       () =>
@@ -286,7 +332,7 @@ describe("useProjectRouteCoordinator", () => {
           status: "inaccessible",
           requestedProjectId: B,
         }),
-      RESOLUTION_TIMEOUT
+      RESOLUTION_TIMEOUT,
     );
     // Bounded: the cap, not an unbounded retry loop.
     expect(switchProject.mock.calls.length).toBeLessThanOrEqual(4);

--- a/mcpjam-inspector/client/src/hooks/__tests__/useProjects.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useProjects.test.ts
@@ -10,11 +10,13 @@ import {
   type ProjectMember,
 } from "../useProjects";
 
-const { mockUseDbUserReady, mockUseMutation, mockUseQuery } = vi.hoisted(() => ({
-  mockUseDbUserReady: vi.fn(() => true),
-  mockUseMutation: vi.fn(),
-  mockUseQuery: vi.fn(),
-}));
+const { mockUseDbUserReady, mockUseMutation, mockUseQuery } = vi.hoisted(
+  () => ({
+    mockUseDbUserReady: vi.fn(() => true),
+    mockUseMutation: vi.fn(),
+    mockUseQuery: vi.fn(),
+  }),
+);
 
 vi.mock("convex/react", () => ({
   useMutation: mockUseMutation,
@@ -89,6 +91,31 @@ describe("useProjectQueries", () => {
     expect(result.current.hasProjects).toBe(false);
     expect(result.current.hasAnyProjects).toBe(false);
     expect(mockUseQuery).toHaveBeenCalledWith("projects:getMyProjects", {});
+  });
+
+  it("does not accept an empty project list before user setup finishes", () => {
+    mockUseDbUserReady.mockReturnValue(false);
+    mockUseQuery.mockImplementation((_name, args) =>
+      args === "skip" ? undefined : [],
+    );
+
+    const { result, rerender } = renderHook(() =>
+      useProjectQueries({ isAuthenticated: true }),
+    );
+
+    expect(mockUseQuery).toHaveBeenLastCalledWith(
+      "projects:getMyProjects",
+      "skip",
+    );
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.allProjects).toBeUndefined();
+
+    mockUseDbUserReady.mockReturnValue(true);
+    rerender();
+
+    expect(mockUseQuery).toHaveBeenLastCalledWith("projects:getMyProjects", {});
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.allProjects).toEqual([]);
   });
 });
 

--- a/mcpjam-inspector/client/src/hooks/use-project-route-coordinator.ts
+++ b/mcpjam-inspector/client/src/hooks/use-project-route-coordinator.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useCurrentPathname } from "@/lib/app-navigation";
-import { isProjectIdShape, readProjectPathSegment } from "@/lib/project-route";
+import { readProjectPathSegment } from "@/lib/project-route";
 import {
   resolveProjectRouteState,
   type ProjectRouteState,
@@ -243,7 +243,10 @@ export function useProjectRouteCoordinator(
       return;
     }
     if (state.status === "inaccessible") {
-      if (suppressInaccessibleTelemetryFor === state.requestedProjectId) {
+      if (
+        state.reason === "not-a-member" &&
+        suppressInaccessibleTelemetryFor === state.requestedProjectId
+      ) {
         return;
       }
       if (
@@ -256,15 +259,9 @@ export function useProjectRouteCoordinator(
         projectId: state.requestedProjectId,
         outcome: "inaccessible",
       };
-      trackProjectRouteInaccessible(
-        !isProjectIdShape(state.requestedProjectId)
-          ? "malformed"
-          : budgetExceededFor === state.requestedProjectId
-            ? "timed-out"
-            : "not-a-member",
-      );
+      trackProjectRouteInaccessible(state.reason);
     }
-  }, [state, budgetExceededFor, suppressInaccessibleTelemetryFor]);
+  }, [state, suppressInaccessibleTelemetryFor]);
 
   return state;
 }

--- a/mcpjam-inspector/client/src/hooks/use-project-route-coordinator.ts
+++ b/mcpjam-inspector/client/src/hooks/use-project-route-coordinator.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/project-route-state";
 import {
   trackProjectRouteInaccessible,
+  trackProjectRouteRecovered,
   trackProjectRouteResolved,
   trackProjectRouteScopeMismatch,
 } from "@/lib/project-route-telemetry";
@@ -28,12 +29,13 @@ export interface ProjectRouteCoordinatorInput {
   projects: Record<string, unknown>;
   /** ALL projects the viewer belongs to; undefined while loading. */
   allProjects:
-    | ReadonlyArray<{ _id: string; organizationId?: string }>
-    | undefined;
+    ReadonlyArray<{ _id: string; organizationId?: string }> | undefined;
   activeProjectId: string | null;
   activeOrganizationId: string | undefined;
   setActiveOrganizationId: (organizationId: string | undefined) => void;
   switchProject: (projectId: string) => Promise<void>;
+  /** A confirmed stale sign-in return is recovered by App before it paints. */
+  suppressInaccessibleTelemetryFor?: string | null;
 }
 
 /**
@@ -56,7 +58,7 @@ export interface ProjectRouteCoordinatorInput {
  * someone else's data" behavior being removed.
  */
 export function useProjectRouteCoordinator(
-  input: ProjectRouteCoordinatorInput
+  input: ProjectRouteCoordinatorInput,
 ): ProjectRouteState {
   const {
     isAuthenticated,
@@ -68,13 +70,14 @@ export function useProjectRouteCoordinator(
     activeOrganizationId,
     setActiveOrganizationId,
     switchProject,
+    suppressInaccessibleTelemetryFor,
   } = input;
 
   const pathname = useCurrentPathname();
   const requestedProjectId = readProjectPathSegment(pathname);
 
   const [budgetExceededFor, setBudgetExceededFor] = useState<string | null>(
-    null
+    null,
   );
   /**
    * Bumped when a switch REJECTS, so the effect below runs again.
@@ -89,7 +92,7 @@ export function useProjectRouteCoordinator(
 
   const activeOrgProjectIds = useMemo(
     () => new Set(Object.keys(projects)),
-    [projects]
+    [projects],
   );
 
   const { state, effect } = resolveProjectRouteState({
@@ -113,10 +116,13 @@ export function useProjectRouteCoordinator(
 
   const switchInFlightRef = useRef<string | null>(null);
   const switchAttemptsRef = useRef<{ projectId: string; count: number } | null>(
-    null
+    null,
   );
   const requestedAtRef = useRef<{ projectId: string; at: number } | null>(null);
-  const reportedRef = useRef<string | null>(null);
+  const reportedRef = useRef<{
+    projectId: string;
+    outcome: "ready" | "inaccessible";
+  } | null>(null);
 
   // Reset the per-request bookkeeping whenever the URL asks for a different
   // project — including a return to an unscoped route.
@@ -153,8 +159,8 @@ export function useProjectRouteCoordinator(
     effect.kind === "none"
       ? "none"
       : effect.kind === "switch-organization"
-      ? `org:${effect.organizationId}`
-      : `project:${effect.projectId}:${switchRetry}`;
+        ? `org:${effect.organizationId}`
+        : `project:${effect.projectId}:${switchRetry}`;
   // The effect body reads everything through refs and depends ONLY on the
   // key. `switchProject` in particular is a `useCallback` over the live server
   // map, so its identity changes constantly — as a dependency it would re-run
@@ -213,28 +219,52 @@ export function useProjectRouteCoordinator(
   // Telemetry: once per requested project, never carrying the id itself.
   useEffect(() => {
     if (state.status === "ready") {
-      if (reportedRef.current === state.projectId) return;
-      reportedRef.current = state.projectId;
+      const reported = reportedRef.current;
+      if (
+        reported?.projectId === state.projectId &&
+        reported.outcome === "ready"
+      ) {
+        return;
+      }
+      reportedRef.current = { projectId: state.projectId, outcome: "ready" };
+      if (
+        reported?.projectId === state.projectId &&
+        reported.outcome === "inaccessible"
+      ) {
+        trackProjectRouteRecovered();
+        return;
+      }
       const started = requestedAtRef.current;
       trackProjectRouteResolved(
         started && started.projectId === state.projectId
           ? Date.now() - started.at
-          : 0
+          : 0,
       );
       return;
     }
     if (state.status === "inaccessible") {
-      if (reportedRef.current === state.requestedProjectId) return;
-      reportedRef.current = state.requestedProjectId;
+      if (suppressInaccessibleTelemetryFor === state.requestedProjectId) {
+        return;
+      }
+      if (
+        reportedRef.current?.projectId === state.requestedProjectId &&
+        reportedRef.current.outcome === "inaccessible"
+      ) {
+        return;
+      }
+      reportedRef.current = {
+        projectId: state.requestedProjectId,
+        outcome: "inaccessible",
+      };
       trackProjectRouteInaccessible(
         !isProjectIdShape(state.requestedProjectId)
           ? "malformed"
           : budgetExceededFor === state.requestedProjectId
-          ? "timed-out"
-          : "not-a-member"
+            ? "timed-out"
+            : "not-a-member",
       );
     }
-  }, [state, budgetExceededFor]);
+  }, [state, budgetExceededFor, suppressInaccessibleTelemetryFor]);
 
   return state;
 }

--- a/mcpjam-inspector/client/src/hooks/useProjects.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjects.ts
@@ -71,9 +71,7 @@ export interface RemoteServer {
   xaaClientAuth?: string;
   xaaDcrClientId?: string;
   xaaDcrTokenEndpointAuthMethod?:
-    | "client_secret_post"
-    | "client_secret_basic"
-    | "none";
+    "client_secret_post" | "client_secret_basic" | "none";
   xaaDcrIssuer?: string;
   xaaDcrClientSecretExpiresAt?: number;
   xaaDcrRegisteredAt?: number;
@@ -124,13 +122,13 @@ export function shouldQueryProjectId(projectId: string | null | undefined) {
   const lower = normalized.toLowerCase();
   return Boolean(
     !INVALID_PROJECT_ID_SENTINELS.has(lower) &&
-      !UUID_PROJECT_ID_PATTERN.test(normalized) &&
-      !LOCAL_PROJECT_ID_PREFIXES.some((prefix) => lower.startsWith(prefix))
+    !UUID_PROJECT_ID_PATTERN.test(normalized) &&
+    !LOCAL_PROJECT_ID_PREFIXES.some((prefix) => lower.startsWith(prefix)),
   );
 }
 
 function isProjectMembersQueryResult(
-  value: unknown
+  value: unknown,
 ): value is ProjectMembersQueryResult {
   return (
     typeof value === "object" &&
@@ -140,7 +138,7 @@ function isProjectMembersQueryResult(
 }
 
 export function normalizeProjectMembersResult(
-  value: ProjectMember[] | ProjectMembersQueryResult | undefined
+  value: ProjectMember[] | ProjectMembersQueryResult | undefined,
 ): ProjectMembersQueryResult {
   if (Array.isArray(value)) {
     return { members: value, canManageMembers: false };
@@ -158,12 +156,12 @@ export function normalizeProjectMembersResult(
 
 export function filterProjectsForOrganization(
   projects: RemoteProject[] | undefined,
-  organizationId?: string
+  organizationId?: string,
 ) {
   if (!projects || !organizationId) return projects;
 
   return projects.filter(
-    (project) => project.organizationId === organizationId
+    (project) => project.organizationId === organizationId,
   );
 }
 
@@ -174,16 +172,24 @@ export function useProjectQueries({
   isAuthenticated: boolean;
   organizationId?: string;
 }) {
+  const isUserReady = useDbUserReady();
+  const canQueryProjects = isAuthenticated && isUserReady;
   const queriedProjects = useQuery(
     "projects:getMyProjects" as any,
-    isAuthenticated ? ({} as any) : "skip"
+    canQueryProjects ? ({} as any) : "skip",
   ) as RemoteProject[] | undefined;
 
-  const isLoading = isAuthenticated && queriedProjects === undefined;
+  // `getMyProjects` deliberately returns [] while the actor's database row
+  // does not exist yet. Starting it during bootstrap therefore turns a
+  // temporary signup state into an authoritative "no memberships" answer.
+  // Wait for user setup first; only a response from the post-bootstrap query
+  // may decide that a scoped project is unavailable.
+  const isLoading =
+    isAuthenticated && (!isUserReady || queriedProjects === undefined);
 
   const projects = useMemo(
     () => filterProjectsForOrganization(queriedProjects, organizationId),
-    [queriedProjects, organizationId]
+    [queriedProjects, organizationId],
   );
 
   const sortedProjects = useMemo(() => {
@@ -212,14 +218,14 @@ export function useProjectMembers({
 
   const membersResult = useQuery(
     "projects:getProjectMembers" as any,
-    enableQuery ? ({ projectId } as any) : "skip"
+    enableQuery ? ({ projectId } as any) : "skip",
   ) as ProjectMember[] | ProjectMembersQueryResult | undefined;
 
   const isLoading = enableQuery && membersResult === undefined;
 
   const { members, canManageMembers } = useMemo(
     () => normalizeProjectMembersResult(membersResult),
-    [membersResult]
+    [membersResult],
   );
 
   const activeMembers = useMemo(() => {
@@ -248,7 +254,7 @@ export function useProjectMembers({
 // member-only queries. A viewer may access Swarms only when they hold a
 // resolved member-or-above role; a guest — or any unresolved role — is denied.
 export function canViewSwarms(
-  role: ProjectMembershipRole | undefined
+  role: ProjectMembershipRole | undefined,
 ): boolean {
   return role === "owner" || role === "admin" || role === "member";
 }
@@ -262,7 +268,7 @@ export function canViewSwarms(
 // into a durable suite artifact" are different questions, and collapsing them
 // would make a future divergence silent. An unresolved role denies.
 export function canPromoteSessions(
-  role: ProjectMembershipRole | undefined
+  role: ProjectMembershipRole | undefined,
 ): boolean {
   return role === "owner" || role === "admin" || role === "member";
 }
@@ -273,7 +279,7 @@ export function canPromoteSessions(
 // New/Edit/Apply/Delete affordance that would 403 on click. An unresolved
 // role denies (fail-closed).
 export function canManageHosts(
-  role: ProjectMembershipRole | undefined
+  role: ProjectMembershipRole | undefined,
 ): boolean {
   return role === "owner" || role === "admin";
 }
@@ -384,7 +390,7 @@ export function useViewerProjectRole({
 export function isViewerRolePending(
   membersLoading: boolean,
   identityLoading: boolean,
-  viewerEmail: string | null | undefined
+  viewerEmail: string | null | undefined,
 ): boolean {
   if (identityLoading) return true;
   if (!viewerEmail?.trim()) return false;
@@ -394,7 +400,7 @@ export function isViewerRolePending(
 export function useProjectMutations() {
   const createProject = useMutation("projects:createProject" as any);
   const ensureDefaultProject = useMutation(
-    "projects:ensureDefaultProject" as any
+    "projects:ensureDefaultProject" as any,
   );
   const updateProject = useMutation("projects:updateProject" as any);
   // Phase 4: write the project default's connection portion through the
@@ -402,20 +408,20 @@ export function useProjectMutations() {
   // is still exported by the backend as a compat wrapper but the
   // inspector no longer calls it.
   const patchProjectDefaultConnection = useMutation(
-    "hostConfigsV2:patchProjectDefaultConnection" as any
+    "hostConfigsV2:patchProjectDefaultConnection" as any,
   );
   const deleteProject = useMutation("projects:deleteProject" as any);
   const inviteProjectMember = useMutation(
-    "projects:inviteProjectMember" as any
+    "projects:inviteProjectMember" as any,
   );
   const removeProjectMember = useMutation(
-    "projects:removeProjectMember" as any
+    "projects:removeProjectMember" as any,
   );
   const updateProjectMemberRole = useMutation(
-    "projects:updateProjectMemberRole" as any
+    "projects:updateProjectMemberRole" as any,
   );
   const updateProjectInviteRole = useMutation(
-    "projects:updateProjectInviteRole" as any
+    "projects:updateProjectInviteRole" as any,
   );
 
   return {
@@ -435,16 +441,16 @@ export function useProjectMutations() {
 export function useServerMutations() {
   const createServer = useMutation("servers:createServer" as any);
   const createServerIfMissing = useMutation(
-    "servers:createServerIfMissing" as any
+    "servers:createServerIfMissing" as any,
   );
   const updateServer = useMutation("servers:updateServer" as any);
   const deleteServer = useMutation("servers:deleteServer" as any);
   const createServerWithClientSecret = useAction(
-    "servers:createServerWithClientSecret" as any
+    "servers:createServerWithClientSecret" as any,
   );
   const moveServerToProject = useAction("servers:moveServerToProject" as any);
   const updateServerWithClientSecret = useAction(
-    "servers:updateServerWithClientSecret" as any
+    "servers:updateServerWithClientSecret" as any,
   );
 
   return {
@@ -472,7 +478,7 @@ export function useProjectServers({
 
   const servers = useQuery(
     "servers:getProjectServers" as any,
-    shouldQuery ? ({ projectId: queryProjectId } as any) : "skip"
+    shouldQuery ? ({ projectId: queryProjectId } as any) : "skip",
   ) as RemoteServer[] | undefined;
 
   const isLoading = shouldQuery && servers === undefined;
@@ -516,7 +522,7 @@ export function useProjectsBulkServers({
     "servers:listForProjects" as any,
     isAuthenticated && stableProjectIds.length > 0
       ? ({ projectIds: stableProjectIds } as any)
-      : "skip"
+      : "skip",
   ) as Record<string, RemoteServer[]> | undefined;
 
   const isLoading =
@@ -524,7 +530,7 @@ export function useProjectsBulkServers({
 
   const serversByProject = useMemo<Record<string, RemoteServer[]>>(
     () => data ?? {},
-    [data]
+    [data],
   );
 
   return {

--- a/mcpjam-inspector/client/src/lib/__tests__/project-route-recovery.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-route-recovery.test.ts
@@ -8,9 +8,11 @@ const STALE = "k5700000000000000000000000a";
 const CURRENT = "k5700000000000000000000000b";
 
 describe("project sign-in return recovery", () => {
-  it("preserves the page, query and hash when switching to the current project", () => {
-    const path = `/p/${STALE}/evals/suite/s1?view=runs#case-3`;
-    const intent = createProjectSignInReturnRecoveryIntent(path);
+  it("preserves the current page, query and hash when switching projects", () => {
+    const intent = createProjectSignInReturnRecoveryIntent(
+      `/p/${STALE}/evals/suite/s1?view=runs#case-3`,
+    );
+    const currentPath = `/p/${STALE}/servers?tab=tools#details`;
 
     expect(
       resolveProjectSignInReturnRecovery({
@@ -18,13 +20,15 @@ describe("project sign-in return recovery", () => {
         routeState: {
           status: "inaccessible",
           requestedProjectId: STALE,
+          reason: "not-a-member",
         },
+        currentPath,
         membershipProjectIds: new Set([CURRENT]),
         fallbackProject: { id: CURRENT, name: "Default Project" },
       }),
     ).toEqual({
       kind: "switch",
-      path: `/p/${CURRENT}/evals/suite/s1?view=runs#case-3`,
+      path: `/p/${CURRENT}/servers?tab=tools#details`,
       message: "Project not found. Switched to Default Project.",
     });
   });
@@ -36,7 +40,9 @@ describe("project sign-in return recovery", () => {
         routeState: {
           status: "inaccessible",
           requestedProjectId: STALE,
+          reason: "not-a-member",
         },
+        currentPath: `/p/${STALE}/servers`,
         membershipProjectIds: new Set([CURRENT]),
         fallbackProject: { id: CURRENT, name: "Default Project" },
       }),
@@ -53,7 +59,9 @@ describe("project sign-in return recovery", () => {
         routeState: {
           status: "inaccessible",
           requestedProjectId: "not-a-project",
+          reason: "malformed",
         },
+        currentPath: "/p/not-a-project/servers",
         membershipProjectIds: new Set([CURRENT]),
         fallbackProject: { id: CURRENT, name: "Default Project" },
       }),
@@ -68,11 +76,42 @@ describe("project sign-in return recovery", () => {
         routeState: {
           status: "inaccessible",
           requestedProjectId: STALE,
+          reason: "timed-out",
         },
-        membershipProjectIds: new Set([STALE, CURRENT]),
+        currentPath: `/p/${STALE}/servers`,
+        membershipProjectIds: new Set([CURRENT]),
         fallbackProject: { id: CURRENT, name: "Default Project" },
       }),
     ).toEqual({ kind: "clear" });
+  });
+
+  it("keeps the recovery intent until membership data has loaded", () => {
+    const intent = createProjectSignInReturnRecoveryIntent(
+      `/p/${STALE}/servers`,
+    );
+    const input = {
+      intent,
+      routeState: {
+        status: "inaccessible" as const,
+        requestedProjectId: STALE,
+        reason: "not-a-member" as const,
+      },
+      currentPath: `/p/${STALE}/servers`,
+      fallbackProject: { id: CURRENT, name: "Default Project" },
+    };
+
+    expect(
+      resolveProjectSignInReturnRecovery({
+        ...input,
+        membershipProjectIds: undefined,
+      }),
+    ).toEqual({ kind: "none" });
+    expect(
+      resolveProjectSignInReturnRecovery({
+        ...input,
+        membershipProjectIds: new Set([CURRENT]),
+      }).kind,
+    ).toBe("switch");
   });
 
   it("uses home when the account has no fallback project", () => {
@@ -85,7 +124,9 @@ describe("project sign-in return recovery", () => {
         routeState: {
           status: "inaccessible",
           requestedProjectId: STALE,
+          reason: "not-a-member",
         },
+        currentPath: `/p/${STALE}/playground`,
         membershipProjectIds: new Set(),
         fallbackProject: null,
       }),
@@ -100,6 +141,7 @@ describe("project sign-in return recovery", () => {
       resolveProjectSignInReturnRecovery({
         intent,
         routeState: { status: "ready", projectId: STALE },
+        currentPath: `/p/${STALE}/servers`,
         membershipProjectIds: new Set([STALE]),
         fallbackProject: { id: STALE, name: "Original" },
       }),
@@ -108,6 +150,7 @@ describe("project sign-in return recovery", () => {
       resolveProjectSignInReturnRecovery({
         intent,
         routeState: { status: "ready", projectId: CURRENT },
+        currentPath: `/p/${CURRENT}/servers`,
         membershipProjectIds: new Set([CURRENT]),
         fallbackProject: { id: CURRENT, name: "Current" },
       }),

--- a/mcpjam-inspector/client/src/lib/__tests__/project-route-recovery.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-route-recovery.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  createProjectSignInReturnRecoveryIntent,
+  resolveProjectSignInReturnRecovery,
+} from "../project-route-recovery";
+
+const STALE = "k5700000000000000000000000a";
+const CURRENT = "k5700000000000000000000000b";
+
+describe("project sign-in return recovery", () => {
+  it("preserves the page, query and hash when switching to the current project", () => {
+    const path = `/p/${STALE}/evals/suite/s1?view=runs#case-3`;
+    const intent = createProjectSignInReturnRecoveryIntent(path);
+
+    expect(
+      resolveProjectSignInReturnRecovery({
+        intent,
+        routeState: {
+          status: "inaccessible",
+          requestedProjectId: STALE,
+        },
+        membershipProjectIds: new Set([CURRENT]),
+        fallbackProject: { id: CURRENT, name: "Default Project" },
+      }),
+    ).toEqual({
+      kind: "switch",
+      path: `/p/${CURRENT}/evals/suite/s1?view=runs#case-3`,
+      message: "Project not found. Switched to Default Project.",
+    });
+  });
+
+  it("does nothing for a direct inaccessible URL", () => {
+    expect(
+      resolveProjectSignInReturnRecovery({
+        intent: null,
+        routeState: {
+          status: "inaccessible",
+          requestedProjectId: STALE,
+        },
+        membershipProjectIds: new Set([CURRENT]),
+        fallbackProject: { id: CURRENT, name: "Default Project" },
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("does not hide malformed URLs or switch timeouts", () => {
+    const malformed = createProjectSignInReturnRecoveryIntent(
+      "/p/not-a-project/servers",
+    );
+    expect(
+      resolveProjectSignInReturnRecovery({
+        intent: malformed,
+        routeState: {
+          status: "inaccessible",
+          requestedProjectId: "not-a-project",
+        },
+        membershipProjectIds: new Set([CURRENT]),
+        fallbackProject: { id: CURRENT, name: "Default Project" },
+      }),
+    ).toEqual({ kind: "clear" });
+
+    const intent = createProjectSignInReturnRecoveryIntent(
+      `/p/${STALE}/servers`,
+    );
+    expect(
+      resolveProjectSignInReturnRecovery({
+        intent,
+        routeState: {
+          status: "inaccessible",
+          requestedProjectId: STALE,
+        },
+        membershipProjectIds: new Set([STALE, CURRENT]),
+        fallbackProject: { id: CURRENT, name: "Default Project" },
+      }),
+    ).toEqual({ kind: "clear" });
+  });
+
+  it("uses home when the account has no fallback project", () => {
+    const intent = createProjectSignInReturnRecoveryIntent(
+      `/p/${STALE}/playground`,
+    );
+    expect(
+      resolveProjectSignInReturnRecovery({
+        intent,
+        routeState: {
+          status: "inaccessible",
+          requestedProjectId: STALE,
+        },
+        membershipProjectIds: new Set(),
+        fallbackProject: null,
+      }),
+    ).toEqual({ kind: "home" });
+  });
+
+  it("clears its one-shot intent after success or unrelated navigation", () => {
+    const intent = createProjectSignInReturnRecoveryIntent(
+      `/p/${STALE}/servers`,
+    );
+    expect(
+      resolveProjectSignInReturnRecovery({
+        intent,
+        routeState: { status: "ready", projectId: STALE },
+        membershipProjectIds: new Set([STALE]),
+        fallbackProject: { id: STALE, name: "Original" },
+      }),
+    ).toEqual({ kind: "clear" });
+    expect(
+      resolveProjectSignInReturnRecovery({
+        intent,
+        routeState: { status: "ready", projectId: CURRENT },
+        membershipProjectIds: new Set([CURRENT]),
+        fallbackProject: { id: CURRENT, name: "Current" },
+      }),
+    ).toEqual({ kind: "clear" });
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/project-route-state.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-route-state.test.ts
@@ -12,15 +12,14 @@ const base = {
   activeProjectId: null as string | null,
   activeOrgProjectIds: new Set<string>(),
   allProjects: undefined as
-    | ReadonlyArray<{ _id: string; organizationId?: string }>
-    | undefined,
+    ReadonlyArray<{ _id: string; organizationId?: string }> | undefined,
   activeOrganizationId: "org_a" as string | undefined,
 };
 
 describe("resolveProjectRouteState", () => {
   it("reports unscoped for a route with no project segment", () => {
     expect(
-      resolveProjectRouteState({ ...base, requestedProjectId: null }).state
+      resolveProjectRouteState({ ...base, requestedProjectId: null }).state,
     ).toEqual({ status: "unscoped" });
   });
 
@@ -32,7 +31,7 @@ describe("resolveProjectRouteState", () => {
         ...base,
         activeProjectId: A,
         isLoadingRemoteProjects: true,
-      }).state
+      }).state,
     ).toEqual({ status: "ready", projectId: A });
   });
 
@@ -44,20 +43,25 @@ describe("resolveProjectRouteState", () => {
         ...base,
         requestedProjectId: "none",
         isAuthLoading: true,
-      }).state
-    ).toEqual({ status: "inaccessible", requestedProjectId: "none" });
+      }).state,
+    ).toEqual({
+      status: "inaccessible",
+      requestedProjectId: "none",
+      reason: "malformed",
+    });
   });
 
   it("waits for auth and for the project list", () => {
     expect(
-      resolveProjectRouteState({ ...base, isAuthLoading: true }).state.status
+      resolveProjectRouteState({ ...base, isAuthLoading: true }).state.status,
     ).toBe("resolving");
     expect(
-      resolveProjectRouteState({ ...base, isAuthenticated: false }).state.status
+      resolveProjectRouteState({ ...base, isAuthenticated: false }).state
+        .status,
     ).toBe("resolving");
     expect(
       resolveProjectRouteState({ ...base, isLoadingRemoteProjects: true }).state
-        .status
+        .status,
     ).toBe("resolving");
   });
 
@@ -84,10 +88,11 @@ describe("resolveProjectRouteState", () => {
 
   it("waits while the membership list is still loading", () => {
     expect(
-      resolveProjectRouteState({ ...base, allProjects: undefined }).effect
+      resolveProjectRouteState({ ...base, allProjects: undefined }).effect,
     ).toEqual({ kind: "none" });
     expect(
-      resolveProjectRouteState({ ...base, allProjects: undefined }).state.status
+      resolveProjectRouteState({ ...base, allProjects: undefined }).state
+        .status,
     ).toBe("resolving");
   });
 
@@ -107,8 +112,12 @@ describe("resolveProjectRouteState", () => {
       resolveProjectRouteState({
         ...base,
         allProjects: [{ _id: B, organizationId: "org_a" }],
-      }).state
-    ).toEqual({ status: "inaccessible", requestedProjectId: A });
+      }).state,
+    ).toEqual({
+      status: "inaccessible",
+      requestedProjectId: A,
+      reason: "not-a-member",
+    });
   });
 
   it("handles an organization-less project on both sides of the filter", () => {
@@ -118,14 +127,14 @@ describe("resolveProjectRouteState", () => {
       resolveProjectRouteState({
         ...base,
         allProjects: [{ _id: A }],
-      }).state.status
+      }).state.status,
     ).toBe("inaccessible");
     expect(
       resolveProjectRouteState({
         ...base,
         activeOrganizationId: undefined,
         allProjects: [{ _id: A }],
-      }).state.status
+      }).state.status,
     ).toBe("resolving");
   });
 
@@ -138,7 +147,11 @@ describe("resolveProjectRouteState", () => {
       activeOrgProjectIds: new Set([B]),
       allProjects: [{ _id: B, organizationId: "org_a" }],
     });
-    expect(state).toEqual({ status: "inaccessible", requestedProjectId: A });
+    expect(state).toEqual({
+      status: "inaccessible",
+      requestedProjectId: A,
+      reason: "not-a-member",
+    });
   });
 
   it("gives up once the resolve budget is spent", () => {
@@ -147,8 +160,12 @@ describe("resolveProjectRouteState", () => {
         ...base,
         allProjects: [{ _id: A, organizationId: "org_a" }],
         hasExceededResolveBudget: true,
-      }).state
-    ).toEqual({ status: "inaccessible", requestedProjectId: A });
+      }).state,
+    ).toEqual({
+      status: "inaccessible",
+      requestedProjectId: A,
+      reason: "timed-out",
+    });
   });
 
   it("still reports ready after the budget is spent if the app caught up", () => {
@@ -158,7 +175,7 @@ describe("resolveProjectRouteState", () => {
         ...base,
         activeProjectId: A,
         hasExceededResolveBudget: true,
-      }).state
+      }).state,
     ).toEqual({ status: "ready", projectId: A });
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/project-route-telemetry.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-route-telemetry.test.ts
@@ -1,0 +1,18 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { track } from "../analytics";
+import { trackStaleProjectReturnRecovered } from "../project-route-telemetry";
+
+vi.mock("../analytics", () => ({ track: vi.fn() }));
+
+describe("project route recovery telemetry", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("emits only low-cardinality recovery properties", () => {
+    trackStaleProjectReturnRecovered("switched");
+
+    expect(vi.mocked(track)).toHaveBeenCalledWith(
+      "project_route_stale_return_recovered",
+      { location: "signin-return", outcome: "switched" },
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/lib/project-route-recovery.ts
+++ b/mcpjam-inspector/client/src/lib/project-route-recovery.ts
@@ -6,7 +6,6 @@ import {
 } from "./project-route";
 
 export interface ProjectSignInReturnRecoveryIntent {
-  path: string;
   requestedProjectId: string;
 }
 
@@ -21,7 +20,7 @@ export function createProjectSignInReturnRecoveryIntent(
   path: string,
 ): ProjectSignInReturnRecoveryIntent | null {
   const requestedProjectId = readProjectPathSegment(path);
-  return requestedProjectId ? { path, requestedProjectId } : null;
+  return requestedProjectId ? { requestedProjectId } : null;
 }
 
 /**
@@ -32,10 +31,17 @@ export function createProjectSignInReturnRecoveryIntent(
 export function resolveProjectSignInReturnRecovery(args: {
   intent: ProjectSignInReturnRecoveryIntent | null;
   routeState: ProjectRouteState;
+  currentPath: string;
   membershipProjectIds: ReadonlySet<string> | undefined;
   fallbackProject: { id: string; name: string } | null;
 }): ProjectSignInReturnRecoveryDecision {
-  const { intent, routeState, membershipProjectIds, fallbackProject } = args;
+  const {
+    intent,
+    routeState,
+    currentPath,
+    membershipProjectIds,
+    fallbackProject,
+  } = args;
   if (!intent) return { kind: "none" };
   if (routeState.status === "unscoped") return { kind: "clear" };
 
@@ -47,16 +53,19 @@ export function resolveProjectSignInReturnRecovery(args: {
   if (routeState.status === "resolving") return { kind: "none" };
   if (routeState.status === "ready") return { kind: "clear" };
 
-  const isConfirmedMissingMembership =
-    isProjectIdShape(intent.requestedProjectId) &&
-    membershipProjectIds !== undefined &&
-    !membershipProjectIds.has(intent.requestedProjectId);
-  if (!isConfirmedMissingMembership) return { kind: "clear" };
+  if (!isProjectIdShape(intent.requestedProjectId)) return { kind: "clear" };
+  if (membershipProjectIds === undefined) return { kind: "none" };
+  if (
+    routeState.reason !== "not-a-member" ||
+    membershipProjectIds.has(intent.requestedProjectId)
+  ) {
+    return { kind: "clear" };
+  }
   if (!fallbackProject) return { kind: "home" };
 
   return {
     kind: "switch",
-    path: replaceProjectInPath(intent.path, fallbackProject.id),
+    path: replaceProjectInPath(currentPath, fallbackProject.id),
     message: `Project not found. Switched to ${fallbackProject.name}.`,
   };
 }

--- a/mcpjam-inspector/client/src/lib/project-route-recovery.ts
+++ b/mcpjam-inspector/client/src/lib/project-route-recovery.ts
@@ -1,0 +1,62 @@
+import type { ProjectRouteState } from "./project-route-state";
+import {
+  isProjectIdShape,
+  readProjectPathSegment,
+  replaceProjectInPath,
+} from "./project-route";
+
+export interface ProjectSignInReturnRecoveryIntent {
+  path: string;
+  requestedProjectId: string;
+}
+
+export type ProjectSignInReturnRecoveryDecision =
+  | { kind: "none" }
+  | { kind: "clear" }
+  | { kind: "home" }
+  | { kind: "switch"; path: string; message: string };
+
+/** Arm recovery only for a path selected by the completed sign-in flow. */
+export function createProjectSignInReturnRecoveryIntent(
+  path: string,
+): ProjectSignInReturnRecoveryIntent | null {
+  const requestedProjectId = readProjectPathSegment(path);
+  return requestedProjectId ? { path, requestedProjectId } : null;
+}
+
+/**
+ * Decide whether a sign-in return is stale using the authoritative membership
+ * response. Timeouts, malformed ids, direct links and ordinary navigation do
+ * not recover to another project.
+ */
+export function resolveProjectSignInReturnRecovery(args: {
+  intent: ProjectSignInReturnRecoveryIntent | null;
+  routeState: ProjectRouteState;
+  membershipProjectIds: ReadonlySet<string> | undefined;
+  fallbackProject: { id: string; name: string } | null;
+}): ProjectSignInReturnRecoveryDecision {
+  const { intent, routeState, membershipProjectIds, fallbackProject } = args;
+  if (!intent) return { kind: "none" };
+  if (routeState.status === "unscoped") return { kind: "clear" };
+
+  const routeProjectId =
+    routeState.status === "ready"
+      ? routeState.projectId
+      : routeState.requestedProjectId;
+  if (routeProjectId !== intent.requestedProjectId) return { kind: "clear" };
+  if (routeState.status === "resolving") return { kind: "none" };
+  if (routeState.status === "ready") return { kind: "clear" };
+
+  const isConfirmedMissingMembership =
+    isProjectIdShape(intent.requestedProjectId) &&
+    membershipProjectIds !== undefined &&
+    !membershipProjectIds.has(intent.requestedProjectId);
+  if (!isConfirmedMissingMembership) return { kind: "clear" };
+  if (!fallbackProject) return { kind: "home" };
+
+  return {
+    kind: "switch",
+    path: replaceProjectInPath(intent.path, fallbackProject.id),
+    message: `Project not found. Switched to ${fallbackProject.name}.`,
+  };
+}

--- a/mcpjam-inspector/client/src/lib/project-route-state.ts
+++ b/mcpjam-inspector/client/src/lib/project-route-state.ts
@@ -26,7 +26,11 @@ export type ProjectRouteState =
   | { status: "unscoped" }
   | { status: "resolving"; requestedProjectId: string }
   | { status: "ready"; projectId: string }
-  | { status: "inaccessible"; requestedProjectId: string };
+  | {
+      status: "inaccessible";
+      requestedProjectId: string;
+      reason: "malformed" | "timed-out" | "not-a-member";
+    };
 
 /**
  * What the caller must DO to move resolution forward. Separate from the
@@ -54,8 +58,7 @@ export interface ProjectRouteResolutionInput {
   activeOrgProjectIds: ReadonlySet<string>;
   /** ALL projects the viewer belongs to; undefined while still loading. */
   allProjects:
-    | ReadonlyArray<{ _id: string; organizationId?: string }>
-    | undefined;
+    ReadonlyArray<{ _id: string; organizationId?: string }> | undefined;
   activeOrganizationId: string | undefined;
   /**
    * The resolving state is bounded: something upstream can stall (a query
@@ -67,7 +70,7 @@ export interface ProjectRouteResolutionInput {
 }
 
 export function resolveProjectRouteState(
-  input: ProjectRouteResolutionInput
+  input: ProjectRouteResolutionInput,
 ): ProjectRouteResolution {
   const {
     requestedProjectId,
@@ -89,14 +92,16 @@ export function resolveProjectRouteState(
     state: { status: "resolving", requestedProjectId },
     effect: { kind: "none" },
   };
-  const inaccessible: ProjectRouteResolution = {
-    state: { status: "inaccessible", requestedProjectId },
+  const inaccessible = (
+    reason: Extract<ProjectRouteState, { status: "inaccessible" }>["reason"],
+  ): ProjectRouteResolution => ({
+    state: { status: "inaccessible", requestedProjectId, reason },
     effect: { kind: "none" },
-  };
+  });
 
   // A malformed id can never become accessible, so it does not wait for auth:
   // `/p/none/servers` and `/p/<typo>/servers` are answered immediately.
-  if (!isProjectIdShape(requestedProjectId)) return inaccessible;
+  if (!isProjectIdShape(requestedProjectId)) return inaccessible("malformed");
 
   // The URL already matches the app's state. Checked before any loading gate
   // so a refresh on the project you are already in renders without a spinner.
@@ -107,7 +112,7 @@ export function resolveProjectRouteState(
     };
   }
 
-  if (hasExceededResolveBudget) return inaccessible;
+  if (hasExceededResolveBudget) return inaccessible("timed-out");
 
   // 1. Auth first: membership is the only thing that can answer this URL, and
   //    it does not exist yet.
@@ -128,15 +133,15 @@ export function resolveProjectRouteState(
   if (allProjects === undefined) return resolving;
 
   const match = allProjects.find(
-    (project) => project._id === requestedProjectId
+    (project) => project._id === requestedProjectId,
   );
-  if (!match) return inaccessible;
+  if (!match) return inaccessible("not-a-member");
 
   if (!match.organizationId) {
     // An organization-less project can never enter an organization-filtered
     // set, so waiting for one would hang forever. With no organization filter
     // active it lands in the unfiltered set on a later pass.
-    return activeOrganizationId ? inaccessible : resolving;
+    return activeOrganizationId ? inaccessible("not-a-member") : resolving;
   }
 
   if (match.organizationId !== activeOrganizationId) {

--- a/mcpjam-inspector/client/src/lib/project-route-telemetry.ts
+++ b/mcpjam-inspector/client/src/lib/project-route-telemetry.ts
@@ -40,13 +40,29 @@ export function trackProjectRouteResolved(durationMs: number): void {
 }
 
 export function trackProjectRouteInaccessible(
-  reason: "malformed" | "not-a-member" | "timed-out"
+  reason: "malformed" | "not-a-member" | "timed-out",
 ): void {
   track("project_route_inaccessible", { location: LOCATION, reason });
 }
 
+export function trackProjectRouteRecovered(): void {
+  track("project_route_recovered", {
+    location: LOCATION,
+    cause: "late-ready",
+  });
+}
+
+export function trackStaleProjectReturnRecovered(
+  outcome: "switched" | "no-fallback",
+): void {
+  track("project_route_stale_return_recovered", {
+    location: "signin-return",
+    outcome,
+  });
+}
+
 export function trackProjectRouteScopeMismatch(
-  guard: "redirect-loop" | "repeated-switch"
+  guard: "redirect-loop" | "repeated-switch",
 ): void {
   track("project_route_scope_mismatch", { location: LOCATION, guard });
 }
@@ -60,7 +76,7 @@ export function trackProjectRouteScopeMismatch(
  *              precedence (scenario, billing, CLI, API keys) won.
  */
 export function trackSignInReturnRestored(
-  outcome: "restored" | "absent" | "superseded"
+  outcome: "restored" | "absent" | "superseded",
 ): void {
   track("app_signin_return_restored", { location: "signin-return", outcome });
 }

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -38,7 +38,6 @@ import {
   PERMALINK_SIGN_IN_STATE_KEY,
   takePermalinkSignInReturn,
 } from "./lib/permalink-signin-return";
-import { clearAppSignInReturnPath } from "./lib/app-signin-return-path";
 import {
   callbackMatchesPending,
   HANDOFF_SIGN_IN_STATE_KEY,
@@ -391,12 +390,10 @@ if (isInIframe) {
         // `replace`, not `assign`: `/callback` is not somewhere the back
         // button should return to.
         if (returnTo) {
-          // The generic "put me back" path is armed by the same click as this
-          // one and is consumed on `/callback` by `App.tsx` — which this
-          // redirect navigates away from before it ever runs. Clearing it here
-          // keeps a path from outliving the sign-in that stored it and
-          // capturing the NEXT one, which is the rule that module states.
-          clearAppSignInReturnPath();
+          // Keep the generic return path through this redirect. `App.tsx`
+          // consumes it on the restored page, where it also arms stale-project
+          // recovery. Clearing it here loses that signal because this replace
+          // navigates away before the callback route's App effect can run.
           window.location.replace(returnTo);
         }
       }}

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -459,6 +459,10 @@ export const ANALYTICS_EVENTS = {
   //   active project.
   // `project_route_inaccessible`       props: reason (malformed | not-a-member
   //   | timed-out). Never says whether the project exists.
+  // `project_route_recovered`          props: cause (late-ready). A route that
+  //   had already looked inaccessible later resolved without navigation.
+  // `project_route_stale_return_recovered` props: outcome (switched |
+  //   no-fallback). A post-sign-in scoped path named a lost membership.
   // `project_route_scope_mismatch`     props: guard (redirect-loop |
   //   repeated-switch). Redirect-loop protection tripped.
   // `app_signin_return_restored`       props: outcome (restored | absent |
@@ -466,6 +470,8 @@ export const ANALYTICS_EVENTS = {
   project_route_legacy_normalized: { source: "client" },
   project_route_resolved: { source: "client" },
   project_route_inaccessible: { source: "client" },
+  project_route_recovered: { source: "client" },
+  project_route_stale_return_recovered: { source: "client" },
   project_route_scope_mismatch: { source: "client" },
   app_signin_return_restored: { source: "client" },
 } as const satisfies Record<string, { source: "client" | "server" }>;


### PR DESCRIPTION
## Summary
- wait for database user setup before accepting project membership results
- recover stale post-sign-in project URLs by switching to the current project without flashing the unavailable screen
- add low-cardinality recovery telemetry

## Testing
- 159 focused client tests pass
- npm run typecheck:client

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false "project unavailable" screens that appeared during sign-in and when returning to a stale project URL.

The project membership query no longer runs before the database user exists, so an empty list during bootstrap no longer reads as "no memberships." After sign-in, if the saved return path points to a project the user no longer belongs to, the app now switches to the current project (or home) instead of flashing the unavailable screen. This also applies when AuthKit restores the permalink before the callback route ever renders.

**Bug Fixes**
- Waits for user setup before accepting project membership results.
- Marks inaccessible routes with a reason (`malformed`, `timed-out`, `not-a-member`) and recovers only the `not-a-member` case; malformed URLs and resolve timeouts still show the unavailable screen.
- Recovers stale sign-in returns restored directly to the permalink before the callback renders.
- Adds recovery telemetry: suppresses the misleading "inaccessible" event for recovered routes and tracks when an inaccessible route later resolves on its own.

<sup>Written for commit 798847ba0c300c1017458f0a2229a65e12d854a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

