### PR TITLE
Bound the Electron logout wait to the sign-out latch

### DIFF
--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
@@ -4,6 +4,7 @@ import type { ButtonHTMLAttributes, ReactNode } from "react";
 import {
   isSignOutInProgress,
   resetSignOutLatchForTests,
+  SIGN_OUT_REQUEST_TIMEOUT_MS,
 } from "@/lib/auth/sign-out-latch";
 
 const authState = vi.hoisted(() => ({
@@ -213,6 +214,48 @@ describe("SidebarUser", () => {
     expect(onBeforeSignOut.mock.invocationCallOrder[0]).toBeLessThan(
       authState.signOutMock.mock.invocationCallOrder[0]
     );
+  });
+
+  it("leaves Electron even when the logout request never answers", async () => {
+    // Nothing else navigates this window: `signOut({navigate: false})` settles
+    // only when its logout fetch does. A request that hung used to outlast the
+    // sign-out latch, and the refresh timer would then redirect the window to
+    // the hosted login page — the same hijack, arriving on a slow network.
+    authState.user = {
+      email: "owner@example.com",
+      firstName: "Owner",
+      lastName: "Example",
+    };
+    window.isElectron = true;
+    authState.signOutMock.mockReturnValue(new Promise(() => {}));
+
+    const assign = vi.fn();
+    const realLocation = window.location;
+    // jsdom's `location` is not writable and its `assign` throws "not
+    // implemented", so replacing the property is the only way to see where the
+    // sign-out would have gone.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { assign, origin: "https://app.example.test" },
+    });
+
+    render(<SidebarUser />);
+    vi.useFakeTimers();
+    try {
+      fireEvent.click(screen.getByText("Log out"));
+
+      expect(assign).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(SIGN_OUT_REQUEST_TIMEOUT_MS);
+
+      expect(assign).toHaveBeenCalledWith("https://app.example.test");
+    } finally {
+      vi.useRealTimers();
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: realLocation,
+      });
+    }
   });
 
   it("uses non-navigation logout in Electron", () => {

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -20,7 +20,10 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
-import { markSignOutInProgress } from "@/lib/auth/sign-out-latch";
+import {
+  markSignOutInProgress,
+  SIGN_OUT_REQUEST_TIMEOUT_MS,
+} from "@/lib/auth/sign-out-latch";
 import { getInitials } from "@/lib/utils";
 import {
   Bell,
@@ -71,11 +74,24 @@ export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
     markSignOutInProgress();
     const returnTo = window.location.origin;
     if (window.isElectron) {
-      void Promise.resolve(signOut({ returnTo, navigate: false })).finally(
-        () => {
+      // Bounded, because the latch above is. This promise settles when the
+      // logout request does, and nothing else navigates this window, so a hung
+      // request would outlive the suppression window and let the refresh timer
+      // redirect to the hosted login page mid-logout. The response is opaque,
+      // so there is nothing to lose by giving up on it and leaving anyway.
+      void Promise.race([
+        Promise.resolve(signOut({ returnTo, navigate: false })),
+        new Promise((resolve) =>
+          setTimeout(resolve, SIGN_OUT_REQUEST_TIMEOUT_MS)
+        ),
+      ])
+        // A failed logout request still gets the navigation: the session is
+        // already gone locally, and stranding the user on the signed-in app
+        // would be a worse answer than leaving.
+        .catch(() => undefined)
+        .finally(() => {
           window.location.assign(returnTo);
-        }
-      );
+        });
       return;
     }
 

--- a/mcpjam-inspector/client/src/lib/auth/__tests__/sign-out-latch.test.ts
+++ b/mcpjam-inspector/client/src/lib/auth/__tests__/sign-out-latch.test.ts
@@ -3,6 +3,7 @@ import {
   isSignOutInProgress,
   markSignOutInProgress,
   resetSignOutLatchForTests,
+  SIGN_OUT_REQUEST_TIMEOUT_MS,
   SIGN_OUT_SUPPRESSION_WINDOW_MS,
 } from "../sign-out-latch";
 
@@ -48,6 +49,17 @@ describe("sign-out latch", () => {
     markSignOutInProgress(start);
 
     expect(isSignOutInProgress(start - 60_000)).toBe(false);
+  });
+
+  it("gives the logout request less time than it suppresses failures for", () => {
+    // The Electron sign-out waits on its logout request and then navigates
+    // itself. If that wait could outlast the window, the latch would lapse
+    // while the logout was still in flight and the refresh timer would
+    // redirect to the hosted login page — the hijack this module exists to
+    // stop. The two constants are only correct relative to each other.
+    expect(SIGN_OUT_REQUEST_TIMEOUT_MS).toBeLessThan(
+      SIGN_OUT_SUPPRESSION_WINDOW_MS,
+    );
   });
 
   it("re-arms on a second sign-out attempt", () => {

--- a/mcpjam-inspector/client/src/lib/auth/sign-out-latch.ts
+++ b/mcpjam-inspector/client/src/lib/auth/sign-out-latch.ts
@@ -41,6 +41,29 @@
  */
 export const SIGN_OUT_SUPPRESSION_WINDOW_MS = 10_000;
 
+/**
+ * How long the Electron sign-out waits for its logout request before it
+ * navigates anyway.
+ *
+ * INVARIANT: must stay BELOW `SIGN_OUT_SUPPRESSION_WINDOW_MS`.
+ *
+ * The Electron path cannot let authkit navigate for it — WorkOS only redirects
+ * to a URI its dashboard allowlists — so it calls `signOut({navigate: false})`,
+ * waits for the promise, and navigates itself. That promise settles when the
+ * logout `fetch` does, and NOTHING else moves the page. A request that hangs
+ * past the suppression window therefore leaves the latch expired while the
+ * logout is still in flight, the refresh timer fires unlatched, and the user
+ * lands on the hosted login page — the exact hijack this module exists to
+ * stop, reappearing on a slow network.
+ *
+ * Bounding the wait is the fix rather than widening the window, because the
+ * response is opaque (`mode: "no-cors"`) and unreadable: waiting longer buys
+ * the caller nothing a timeout does not. Five seconds is generous for a
+ * request whose only job is to reach WorkOS, and half the window, so the
+ * navigation always happens with the latch still held.
+ */
+export const SIGN_OUT_REQUEST_TIMEOUT_MS = 5_000;
+
 let signOutStartedAt: number | null = null;
 
 /**


### PR DESCRIPTION
Stacked on #4684.

- On desktop, Log out sends the logout request itself and waits for a reply before leaving the page, because WorkOS will not redirect back to the app.
- If that request hangs for more than 10 seconds, the "a sign-out is happening" mark from #4684 wears off while the logout is still going, and you get bounced to the login screen again — the same bug, just needing a slow network to show up.
- Now the wait gives up after 5 seconds and leaves anyway. The reply is unreadable by design, so waiting longer never told us anything.
- The 5s and the 10s have to stay in that order, so they now sit side by side with a test that fails if anyone flips them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Electron logout so a hung logout request no longer bounces the user back to the login screen. The sign-out wait previously outlasted the 10-second sign-out latch on slow networks, letting the refresh timer redirect to the hosted login page mid-logout; now the wait gives up after 5 seconds and navigates anyway. Tests enforce that the request timeout stays below the suppression window and that Electron navigates even when the request never answers.

<sup>Written for commit 87ae64a682698190aca005e9bae03880cb7f6097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

