### PR TITLE
Evaluate (New): a suite that has never run says so

### DIFF
--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-detail-overview.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-detail-overview.test.tsx
@@ -218,7 +218,9 @@ describe("SuiteDetailOverview", () => {
     );
     expect(screen.queryByRole("heading", { name: "Run History" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "Test Cases" })).toBeNull();
-    expect(screen.queryByText("No runs yet. Run this suite to see history.")).toBeNull();
+    // A suite with no cases cannot have run, so it gets the hero alone — not
+    // an empty run history stacked on top of an empty case list.
+    expect(screen.queryByTestId("suite-run-history-empty")).toBeNull();
     expect(screen.queryByText("No test cases yet.")).toBeNull();
 
     await user.click(screen.getByTestId("suite-empty-action-describe"));
@@ -325,7 +327,10 @@ describe("SuiteDetailOverview", () => {
     expect(screen.getByTestId("suite-run-row-run-0")).toBeTruthy();
   });
 
-  it("hides run history when the suite has cases but no runs", () => {
+  it("says a runnable suite has no runs yet instead of hiding run history", () => {
+    // A suite that has cases can be run, so the card is its run surface even
+    // before the first run: "never run" and "runs failed to load" must not
+    // both render as an absent card.
     renderWithProviders(
       <SuiteDetailOverview
         suite={makeSuite()}
@@ -343,7 +348,17 @@ describe("SuiteDetailOverview", () => {
       />,
     );
 
-    expect(screen.queryByRole("heading", { name: "Run History" })).toBeNull();
+    expect(screen.getByRole("heading", { name: "Run History" })).toBeTruthy();
+    expect(screen.getByTestId("suite-run-history-empty")).toHaveTextContent(
+      "No runs yet.",
+    );
+    // The filtered-to-nothing copy would be a lie here — nothing is filtered.
+    expect(screen.queryByText("No runs match these filters.")).toBeNull();
+    // Nothing to summarize and nothing to filter, so neither chrome appears.
+    expect(screen.queryByTestId("suite-run-history-snapshot")).toBeNull();
+    expect(
+      screen.queryByRole("combobox", { name: "Filter by verdict" }),
+    ).toBeNull();
     expect(screen.getByRole("heading", { name: "Test Cases" })).toBeTruthy();
   });
 
@@ -460,10 +475,14 @@ describe("SuiteDetailOverview", () => {
     // `isSuiteRunsLoading` is its own query and resolves AFTER the detail
     // spinner clears, so a suite with runs would otherwise show nothing here
     // and then pop the whole section in.
+    //
+    // Cased on a suite with NO cases so `runsLoading` is the only term keeping
+    // the frame up: with cases the card renders either way, and this assertion
+    // would pass without testing anything.
     renderWithProviders(
       <SuiteDetailOverview
         suite={makeSuite()}
-        cases={[makeCase({ _id: "case-1" })]}
+        cases={[]}
         runs={[]}
         runsLoading
         allIterations={[]}

--- a/mcpjam-inspector/client/src/components/evaluate/suite-detail-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/suite-detail-overview.tsx
@@ -216,10 +216,27 @@ export function SuiteDetailOverview({
   });
   const runDisabled = Boolean(runBlockedReason);
   const hasCases = cases.length > 0;
-  // Runs load after the detail spinner has already cleared (`isSuiteRunsLoading`
-  // is its own query), so keying purely on `runs.length` hides the whole section
-  // from a suite that HAS runs and then pops it in. Hold the frame instead.
-  const showRunHistory = runs.length > 0 || runsLoading;
+  /**
+   * The card is the suite's run surface, so it is present whenever the suite
+   * COULD have runs — not only when it happens to have some.
+   *
+   * Keying purely on `runs.length` made "this suite has never run" and "this
+   * suite's runs did not load" the same picture: no card, no heading, nothing
+   * to distinguish an empty history from a broken one. A reader looking at a
+   * suite they had just run over the API had no way to tell which they were
+   * seeing. The empty history says so in words instead.
+   *
+   * `runsLoading` still counts on its own: runs resolve AFTER the detail
+   * spinner clears (`isSuiteRunsLoading` is its own query), and the frame has
+   * to be held for a suite that has runs rather than popped in under the
+   * reader.
+   *
+   * The one case that stays hidden is a suite with NO CASES: it cannot have
+   * run, the empty-cases hero owns that page, and an empty history card above
+   * it would be scaffolding around a suite that has nothing yet.
+   */
+  const showRunHistory = hasCases || runs.length > 0 || runsLoading;
+  const hasRuns = runs.length > 0;
   const showEmptyCasesHero = !hasCases;
 
   const runButton = (
@@ -366,8 +383,20 @@ export function SuiteDetailOverview({
         <SuiteRunHistorySnapshot runs={runs} allIterations={allIterations} />
 
         {filteredRows.length === 0 ? (
-          <div className="bg-card px-5 py-10 text-center text-sm text-muted-foreground">
-            {runsLoading ? "Loading runs…" : "No runs match these filters."}
+          <div
+            className="bg-card px-5 py-10 text-center text-sm text-muted-foreground"
+            data-testid="suite-run-history-empty"
+          >
+            {/*
+              Three different states, and they must not read alike: still
+              loading, never run, and filtered down to nothing. The middle one
+              is the reason this card renders at all now.
+            */}
+            {runsLoading
+              ? "Loading runs…"
+              : hasRuns
+                ? "No runs match these filters."
+                : "No runs yet. Run this suite — verdict, pass rate, latency and cost land here."}
           </div>
         ) : (
           <div className="overflow-x-auto bg-card">


### PR DESCRIPTION
## What

On the Evaluate (New) suite page, the Run History card was hidden whenever the runs list came back empty:

```ts
const showRunHistory = runs.length > 0 || runsLoading;
```

So a suite that has never run and a suite whose runs failed to load look exactly alike — no card, no heading, nothing between the suite name and Test Cases.

That is how this was found: two runs had just been launched against a suite over the public API, and the suite page showed no trace of them. The runs were real (`listTestSuiteRuns` returned both), the page was simply stale — but there was nothing on screen to say "no runs yet" versus "runs not loaded", so the empty page read as a bug in the run itself.

## Change

The card renders whenever the suite **could** have runs — whenever it has cases — and an empty history says so:

| state | copy |
| --- | --- |
| runs still loading | `Loading runs…` |
| never run | `No runs yet. Run this suite — verdict, pass rate, latency and cost land here.` |
| filtered to nothing | `No runs match these filters.` (unchanged) |

The filter pills and the metric snapshot still appear only when there are rows to filter or summarize, so an empty card is a heading plus one line — no empty table chrome.

A suite with **no cases** keeps the old behaviour: it cannot have run, the empty-cases hero owns that page, and an empty history stacked above an empty case list is scaffolding around a suite that has nothing yet.

## Scope

Client-only, and only `components/evaluate/` — the shipped `/evals` tab does not mount `SuiteDetailOverview`, so nothing outside the `evaluate-enabled` flag changes.

## Tests

`client/src/components/evaluate/__tests__/suite-detail-overview.test.tsx`

- "hides run history when the suite has cases but no runs" → "says a runnable suite has no runs yet", asserting the empty copy, and that neither the filtered-to-nothing copy nor the snapshot nor the filter pills appear.
- The loading-frame test is re-cased on a suite with **no** cases, so `runsLoading` is actually the term under test — with cases the card now renders either way and that assertion would have passed without testing anything.
- The no-cases hero test now asserts the empty-history block is absent by test id rather than by a copy string that no longer existed.

326 tests green across `components/evaluate/` plus `suite-iterations-master-detail`; `typecheck:client` clean. Pre-existing Prettier drift in both files left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HR8WdLo49TnqKKUQZWDHLF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes in the evaluate feature behind existing routing/flags, with no auth or data-layer impact.
> 
> **Overview**
> On the Evaluate suite detail page, **Run History** no longer disappears when a suite has test cases but zero runs. The section shows whenever the suite **could** have runs (`hasCases`, existing runs, or `runsLoading`); suites with **no cases** still hide it so the empty-cases hero isn’t stacked under a useless history card.
> 
> The empty state is split into three messages via `data-testid="suite-run-history-empty"`: loading (`Loading runs…`), never run (`No runs yet…`), and filters with no matches (`No runs match these filters.`). Filter controls and the metric snapshot still only appear when there are rows to filter or summarize.
> 
> Tests were updated to expect the heading and empty copy for runnable suites, assert the no-cases path omits the empty-history block, and re-case the loading-frame test on zero cases so `runsLoading` is what keeps the section visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f26076cfda8931ad708801537bc2a12c174caedb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Evaluate (New) Run History card visible for suites that have never run, so an empty history no longer looks identical to one whose runs failed to load.

- Old behavior hid the card whenever the runs list was empty, conflating "never run" with "runs not loaded."
- The card now renders whenever the suite has cases, with distinct copy for loading, never run, and filtered to nothing.
- Filter pills and the metric snapshot still appear only when there are rows to filter or summarize.
- Suites with no cases keep the old behavior; the empty-cases hero owns that page.
- Scope is client-only, limited to `components/evaluate/`.

<sup>Written for commit f26076cfda8931ad708801537bc2a12c174caedb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

