### PR TITLE
evals: the review follow-ups from #4682

### DIFF
--- a/.changeset/eval-settings-review-follow-ups.md
+++ b/.changeset/eval-settings-review-follow-ups.md
@@ -1,0 +1,17 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Eval settings: the review follow-ups
+
+**A reviewer label could land on the wrong trial.** The trial review panel kept the previous trial's label on screen while the next one loaded, and a label clicked before the first read finished counted as a fresh blind label. The panel is now scoped to the trial it shows, renders a neutral placeholder until its read lands, and never mounts on a quick-run trial that has no run to review. On a run judged with trial keys, a trial with no verdict of its own no longer borrows a sibling repetition's.
+
+**Backtest and "Compare with run" picked the oldest run.** Both now take the newest, and a run whose judge never stored a verdict is not offered for backtest.
+
+**The gate switch could not be lowered once stale.** A judge already set to gate whose calibration lapsed left the switch disabled while on. It can always be turned off; only turning it on waits for calibration.
+
+**The pass threshold field saved 0 when blanked, committed on Escape, and drifted on a no-edit blur.** A blank reverts, Escape reverts, and a stored 85.5% shown as 86 stays 85.5% until somebody types.
+
+**Revision history labels come from the settings manifest**, so a rename propagates, and an edit by someone who has left the organization reads "A former member" rather than "System".
+
+**A held run's rail and mini-bar are amber**, matching its badge, in the runs list and run overview. The judge's agreement line shows the chance-corrected figure when the backend reports one.

--- a/.changeset/eval-suite-revisions-for-agents.md
+++ b/.changeset/eval-suite-revisions-for-agents.md
@@ -1,6 +1,7 @@
 ---
 "@mcpjam/inspector": patch
 "@mcpjam/sdk": minor
+"@mcpjam/cli": patch
 ---
 
 Agents can read a suite's settings history

