### PR TITLE
Make the trace-destination scope-ordering test actually check ordering

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrgScopedWrite.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrgScopedWrite.test.tsx
@@ -167,34 +167,6 @@ describe("useOrgScopedWrite", () => {
     await waitFor(() => expect(result.current.isSaving).toBe(false));
   });
 
-  it("keeps the spinner up until the LAST write of a visit finishes", async () => {
-    // The counter's own job, in the ordering that motivated it.
-    const first = deferred();
-    const second = deferred();
-    const { result } = renderHook(() => useOrgScopedWrite("org-a"));
-
-    let firstSettled: Promise<void>;
-    let secondSettled: Promise<void>;
-    act(() => {
-      firstSettled = result.current.run(() => first.promise).catch(() => {});
-    });
-    act(() => {
-      secondSettled = result.current.run(() => second.promise).catch(() => {});
-    });
-
-    await act(async () => {
-      second.resolve();
-      await secondSettled;
-    });
-    expect(result.current.isSaving).toBe(true);
-
-    await act(async () => {
-      first.resolve();
-      await firstSettled;
-    });
-    await waitFor(() => expect(result.current.isSaving).toBe(false));
-  });
-
   it("lets only the NEWEST write of the same org report", async () => {
     // The org id alone cannot separate these: both writes belong to org-a.
     // Without a generation, the first to finish clears `isSaving` while the

--- a/mcpjam-inspector/server/routes/v1/__tests__/trace-destinations-write-only.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/trace-destinations-write-only.test.ts
@@ -176,12 +176,34 @@ describe("the trace-destinations surface is write-only for header values", () =>
 
     for (const body of byId) {
       const path = body.slice(0, body.indexOf('",'));
-      const preflights = body.includes("assertDestinationInOrg(");
-      const scopingRead = /readDestination\([^;]*?\btrue\b/s.test(body);
+
+      // POSITION, not presence. Asserting only that a scope check appears
+      // somewhere in the handler let the very regression this test names pass:
+      // a route that mutated first and checked the organization afterwards
+      // contains both, in the wrong order. So the decision has to come before
+      // the first call that reaches Convex.
+      const firstWriteAt = Math.min(
+        ...["client.action(", "client.mutation("]
+          .map((call) => body.indexOf(call))
+          .filter((at) => at >= 0)
+          .concat(Number.MAX_SAFE_INTEGER),
+      );
+      const preflightAt = body.indexOf("assertDestinationInOrg(");
+      const scopingReadAt = body.search(/readDestination\([^;]*?\btrue\b/s);
+      const decidedAt = Math.min(
+        ...[preflightAt, scopingReadAt]
+          .filter((at) => at >= 0)
+          .concat(Number.MAX_SAFE_INTEGER),
+      );
+
       expect(
-        preflights || scopingRead,
-        `${path} serves a caller-supplied id without deciding scope first`,
-      ).toBe(true);
+        decidedAt,
+        `${path} serves a caller-supplied id without deciding scope at all`,
+      ).toBeLessThan(Number.MAX_SAFE_INTEGER);
+      expect(
+        decidedAt,
+        `${path} reaches Convex before it decides whether the caller may address this id`,
+      ).toBeLessThan(firstWriteAt);
     }
 
     // And the preflight itself is a scoping read, or every route above


### PR DESCRIPTION
Two test-quality findings from the review of #4674, raised independently by cubic and CodeRabbit before it merged. Both correct. Tests only — no behaviour change.

### The ordering guard did not check ordering

The test's own comment says:

> A route that read the row, acted on it, and only then checked the organization would mutate another org's destination and report 404 afterwards.

…and then it asserted only that a scope check appears *somewhere* in the handler:

```ts
const preflights = body.includes("assertDestinationInOrg(");
const scopingRead = /readDestination\([^;]*?\btrue\b/s.test(body);
expect(preflights || scopingRead).toBe(true);
```

A handler in exactly that broken order contains both calls and passed. It now compares positions: the decision has to precede the first call that reaches Convex.

Proof it works — moving the DELETE route's preflight after its mutation, the precise regression the comment names:

```
moved DELETE preflight after the mutation
Tests  1 failed | 7 passed (8)
```

This is the same defect as the vacuous assertions this file's history is made of, reintroduced in the test written to close them. A guard that overstates what it proves is worse than an absent one, because it answers the question nobody re-asks.

### A test I duplicated

`keeps the spinner up until the LAST write of a visit finishes` was already covered by `keeps isSaving true until the LAST overlapping write finishes`, added to the same file in a parallel change I had not read before adding mine — same two writes, same ordering, same assertions. Removed. The visit-token case it was grouped with stays; that one is about something else.

### Verification

`--project server server/routes/v1/__tests__` — 64 files, 1553 passing. `--project client src/hooks/__tests__ src/components/organization/observability` — 1245 passing. Root typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013diYduL8HohVHbGw9Ej64Z

---
_Generated by [Claude Code](https://claude.ai/code/session_013diYduL8HohVHbGw9Ej64Z)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5980744a3a51bed505fb96113cc3eefd6eb18321. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the trace-destination scope-ordering test so it actually verifies the scope check happens before any Convex call, not just that it appears somewhere in the handler. Also removes a duplicated spinner test. Tests only, no behavior change.

- The ordering assertion now compares positions: the scope decision must precede the first call that reaches Convex, so a handler that mutates before checking scope fails as intended.
- Removes `keeps the spinner up until the LAST write of a visit finishes`, which duplicated `keeps isSaving true until the LAST overlapping write finishes` with the same writes, ordering, and assertions.

<sup>Written for commit 5980744a3a51bed505fb96113cc3eefd6eb18321. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

