### PR TITLE
Show Claude Code and Codex in client Compare

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -236,30 +236,24 @@ export function HostConfigCompareView({
   const selectionScopeId = presetOnly ? "public" : projectId ?? "";
 
   // Catalog host profiles (Claude, ChatGPT, Cursor, …) offered as opt-in
-  // comparison columns even when the user hasn't created them.
+  // read-only comparison columns even when the user cannot create them.
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const claudeCodeEnabled = useClaudeCodeHostEnabled();
   const codexEnabled = useCodexHostEnabled();
   const cursorCliEnabled = useCursorHostEnabled();
-  // The flags gate the New Host template picker, not this matrix — so they
-  // apply only to the signed-in surface, where a preset column sits next to
-  // hosts you can actually create. In public (caniuse) mode the matrix is
-  // reference data about third-party hosts and shows every catalog row;
-  // gating it there hid Claude Code and Codex from every anonymous visitor,
-  // since the hooks read an unresolved flag as off and the flags are scoped
-  // to @mcpjam.com users.
-  //
-  // DERIVED from the shared FLAG_GATED_HOSTS map, not typed out per host: the
-  // hand-written version gated each id with its own `if`, so a newly gated host
-  // was hidden on the five surfaces that share the map and silently offered
-  // here.
+  // Claude Code and Codex are always useful as read-only reference data here,
+  // like on caniuse.dev. Their creation flags still gate the New Client picker
+  // and every mutation path. Other gated hosts keep their existing rollout.
   const excludedPresetTemplateIds = useMemo(() => {
     if (presetOnly) return new Set<string>();
-    return excludedFlagGatedHostIds({
+    const excluded = excludedFlagGatedHostIds({
       claudeCode: claudeCodeEnabled,
       codex: codexEnabled,
       cursorCli: cursorCliEnabled,
     });
+    excluded.delete("claude-code");
+    excluded.delete("codex");
+    return excluded;
   }, [claudeCodeEnabled, codexEnabled, cursorCliEnabled, presetOnly]);
   // Public caniuse still displays flag-gated hosts as reference data, but must
   // not offer their verify links because those links auto-create a host, and

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
@@ -105,13 +105,13 @@ describe("HostConfigCompareView public mode", () => {
     document.documentElement.classList.remove("dark");
   });
 
-  it("offers the flag-gated hosts in public mode but not in the signed-in matrix", async () => {
+  it("shows Claude Code and Codex in public and signed-in Compare", async () => {
     // `useFeatureFlagEnabled` is mocked false above — the anonymous-visitor
     // case, and the one that used to drop these two from caniuse entirely.
     // They sit past the 6-chip inline limit, so assert them where they live:
     // the More menu. Public caniuse is reference data and lists every catalog
-    // host; the signed-in matrix sits beside hosts you can actually create,
-    // so it keeps the rollout gate. Pinned together so the split can't drift.
+    // host. The signed-in matrix is also reference data, even though its New
+    // Client picker remains gated separately.
     const { unmount } = render(
       <MemoryRouter>
         <HostConfigCompareView
@@ -139,11 +139,12 @@ describe("HostConfigCompareView public mode", () => {
       screen.getByTestId("host-compare-chip-preset:claude")
     ).toBeInTheDocument();
     fireEvent.click(screen.getByTestId("host-compare-overflow-trigger"));
-    // ...and the overflow menu opened and lists other unranked presets, so
-    // the two absences below are the gate, not an unrendered menu.
+    // ...and the overflow menu includes the requested read-only presets while
+    // unrelated gated hosts retain their existing rollout behavior.
     expect(await screen.findByText("Notion")).toBeInTheDocument();
-    expect(screen.queryByText("Claude Code")).not.toBeInTheDocument();
-    expect(screen.queryByText("Codex")).not.toBeInTheDocument();
+    expect(screen.getByText("Claude Code")).toBeInTheDocument();
+    expect(screen.getByText("Codex")).toBeInTheDocument();
+    expect(screen.queryByText("Cursor CLI")).not.toBeInTheDocument();
   });
 
   it("renders preset compare content without requiring sign-in or a project", async () => {

--- a/mcpjam-inspector/client/src/lib/host-compat/__tests__/feature-visibility.test.ts
+++ b/mcpjam-inspector/client/src/lib/host-compat/__tests__/feature-visibility.test.ts
@@ -112,6 +112,12 @@ describe("every surface reads the same map", () => {
     { id: "codex" },
   ];
 
+  it("hides Claude Code and Codex from gated pickers when flags are off", () => {
+    expect(
+      filterHostsByFeatureFlags(hosts, ALL_OFF).map((host) => host.id)
+    ).toEqual(["cursor"]);
+  });
+
   it("hides cursor-cli from the host picker, the reports, and the profiles alike", () => {
     const visibility = { ...ALL_ON, cursorCli: false };
     expect(


### PR DESCRIPTION
## Summary

Show Claude Code and Codex as read-only catalog presets in the signed-in Client Compare view, matching their visibility on caniuse.dev.

## Behavior

- Claude Code and Codex appear in the Compare client selector even when their rollout flags are off.
- Selecting either preset renders catalog capability data; no saved client is created.
- The New Client picker and other gated creation/execution paths still use the existing feature flags, so these clients remain unavailable to users outside the rollout audience.
- Cursor CLI keeps its existing rollout behavior and remains hidden from signed-in Compare when its flag is off.
- Public caniuse.dev behavior is unchanged.

## Implementation

The Compare view still derives its exclusion set from the shared feature-gated host catalog, then explicitly removes Claude Code and Codex from that display-only exclusion set. This keeps the creation gates untouched and preserves future/default gating for every other host.

## Tests

- Updated the Compare regression test to assert Claude Code and Codex are visible in both public and signed-in Compare while feature flags are off.
- Added coverage that the shared gated picker filter still excludes Claude Code and Codex when their flags are off.
- Confirmed Cursor CLI remains excluded from signed-in Compare when its flag is off.
- Focused Vitest: 25 passed.
- Client TypeScript typecheck: passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows Claude Code and Codex as read-only presets in the signed-in Client Compare view even when their rollout flags are off, matching their visibility on public caniuse.dev.

- Compare view previously hid these clients when flags were off; now they always appear as read-only reference data.
- New Client picker and creation paths still respect the flags, so these clients remain unavailable outside the rollout audience.
- Cursor CLI keeps its existing gated behavior in signed-in Compare.
- Public caniuse.dev behavior is unchanged.

<sup>Written for commit 3101eb2cf7f09026b7cecebddecd59a5222afbaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