--- a/.changeset/judge-gate-inspector-half.md
+++ b/.changeset/judge-gate-inspector-half.md
@@ -37,8 +37,8 @@ eval run` and `eval gate` extend their own wait by the backend's 30-minute hold
 when the caller did not pin `--wait-timeout` (an explicit budget is still
 honoured exactly); the GitHub check worker waits out the hold while it still
 holds its lease, and stops waiting the moment it does not; and the Slack watcher
-posts "grading" as an informational update with no counts and no chain, because
-a held run has no chain to show yet.
+extends its own deadline through the hold instead of posting an outcome for a
+run that has none (it posts nothing until the verdict lands).
 
 **Nothing about the exit-code contract changed.** A run that finishes grading
 exits on its real result, and a run still grading when an explicit deadline

--- a/.changeset/sdk-forwards-expected-revision.md
+++ b/.changeset/sdk-forwards-expected-revision.md
@@ -1,0 +1,15 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/cli": patch
+---
+
+`update_eval_suite` forwards `expectedRevisionNumber`
+
+**The compare-and-set was accepted and then dropped.** `update_eval_suite`
+took an `expectedRevisionNumber`, and the SDK, the CLI and MCP all documented it
+as the way to refuse an edit against a suite that had moved on. The PATCH body
+was built from a fixed list of settings keys that did not include it, so the
+number never left the process and every edit was last-write-wins — with no
+error to say so. The body now carries `expectedRevisionNumber` whenever it is
+given, so a stale revision is refused with a 409 having written nothing, as the
+description always said.

--- a/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-presentation.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-presentation.test.tsx
@@ -264,6 +264,23 @@ describe("resolveIterationJudge (case drill-in join)", () => {
       ).toBe(0.9);
     });
 
+    it("returns null on a keyed run when this trial has no verdict", () => {
+      // Trial 3 was skipped, errored, or is not yet graded: the run carries
+      // trial keys, so a miss is the answer. A `caseKey` join here would show
+      // trial 1's 0.1 as trial 3's — and let a reviewer label it.
+      expect(
+        resolveIterationJudge(
+          {
+            _id: "it-3",
+            suiteRunId: "run-A",
+            iterationNumber: 3,
+            testCaseSnapshot: { caseKey: "case-1" },
+          },
+          repeated,
+        ),
+      ).toBeNull();
+    });
+
     it("still joins a legacy run by caseKey alone", () => {
       // Runs judged before either key existed carry neither, and on those
       // `caseKey` is exactly what their verdicts were keyed by.

--- a/mcpjam-inspector/client/src/components/evals/__tests__/helpers-status-border.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/helpers-status-border.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { evalStatusLeftBorderClasses } from "../helpers";
+
+describe("evalStatusLeftBorderClasses", () => {
+  it("paints a grading run's rail amber, like a running one", () => {
+    // A held run's badge is amber; a muted rail beside it reads as a
+    // different state than the one the badge names.
+    expect(evalStatusLeftBorderClasses("grading")).toBe("border-l-warning/50");
+    expect(evalStatusLeftBorderClasses("grading")).toBe(
+      evalStatusLeftBorderClasses("running"),
+    );
+  });
+
+  it("keeps running on the warning rail", () => {
+    expect(evalStatusLeftBorderClasses("running")).toBe("border-l-warning/50");
+  });
+
+  it("does not promote unknown statuses to the warning rail", () => {
+    expect(evalStatusLeftBorderClasses("nonsense")).toBe(
+      "border-l-muted-foreground/50",
+    );
+  });
+});
+
+describe("evalStatusMiniBarClasses", () => {
+  it("pulses a grading run like a running one, never the muted default", async () => {
+    const { evalStatusMiniBarClasses } = await import("../helpers");
+    expect(evalStatusMiniBarClasses("grading")).toBe(
+      evalStatusMiniBarClasses("running"),
+    );
+    expect(evalStatusMiniBarClasses("grading")).toContain("bg-warning");
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/iteration-details-ui.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/iteration-details-ui.test.tsx
@@ -40,6 +40,15 @@ vi.mock("@/lib/apis/mcp-tools-api", () => ({
   listTools: vi.fn(),
 }));
 
+vi.mock("../trial-judge-review", () => ({
+  TrialJudgeReviewPanel: (props: { iterationId: string }) => (
+    <div
+      data-testid="mock-trial-judge-review"
+      data-iteration={props.iterationId}
+    />
+  ),
+}));
+
 vi.mock("../trace-viewer", () => ({
   TraceViewer: (props: {
     chromeDensity?: string;
@@ -277,6 +286,57 @@ describe("IterationDetails trace blob load error", () => {
       screen.getByText(
         /Something went wrong while loading the recorded trace/i,
       ),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("IterationDetails judge review gate", () => {
+  const judgeCase = {
+    caseKey: "case-1",
+    gradingKey: "case-1#1",
+    iterationId: "iter-1",
+    score: 0.42,
+    passed: false,
+    reason: "The answer never named the file.",
+    rubricHits: [],
+  };
+
+  beforeEach(() => {
+    mockGetBlob.mockReset();
+    mockJsonEditor.mockClear();
+  });
+
+  it("offers the calibration label for a trial from a suite run", () => {
+    render(
+      <IterationDetails
+        layoutMode="full"
+        iteration={{ ...iteration, suiteRunId: "run-1" }}
+        testCase={testCase}
+        judgeCase={judgeCase}
+        enableJudgeReview
+      />,
+    );
+    expect(screen.getByTestId("mock-trial-judge-review")).toHaveAttribute(
+      "data-iteration",
+      "iter-1",
+    );
+  });
+
+  it("shows only the read-only verdict for a quick-run trial", () => {
+    // No `suiteRunId`: the backend refuses every label for this trial
+    // (`JUDGE_REVIEW_NO_RUN`), so the control is not offered at all.
+    render(
+      <IterationDetails
+        layoutMode="full"
+        iteration={iteration}
+        testCase={testCase}
+        judgeCase={judgeCase}
+        enableJudgeReview
+      />,
+    );
+    expect(screen.queryByTestId("mock-trial-judge-review")).toBeNull();
+    expect(
+      screen.getByText(/The answer never named the file/),
     ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/judge-gate-panel.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/judge-gate-panel.test.tsx
@@ -223,6 +223,39 @@ describe("JudgeGatePanel", () => {
     });
   });
 
+  it("lets a gate that has gone stale be lowered, never raised", async () => {
+    // The draft already gates and the deployment (or calibration) no longer
+    // allows it. Disabling the switch outright would trap the suite in a state
+    // the page itself says is not allowed; only turning it ON needs evidence.
+    const user = userEvent.setup();
+    const stale = judge({
+      gating: { enabled: false, reason: "not_enabled_on_deployment" },
+    });
+    const { onJudgeConfigChange, unmount } = renderPanel({
+      judge: stale,
+      role: "gating",
+    });
+    const gate = screen.getByRole("switch", {
+      name: "Let the judge decide pass or fail",
+    });
+    expect(gate).toBeEnabled();
+    // The reason is still said, so the reader knows why it cannot go back up.
+    expect(screen.getByTestId("judge-gate-disabled-reason").textContent).toBe(
+      "Not available on this deployment",
+    );
+    await user.click(gate);
+    expect(onJudgeConfigChange).toHaveBeenCalledWith({
+      goalCompletion: { role: "advisory" },
+    });
+    unmount();
+
+    // Same judge, advisory draft: raising the gate is still refused.
+    renderPanel({ judge: stale, role: "advisory" });
+    expect(
+      screen.getByRole("switch", { name: "Let the judge decide pass or fail" }),
+    ).toBeDisabled();
+  });
+
   it("says when a gate rests on an acknowledgement rather than evidence", () => {
     renderPanel({
       judge: judge({
@@ -251,5 +284,20 @@ describe("gateSwitchDisabledReason — when the capabilities read failed", () =>
         "Could not check availability right now",
       ),
     ).toBe("Could not check availability right now");
+  });
+});
+
+describe("describeAgreement — chance-corrected agreement", () => {
+  it("shows kappa beside the rate when the backend reports it, and nothing when it does not", () => {
+    expect(describeAgreement({ ...judge().agreement, kappa: 0.7143 })).toBe(
+      "Agrees with reviewers 18/20 · 90% (at least 72% likely) · chance-corrected 0.71",
+    );
+    // `null` is "undefined for this corpus" (both raters constant), not 0.
+    expect(describeAgreement({ ...judge().agreement, kappa: null })).toBe(
+      "Agrees with reviewers 18/20 · 90% (at least 72% likely)",
+    );
+    expect(describeAgreement(judge().agreement)).not.toContain(
+      "chance-corrected",
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-run-pickers.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-run-pickers.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Which run the settings sheet reaches for.
+ *
+ * `compareRunsBySequence` sorts ASCENDING, so a bare sort hands back run #1 —
+ * and the sheet once backtested a draft rubric against a suite's very first
+ * run, and opened "Compare with run" on it too. These pin the newest run.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+// The helpers are pure, but they live in the view module, which reads
+// per-suite capabilities through Convex. Same isolation as the master-detail
+// suite: nothing here ever renders, so nothing here ever needs the real hook.
+vi.mock("@/hooks/use-suite-capabilities", () => ({
+  useSuiteCapabilities: () => ({ state: "unavailable", capabilities: null }),
+}));
+
+import {
+  pickBacktestableRun,
+  sortRunsNewestFirst,
+} from "../suite-iterations-view";
+import type { EvalSuiteRun } from "../types";
+
+function run(
+  runNumber: number,
+  overrides: Partial<EvalSuiteRun> = {},
+): EvalSuiteRun {
+  return {
+    _id: `run-${runNumber}`,
+    suiteId: "suite-1",
+    createdBy: "u",
+    runNumber,
+    configRevision: "r",
+    configSnapshot: { tests: [], environment: { servers: [] } },
+    status: "completed",
+    result: "passed",
+    createdAt: runNumber,
+    completedAt: runNumber + 1,
+    source: "ui",
+    goalCompletion: {
+      summary: "",
+      generatedAt: runNumber + 1,
+      modelUsed: "m",
+      threshold: 0.7,
+      cases: [],
+    },
+    ...overrides,
+  } as EvalSuiteRun;
+}
+
+describe("sortRunsNewestFirst", () => {
+  it("puts the newest run first, whatever order the list arrived in", () => {
+    expect(
+      sortRunsNewestFirst([run(1), run(3), run(2)]).map((r) => r._id),
+    ).toEqual(["run-3", "run-2", "run-1"]);
+    expect(sortRunsNewestFirst([])).toEqual([]);
+  });
+});
+
+describe("pickBacktestableRun", () => {
+  it("backtests against run #3, not run #1, when both were judged", () => {
+    expect(pickBacktestableRun([run(1), run(3)])?.runNumber).toBe(3);
+  });
+
+  it("skips runs still going and runs never judged, including a null verdict", () => {
+    expect(
+      pickBacktestableRun([
+        run(1),
+        run(2, { goalCompletion: undefined }),
+        // A `null` verdict is stored on runs the judge never graded; it is no
+        // more comparable than an absent one.
+        run(3, { goalCompletion: null as unknown as undefined }),
+        run(4, { status: "running", completedAt: undefined }),
+      ])?.runNumber,
+    ).toBe(1);
+    expect(pickBacktestableRun([run(5, { status: "running" })])).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-policy-controls.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-policy-controls.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * The percent field behind the v2 policy and validity controls.
+ *
+ * Three ways a field that LOOKS idle can rewrite a suite:
+ *
+ *   - a blank Pass threshold committing 0, which turns an empty box into an
+ *     accept-anything policy;
+ *   - Escape committing the typed value, because `blur()` runs the commit
+ *     against the text still on screen;
+ *   - focus + blur on a stored 0.855, which the field shows as "86", saving
+ *     0.86 for a reader who typed nothing.
+ *
+ * The validity fields share the component and keep the OTHER meaning of a
+ * blank: leave it empty to select the contract default.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  VerdictPolicyV2Controls,
+  VerdictValidityControls,
+} from "../suite-policy-controls";
+
+const THRESHOLD = /fraction of a case's trials that must pass/i;
+
+function renderThreshold(passThreshold: number) {
+  const onChange = vi.fn();
+  render(
+    <VerdictPolicyV2Controls
+      defaults={{ repetitions: 3, passThreshold }}
+      onChange={onChange}
+    />,
+  );
+  return {
+    onChange,
+    input: screen.getByLabelText(THRESHOLD) as HTMLInputElement,
+  };
+}
+
+describe("VerdictPolicyV2Controls pass threshold", () => {
+  it("reverts a blank to the stored value instead of committing 0", async () => {
+    const user = userEvent.setup();
+    const { onChange, input } = renderThreshold(0.8);
+    await user.clear(input);
+    await user.tab();
+    // A blank is not a bar of zero. Nothing was drafted, and the field shows
+    // what the suite still holds.
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input.value).toBe("80");
+  });
+
+  it("reverts on Escape without committing the typed value", async () => {
+    const user = userEvent.setup();
+    const { onChange, input } = renderThreshold(0.8);
+    await user.clear(input);
+    await user.type(input, "55");
+    await user.keyboard("{Escape}");
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input.value).toBe("80");
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  it("does not commit a rounded display value on a no-edit blur", async () => {
+    const user = userEvent.setup();
+    const { onChange, input } = renderThreshold(0.855);
+    expect(input.value).toBe("86");
+    await user.click(input);
+    await user.tab();
+    // The field could only show 86, but the suite holds 0.855, and a reader
+    // who edited nothing must not have moved it to 0.86.
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input.value).toBe("86");
+  });
+
+  it("still commits a value that actually changed", async () => {
+    const user = userEvent.setup();
+    const { onChange, input } = renderThreshold(0.855);
+    await user.clear(input);
+    await user.type(input, "90");
+    await user.tab();
+    expect(onChange).toHaveBeenCalledWith({
+      repetitions: 3,
+      passThreshold: 0.9,
+    });
+  });
+});
+
+describe("VerdictValidityControls", () => {
+  it("keeps a blank meaning unset on the optional fields", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <VerdictValidityControls
+        defaults={{
+          repetitions: 1,
+          passThreshold: 1,
+          validity: { minCompletionRate: 0.8 },
+        }}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByLabelText(
+      /minimum share of trials that must have completed/i,
+    );
+    await user.clear(input);
+    await user.tab();
+    // Empty selects the contract default, so the ceiling is dropped rather
+    // than reverted — the opposite of what the required threshold does.
+    expect(onChange).toHaveBeenCalledWith({
+      repetitions: 1,
+      passThreshold: 1,
+      validity: undefined,
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-revision-history.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-revision-history.test.tsx
@@ -30,6 +30,13 @@ vi.mock("convex/react", () => ({
 }));
 
 import { SuiteRevisionHistory, fieldLabel } from "../suite-revision-history";
+import { EVAL_SUITE_SETTINGS_MANIFEST } from "@/shared/eval-suite-settings-manifest";
+
+function manifestLabel(key: string): string {
+  const row = EVAL_SUITE_SETTINGS_MANIFEST.find((entry) => entry.key === key);
+  if (!row) throw new Error(`no manifest row for ${key}`);
+  return row.label;
+}
 
 function row(overrides: Record<string, unknown> = {}) {
   return {
@@ -94,8 +101,16 @@ describe("SuiteRevisionHistory", () => {
   });
 
   it("attributes an unclaimed write to System, not to nobody", () => {
-    renderHistory([row({ createdByName: null })]);
+    renderHistory([row({ createdBy: null, createdByName: null })]);
     expect(screen.getByText("System")).toBeTruthy();
+  });
+
+  it("does not call a former member's edit System", () => {
+    // The author left the organization: the id survives, the name does not.
+    // "System" would hide that a person made this change.
+    renderHistory([row({ createdBy: "user-gone", createdByName: null })]);
+    expect(screen.getByText("A former member")).toBeTruthy();
+    expect(screen.queryByText("System")).toBeNull();
   });
 
   it("offers Load more only while there are more pages", () => {
@@ -134,10 +149,25 @@ describe("SuiteRevisionHistory", () => {
 });
 
 describe("fieldLabel", () => {
-  it("maps the storage keys the revision log actually records", () => {
-    expect(fieldLabel("judgeRubric")).toBe("Judge criteria");
+  it("reads a labelled row's name from the manifest, not a copy of it", () => {
+    // Asserted against the manifest row rather than a literal, so a rename on
+    // the settings page is a rename here without a second edit. Both the
+    // aliased spelling and the shared one go through the manifest.
+    expect(fieldLabel("defaultPredicates")).toBe(manifestLabel("checks"));
+    expect(fieldLabel("environmentIds")).toBe(manifestLabel("environments"));
+    expect(fieldLabel("environment")).toBe(
+      manifestLabel("computerEnvironment"),
+    );
+    expect(fieldLabel("judgeRubric")).toBe(manifestLabel("judgeRubric"));
+  });
+
+  it("keeps a hand-written label only for a key with no settings row", () => {
+    expect(
+      EVAL_SUITE_SETTINGS_MANIFEST.some(
+        (entry) => entry.key === "verdictPolicyDefaults",
+      ),
+    ).toBe(false);
     expect(fieldLabel("verdictPolicyDefaults")).toBe("Policy defaults");
-    expect(fieldLabel("environmentIds")).toBe("Environments");
     expect(fieldLabel("unknownKey")).toBe("unknownKey");
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trial-judge-review.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trial-judge-review.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * The label read is scoped to the trial it was issued for.
+ *
+ * A calibration label is attributed to whichever trial the panel was showing
+ * when it was chosen, and "no label yet" is what unlocks the blind control. So
+ * two things must never happen: one trial's label rendered under another
+ * trial's verdict, and the blind control offered before the read for THIS
+ * trial has landed — a label submitted then is a fresh `blind: true` row that
+ * supersedes one the reviewer never saw.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TrialJudgeReviewPanel } from "../trial-judge-review";
+import type {
+  JudgeCase,
+  TrialJudgeReview,
+} from "../goal-completion-presentation";
+
+const { mockQuery, mockSubmit } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+  mockSubmit: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useConvex: () => ({ query: mockQuery }),
+  useMutation: () => mockSubmit,
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const JUDGE_CASE: JudgeCase = {
+  caseKey: "case_a",
+  gradingKey: "case_a#1",
+  iterationId: "it_1",
+  score: 0.42,
+  passed: false,
+  reason: "The answer never named the file.",
+  rubricHits: [],
+};
+
+function review(reviewerVerdict: TrialJudgeReview["reviewerVerdict"]) {
+  return {
+    reviewerVerdict,
+    judgeVerdict: "partial",
+    note: null,
+    blind: true,
+    createdAt: 1,
+  } satisfies TrialJudgeReview;
+}
+
+/** One read per trial, each settled by the test and not before. */
+function deferredReads() {
+  const pending = new Map<string, (row: TrialJudgeReview | null) => void>();
+  mockQuery.mockImplementation(
+    (_fn: unknown, args: { iterationId: string }) =>
+      new Promise<TrialJudgeReview | null>((resolve) => {
+        pending.set(args.iterationId, resolve);
+      }),
+  );
+  return async (iterationId: string, row: TrialJudgeReview | null) => {
+    const resolve = pending.get(iterationId);
+    if (!resolve) throw new Error(`no pending read for ${iterationId}`);
+    await act(async () => {
+      resolve(row);
+    });
+  };
+}
+
+describe("TrialJudgeReviewPanel trial scoping", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockSubmit.mockReset();
+    mockSubmit.mockResolvedValue(undefined);
+  });
+
+  it("offers neither a label nor a reveal while the read is pending", () => {
+    deferredReads();
+    render(<TrialJudgeReviewPanel iterationId="it_1" judgeCase={JUDGE_CASE} />);
+    expect(screen.getByTestId("trial-review-loading")).toBeTruthy();
+    expect(screen.queryByTestId("trial-review-control")).toBeNull();
+    expect(screen.queryByRole("button", { name: "pass" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Reveal judge verdict" }),
+    ).toBeNull();
+    // The verdict itself is hidden too: a reveal before the label is known
+    // would un-blind the label about to be given.
+    expect(screen.queryByText(/The answer never named the file/)).toBeNull();
+  });
+
+  it("drops the previous trial's label the moment the trial changes", async () => {
+    const settle = deferredReads();
+    const { rerender } = render(
+      <TrialJudgeReviewPanel iterationId="it_1" judgeCase={JUDGE_CASE} />,
+    );
+    await settle("it_1", review("fail"));
+    expect(screen.getByTestId("trial-review-provenance").textContent).toContain(
+      "Reviewer: fail",
+    );
+
+    rerender(
+      <TrialJudgeReviewPanel
+        iterationId="it_2"
+        judgeCase={{ ...JUDGE_CASE, iterationId: "it_2" }}
+      />,
+    );
+    // Not trial 1's label, and not the label control either — nothing is
+    // known about trial 2 yet.
+    expect(screen.queryByTestId("trial-review-provenance")).toBeNull();
+    expect(screen.queryByTestId("trial-review-control")).toBeNull();
+    expect(screen.getByTestId("trial-review-loading")).toBeTruthy();
+
+    await settle("it_2", review("pass"));
+    expect(screen.getByTestId("trial-review-provenance").textContent).toContain(
+      "Reviewer: pass",
+    );
+    expect(screen.queryByTestId("trial-review-loading")).toBeNull();
+  });
+
+  it("submits a label against the trial that was loaded, not the one before", async () => {
+    const user = userEvent.setup();
+    const settle = deferredReads();
+    const { rerender } = render(
+      <TrialJudgeReviewPanel iterationId="it_1" judgeCase={JUDGE_CASE} />,
+    );
+    await settle("it_1", null);
+    expect(screen.getByTestId("trial-review-control")).toBeTruthy();
+
+    rerender(
+      <TrialJudgeReviewPanel
+        iterationId="it_2"
+        judgeCase={{ ...JUDGE_CASE, iterationId: "it_2" }}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "pass" })).toBeNull();
+
+    await settle("it_2", null);
+    await user.click(screen.getByRole("button", { name: "pass" }));
+    expect(mockSubmit).toHaveBeenCalledTimes(1);
+    expect(mockSubmit).toHaveBeenCalledWith({
+      iterationId: "it_2",
+      reviewerVerdict: "pass",
+      blind: true,
+    });
+  });
+
+  it("ignores a read that lands after the trial has moved on", async () => {
+    const settle = deferredReads();
+    const { rerender } = render(
+      <TrialJudgeReviewPanel iterationId="it_1" judgeCase={JUDGE_CASE} />,
+    );
+    rerender(
+      <TrialJudgeReviewPanel
+        iterationId="it_2"
+        judgeCase={{ ...JUDGE_CASE, iterationId: "it_2" }}
+      />,
+    );
+    // Trial 1's answer arrives late. It must not be taken for trial 2's.
+    await settle("it_1", review("fail"));
+    expect(screen.queryByTestId("trial-review-provenance")).toBeNull();
+    expect(screen.getByTestId("trial-review-loading")).toBeTruthy();
+
+    await settle("it_2", null);
+    expect(screen.getByTestId("trial-review-control")).toBeTruthy();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-presentation.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-presentation.tsx
@@ -199,6 +199,10 @@ export function resolveCellWorkflow(
  *   3. `caseKey` — the LEGACY fallback, correct only when a case ran once.
  *      Kept for runs judged before the keys existed, which is the only
  *      population it can still be wrong for and the only one it can serve.
+ *      It fires ONLY when no case in the array carries either key: on a keyed
+ *      run, a trial with no match has no verdict (skipped, errored, not yet
+ *      graded), and borrowing a sibling repetition's would show the wrong one
+ *      — and let a reviewer label it.
  */
 export function resolveIterationJudge(
   iteration:
@@ -231,9 +235,14 @@ export function resolveIterationJudge(
     const byGradingKey = cases.find((c) => c.gradingKey === gradingKey);
     if (byGradingKey) return byGradingKey;
   }
-  // Legacy only. A run whose cases carry EITHER new key has already been
-  // handled above, so falling through here means this run predates them —
+  // Legacy only. On a run whose cases carry EITHER new key, a miss above is
+  // the answer: this trial has no verdict, and a `caseKey` join would hand it
+  // a sibling repetition's. Only a run that predates both keys falls through —
   // and on such a run `caseKey` is what its verdicts were keyed by.
+  const keyed = cases.some(
+    (c) => c.iterationId !== undefined || c.gradingKey !== undefined,
+  );
+  if (keyed) return null;
   return cases.find((c) => c.caseKey === caseKey) ?? null;
 }
 

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -693,6 +693,7 @@ export function evalStatusLeftBorderClasses(result: string): string {
       return "border-l-destructive/50";
     case RESULT_STATUS.PENDING:
     case "running":
+    case "grading":
       return "border-l-warning/50";
     case RESULT_STATUS.CANCELLED:
       return "border-l-muted";
@@ -718,6 +719,7 @@ export function evalStatusMiniBarClasses(result: string): string {
       return "bg-destructive/50";
     case RESULT_STATUS.PENDING:
     case "running":
+    case "grading":
       return "bg-warning/50 animate-pulse";
     case RESULT_STATUS.CANCELLED:
       return "bg-muted-foreground/50";

--- a/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
+++ b/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
@@ -240,7 +240,10 @@ export function IterationDetails({
    * Opt-in for the same reason `trialChainSlot` is a slot: this component has
    * five hosts, and the label's read and write have no business firing for the
    * four that never asked. The host that shows a trial from a real suite run
-   * turns it on; the quick-run and playground hosts do not.
+   * turns it on; the quick-run and playground hosts do not. Even when on, a
+   * trial with no `suiteRunId` (a quick run) gets the read-only verdict: the
+   * backend refuses every label for it (`JUDGE_REVIEW_NO_RUN`), so offering
+   * the control would only offer the refusal.
    */
   enableJudgeReview?: boolean;
   /**
@@ -1057,8 +1060,11 @@ export function IterationDetails({
           every tab (Steps/Chat/Results/Trace/App/Raw), not buried in one. */}
       {layoutMode === "full" && judgeCase ? (
         <div className="shrink-0 px-3">
-          {enableJudgeReview ? (
+          {enableJudgeReview && iteration.suiteRunId ? (
+            // Keyed by trial: a switch remounts the panel, so no read or label
+            // state from the previous trial can survive into this one.
             <TrialJudgeReviewPanel
+              key={iteration._id}
               iterationId={iteration._id}
               judgeCase={judgeCase}
             />

--- a/mcpjam-inspector/client/src/components/evals/judge-gate-panel.tsx
+++ b/mcpjam-inspector/client/src/components/evals/judge-gate-panel.tsx
@@ -53,9 +53,18 @@ export function describeAgreement(
   const base = `Agrees with reviewers ${agreement.agreements}/${agreement.reviews} · ${Math.round(
     agreement.rate * 100,
   )}%`;
-  return agreement.lowerBound === null
-    ? base
-    : `${base} (at least ${Math.round(agreement.lowerBound * 100)}% likely)`;
+  const withBound =
+    agreement.lowerBound === null
+      ? base
+      : `${base} (at least ${Math.round(agreement.lowerBound * 100)}% likely)`;
+  // Chance-corrected agreement, when the backend reports it. Raw agreement is
+  // inflated on a corpus the judge mostly passes; kappa says how much of the
+  // rate is better than guessing the majority class. Rendered from the server
+  // number, never derived here, and absent on a backend that predates it.
+  const kappa = agreement.kappa;
+  return typeof kappa === "number"
+    ? `${withBound} · chance-corrected ${kappa.toFixed(2)}`
+    : withBound;
 }
 
 /**
@@ -182,7 +191,10 @@ export function JudgeGatePanel({
         </div>
         <Switch
           checked={isGating}
-          disabled={disabledReason !== undefined}
+          // Only turning the gate ON needs the evidence. A draft that already
+          // gates while calibration has lapsed (or the deployment turned the
+          // gate off) must still be able to come back down to advisory.
+          disabled={disabledReason !== undefined && !isGating}
           aria-label="Let the judge decide pass or fail"
           onCheckedChange={(checked) =>
             onJudgeConfigChange({

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -298,6 +298,40 @@ function SuiteGithubChecksSettingsSection({
   );
 }
 
+/**
+ * The suite's runs NEWEST FIRST. `compareRunsBySequence` sorts ascending by
+ * run number, so a bare sort puts run #1 first — which is how a suite with
+ * fifty runs once backtested a draft rubric against its very first run.
+ */
+export function sortRunsNewestFirst(runs: EvalSuiteRun[]): EvalSuiteRun[] {
+  return [...runs].sort((a, b) => compareRunsBySequence(b, a));
+}
+
+const TERMINAL_RUN_STATUSES = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+  "timed_out",
+]);
+
+/**
+ * S6 — the run a rubric edit can be backtested against.
+ *
+ * The newest TERMINAL run that was actually judged: a run whose
+ * `goalCompletion` is absent or `null` has no stored verdict to compare a
+ * draft against, and a run still going has nothing to re-grade at all.
+ * `null` means the panel is not offered rather than offered and refused.
+ */
+export function pickBacktestableRun(runs: EvalSuiteRun[]): EvalSuiteRun | null {
+  return (
+    sortRunsNewestFirst(runs).find(
+      (run) =>
+        TERMINAL_RUN_STATUSES.has(run.status ?? "") &&
+        run.goalCompletion != null,
+    ) ?? null
+  );
+}
+
 export function SuiteIterationsView({
   suite,
   cases,
@@ -642,23 +676,8 @@ export function SuiteIterationsView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [liveSettingsKey]);
 
-  // S6 — the run a rubric edit can be backtested against.
-  //
-  // The newest TERMINAL run that was actually judged: a run with no
-  // `goalCompletion` has no stored verdict to compare a draft against, and a
-  // run still going has nothing to re-grade at all. Absent means the panel is
-  // not offered rather than offered and refused.
-  const backtestableRun = useMemo(() => {
-    const terminal = new Set(["completed", "failed", "cancelled", "timed_out"]);
-    return (
-      [...runs]
-        .sort(compareRunsBySequence)
-        .find(
-          (run) =>
-            terminal.has(run.status ?? "") && run.goalCompletion !== undefined,
-        ) ?? null
-    );
-  }, [runs]);
+  // S6 — the run a rubric edit can be backtested against (see the helper).
+  const backtestableRun = useMemo(() => pickBacktestableRun(runs), [runs]);
 
   const handleCommitSettings = useCallback(
     async (note: string) => {
@@ -978,13 +997,14 @@ export function SuiteIterationsView({
     });
   };
 
-  // The suite's newest run, for the history panel's "Compare with run". Absent
-  // on a suite that has never run, in which case the footer action is not
-  // offered rather than being offered and doing nothing.
-  const latestRunForCompare = useMemo(
-    () => [...runs].sort(compareRunsBySequence)[0] ?? null,
-    [runs],
-  );
+  // The suite's newest run, for the history panel's "Compare with run", and
+  // the one before it as the compare base. Absent on a suite that has never
+  // run, in which case the footer action is not offered rather than being
+  // offered and doing nothing; a suite with a single run opens it uncompared.
+  const [latestRunForCompare, previousRunForCompare] = useMemo(() => {
+    const newestFirst = sortRunsNewestFirst(runs);
+    return [newestFirst[0] ?? null, newestFirst[1] ?? null] as const;
+  }, [runs]);
 
   const handleCompareRuns = useCallback(
     (baseRunId: string, compareRunId: string) => {
@@ -2309,7 +2329,7 @@ export function SuiteIterationsView({
                   suite._id,
                   latestRunForCompare._id,
                   undefined,
-                  {},
+                  { compareToRunId: previousRunForCompare?._id },
                 );
               }
             : undefined

--- a/mcpjam-inspector/client/src/components/evals/suite-policy-controls.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-policy-controls.tsx
@@ -15,7 +15,7 @@
  * `entered / 100`, and nothing else on this path divides by anything.
  */
 
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { Button } from "@mcpjam/design-system/button";
 import type { SuiteVerdictPolicyDefaults } from "./suite-settings-draft";
 
@@ -38,6 +38,17 @@ const VALIDITY_PLACEHOLDERS = {
  * without the field rewriting itself to 8% under their cursor. Commits on blur
  * and on Enter, clamped into [0,1] — the backend refuses anything outside, and
  * a refusal after the save is a worse way to learn it.
+ *
+ * ONLY A CHANGE COMMITS. The field shows a ROUNDED percent, so a stored 0.855
+ * reads "86"; if merely focusing and leaving committed what was on screen, the
+ * suite would be rewritten to 0.86 by a reader who edited nothing. So the
+ * typed number is compared with the stored one — the exact fraction, or the
+ * percent the field already showed — and a match drafts nothing.
+ *
+ * A BLANK means two things, so the caller says which. On an optional field
+ * (`required` unset) it commits `undefined`: the contract default. On a
+ * required one it reverts to the stored value: there is no default to fall
+ * back to, and committing 0 would turn an empty box into "accept anything".
  */
 function PercentInput({
   label,
@@ -45,25 +56,42 @@ function PercentInput({
   placeholder,
   onCommit,
   ariaLabel,
+  required = false,
 }: {
   label?: string;
   value: number | undefined;
   placeholder?: string;
+  /** Receives `undefined` only when the field is optional and left blank. */
   onCommit: (fraction: number | undefined) => void;
   ariaLabel: string;
+  /** A blank reverts to the stored value instead of committing `undefined`. */
+  required?: boolean;
 }) {
   const asPercent = value === undefined ? "" : String(Math.round(value * 100));
   const [text, setText] = useState(asPercent);
   const [editing, setEditing] = useState(false);
+  // Escape reverts. It does so by blurring, and `blur()` runs the blur handler
+  // synchronously against the text that was on screen, so the handler needs
+  // to be told the blur is a revert before it can read anything.
+  const revertOnBlur = useRef(false);
   useEffect(() => {
     if (!editing) setText(asPercent);
   }, [asPercent, editing]);
 
   const commit = () => {
     setEditing(false);
+    if (revertOnBlur.current) {
+      revertOnBlur.current = false;
+      setText(asPercent);
+      return;
+    }
     const trimmed = text.trim();
     if (trimmed === "") {
-      onCommit(undefined);
+      if (required) {
+        setText(asPercent);
+        return;
+      }
+      if (value !== undefined) onCommit(undefined);
       return;
     }
     const parsed = Number(trimmed);
@@ -71,8 +99,16 @@ function PercentInput({
       setText(asPercent);
       return;
     }
-    const clamped = Math.min(100, Math.max(0, parsed));
-    onCommit(clamped / 100);
+    // Compared BEFORE clamping: "140" over a stored 100% is still an edit,
+    // and the commit is what snaps the field back into range.
+    const unchanged =
+      value !== undefined &&
+      (parsed / 100 === value || parsed === Math.round(value * 100));
+    if (unchanged) {
+      setText(asPercent);
+      return;
+    }
+    onCommit(Math.min(100, Math.max(0, parsed)) / 100);
   };
 
   return (
@@ -91,8 +127,7 @@ function PercentInput({
           onKeyDown={(event) => {
             if (event.key === "Enter") event.currentTarget.blur();
             if (event.key === "Escape") {
-              setEditing(false);
-              setText(asPercent);
+              revertOnBlur.current = true;
               event.currentTarget.blur();
             }
           }}
@@ -151,9 +186,14 @@ export function VerdictPolicyV2Controls({
           label="Pass threshold"
           value={current.passThreshold}
           ariaLabel="Fraction of a case's trials that must pass"
-          onCommit={(fraction) =>
-            onChange({ ...current, passThreshold: fraction ?? 0 })
-          }
+          required
+          onCommit={(fraction) => {
+            // A required field never commits a blank, so `undefined` cannot
+            // reach here; the guard is so it can never be read as a 0 either.
+            if (fraction !== undefined) {
+              onChange({ ...current, passThreshold: fraction });
+            }
+          }}
         />
       </div>
       <p className="text-[11px] text-muted-foreground/60">

--- a/mcpjam-inspector/client/src/components/evals/suite-revision-history.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-revision-history.tsx
@@ -31,6 +31,10 @@ import {
 } from "@mcpjam/design-system/sheet";
 import { Button } from "@mcpjam/design-system/button";
 import { formatRelativeTime } from "./helpers";
+import {
+  EVAL_SUITE_SETTINGS_MANIFEST,
+  type EvalSuiteSettingKey,
+} from "@/shared/eval-suite-settings-manifest";
 
 /** Where a revision came from. `unattributed` is a write nothing claimed. */
 export const REVISION_SOURCE_LABELS: Record<string, string> = {
@@ -44,27 +48,52 @@ export const REVISION_SOURCE_LABELS: Record<string, string> = {
 };
 
 /**
- * Storage key → the settings row a reader edited.
+ * Manifest key → the label the settings page shows for that row.
  *
- * Built from the manifest, so a row that is renamed on the settings page is
- * renamed here too. The mapping is by DOTTED API LEAF where one exists, because
- * that is the closest thing the manifest has to a storage name.
+ * Read from the manifest rather than copied out of it, so a row renamed on the
+ * settings page is renamed here in the same edit.
  */
-const FIELD_LABELS: Record<string, string> = {
-  name: "Name",
+const MANIFEST_LABELS: Record<string, string> = Object.fromEntries(
+  EVAL_SUITE_SETTINGS_MANIFEST.map((row) => [row.key, row.label]),
+);
+
+/**
+ * Storage key → manifest key, for the keys whose two spellings differ.
+ *
+ * A snapshot key that is ALREADY a manifest key (`name`, `judgeRubric`, …)
+ * needs no entry. The value type is the manifest's key union, so an alias to a
+ * row that no longer exists is a type error rather than a raw key on screen.
+ */
+const SNAPSHOT_KEY_TO_MANIFEST_KEY: Record<string, EvalSuiteSettingKey> = {
+  defaultPassCriteria: "minimumAccuracy",
+  minIterations: "minimumIterations",
+  defaultMatchOptions: "matchOptions",
+  defaultPredicates: "checks",
+  judgeConfig: "judge",
+  verdictPolicyVersion: "policy",
+  environment: "computerEnvironment",
+  environmentIds: "environments",
+};
+
+/**
+ * Storage keys with NO settings row to borrow a label from.
+ *
+ * Each is stored on the suite and can appear in `changedFields`, but is
+ * written from somewhere other than the settings sheet — the suite header
+ * (`description`, `tags`), the host and skill pickers (`hostConfigId`,
+ * `serverAttachmentId`, `namedHostId`, `hostAttachments`,
+ * `selectedSkillIds`), the environment resolver (`environmentFingerprints`),
+ * or the policy upgrade and rollout machinery (`verdictPolicyDefaults`,
+ * `verdictPolicyRolloutMode`, `gradingEngine`). The manifest's `repetitions`,
+ * `passThreshold` and `validity` rows all edit `verdictPolicyDefaults`, so it
+ * gets one label of its own rather than three. Add a row to the manifest and
+ * an alias above before adding here.
+ */
+const UNLISTED_FIELD_LABELS: Record<string, string> = {
   description: "Description",
-  defaultPassCriteria: "Minimum accuracy",
-  minIterations: "Minimum iterations",
-  defaultMatchOptions: "Tool-call matching",
-  defaultPredicates: "Checks",
-  judgeConfig: "Judge",
-  judgeRubric: "Judge criteria",
-  verdictPolicyVersion: "Policy",
   verdictPolicyDefaults: "Policy defaults",
   verdictPolicyRolloutMode: "Policy rollout",
   gradingEngine: "Grading engine",
-  environment: "Environment",
-  environmentIds: "Environments",
   environmentFingerprints: "Environment fingerprints",
   hostConfigId: "Execution config",
   serverAttachmentId: "Server attachment",
@@ -75,7 +104,8 @@ const FIELD_LABELS: Record<string, string> = {
 };
 
 export function fieldLabel(key: string): string {
-  return FIELD_LABELS[key] ?? key;
+  const manifestKey = SNAPSHOT_KEY_TO_MANIFEST_KEY[key] ?? key;
+  return MANIFEST_LABELS[manifestKey] ?? UNLISTED_FIELD_LABELS[key] ?? key;
 }
 
 type RevisionRow = {
@@ -226,10 +256,16 @@ function RevisionList({
                 </span>
               </div>
               <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-[11px] text-muted-foreground">
-                {/* `createdByName` is null for a write nobody is attributed
-                    for — a scheduled job, a system migration. "System" is the
-                    honest rendering; a blank would read as a missing name. */}
-                <span>{row.createdByName ?? "System"}</span>
+                {/* `createdByName` is null in two cases that must not read
+                    the same. A write with an author who has since left the
+                    organization keeps its `createdBy` and loses the name; a
+                    write nobody is attributed for — a scheduled job, a system
+                    migration — has neither. Calling the first "System" would
+                    hide that a person made the change. */}
+                <span>
+                  {row.createdByName ??
+                    (row.createdBy ? "A former member" : "System")}
+                </span>
                 <span aria-hidden>·</span>
                 <span>{REVISION_SOURCE_LABELS[row.source] ?? row.source}</span>
                 <span aria-hidden>·</span>

--- a/mcpjam-inspector/client/src/components/evals/trial-judge-review.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trial-judge-review.tsx
@@ -16,6 +16,16 @@
  * refusals — a guest, a trial from a quick run, a deployment that predates it.
  * Any of them would take the whole trial view down. A rejection is a value
  * here, and the panel simply renders without a label.
+ *
+ * WHY THE READ IS SCOPED TO THE TRIAL. A label is attributed to whichever
+ * trial the panel was showing when it was chosen, and "no label yet" is what
+ * unlocks the blind control. So the panel must never show one trial's label
+ * under another trial's verdict, and must never offer the blind control before
+ * it knows whether a label exists — a label submitted then would be a fresh
+ * `blind: true` row superseding one the reviewer never saw. Both are the same
+ * fix: the fetched row remembers which trial it answers for, and until the
+ * answer for THIS trial has landed the panel renders a placeholder with no
+ * control and no reveal.
  */
 
 import { useCallback, useEffect, useState } from "react";
@@ -61,7 +71,16 @@ export function TrialJudgeReviewPanel({
   canReview?: boolean;
 }) {
   const convex = useConvex();
-  const [review, setReview] = useState<TrialJudgeReviewRow | null>(null);
+  // The row is stamped with the trial it answers for, and `loaded` below is
+  // derived from that stamp rather than from a flag reset in an effect: an
+  // effect runs AFTER the render that would have shown the previous trial's
+  // label, and a derivation never does.
+  const [fetched, setFetched] = useState<{
+    iterationId: string;
+    review: TrialJudgeReviewRow | null;
+  } | null>(null);
+  const loaded = fetched !== null && fetched.iterationId === iterationId;
+  const review = loaded ? fetched.review : null;
   const [refreshKey, setRefreshKey] = useState(0);
 
   const submitJudgeReview = useMutation(
@@ -76,18 +95,20 @@ export function TrialJudgeReviewPanel({
   useEffect(() => {
     let cancelled = false;
     void (async () => {
+      let review: TrialJudgeReviewRow | null;
       try {
         const row = await convex.query(
           "evalJudgeReviews:getIterationJudgeReview" as never,
           { iterationId } as never,
         );
-        if (!cancelled) {
-          setReview((row as TrialJudgeReviewRow | null) ?? null);
-        }
+        review = (row as TrialJudgeReviewRow | null) ?? null;
       } catch {
         // A refused or undeployed read is "no label", not a broken page.
-        if (!cancelled) setReview(null);
+        review = null;
       }
+      // `cancelled` is belt; the stamp is braces. A read that outlives a
+      // trial switch cannot be mistaken for the new trial's answer.
+      if (!cancelled) setFetched({ iterationId, review });
     })();
     return () => {
       cancelled = true;
@@ -120,6 +141,22 @@ export function TrialJudgeReviewPanel({
     },
     [iterationId, submitJudgeReview],
   );
+
+  if (!loaded) {
+    // No label control and no reveal until this trial's row is known: a
+    // label chosen now would be recorded blind over one the reviewer has
+    // not seen, and a reveal now would un-blind the one they are about to
+    // give. On a refresh after a submit the previous row stays up instead —
+    // it is this trial's, and the stamp says so.
+    return (
+      <div
+        className="rounded-lg border border-border/50 p-2 text-xs text-muted-foreground"
+        data-testid="trial-review-loading"
+      >
+        Checking for a label…
+      </div>
+    );
+  }
 
   return (
     <JudgeVerdictPanel

--- a/mcpjam-inspector/client/src/hooks/use-suite-capabilities.ts
+++ b/mcpjam-inspector/client/src/hooks/use-suite-capabilities.ts
@@ -61,6 +61,14 @@ export type SuiteJudgeAgreement = {
   /** `null` at zero reviews — 0/0 is no evidence, not 0% agreement. */
   rate: number | null;
   lowerBound: number | null;
+  /**
+   * Cohen's kappa over the same blind labels: agreement corrected for what
+   * two raters would reach by chance on this corpus's class mix. `null` at
+   * zero reviews, or when both raters were constant on one class (undefined,
+   * not 1). Reported beside the rate, never gated on; absent on a backend that
+   * predates it.
+   */
+  kappa?: number | null;
   threshold: number;
   minReviews: number;
   eligible: boolean;

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -573,7 +573,10 @@ const syncFileOwnedSuiteSchema = z
         passThreshold: z.number().min(0).max(1),
         validity: z
           .object({
-            minEligibleTrials: z.number().int().min(0).optional(),
+            // `min(1)`, like the SDK contract and the backend validator: a floor
+            // of zero eligible trials is not a validity rule, and the backend
+            // refuses it after the file has already been accepted here.
+            minEligibleTrials: z.number().int().min(1).optional(),
             minCompletionRate: z.number().min(0).max(1).optional(),
             maxEvaluatorErrorRate: z.number().min(0).max(1).optional(),
           })

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -5398,6 +5398,7 @@ export const updateEvalSuiteOperation: PlatformOperation<
       "executionConfig",
       "hosts",
       "settings",
+      "expectedRevisionNumber",
     ] as const) {
       if (input[key] !== undefined) body[key] = input[key];
     }

--- a/sdk/tests/platform/operations.test.ts
+++ b/sdk/tests/platform/operations.test.ts
@@ -27,6 +27,7 @@ import {
   listEvalRunIterationsOperation,
   listEvalSuiteRunsOperation,
   listEvalSuitesOperation,
+  updateEvalSuiteOperation,
   listProjectPluginsOperation,
   listProjectServersOperation,
   listProjectsOperation,
@@ -858,6 +859,59 @@ describe("listEvalSuiteRunsOperation", () => {
     expect((error as PlatformApiError).message).toContain(
       "Smoke (id: suite-1)"
     );
+  });
+});
+
+
+describe("updateEvalSuiteOperation", () => {
+  function makePatchClient(): {
+    client: PlatformApiClient;
+    patchBodies: Array<Record<string, unknown>>;
+  } {
+    const { client, fetchMock } = makeClient();
+    const fallback = fetchMock.getMockImplementation();
+    const patchBodies: Array<Record<string, unknown>> = [];
+    fetchMock.mockImplementation(
+      async (target: unknown, init?: RequestInit) => {
+        const path = new URL(String(target)).pathname;
+        if (
+          /^\/api\/v1\/projects\/[^/]+\/eval-suites\/[^/]+$/.test(path) &&
+          init?.method === "PATCH"
+        ) {
+          patchBodies.push(
+            JSON.parse(String(init.body)) as Record<string, unknown>
+          );
+          return Response.json({ ...SUITES[0], revisionNumber: 8 });
+        }
+        return fallback!(target, init);
+      }
+    );
+    return { client, patchBodies };
+  }
+
+  it("forwards expectedRevisionNumber so the edit is a compare-and-set", async () => {
+    const { client, patchBodies } = makePatchClient();
+
+    await updateEvalSuiteOperation.execute(
+      { suite: "smoke", name: "renamed", expectedRevisionNumber: 7 },
+      { client }
+    );
+
+    expect(patchBodies).toEqual([
+      { name: "renamed", expectedRevisionNumber: 7 },
+    ]);
+  });
+
+  it("omits expectedRevisionNumber when the caller did not supply one", async () => {
+    const { client, patchBodies } = makePatchClient();
+
+    await updateEvalSuiteOperation.execute(
+      { suite: "smoke", name: "renamed" },
+      { client }
+    );
+
+    expect(patchBodies).toEqual([{ name: "renamed" }]);
+    expect(patchBodies[0]).not.toHaveProperty("expectedRevisionNumber");
   });
 });
 


### PR DESCRIPTION
Everything the review of #4682 found and deferred, in one pass. The backend half, chance-corrected judge agreement, is MCPJam/mcpjam-backend#1247; this PR renders it when present and degrades to today's line when absent, so the two merge in either order.

**A reviewer label could land on the wrong trial.** The trial review panel kept the previous trial's label on screen while the next one loaded, and a label clicked before the first read finished counted as a fresh blind label superseding one the reviewer never saw. Those labels feed the agreement rate that unlocks a CI gate. The panel is now scoped to the trial it shows (a stamped read, not an effect reset, so no render can show another trial's label), renders a neutral placeholder until its read lands, is keyed by trial, and never mounts on a quick-run trial that has no run to review. On a run judged with trial keys, a trial with no verdict of its own no longer borrows a sibling repetition's: the `caseKey` fallback is legacy-only.

**The SDK dropped the compare-and-set it accepted.** `update_eval_suite` validated `expectedRevisionNumber` and built the PATCH body from a key list that omitted it. It travels now; `@mcpjam/cli` is added to the revisions changeset it was missing from.

**Backtest and "Compare with run" picked the oldest run.** Both take the newest, with the second-newest as the compare target; a run whose judge stored no verdict is not offered.

**The gate switch could not be lowered once stale.** Only turning it on waits for calibration now.

**The pass threshold field** saved 0 when blanked, committed on Escape, and drifted a stored 85.5% to 86% on a no-edit blur. All three revert.

**Smaller:** revision history labels derive from the settings manifest; a departed author reads "A former member", not "System"; the suite-file schema's validity floor matches the SDK contract and the backend; a held run's rail and mini-bar are amber; the judge-gate changeset no longer claims the Slack watcher posts a grading update.

**Deliberately not changed:** the porous blind label (the Scores list on the same trial prints the judge row) is a product call on what a blind label means, and stays open. Cubic's `__proto__` predicate kind and the acknowledgement-without-permission comment are as designed.

**Tests:** every fix has a test that fails with it reverted, checked by reverting. Locally: evals, evaluate, hooks, v1 routes, eval services — 431 files, 5,561 passed; SDK 7,073 passed, typecheck clean; client typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect judge calibration labeling, suite compare-and-set, and verdict policy defaults—areas that influence CI gating and saved suite config, though mostly UI correctness and SDK wiring with tests.
> 
> **Overview**
> Follow-ups from eval settings review: fixes wrong trial attribution, stale suite edits, and several settings UX bugs.
> 
> **Trial calibration labels** are scoped per trial: the review panel shows a loading state until the read for the current trial lands, ignores late responses after navigation, remounts on trial change, and only appears when the trial has a `suiteRunId`. **`resolveIterationJudge`** no longer maps a sibling repetition’s verdict onto a keyed trial with no verdict of its own.
> 
> **SDK `update_eval_suite`** now sends **`expectedRevisionNumber`** on PATCH so compare-and-set can return 409 instead of silent last-write-wins.
> 
> **Backtest** and **Compare with run** use the **newest** judged terminal run (second-newest as compare base); runs with missing/`null` judge output are excluded.
> 
> **Judge gate** switch stays **enabled to turn off** when gating is stale; turning **on** still requires calibration. Agreement copy adds **chance-corrected kappa** when the backend provides it. **`grading`** runs get **amber** list rail/mini-bar styling.
> 
> **Pass threshold** percent input reverts blanks and Escape, and does not commit rounded display on focus/blur without edits; optional validity fields still treat blank as unset.
> 
> **Revision history** field names come from the **settings manifest**; edits by users who left the org show **“A former member”**. Suite PATCH schema aligns **`minEligibleTrials`** with `min(1)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ad2e9da402f685712a2bc831fc1324f354c6b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the follow-ups from the eval-settings review: the trial review panel no longer shows or accepts a label for the wrong trial, the SDK now forwards `expectedRevisionNumber` to the API, and backtest/Compare-with-run pick the newest run instead of the oldest. Also fixes a stale gate switch that couldn't be lowered, and three ways the pass threshold field could silently rewrite a suite.

**Changes**
- Trial review panel is scoped to its trial, shows a placeholder until the read lands, and never mounts for quick runs; a keyed run's missing verdict no longer falls back to a sibling repetition via `caseKey`.
- `update_eval_suite` includes `expectedRevisionNumber` in the PATCH body; the CLI is added to the revisions changeset.
- Backtest and "Compare with run" take the newest run (and second-newest as compare target); runs without a stored verdict aren't offered.
- Gate switch can always be turned off; only turning it on waits for calibration.
- Pass threshold blank, Escape, and no-edit blur all revert to the stored value rather than committing 0 or a rounded display value.
- Revision history labels come from the settings manifest; edits by former members read "A former member".
- Held runs get an amber rail and mini-bar; judge agreement shows the chance-corrected kappa when the backend supplies it.
- The suite-file schema's validity floor now allows at least one eligible trial, matching the SDK contract and backend.

<sup>Written for commit 3ad2e9da402f685712a2bc831fc1324f354c6b12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

