### PR TITLE
Close four trace-destination review findings that landed after #4656 merged

### DIFF
--- a/cli/src/commands/trace-destinations.ts
+++ b/cli/src/commands/trace-destinations.ts
@@ -97,14 +97,18 @@ function splitOnFirst(
   flag: string
 ): [string, string] {
   const index = raw.indexOf(separator);
-  if (index <= 0) {
+  // `< 0` and `=== 0` are different mistakes and get different sentences.
+  // Folding them into `<= 0` told someone who wrote ": value" that their
+  // argument had no separator, which is the one thing it did have, and made
+  // the empty-name message below unreachable.
+  if (index < 0) {
     throw usageError(
       `${flag} expects "Name${separator}value"; the argument had no "${separator}".`
     );
   }
   const name = raw.slice(0, index).trim();
   if (!name) {
-    throw usageError(`${flag} has an empty header name.`);
+    throw usageError(`${flag} has an empty name before the "${separator}".`);
   }
   return [name, raw.slice(index + separator.length)];
 }
@@ -155,8 +159,13 @@ export function resolveHeaders(
     // header-injection attempt, and it should not travel the wire to be
     // refused as a malformed record key. Same pattern the route enforces.
     if (!HEADER_NAME_PATTERN.test(name)) {
+      // The name is NOT echoed. `--header` splits on the first colon, so a
+      // malformed argument can put credential material in the name position
+      // (`--header "Bearer sk-live-…"` with the colon mistyped), and this
+      // message goes to stderr and into CI logs. The rule is enough to act on
+      // without quoting what failed it.
       throw usageError(
-        `Header name "${name}" is not an HTTP token. Use letters, digits and !#$%&'*+.^_\`|~- only.`
+        `That ${flag} name is not an HTTP token. Use letters, digits and !#$%&'*+.^_\`|~- only.`
       );
     }
     const key = name.toLowerCase();

--- a/cli/tests/trace-destination-header-source.test.ts
+++ b/cli/tests/trace-destination-header-source.test.ts
@@ -51,6 +51,34 @@ test("--clear-headers refuses to be combined with a header", () => {
   );
 });
 
+test("an argument with no separator says so; an empty name says THAT", () => {
+  // Two different mistakes, and folding them into one check told someone who
+  // wrote ": value" that their argument had no separator — the one thing it
+  // did have — while making the empty-name message unreachable.
+  assert.throws(
+    () => resolveHeaders({ header: ["Authorization Bearer tok"] }),
+    /had no ":"/
+  );
+  assert.throws(
+    () => resolveHeaders({ header: [": Bearer tok"] }),
+    /empty name before/
+  );
+});
+
+test("a malformed header does not echo what was in the name position", () => {
+  // `--header` splits on the FIRST colon, so a mistyped argument can put the
+  // credential in the name position. The message goes to stderr and into CI
+  // logs, so it states the rule and quotes nothing.
+  let message = "";
+  try {
+    resolveHeaders({ header: ["Bearer sk-live-do-not-echo=x: v"] });
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error);
+  }
+  assert.match(message, /not an HTTP token/);
+  assert.doesNotMatch(message, /sk-live-do-not-echo/);
+});
+
 test("--header splits on the first colon only", () => {
   assert.deepEqual(
     resolveHeaders({ header: ["Authorization: Bearer a:b:c"] }),

--- a/mcpjam-inspector/client/src/components/organization/observability/__tests__/TraceDestinationDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/organization/observability/__tests__/TraceDestinationDialog.test.tsx
@@ -164,10 +164,21 @@ describe("TraceDestinationDialog", () => {
     fireEvent.change(screen.getByLabelText("Endpoint URL"), {
       target: { value: "https://my-collector.internal.example.com" },
     });
-    // Picking a vendor for its header names must not discard the URL.
+
+    // The OPTION has to be picked, not just the trigger clicked. `applyPreset`
+    // runs from the Select's `onValueChange`, so opening the list alone
+    // exercises nothing and the assertion below would hold even if picking a
+    // vendor discarded the URL.
     fireEvent.click(screen.getByLabelText(/vendor/i));
-    expect(
-      screen.getByDisplayValue("https://my-collector.internal.example.com"),
-    ).toBeTruthy();
+    const option = await screen.findByRole("option", { name: /coralogix/i });
+    fireEvent.click(option);
+
+    await waitFor(() =>
+      expect(
+        screen.getByDisplayValue("https://my-collector.internal.example.com"),
+      ).toBeTruthy(),
+    );
+    // And the preset still did its real job: its header name is now offered.
+    expect(screen.getByDisplayValue("Authorization")).toBeTruthy();
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrgScopedWrite.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrgScopedWrite.test.tsx
@@ -127,6 +127,74 @@ describe("useOrgScopedWrite", () => {
     await waitFor(() => expect(result.current.isSaving).toBe(false));
   });
 
+  it("ignores a write left over from a PREVIOUS visit to the same org", async () => {
+    // `A → B → A` returns to the same id, so an id-equality check cannot tell
+    // the two visits apart. Without a visit token the first visit's write
+    // decremented the second visit's in-flight count and stopped the spinner
+    // while the second visit's own write was still running.
+    const stale = deferred();
+    const fresh = deferred();
+    const { result, rerender } = renderHook(
+      ({ org }: { org: string }) => useOrgScopedWrite(org),
+      { initialProps: { org: "org-a" } },
+    );
+
+    let staleSettled: Promise<void>;
+    act(() => {
+      staleSettled = result.current.run(() => stale.promise).catch(() => {});
+    });
+
+    rerender({ org: "org-b" });
+    rerender({ org: "org-a" });
+
+    let freshSettled: Promise<void>;
+    act(() => {
+      freshSettled = result.current.run(() => fresh.promise).catch(() => {});
+    });
+    expect(result.current.isSaving).toBe(true);
+
+    await act(async () => {
+      stale.resolve();
+      await staleSettled;
+    });
+    // The second visit's write is still in flight, so Save stays disabled.
+    expect(result.current.isSaving).toBe(true);
+
+    await act(async () => {
+      fresh.resolve();
+      await freshSettled;
+    });
+    await waitFor(() => expect(result.current.isSaving).toBe(false));
+  });
+
+  it("keeps the spinner up until the LAST write of a visit finishes", async () => {
+    // The counter's own job, in the ordering that motivated it.
+    const first = deferred();
+    const second = deferred();
+    const { result } = renderHook(() => useOrgScopedWrite("org-a"));
+
+    let firstSettled: Promise<void>;
+    let secondSettled: Promise<void>;
+    act(() => {
+      firstSettled = result.current.run(() => first.promise).catch(() => {});
+    });
+    act(() => {
+      secondSettled = result.current.run(() => second.promise).catch(() => {});
+    });
+
+    await act(async () => {
+      second.resolve();
+      await secondSettled;
+    });
+    expect(result.current.isSaving).toBe(true);
+
+    await act(async () => {
+      first.resolve();
+      await firstSettled;
+    });
+    await waitFor(() => expect(result.current.isSaving).toBe(false));
+  });
+
   it("lets only the NEWEST write of the same org report", async () => {
     // The org id alone cannot separate these: both writes belong to org-a.
     // Without a generation, the first to finish clears `isSaving` while the

--- a/mcpjam-inspector/client/src/hooks/useOrgScopedWrite.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrgScopedWrite.ts
@@ -92,6 +92,18 @@ export function useOrgScopedWrite(organizationId: string | null): {
    */
   const inFlightRef = useRef(0);
 
+  /**
+   * Which VISIT to an organization this is.
+   *
+   * The id cannot stand in for it. Switching `A → B → A` returns to the same
+   * id, so a write left over from the first visit to A satisfied an
+   * id-equality check on the second — and decremented a counter that had been
+   * zeroed in between, stopping the spinner while the second visit's own write
+   * was still in flight. A monotonic token separates the two visits, which an
+   * id by construction cannot.
+   */
+  const visitRef = useRef(0);
+
   // LAYOUT, not passive. A passive effect runs after the browser paints, and a
   // write for the previous org can settle in the window between the commit for
   // the new one and that flush — reading a `currentOrgRef` that still says the
@@ -103,6 +115,11 @@ export function useOrgScopedWrite(organizationId: string | null): {
     // Retire every write in flight: a completion from the previous org must
     // not land on this one, whatever order the round trips finish in.
     generationRef.current += 1;
+    // A NEW VISIT, even to an org just left. `A → B → A` reuses the id, so
+    // comparing ids alone let the first visit's write decrement the second
+    // visit's counter — clearing `isSaving` while the second visit's own
+    // write was still in flight, and re-enabling Save under it.
+    visitRef.current += 1;
     inFlightRef.current = 0;
     setError(null);
     setIsSaving(false);
@@ -116,11 +133,15 @@ export function useOrgScopedWrite(organizationId: string | null): {
       // own — reports to nobody rather than to the wrong page or over a
       // fresher answer.
       const startedFor = organizationId;
+      const visit = visitRef.current;
       generationRef.current += 1;
       const generation = generationRef.current;
-      const isSameOrg = () => currentOrgRef.current === startedFor;
+      // THE VISIT, not the id. Both have to match: the id alone cannot tell
+      // this visit to org A from the last one.
+      const isSameVisit = () =>
+        currentOrgRef.current === startedFor && visitRef.current === visit;
       const isNewest = () =>
-        isSameOrg() && generationRef.current === generation;
+        isSameVisit() && generationRef.current === generation;
 
       inFlightRef.current += 1;
       setError(null);
@@ -131,10 +152,11 @@ export function useOrgScopedWrite(organizationId: string | null): {
         if (isNewest()) setError(messageOf(nextError));
         throw nextError;
       } finally {
-        // The org, not the generation: an older write of the SAME org still
+        // The visit, not the generation: an older write of THIS visit still
         // has to decrement the count it incremented, or the spinner never
-        // stops.
-        if (isSameOrg()) {
+        // stops. A write from a previous visit decrements nothing — its
+        // counter was reset when the visit ended.
+        if (isSameVisit()) {
           inFlightRef.current -= 1;
           if (inFlightRef.current <= 0) {
             inFlightRef.current = 0;

--- a/mcpjam-inspector/server/routes/v1/__tests__/trace-destinations-write-only.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/trace-destinations-write-only.test.ts
@@ -150,6 +150,47 @@ describe("the trace-destinations surface is write-only for header values", () =>
     }
   });
 
+  it("decides scope before serving any caller-supplied destination id", () => {
+    // Two things have to hold on every by-id route, and they are different.
+    //
+    // SCOPE IS DECIDED FIRST — by a preflight (`assertDestinationInOrg`) or,
+    // where the read IS the response, by a scoping read. A route that read the
+    // row, acted on it, and only then checked the organization would mutate
+    // another org's destination and report 404 afterwards.
+    //
+    // AND THAT DECISION ANSWERS 404 — `isScopingPreflight`. Without it a
+    // refusal the gateway cannot attribute surfaces as 502, which
+    // distinguishes "no such id" from "exists, elsewhere" and pages someone
+    // per probe. The re-reads that follow a decision deliberately stay 502:
+    // there a 404 would tell a caller the destination they just wrote does
+    // not exist, when the read simply failed.
+    const source = readFileSync(ROUTE_PATH, "utf8");
+    const handlers = source
+      .split(/traceDestinations\.(?:get|post|patch|delete)\(/)
+      .slice(1);
+
+    const byId = handlers.filter((body) =>
+      body.includes('c.req.param("destinationId")'),
+    );
+    expect(byId.length).toBeGreaterThanOrEqual(8);
+
+    for (const body of byId) {
+      const path = body.slice(0, body.indexOf('",'));
+      const preflights = body.includes("assertDestinationInOrg(");
+      const scopingRead = /readDestination\([^;]*?\btrue\b/s.test(body);
+      expect(
+        preflights || scopingRead,
+        `${path} serves a caller-supplied id without deciding scope first`,
+      ).toBe(true);
+    }
+
+    // And the preflight itself is a scoping read, or every route above
+    // inherits a 502 for a refusal that should read as 404.
+    expect(source).toMatch(
+      /async function assertDestinationInOrg[\s\S]*?readDestination\([^;]*?\btrue\b/,
+    );
+  });
+
   it("is absent from the guest allowlist, so guests cannot reach it", () => {
     // `guest-allowed-paths.ts` is default-deny, so this is not "no rule denies
     // it" — it is "no rule ADMITS it". A single added entry would be the one

--- a/mcpjam-inspector/server/routes/v1/trace-destinations.ts
+++ b/mcpjam-inspector/server/routes/v1/trace-destinations.ts
@@ -79,7 +79,7 @@ const traceDestinations = new Hono();
  */
 function translateReadError(
   error: unknown,
-  isScopingPreflight = false
+  isScopingPreflight = false,
 ): WebRouteError {
   return translateConvexReadError(error, {
     scope: "v1.traceDestinations",
@@ -425,10 +425,16 @@ traceDestinations.get(
   "/organizations/:organizationId/trace-destinations/:destinationId",
   async (c) => {
     const client = createConvexClient(await getConvexBearerForRequest(c));
+    // `true`, like the list route and every write preflight: this read
+    // DECIDES whether the caller may see an id they supplied, so a refusal it
+    // cannot attribute has to read as 404. Left at the default, a
+    // cross-organization probe answered 502 where a missing id answered 404 —
+    // an existence oracle, and a Sentry page per probe.
     const row = await readDestination(
       client,
       c.req.param("destinationId"),
       c.req.param("organizationId"),
+      true,
     );
     return v1Resource(c, toTraceDestinationDto(row));
   },


### PR DESCRIPTION
The last review round on #4656 arrived between the final push and the merge, so four real defects shipped. Each is verified against merged `main` and has a test that fails without the fix.

### One finding I checked and rejected

CodeRabbit reported (Major, security) that Commander defaults `includeContent` to `true` when a `--no-` counterpart is declared, so every `update` omitting both flags would silently enable content export. That is not true on Commander 14 — a positive option declared alongside `--no-X` leaves the default `undefined`:

```
neither flag  -> undefined
--no-...      -> false
commander version: 14.0.3
```

The existing `options.includeContent !== undefined` guard is correct. No change.

### Returning to an organization is a new visit

`useOrgScopedWrite` counts writes in flight and compared the **org ID** to decide whether a completion still mattered. `A → B → A` reuses the ID, so a write left over from the first visit satisfied the check on the second and decremented a counter that had been zeroed in between — stopping the spinner and re-enabling **Save** while the second visit's own write was still running.

A monotonic visit token separates the two, which an ID by construction cannot. Two new tests: one for the stale-visit case, one confirming the counter still does its own job (the spinner stays up until the *last* write of a visit finishes).

### The single GET was an existence oracle

Every other by-id path decides scope through a preflight that answers 404 to a refusal it cannot attribute. The single GET *is* its own decision and was left at the default, so a cross-organization probe answered **502** where a missing id answered **404** — the difference is the answer — and paged someone per probe.

Its test now states the rule for the whole surface rather than one line: scope is decided before any caller-supplied id is served, and that decision reads as 404. The re-reads that *follow* a decision deliberately stay 502, since a 404 there would tell a caller the destination they just wrote does not exist when the read merely failed. (I confirmed the test fails with the flag removed.)

### A malformed `--header` echoed the name position

`--header` splits on the first colon, so a mistyped argument puts the credential *there* — and the error went to stderr and into CI logs. It states the rule now and quotes nothing.

Relatedly, `index <= 0` told someone who wrote `": value"` that their argument had no separator, which is the one thing it had, and made the empty-name message unreachable.

### A test of mine that tested nothing

It clicked the vendor `Select`'s trigger, which only opens the list. `applyPreset` runs from `onValueChange`, so the assertion held whether or not picking a vendor discarded a typed endpoint. It picks an option now, and also checks the preset did its real job.

### Note on the CI failure on #4656's head

`Inspector Tests 4/4` was red on `6206d6d` with `No "VIEW_MOUNT_MODE" export is defined on the "@/lib/config" mock` in `use-widget-host.test.tsx` — MCP-apps code this diff does not touch, from #4671 merging into `main` while the branch was behind. Merged `main` carries a consistent mock, so it is resolved and nothing is ported here.

### Verification

Root typecheck and `typecheck:client` clean; v1 + workspace partitions 1574 passing; client 1428 passing; SDK 7034; CLI 1234 (5 new); MCP 88; `test:checks` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013diYduL8HohVHbGw9Ej64Z

---
_Generated by [Claude Code](https://claude.ai/code/session_013diYduL8HohVHbGw9Ej64Z)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-adjacent trace-destination GET error semantics and org-scoped save state; CLI changes reduce credential leakage in logs. Scope is bounded with targeted tests.
> 
> **Overview**
> Addresses four defects that shipped after trace-destinations merged: safer CLI header parsing, correct org-save races, closed GET existence oracle, and a UI test that did not exercise preset selection.
> 
> **CLI** `splitOnFirst` now treats “no separator” (`index < 0`) separately from “empty name before separator” (`index === 0`), so `": value"` gets the right message. Invalid `--header` names are no longer echoed in errors (credentials can land in the name position when the colon is mistyped).
> 
> **Inspector** `useOrgScopedWrite` adds a monotonic **visit** token so `A → B → A` is not confused with the first stay on org A; stale completions no longer clear `isSaving` while a new visit’s write is still running.
> 
> **API** `GET …/trace-destinations/:id` passes `isScopingPreflight: true` into `readDestination`, aligning cross-org probes with other by-id routes (404 instead of 502). A source test locks in “scope before serve” for all by-id handlers.
> 
> **Test** `TraceDestinationDialog` vendor test now selects a Coralogix option (not only opens the select) and asserts preset headers apply without overwriting a typed endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360df303f44970d430f497958d3e63f28f3c8ce3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four review findings that shipped after the trace-destinations merge, covering stale write tracking, an existence-leaking 502, and a `--header` error that echoed credential material.

**Bug Fixes**
- `useOrgScopedWrite` now matches on a monotonic visit token in addition to the org id, so a write left over from the previous visit to the same org no longer decrements the new visit's counter or stops its spinner.
- The single GET now marks its read as a scoping preflight, so a refusal it cannot attribute reads as 404 instead of 502 and no longer pages someone per probe.
- The `--header` errors now distinguish "no separator" from "empty name," and the invalid-name message states the rule without quoting the offending value.
- A vendor-preset test now picks an option instead of just opening the list, so it actually verifies the preset applies without discarding a typed endpoint.

<sup>Written for commit 360df303f44970d430f497958d3e63f28f3c8ce3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

