### PR TITLE
Count reads in the trace-destination scope-ordering guard

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/trace-destinations-write-only.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/trace-destinations-write-only.test.ts
@@ -180,10 +180,18 @@ describe("the trace-destinations surface is write-only for header values", () =>
       // POSITION, not presence. Asserting only that a scope check appears
       // somewhere in the handler let the very regression this test names pass:
       // a route that mutated first and checked the organization afterwards
-      // contains both, in the wrong order. So the decision has to come before
-      // the first call that reaches Convex.
-      const firstWriteAt = Math.min(
-        ...["client.action(", "client.mutation("]
+      // contains both, in the wrong order.
+      //
+      // READS COUNT TOO, which is why this is not just the writes. Fetching a
+      // destination's rows before deciding whether the caller may address it
+      // hands over another organization's data whether or not anything is
+      // written afterwards — `listBackfillJobs` on a foreign id would be
+      // exactly that. So the decision precedes the first call of ANY kind that
+      // reaches Convex. (`readDestination` and `assertDestinationInOrg` issue
+      // their queries inside themselves, not in the handler body, so a
+      // handler that decides properly has nothing before its decision.)
+      const firstConvexCallAt = Math.min(
+        ...["client.action(", "client.mutation(", "client.query("]
           .map((call) => body.indexOf(call))
           .filter((at) => at >= 0)
           .concat(Number.MAX_SAFE_INTEGER),
@@ -203,7 +211,7 @@ describe("the trace-destinations surface is write-only for header values", () =>
       expect(
         decidedAt,
         `${path} reaches Convex before it decides whether the caller may address this id`,
-      ).toBeLessThan(firstWriteAt);
+      ).toBeLessThan(firstConvexCallAt);
     }
 
     // And the preflight itself is a scoping read, or every route above


### PR DESCRIPTION
One finding from the review of #4678, raised by cubic and CodeRabbit independently. Test only.

The guard's comment said **"the first call that reaches Convex"** while the matcher scanned only `client.action(` and `client.mutation(`. That is the defect #4678's own commit message was about — a comment claiming more than the code checks — reintroduced one layer up.

cubic offered two ways out: narrow the wording to "the first *write*", or widen the matcher to include reads. **Widening is the right one.** Fetching a destination's rows before deciding whether the caller may address it hands over another organization's data whether or not anything is written afterwards — `GET …/{destinationId}/backfills` on a foreign id is exactly that shape, and the write-only matcher never covered it because that route writes nothing.

So `client.query(` joins the matcher, and `firstWriteAt` becomes `firstConvexCallAt` — which is what the assertion message had been comparing against all along.

Proof, moving the backfills read ahead of its own scope decision:

```
moved the backfills read before its scope decision
Tests  1 failed | 7 passed (8)
```

That case passed under the old matcher.

`readDestination` and `assertDestinationInOrg` issue their queries inside themselves rather than in the handler body, so a handler that decides properly has nothing before its decision and the widened matcher is not noisy.

### Verification

`--project server server/routes/v1/__tests__` — 64 files, 1553 passing. Root typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013diYduL8HohVHbGw9Ej64Z

---
_Generated by [Claude Code](https://claude.ai/code/session_013diYduL8HohVHbGw9Ej64Z)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only tightening of a security-ordering assertion; no production route behavior changes in this diff.
> 
> **Overview**
> The **decides scope before serving any caller-supplied destination id** test no longer treats only mutations/actions as the first Convex touchpoint. It now treats **`client.query(`** the same as **`client.action(`** and **`client.mutation(`**, and compares scope decisions against **`firstConvexCallAt`** instead of **`firstWriteAt`**.
> 
> That closes a gap where a handler could **read another org’s destination data** (e.g. listing backfills by foreign `destinationId`) before **`assertDestinationInOrg`** or a scoping **`readDestination`**, while still passing the old write-only ordering check. Comments in the test spell out why reads must precede the decision, not just writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06f8bf264e7a9f372cba1cec21dfd0537f6ce851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the trace-destinations scope-ordering guard to count reads (`client.query(`) as well as writes, so the test catches routes that fetch a destination's rows before checking the caller's access. Previously only `client.action(` and `client.mutation(` were matched, missing read-only routes like `listBackfillJobs` that could leak another organization's data.

- The matcher now considers `client.action(`, `client.mutation(`, and `client.query(`; `firstWriteAt` becomes `firstConvexCallAt`.
- Moves the backfills read ahead of its scope decision to prove the new matcher catches the leak.

<sup>Written for commit 06f8bf264e7a9f372cba1cec21dfd0537f6ce851. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

