### PR TITLE
Fix sign-out landing on the login page

### DIFF
--- a/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
@@ -37,6 +37,7 @@ import {
   rememberHandoffSignInReturn,
   rememberPendingAuthorization,
 } from "@/lib/server-connection-handoff";
+import { markSignOutInProgress } from "@/lib/auth/sign-out-latch";
 import {
   readClaimRefusal,
   type ClaimRefusalDetails,
@@ -518,6 +519,10 @@ export function ServerConnectionHandoff() {
    */
   const switchAccount = useCallback(() => {
     setBusy(true);
+    // See `sign-out-latch`: without this, the refresh timer notices the
+    // revoked session mid-navigation and redirects to sign-in, losing the
+    // handoff link this function exists to return to.
+    markSignOutInProgress();
     const back = `${window.location.pathname}${window.location.search}`;
     void Promise.resolve(signOut({ navigate: false }))
       .catch(() => {

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
+import {
+  isSignOutInProgress,
+  resetSignOutLatchForTests,
+} from "@/lib/auth/sign-out-latch";
 
 const authState = vi.hoisted(() => ({
   signInMock: vi.fn(),
@@ -110,8 +114,9 @@ describe("SidebarUser", () => {
   beforeEach(() => {
     authState.user = null;
     authState.signInMock.mockClear();
-    authState.signOutMock.mockClear();
+    authState.signOutMock.mockReset();
     window.isElectron = false;
+    resetSignOutLatchForTests();
   });
 
   it("renders nothing when unauthenticated", () => {
@@ -147,6 +152,28 @@ describe("SidebarUser", () => {
     expect(screen.getByText("Settings")).toBeInTheDocument();
     expect(screen.getByText("Notifications")).toBeInTheDocument();
     expect(screen.getByText("Support")).toBeInTheDocument();
+  });
+
+  it("latches sign-out before calling WorkOS, not after", () => {
+    // authkit's refresh timer fires ~1s later, sees the revoked session, and
+    // would redirect this tab to the hosted login page on top of the logout
+    // navigation. The latch has to be set by the time `signOut` is entered.
+    authState.user = {
+      email: "owner@example.com",
+      firstName: "Owner",
+      lastName: "Example",
+    };
+    let latchedWhenSignOutRan = false;
+    authState.signOutMock.mockImplementation(() => {
+      latchedWhenSignOutRan = isSignOutInProgress();
+    });
+
+    render(<SidebarUser />);
+
+    fireEvent.click(screen.getByText("Log out"));
+
+    expect(authState.signOutMock).toHaveBeenCalled();
+    expect(latchedWhenSignOutRan).toBe(true);
   });
 
   it("returns logout to the app origin instead of the callback route", () => {

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -20,6 +20,7 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { markSignOutInProgress } from "@/lib/auth/sign-out-latch";
 import { getInitials } from "@/lib/utils";
 import {
   Bell,
@@ -64,6 +65,10 @@ export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
   const initials = getInitials(displayName);
 
   const finishSignOut = () => {
+    // Before `signOut()`, never after: authkit's refresh timer can fire on the
+    // next tick, and an unlatched failure would redirect this tab to the login
+    // page on top of the logout navigation below. See `sign-out-latch`.
+    markSignOutInProgress();
     const returnTo = window.location.origin;
     if (window.isElectron) {
       void Promise.resolve(signOut({ returnTo, navigate: false })).finally(

--- a/mcpjam-inspector/client/src/lib/auth/__tests__/sign-out-latch.test.ts
+++ b/mcpjam-inspector/client/src/lib/auth/__tests__/sign-out-latch.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  isSignOutInProgress,
+  markSignOutInProgress,
+  resetSignOutLatchForTests,
+  SIGN_OUT_SUPPRESSION_WINDOW_MS,
+} from "../sign-out-latch";
+
+describe("sign-out latch", () => {
+  beforeEach(() => {
+    resetSignOutLatchForTests();
+  });
+
+  it("is off until a sign-out starts", () => {
+    expect(isSignOutInProgress()).toBe(false);
+  });
+
+  it("suppresses for the whole window a real sign-out needs", () => {
+    const start = 1_000_000;
+    markSignOutInProgress(start);
+
+    // The refresh timer ticks every second, so the very next tick and every
+    // one up to the navigation completing must be covered.
+    expect(isSignOutInProgress(start)).toBe(true);
+    expect(isSignOutInProgress(start + 1_000)).toBe(true);
+    expect(isSignOutInProgress(start + SIGN_OUT_SUPPRESSION_WINDOW_MS)).toBe(
+      true,
+    );
+  });
+
+  it("expires, so a sign-out that never navigates cannot blind the tab", () => {
+    // authkit's `signOut()` returns early without navigating when the access
+    // token is already gone — pressing Log out on an ALREADY-dead session.
+    // A permanent latch would leave this tab swallowing every genuine session
+    // failure from then on, which is worse than the redirect being fixed.
+    const start = 1_000_000;
+    markSignOutInProgress(start);
+
+    expect(
+      isSignOutInProgress(start + SIGN_OUT_SUPPRESSION_WINDOW_MS + 1),
+    ).toBe(false);
+  });
+
+  it("stops suppressing when the clock moves backwards", () => {
+    // A backwards jump would otherwise read as "elapsed is negative", i.e.
+    // still inside the window, and hold the latch open indefinitely.
+    const start = 1_000_000;
+    markSignOutInProgress(start);
+
+    expect(isSignOutInProgress(start - 60_000)).toBe(false);
+  });
+
+  it("re-arms on a second sign-out attempt", () => {
+    const start = 1_000_000;
+    markSignOutInProgress(start);
+    const afterExpiry = start + SIGN_OUT_SUPPRESSION_WINDOW_MS + 1;
+    expect(isSignOutInProgress(afterExpiry)).toBe(false);
+
+    markSignOutInProgress(afterExpiry);
+
+    expect(isSignOutInProgress(afterExpiry)).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/auth/__tests__/sign-out-latch.test.ts
+++ b/mcpjam-inspector/client/src/lib/auth/__tests__/sign-out-latch.test.ts
@@ -60,4 +60,28 @@ describe("sign-out latch", () => {
 
     expect(isSignOutInProgress(afterExpiry)).toBe(true);
   });
+
+  it("stays expired once the window has lapsed, even if time is re-read", () => {
+    // Expiry must be permanent, not a per-call verdict: a later reading back
+    // inside the window would revive a latch already declared dead and hide a
+    // genuine session failure.
+    const start = 1_000_000;
+    markSignOutInProgress(start);
+
+    expect(
+      isSignOutInProgress(start + SIGN_OUT_SUPPRESSION_WINDOW_MS + 1),
+    ).toBe(false);
+    expect(isSignOutInProgress(start + 1_000)).toBe(false);
+  });
+
+  it("stays off after a backward clock jump, even once the clock catches up", () => {
+    // An NTP correction mid-sign-out reads as "elapsed is negative". Once that
+    // has ended suppression, the clock returning to real time must not put the
+    // latch back on.
+    const start = 1_000_000;
+    markSignOutInProgress(start);
+
+    expect(isSignOutInProgress(start - 60_000)).toBe(false);
+    expect(isSignOutInProgress(start + 1_000)).toBe(false);
+  });
 });

--- a/mcpjam-inspector/client/src/lib/auth/__tests__/workos-refresh-failure.test.ts
+++ b/mcpjam-inspector/client/src/lib/auth/__tests__/workos-refresh-failure.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleWorkosRefreshFailure } from "../workos-refresh-failure";
+import {
+  markSignOutInProgress,
+  resetSignOutLatchForTests,
+  SIGN_OUT_SUPPRESSION_WINDOW_MS,
+} from "../sign-out-latch";
 import { useSessionRefreshStore } from "@/stores/session-refresh-store";
 
 const mockState = vi.hoisted(() => ({
@@ -23,6 +28,7 @@ vi.mock("@/lib/permalink-signin-return", () => ({
 describe("handleWorkosRefreshFailure", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetSignOutLatchForTests();
     useSessionRefreshStore.setState({
       status: "idle",
       kind: null,
@@ -73,5 +79,34 @@ describe("handleWorkosRefreshFailure", () => {
 
     expect(() => handleWorkosRefreshFailure({ signIn })).not.toThrow();
     expect(signIn).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores the refresh failure a sign-out causes itself", () => {
+    // Signing out revokes the session, and authkit's refresh timer keeps
+    // ticking through the logout navigation — so it reports the revocation we
+    // asked for. Redirecting on it would `location.assign` to the hosted login
+    // page over the still-pending logout, which is what put the user on a sign
+    // in screen when they pressed Log out.
+    const signIn = vi.fn();
+    markSignOutInProgress();
+
+    handleWorkosRefreshFailure({ signIn });
+
+    expect(signIn).not.toHaveBeenCalled();
+    expect(mockState.captureAppSignInReturnPath).not.toHaveBeenCalled();
+    expect(mockState.reportCaught).not.toHaveBeenCalled();
+    expect(useSessionRefreshStore.getState().status).toBe("idle");
+  });
+
+  it("resumes redirecting once the sign-out window lapses", () => {
+    // A sign-out on an already-dead session never navigates, so the tab lives
+    // on. It must go back to handling real session failures.
+    const signIn = vi.fn();
+    markSignOutInProgress(Date.now() - SIGN_OUT_SUPPRESSION_WINDOW_MS - 1);
+
+    handleWorkosRefreshFailure({ signIn });
+
+    expect(signIn).toHaveBeenCalledTimes(1);
+    expect(useSessionRefreshStore.getState().kind).toBe("signed_out");
   });
 });

--- a/mcpjam-inspector/client/src/lib/auth/sign-out-latch.ts
+++ b/mcpjam-inspector/client/src/lib/auth/sign-out-latch.ts
@@ -59,7 +59,16 @@ export function isSignOutInProgress(now: number = Date.now()): boolean {
   const elapsed = now - signOutStartedAt;
   // A clock that moved backwards is not a reason to keep suppressing, any more
   // than one that moved forward past the window is.
-  if (elapsed < 0 || elapsed > SIGN_OUT_SUPPRESSION_WINDOW_MS) return false;
+  //
+  // The timestamp is CLEARED here, not merely reported as expired: leaving it
+  // in place lets a clock that later catches up revive a latch this call has
+  // already declared dead — and a revived latch hides exactly the genuine
+  // session failure the expiry exists to let through. Once suppression ends it
+  // stays ended, until a new sign-out arms it again.
+  if (elapsed < 0 || elapsed > SIGN_OUT_SUPPRESSION_WINDOW_MS) {
+    signOutStartedAt = null;
+    return false;
+  }
   return true;
 }
 

--- a/mcpjam-inspector/client/src/lib/auth/sign-out-latch.ts
+++ b/mcpjam-inspector/client/src/lib/auth/sign-out-latch.ts
@@ -1,0 +1,69 @@
+/**
+ * "This tab is on its way out — stop treating a dead session as a surprise."
+ *
+ * Signing out is itself a refresh failure, and everything downstream of a
+ * refresh failure is built to fight one.
+ *
+ * The sequence: `signOut()` wipes the in-memory session and starts navigating
+ * to WorkOS's logout endpoint. authkit-js's automatic refresh timer keeps
+ * ticking on its 1s interval through that navigation (it is never cancelled —
+ * only `dispose()` clears it, and nothing calls that here). The next tick
+ * finds no token, attempts a refresh, and WorkOS rejects it because the
+ * session it just revoked is gone. That rejection is indistinguishable from a
+ * session that died on its own, so it fires `onRefreshFailure`, which raises
+ * the "Your session has expired." banner and calls `signIn()` — a SECOND
+ * `location.assign` that replaces the still-pending logout navigation.
+ *
+ * The user clicks Sign out and lands on the hosted login page instead of the
+ * signed-out app, having been signed out correctly the whole time. The
+ * `?state=…mcpjamPermalinkReturn…` on that URL is this handler's fingerprint.
+ *
+ * So: latch before every `signOut()` call, and the failure handlers ignore the
+ * rejection they are guaranteed to see.
+ */
+
+/**
+ * How long a sign-out suppresses refresh failures.
+ *
+ * The latch EXPIRES, and that is the whole design, because a sign-out is not
+ * guaranteed to navigate. authkit's `signOut()` builds its logout URL from the
+ * session id inside the access token, and returns early — no request, no
+ * redirect — when that token is already gone. Pressing Sign out on a session
+ * that has ALREADY died is exactly that case: the latch would be set, the page
+ * would stay put, and a permanent flag would leave the tab silently swallowing
+ * every genuine session failure from then on. That is a worse bug than the
+ * redirect this module exists to stop.
+ *
+ * Ten seconds covers the gap a real sign-out has to bridge — a click, a
+ * revocation round trip, and a full-page navigation, against a refresh timer
+ * that ticks every second — while a tab that never navigates is back to
+ * reporting failures honestly a moment later.
+ */
+export const SIGN_OUT_SUPPRESSION_WINDOW_MS = 10_000;
+
+let signOutStartedAt: number | null = null;
+
+/**
+ * Call IMMEDIATELY before `signOut()`, on every path that signs out.
+ *
+ * Synchronous and un-awaited on purpose: the refresh timer can fire on the
+ * very next tick, so anything deferred is already too late.
+ */
+export function markSignOutInProgress(now: number = Date.now()): void {
+  signOutStartedAt = now;
+}
+
+/** True while a sign-out started recently enough to explain a dead session. */
+export function isSignOutInProgress(now: number = Date.now()): boolean {
+  if (signOutStartedAt === null) return false;
+  const elapsed = now - signOutStartedAt;
+  // A clock that moved backwards is not a reason to keep suppressing, any more
+  // than one that moved forward past the window is.
+  if (elapsed < 0 || elapsed > SIGN_OUT_SUPPRESSION_WINDOW_MS) return false;
+  return true;
+}
+
+/** Test-only: drop the latch without waiting out the window. */
+export function resetSignOutLatchForTests(): void {
+  signOutStartedAt = null;
+}

--- a/mcpjam-inspector/client/src/lib/auth/workos-refresh-failure.ts
+++ b/mcpjam-inspector/client/src/lib/auth/workos-refresh-failure.ts
@@ -1,4 +1,5 @@
 import { captureAppSignInReturnPath } from "@/lib/app-signin-return-path";
+import { isSignOutInProgress } from "@/lib/auth/sign-out-latch";
 import { reportCaught } from "@/lib/error-reporting";
 import { permalinkSignInOptions } from "@/lib/permalink-signin-return";
 import { useSessionRefreshStore } from "@/stores/session-refresh-store";
@@ -21,6 +22,12 @@ import { useSessionRefreshStore } from "@/stores/session-refresh-store";
  * authkit skips this callback from its INITIAL state, so a signed-out visitor
  * is never redirected.
  *
+ * A sign-out in flight is the one rejection that is NOT a dead session
+ * surprising us — it is the session we just deliberately revoked, seen by a
+ * refresh timer that keeps ticking through the logout navigation. Acting on it
+ * would send `signIn()` over the top of that navigation and land the user on
+ * the login page instead of the signed-out app. See `sign-out-latch`.
+ *
  * Lives here rather than inline in `main.tsx` so it is testable: `main.tsx`
  * calls `initSentry()` and `createRoot()` at module scope and cannot be
  * imported from a test.
@@ -32,6 +39,7 @@ export function handleWorkosRefreshFailure({
     state?: Record<string, string>;
   }) => void | Promise<void>;
 }): void {
+  if (isSignOutInProgress()) return;
   reportCaught(new Error("WorkOS session refresh failed"), {
     source: "workos_refresh_failure",
     level: "warning",

--- a/mcpjam-inspector/client/src/stores/__tests__/session-refresh-store.test.ts
+++ b/mcpjam-inspector/client/src/stores/__tests__/session-refresh-store.test.ts
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { useSessionRefreshStore } from "../session-refresh-store";
+import {
+  markSignOutInProgress,
+  resetSignOutLatchForTests,
+} from "@/lib/auth/sign-out-latch";
 
 describe("session-refresh-store", () => {
   beforeEach(() => {
+    resetSignOutLatchForTests();
     useSessionRefreshStore.setState({
       status: "idle",
       kind: null,
@@ -49,5 +54,30 @@ describe("session-refresh-store", () => {
     useSessionRefreshStore.getState().notifyFailure("transient");
 
     expect(useSessionRefreshStore.getState().kind).toBe("transient");
+  });
+
+  it("ignores the failure a sign-out causes itself", () => {
+    markSignOutInProgress();
+
+    useSessionRefreshStore.getState().notifyFailure("signed_out");
+
+    expect(useSessionRefreshStore.getState().status).toBe("idle");
+    expect(useSessionRefreshStore.getState().kind).toBeNull();
+  });
+
+  it("takes down an in-flight Retry banner when the user signs out", () => {
+    // Pressing Retry and then Log out: the retry fails because the session is
+    // being revoked. Dropping that failure silently would leave the banner
+    // stuck on a disabled "Retrying…" with nothing left to resolve it, since
+    // Convex does not re-fire once its token fetch returns null.
+    useSessionRefreshStore.getState().notifyFailure("transient");
+    useSessionRefreshStore.getState().retry();
+    expect(useSessionRefreshStore.getState().status).toBe("retrying");
+
+    markSignOutInProgress();
+    useSessionRefreshStore.getState().notifyFailure("signed_out");
+
+    expect(useSessionRefreshStore.getState().status).toBe("idle");
+    expect(useSessionRefreshStore.getState().kind).toBeNull();
   });
 });

--- a/mcpjam-inspector/client/src/stores/session-refresh-store.ts
+++ b/mcpjam-inspector/client/src/stores/session-refresh-store.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
 
+import { isSignOutInProgress } from "@/lib/auth/sign-out-latch";
+
 /**
  * Why the Convex auth token could not be refreshed.
  *
@@ -32,6 +34,14 @@ export const useSessionRefreshStore = create<SessionRefreshState>(
     kind: null,
     retryNonce: 0,
     notifyFailure: (kind) => {
+      // A sign-out in flight produces this failure on purpose: the session was
+      // just revoked, and the refresh timer is reporting the revocation we
+      // asked for. Banner-ing it would flash "Your session has expired." over
+      // a page the user is deliberately leaving — and, on the `signed_out`
+      // path, redirect them to login mid-logout. Checked HERE rather than at
+      // each caller so every source of a failure is covered, transient ones
+      // and future ones included. See `sign-out-latch`.
+      if (isSignOutInProgress()) return;
       // A dead session never degrades back into a retryable one: once WorkOS
       // has rejected the refresh, a later network-flavored exhaustion must not
       // relabel it and offer a Retry that cannot possibly work.

--- a/mcpjam-inspector/client/src/stores/session-refresh-store.ts
+++ b/mcpjam-inspector/client/src/stores/session-refresh-store.ts
@@ -41,7 +41,19 @@ export const useSessionRefreshStore = create<SessionRefreshState>(
       // path, redirect them to login mid-logout. Checked HERE rather than at
       // each caller so every source of a failure is covered, transient ones
       // and future ones included. See `sign-out-latch`.
-      if (isSignOutInProgress()) return;
+      //
+      // Cleared rather than just dropped, because the state this failure
+      // arrives into may already be a banner. A user who pressed Retry and
+      // then Log out sits at a disabled "Retrying…", and swallowing the
+      // failure silently would strand them there — the retry that would
+      // resolve it is the very thing that just failed, and Convex does not
+      // re-fire on its own. Harmless when the logout navigates; the difference
+      // only shows on the sign-out that cannot navigate because the session is
+      // already dead.
+      if (isSignOutInProgress()) {
+        set({ status: "idle", kind: null });
+        return;
+      }
       // A dead session never degrades back into a retryable one: once WorkOS
       // has rejected the refresh, a later network-flavored exhaustion must not
       // relabel it and offer a Retry that cannot possibly work.


### PR DESCRIPTION
- Clicking Log out signed you out fine, but then dropped you on the login screen instead of the signed-out app, usually after a flash of "Your session has expired."
- Cause: signing out revokes your session, and AuthKit's background refresh timer keeps running through the logout. It notices the revoked session a second later, assumes your session died on its own, and redirects you to sign in on top of the logout that was still in progress.
- Fix: mark that a sign-out is happening, and have the "session died" handler ignore the one failure that sign-out causes itself.
- The mark clears itself after 10 seconds on purpose. Sign-out does nothing at all when your session was already dead, so the page never navigates away, and a permanent mark would leave that tab quietly ignoring every real session problem afterwards.
- Still broken, separate fix: pressing Log out when your session is already dead does nothing, because AuthKit needs the token it just threw away to build the logout link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes clicking Log out landing on the login page instead of the signed-out app, and removes the "Your session has expired." flash.

Sign-out revokes the session, but AuthKit's refresh timer keeps running through the logout, sees the revocation, and redirects to sign-in mid-navigation. Added a latch set before every `signOut()` call that suppresses refresh failures for 10 seconds — long enough for the logout to complete — then expires so tabs that never navigate (when the session was already dead) still handle real session failures. The latch now clears its timestamp on expiry so a backward clock jump can't revive it, and suppressing a failure while a Retry banner is in flight clears the banner back to idle instead of stranding it.

Known remaining issue: pressing Log out on a session that's already dead still does nothing because AuthKit needs the token it just threw away to build the logout link.

<sup>Written for commit 40016f83b52679b1b0bdbdab75b00f34e0f1371a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

