### PR TITLE
Drop the support-level filter pills from client Compare

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
@@ -20,7 +20,6 @@ import { resolveHostLogoByName } from "@/lib/host-logo";
 import type { HostListItem } from "@/hooks/useClients";
 import type { HostComparisonSubject } from "@/lib/host-config-field-schema";
 import type { HostThemeMode } from "@/lib/client-styles";
-import type { SupportFilterMode } from "./support-level";
 import { PUBLIC_CAN_I_USE_INLINE_PRESET_IDS } from "./caniuse-capability-catalog";
 import { clientDisplayName } from "@/lib/client-display-name";
 import { HostChipLogo } from "@/components/hosts/host-chip";
@@ -39,29 +38,6 @@ const INITIAL_INLINE_CHIP_LIMIT = Math.max(
   PUBLIC_CAN_I_USE_INLINE_PRESET_IDS.length,
 );
 
-const SUPPORT_FILTERS: ReadonlyArray<{
-  value: SupportFilterMode;
-  label: string;
-  title: string;
-}> = [
-  { value: "all", label: "All", title: "Show every field" },
-  {
-    value: "missing",
-    label: "Missing",
-    title: "Capabilities not supported by at least one client",
-  },
-  {
-    value: "partial",
-    label: "Partial",
-    title: "Capabilities that are partial / Auto for at least one client",
-  },
-  {
-    value: "supported",
-    label: "Full",
-    title: "Capabilities supported by every client",
-  },
-];
-
 interface HostCompareSelectorProps {
   hosts: ReadonlyArray<HostListItem>;
   selectedHostIds: ReadonlyArray<string>;
@@ -72,9 +48,6 @@ interface HostCompareSelectorProps {
   disableListView?: boolean;
   divergingOnly: boolean;
   onDivergingOnlyChange: (enabled: boolean) => void;
-  supportFilter: SupportFilterMode;
-  onSupportFilterChange: (mode: SupportFilterMode) => void;
-  supportFiltersDisabled?: boolean;
   showDescriptions: boolean;
   onShowDescriptionsChange: (enabled: boolean) => void;
   descriptionsDisabled?: boolean;
@@ -93,9 +66,6 @@ export function HostCompareSelector({
   disableListView = false,
   divergingOnly,
   onDivergingOnlyChange,
-  supportFilter,
-  onSupportFilterChange,
-  supportFiltersDisabled = false,
   showDescriptions,
   onShowDescriptionsChange,
   descriptionsDisabled = false,
@@ -157,44 +127,6 @@ export function HostCompareSelector({
             disabled={disabled}
           />
         ) : null}
-        {mobileOptimized ? null : (
-          <div
-            role="group"
-            aria-label="Filter by support level"
-            className="flex items-center gap-0.5 rounded-full border border-border p-0.5"
-          >
-            {SUPPORT_FILTERS.map((f) => {
-              const active = supportFilter === f.value;
-              const filterDisabled = disabled || supportFiltersDisabled;
-              return (
-                <button
-                  key={f.value}
-                  type="button"
-                  disabled={filterDisabled}
-                  title={
-                    supportFiltersDisabled
-                      ? "Search for a capability before filtering by support"
-                      : f.title
-                  }
-                  aria-pressed={active}
-                  data-testid={`support-filter-${f.value}`}
-                  onClick={() => onSupportFilterChange(f.value)}
-                  className={cn(
-                    "rounded-full px-2.5 py-0.5 text-[11px] transition-colors",
-                    mobileOptimized && "shrink-0",
-                    "disabled:cursor-not-allowed disabled:opacity-50",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-                    active
-                      ? "bg-primary/10 text-foreground"
-                      : "text-muted-foreground hover:text-foreground",
-                  )}
-                >
-                  {f.label}
-                </button>
-              );
-            })}
-          </div>
-        )}
         <label
           className={cn(
             "flex cursor-pointer items-center gap-2 text-[12px] text-muted-foreground",

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -664,9 +664,6 @@ export function HostConfigCompareView({
               disableListView={showDescriptions}
               divergingOnly={divergingOnly}
               onDivergingOnlyChange={setDivergingOnly}
-              supportFilter={supportFilter}
-              onSupportFilterChange={setSupportFilter}
-              supportFiltersDisabled={!hasFieldSearchQuery}
               showDescriptions={showDescriptions}
               onShowDescriptionsChange={handleShowDescriptionsChange}
               descriptionsDisabled={viewMode === "list"}

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostCompareSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostCompareSelector.test.tsx
@@ -29,8 +29,6 @@ describe("HostCompareSelector", () => {
         onToggleHost={vi.fn()}
         divergingOnly={false}
         onDivergingOnlyChange={vi.fn()}
-        supportFilter="all"
-        onSupportFilterChange={vi.fn()}
         showDescriptions={false}
         onShowDescriptionsChange={vi.fn()}
       />,
@@ -56,8 +54,6 @@ describe("HostCompareSelector", () => {
         onToggleHost={onToggleHost}
         divergingOnly={false}
         onDivergingOnlyChange={vi.fn()}
-        supportFilter="all"
-        onSupportFilterChange={vi.fn()}
         showDescriptions={false}
         onShowDescriptionsChange={vi.fn()}
       />,
@@ -90,8 +86,6 @@ describe("HostCompareSelector", () => {
         onToggleHost={vi.fn()}
         divergingOnly={false}
         onDivergingOnlyChange={vi.fn()}
-        supportFilter="all"
-        onSupportFilterChange={vi.fn()}
         showDescriptions={false}
         onShowDescriptionsChange={vi.fn()}
       />,
@@ -116,8 +110,6 @@ describe("HostCompareSelector", () => {
         onToggleHost={vi.fn()}
         divergingOnly={false}
         onDivergingOnlyChange={vi.fn()}
-        supportFilter="all"
-        onSupportFilterChange={vi.fn()}
         showDescriptions={false}
         onShowDescriptionsChange={vi.fn()}
       />,
@@ -150,8 +142,6 @@ describe("HostCompareSelector", () => {
         onToggleHost={vi.fn()}
         divergingOnly={false}
         onDivergingOnlyChange={vi.fn()}
-        supportFilter="all"
-        onSupportFilterChange={vi.fn()}
         showDescriptions={false}
         onShowDescriptionsChange={vi.fn()}
       />,
@@ -176,8 +166,6 @@ describe("HostCompareSelector", () => {
         onToggleHost={vi.fn()}
         divergingOnly={false}
         onDivergingOnlyChange={vi.fn()}
-        supportFilter="all"
-        onSupportFilterChange={vi.fn()}
         showDescriptions={false}
         onShowDescriptionsChange={vi.fn()}
       />,
@@ -189,56 +177,6 @@ describe("HostCompareSelector", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("emits the chosen support filter mode", async () => {
-    const user = userEvent.setup();
-    const onSupportFilterChange = vi.fn();
-
-    render(
-      <HostCompareSelector
-        hosts={[makeHost("h_a", "Claude")]}
-        selectedHostIds={["h_a"]}
-        subjectsByHost={{}}
-        onToggleHost={vi.fn()}
-        divergingOnly={false}
-        onDivergingOnlyChange={vi.fn()}
-        supportFilter="all"
-        onSupportFilterChange={onSupportFilterChange}
-        showDescriptions={false}
-        onShowDescriptionsChange={vi.fn()}
-      />,
-    );
-
-    await user.click(screen.getByTestId("support-filter-missing"));
-    expect(onSupportFilterChange).toHaveBeenCalledWith("missing");
-  });
-
-  it("does not emit support filter changes while support filters are disabled", async () => {
-    const user = userEvent.setup();
-    const onSupportFilterChange = vi.fn();
-
-    render(
-      <HostCompareSelector
-        hosts={[makeHost("h_a", "Claude")]}
-        selectedHostIds={["h_a"]}
-        subjectsByHost={{}}
-        onToggleHost={vi.fn()}
-        divergingOnly={false}
-        onDivergingOnlyChange={vi.fn()}
-        supportFilter="all"
-        onSupportFilterChange={onSupportFilterChange}
-        supportFiltersDisabled
-        showDescriptions={false}
-        onShowDescriptionsChange={vi.fn()}
-      />,
-    );
-
-    const missingFilter = screen.getByTestId("support-filter-missing");
-    expect(missingFilter).toBeDisabled();
-
-    await user.click(missingFilter);
-    expect(onSupportFilterChange).not.toHaveBeenCalled();
-  });
-
   it("disables the diverging toggle when the selector is disabled", () => {
     render(
       <HostCompareSelector
@@ -248,8 +186,6 @@ describe("HostCompareSelector", () => {
         onToggleHost={vi.fn()}
         divergingOnly={false}
         onDivergingOnlyChange={vi.fn()}
-        supportFilter="all"
-        onSupportFilterChange={vi.fn()}
         showDescriptions={false}
         onShowDescriptionsChange={vi.fn()}
         disabled


### PR DESCRIPTION
The All / Missing / Partial / Full segmented control is no longer used, so it comes out of `HostCompareSelector` — the options table, the three props (`supportFilter`, `onSupportFilterChange`, `supportFiltersDisabled`), the `SupportFilterMode` import, and the two tests that drove it.

**Filtering itself is untouched.** The `supportFilter` state stays where it was, driven by the caniuse page's own `SupportFilterFunnel`, and `HostConfigCompareView` still passes it to the matrix and list views — only the pass-through to the selector goes away. The matrix tests exercising `supportFilter="missing"` and `"supported"` still cover the logic.

Deletions only: 135 lines, no replacement UI, no insertions.

## Note on formatting

Running `npx prettier` on `HostConfigCompareView.tsx` reflowed ~114 unrelated lines (trailing commas, parenthesized `??`), which means the version npx resolves differs from the repo's. I reverted that and re-applied the three-line removal by hand, so the diff here is only the intended change. Worth knowing before someone else formats that file.

51 test files, 514 tests pass under `client/src/components/hosts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused All / Missing / Partial / Full filter pills from `HostCompareSelector`, along with their three props and the tests that drove them.

- Filtering behavior is unchanged; the `supportFilter` state stays driven by the caniuse page's funnel and is still passed to the matrix and list views.
- Deletions only — 135 lines removed, no replacement UI.

<sup>Written for commit c4fe6e3358bacadd9c742118c06e0a227164a3d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

