### PR TITLE
local-harness: Windows is a native platform

### DIFF
--- a/.github/workflows/local-harness-conformance.yml
+++ b/.github/workflows/local-harness-conformance.yml
@@ -212,21 +212,20 @@ jobs:
             exit 1
           fi
 
-  # Windows, and the one job here that is allowed to fail.
+  # Windows. Gating, like the POSIX legs, since `nativePlatforms` lists win32:
+  # this job going green is what earned that entry, and it going red is what
+  # would make the entry a lie. The two are the SAME change and must move
+  # together — `continue-on-error` does not come back without `win32` leaving
+  # the manifest.
   #
-  # `continue-on-error` is not laziness: Windows is REFUSED today
-  # (`nativePlatforms` omits win32, `supportsOwnershipProof('win32')` answers
-  # false without a verified helper), so a red leg here blocks nothing a user
-  # can reach. What it does is make the gap visible on every run instead of in
-  # somebody's memory.
-  #
-  # Removing `continue-on-error` and adding `win32` to `nativePlatforms` are the
-  # SAME change, and this job going green is what earns it.
+  # What it proves that the POSIX legs cannot: whole-tree cleanup through a
+  # Job Object rather than a process group, a FILETIME birth identity read
+  # through PowerShell, the launcher's stdin lifeline, and the adapter's POSIX
+  # path composition surviving contact with a drive letter.
   windows:
-    name: windows-latest scenarios (not yet gating)
+    name: windows-latest scenarios
     needs: unit
     runs-on: windows-latest
-    continue-on-error: true
     defaults:
       run:
         shell: bash
@@ -340,10 +339,11 @@ jobs:
 
   summarize:
     name: conformance version
-    # Deliberately NOT `needs: windows`. A conformance version records the
-    # evidence that exists; Windows is refused, so its leg is informational and
-    # must not hold up a stamp the supported platforms have earned.
-    needs: scenarios
+    # A conformance version records the evidence behind EVERY platform the
+    # manifest calls native. Windows is one of them now, so its leg holds up
+    # the stamp exactly as the POSIX legs do: a version minted without it
+    # would certify a platform whose scenarios had not run.
+    needs: [scenarios, windows]
     runs-on: ubuntu-latest
     outputs:
       conformance_version: ${{ steps.stamp.outputs.version }}

--- a/.github/workflows/local-harness-pack.yml
+++ b/.github/workflows/local-harness-pack.yml
@@ -161,7 +161,13 @@ jobs:
         # is a workflow whose Windows leg breaks on a change nobody tested on
         # Windows. Git Bash ships on the windows runner image.
         shell: bash
-        run: go build -trimpath -ldflags="-s -w" -o "$RUNNER_TEMP/mcpjam-job-launcher.exe" .
+        # `-buildvcs=false`: by default `go build` stamps the checkout's
+        # vcs.revision into the binary, and the binary is inside the pack's
+        # tree digest — so the digest changed on every commit to main, and the
+        # committed table was one SHA stale by construction (that is why the
+        # 3.3.6 table was unshipped). The Go toolchain is still the runner
+        # image's; a bump there changes the binary too, and the table with it.
+        run: go build -trimpath -buildvcs=false -ldflags="-s -w" -o "$RUNNER_TEMP/mcpjam-job-launcher.exe" .
 
       # A release that publishes unsigned packs publishes packs no Inspector
       # will install: `verifyPackManifestSignature` refuses a network-sourced

--- a/mcpjam-inspector/docs/local-harness.md
+++ b/mcpjam-inspector/docs/local-harness.md
@@ -248,50 +248,71 @@ Verify with `feature-flags-test-evaluation-create` against a real distinct id
 before each widening; a flag that evaluates `undefined` is off, which is the
 correct failure but an invisible one.
 
-## What blocks Windows
+## What Windows needed
 
-Windows is refused in three places that agree, and the conformance leg is
-non-gating. That is a decision, not an oversight — but as of this branch it is
-also a *measured* one, because the windows leg now runs far enough to say why.
+Windows is a native platform. It was refused until 2026-09-04, and the
+reasons it was refused were real; each has a specific answer, and the
+`windows-latest` conformance leg — gating, like the POSIX legs — is what
+proves the answers hold against the real pack, the real bridge and the real
+vendor CLI.
 
-The pack builds, installs, digest-verifies and resolves. Availability passes.
-A session is created. It then fails inside the framework's bootstrap recipe:
+**The path problem was ours, not upstream's.** `@ai-sdk/harness` composes
+every path with POSIX string operations on every platform, and an earlier
+version of this section read that as a blocker to be fixed in Vercel's code.
+It is not: the provider supplies `defaultWorkingDirectory` itself, and the
+framework never hands that value to a native OS call — it only resolves and
+concatenates onto it. So the provider presents the session's roots to the
+adapter in the MSYS spelling (`/c/Users/…`, `adapter-path.ts`), every path the
+framework derives stays forward-slashed, the translator's metacharacter check
+is untouched, and `confine` — the one place every operand already crosses into
+a real OS call, the bridge's own argv included — maps back to native. The
+child's environment (`HOME`, `PWD`, cwd) stays native; the OS reads that, not
+the adapter.
 
-```
-CommandTranslationError: path operand
-"/a/inspector/inspector/mcpjam-inspector/C:\Users\runneradmin\.mcpjam\…\work/.harness-bootstrap/claude-code"
-contains a shell metacharacter or glob
-```
+**Whole-tree cleanup is a Job Object.** There is no process group. The
+supervisor spawns the pack's `mcpjam-job-launcher.exe` — digest-verified, so
+`supportsOwnershipProof('win32')` answers false on a pack without it — in
+front of the bridge; the launcher creates a job with `KILL_ON_JOB_CLOSE`,
+starts the bridge suspended, assigns it, and only then resumes it. The
+launcher's exit, by any route, closes the last job handle and the kernel
+terminates every member. That makes the root's liveness the group's liveness,
+which is what `probeProcessGroup` reads on win32, and it is why the
+supervisor's stdin to the launcher is a LIFELINE: a pipe held open and never
+written, whose EOF means the Inspector is gone. The launcher gives the bridge
+`NUL` instead — two readers on one silent pipe hung the bridge before it
+could listen. It also passes its environment through explicitly, because the
+low-level `syscall.StartProcess` treats a nil environment as empty, and a
+Node binary with no `SYSTEMROOT` dies inside OpenSSL before it runs a line
+of JavaScript.
 
-Read that string carefully: a POSIX-looking prefix, then a Windows absolute
-path appended to it rather than replacing it. `@ai-sdk/harness` composes the
-bootstrap directory with
+**Birth identity is a FILETIME.** No `/proc`, no `ps`; `kill(pid, 0)`
+answers liveness without a subprocess (libuv reports an exited process as
+gone even while a handle is held), and only a live pid pays for PowerShell's
+`Get-Process`, whose `StartTime` is the kernel's creation time at 100 ns —
+a stronger discriminator than darwin's second-granular `lstart`. PowerShell
+is started with the parent's environment and stdin closed; a stripped
+environment stalls it past the probe's timeout.
 
-```ts
-posix.isAbsolute(path) ? path : posix.resolve(defaultWorkingDirectory, path)
-```
+**The vendor CLI's shell is named, not searched for.** Claude Code on
+Windows runs its Bash tool through Git for Windows, found on PATH — which the
+child does not have, by design — or in `CLAUDE_CODE_GIT_BASH_PATH`. The
+provider resolves a real `bash.exe` (the parent's own setting, else the
+default install) and names it in the child's environment only if it exists;
+the name is denylisted for scoped values.
 
-unconditionally, on every platform. `posix.isAbsolute("C:\Users\…")` is
-`false`, so on Windows it resolves a native absolute path against the process
-cwd and produces that hybrid. `supervised-provider.ts` mirrors this deliberately
-— the translator has to expect the exact string the adapter will emit — so our
-side is right and must NOT be "fixed" to use win32 resolution. Doing that would
-make the translator stop recognising the adapter's own commands, which is worse
-than the refusal.
+**Known gaps, none of them a cleanup or exposure hole:**
 
-Two things therefore stand between this and Windows support, in order:
-
-1. **Upstream.** The framework's bootstrap recipe is POSIX-only. Until it
-   resolves paths per-platform, no adapter command on Windows carries a path
-   the translator can accept.
-2. **Then ours.** `assertPlainPathOperand` rejects `\` as a shell
-   metacharacter, which is correct on POSIX and wrong on a platform where it is
-   the path separator. Making it platform-aware is a change to a security
-   boundary and wants its own tests: a backslash that separates must be
-   admitted, a backslash that escapes must not.
-
-Neither is a reason to hold the darwin/linux ship. `nativePlatforms` keeps
-refusing win32, and the leg keeps reporting — which is the point of running it.
+- The OS-level loopback corroboration (`lsof`) and the model gateway's
+  peer-pid check return null on win32 and are skipped. The enforcing TCP
+  connect probe runs everywhere.
+- The conformance runner's env-leak check reads `ps -E`; it passes vacuously
+  on win32.
+- The child's PATH is System32 only. `pwd` and the built-ins work; a Bash
+  tool call that needs `git` or a language runtime will not find one until
+  PATH policy is decided for Windows.
+- The first identity probe pays PowerShell's cold start (seconds on CI).
+- The Job Object launcher is built by the runner image's Go toolchain; a
+  toolchain bump changes the binary and therefore the pack digest.
 
 ## Launch / rollback checklist
 

--- a/mcpjam-inspector/server/utils/harness/local/README.md
+++ b/mcpjam-inspector/server/utils/harness/local/README.md
@@ -45,13 +45,13 @@ Per platform, for `local-native`:
 | -------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | linux    | Yes            | POSIX process groups; `/proc/<pid>/stat` gives an exact process birth identity                                                                                                               |
 | darwin   | Yes            | POSIX process groups; `ps -o lstart=` gives a second-granular birth identity                                                                                                                 |
-| win32    | **No**         | No process-group primitive here, and no Job Object implementation yet, so whole-tree cleanup cannot be guaranteed — and Job Objects would not be filesystem or network isolation in any case |
+| win32    | Yes            | No process group; the verified `mcpjam-job-launcher.exe` inside the pack puts the tree in a Job Object with `KILL_ON_JOB_CLOSE`, and PowerShell's `Get-Process` gives a FILETIME birth identity. Refused on a machine whose pack lacks the launcher. Not filesystem or network isolation, same as the other two |
 
 Per harness:
 
 | Harness     | Native                   | Why                                                                                                                                                                                                                                               |
 | ----------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| claude-code | Eligible (darwin, linux) | `@ai-sdk/harness-claude-code@1.0.100` declares `supportsBuiltinToolApprovals: true` and maps `allow-reads`/`allow-edits` onto real approval callbacks                                                                                             |
+| claude-code | Eligible (darwin, linux, win32) | `@ai-sdk/harness-claude-code@1.0.100` declares `supportsBuiltinToolApprovals: true` and maps `allow-reads`/`allow-edits` onto real approval callbacks                                                                                      |
 | codex       | **Never**                | `@ai-sdk/harness-codex@1.0.98` declares `supportsBuiltinToolApprovals: false` and rejects every mode but `allow-all`, starting Codex unrestricted. That is safe only when the sandbox provider IS the boundary. Hosted or verified-isolated only. |
 | cursor      | Not supported            | No AI SDK adapter to pin or audit                                                                                                                                                                                                                 |
 

--- a/mcpjam-inspector/server/utils/harness/local/__tests__/adapter-path.test.ts
+++ b/mcpjam-inspector/server/utils/harness/local/__tests__/adapter-path.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  AdapterPathError,
+  fromAdapterPath,
+  isAdapterShapedWindowsPath,
+  toAdapterPath,
+} from "../adapter-path.js";
+
+describe("adapter-facing paths on POSIX", () => {
+  it("are the native path, untouched, in both directions", () => {
+    for (const platform of ["darwin", "linux"] as const) {
+      expect(toAdapterPath("/Users/me/.mcpjam/sessions/s1/work", platform)).toBe(
+        "/Users/me/.mcpjam/sessions/s1/work",
+      );
+      expect(fromAdapterPath("/Users/me/.mcpjam/sessions/s1/work", platform)).toBe(
+        "/Users/me/.mcpjam/sessions/s1/work",
+      );
+      // Even a string that LOOKS like an MSYS drive path is left alone off
+      // Windows: `/c/...` is a perfectly ordinary directory there.
+      expect(fromAdapterPath("/c/Users/x", platform)).toBe("/c/Users/x");
+    }
+  });
+});
+
+describe("adapter-facing paths on Windows", () => {
+  it("present a drive-letter path in the MSYS spelling the adapter can resolve", () => {
+    expect(
+      toAdapterPath("C:\\Users\\runneradmin\\.mcpjam\\sessions\\s1\\work", "win32"),
+    ).toBe("/c/Users/runneradmin/.mcpjam/sessions/s1/work");
+    // Forward slashes and a trailing separator are normalised away.
+    expect(toAdapterPath("D:/a/_temp/conformance/", "win32")).toBe(
+      "/d/a/_temp/conformance",
+    );
+    expect(toAdapterPath("C:\\", "win32")).toBe("/c");
+  });
+
+  it("is what the adapter's own POSIX composition then works on", async () => {
+    const { posix } = await import("node:path");
+    const root = toAdapterPath("C:\\Users\\x\\work", "win32");
+    // The two compositions the framework actually performs.
+    expect(posix.resolve(root, ".harness-bootstrap/claude-code")).toBe(
+      "/c/Users/x/work/.harness-bootstrap/claude-code",
+    );
+    expect(`${root}/.agent-runs/s1/bridge`).toBe(
+      "/c/Users/x/work/.agent-runs/s1/bridge",
+    );
+    expect(posix.isAbsolute(root)).toBe(true);
+  });
+
+  it("maps the adapter's spelling back to the native path", () => {
+    expect(fromAdapterPath("/c/Users/x/work/.agent-runs/s1/bridge", "win32")).toBe(
+      "C:\\Users\\x\\work\\.agent-runs\\s1\\bridge",
+    );
+    expect(fromAdapterPath("/c", "win32")).toBe("C:\\");
+    expect(fromAdapterPath("/c/", "win32")).toBe("C:\\");
+  });
+
+  it("round-trips", () => {
+    for (const native of [
+      "C:\\Users\\runneradmin\\.mcpjam\\harness-local\\sessions\\conformance-1\\work",
+      "D:\\a\\_temp\\conformance\\home",
+      "C:\\",
+    ]) {
+      expect(fromAdapterPath(toAdapterPath(native, "win32"), "win32")).toBe(
+        native,
+      );
+    }
+  });
+
+  it("resolves `..` in the adapter's shape before re-seating on the drive", () => {
+    expect(fromAdapterPath("/c/Users/x/work/../home", "win32")).toBe(
+      "C:\\Users\\x\\home",
+    );
+    // Climbing above the drive root clamps to the root. Confinement, not this
+    // module, is what refuses it.
+    expect(fromAdapterPath("/c/../../etc", "win32")).toBe("C:\\etc");
+  });
+
+  it("hands back anything that is not an MSYS drive path, unchanged", () => {
+    // A native path arriving here (the provider's own overlay paths do) passes
+    // straight through to confinement.
+    expect(fromAdapterPath("C:\\Users\\x\\bootstrap\\.ok", "win32")).toBe(
+      "C:\\Users\\x\\bootstrap\\.ok",
+    );
+    // Not one of ours: no drive letter to seat it on. Confinement refuses it.
+    expect(fromAdapterPath("/tmp/harness/claude-code", "win32")).toBe(
+      "/tmp/harness/claude-code",
+    );
+    expect(fromAdapterPath("/cc/looks/like/a/drive", "win32")).toBe(
+      "/cc/looks/like/a/drive",
+    );
+    expect(fromAdapterPath("relative/path", "win32")).toBe("relative/path");
+  });
+
+  it("refuses to invent a POSIX shape for a path that has none", () => {
+    expect(() => toAdapterPath("\\\\server\\share\\dir", "win32")).toThrow(
+      AdapterPathError,
+    );
+    expect(() => toAdapterPath("relative\\dir", "win32")).toThrow(
+      AdapterPathError,
+    );
+    expect(() => toAdapterPath("C:relative", "win32")).toThrow(AdapterPathError);
+  });
+
+  it("recognises the shape it translates", () => {
+    expect(isAdapterShapedWindowsPath("/c/Users")).toBe(true);
+    expect(isAdapterShapedWindowsPath("/c")).toBe(true);
+    expect(isAdapterShapedWindowsPath("/cc/Users")).toBe(false);
+    expect(isAdapterShapedWindowsPath("C:\\Users")).toBe(false);
+    expect(isAdapterShapedWindowsPath("/tmp")).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/local/__tests__/compatibility.test.ts
+++ b/mcpjam-inspector/server/utils/harness/local/__tests__/compatibility.test.ts
@@ -208,7 +208,11 @@ describe("claude-code native resolution", () => {
     ).toMatchObject({ ok: true, permissionMode: "allow-edits" });
   });
 
-  it("refuses Windows native, where process-tree ownership is unproven", () => {
+  it("offers Windows native, where the Job Object launcher is the tree guarantee", () => {
+    // Eligibility only. Whether a given machine may actually run a session is
+    // still gated by `supportsOwnershipProof('win32')`, which stays false
+    // until runtime resolution has verified the launcher inside the pack —
+    // see `process-identity.test.ts` and `availability.test.ts`.
     expect(
       resolveLocalCompatibility(
         {
@@ -220,7 +224,7 @@ describe("claude-code native resolution", () => {
         },
         manifests,
       ),
-    ).toMatchObject({ status: "native-not-eligible" });
+    ).toMatchObject({ ok: true, permissionMode: "allow-edits" });
   });
 
   it("refuses an unrestricted native turn even if a manifest offered it", () => {

--- a/mcpjam-inspector/server/utils/harness/local/__tests__/process-identity.test.ts
+++ b/mcpjam-inspector/server/utils/harness/local/__tests__/process-identity.test.ts
@@ -204,12 +204,16 @@ describe("terminating a tree we own", () => {
     // The old post-grace re-check went through `isSameProcess`, which folds
     // "gone", "not ours" and "could not look" into one `false` — so a probe
     // failure reported the tree as gracefully stopped.
+    //
+    // `freebsd`, not `win32`: Windows now HAS a primitive (`kill(0)` then
+    // `Get-Process`), so it answers "gone" for a pid nobody holds rather than
+    // "unknown", and this case is about a platform that cannot look at all.
     const outcome = await terminateOwnedProcessGroup({
       pid: 4_242,
-      birthIdentity: "win32:whatever",
+      birthIdentity: "freebsd:whatever",
       graceMs: 10,
       pollMs: 5,
-      platform: "win32",
+      platform: "freebsd",
     });
     expect(outcome.outcome).toBe("unknown");
   });
@@ -437,7 +441,36 @@ describe("probing a process GROUP", () => {
     // which is what makes `terminateOwnedProcessGroup` report the tree gone
     // and what makes the janitor DROP a durable record. A platform with no
     // enumeration must not read as "the group is empty".
-    await expect(probeProcessGroup(4_242, "win32")).resolves.toBe("unknown");
+    //
+    // `freebsd`: Windows now answers this from the Job Object contract (the
+    // root's liveness is the group's), so it is no longer the "no primitive"
+    // example.
+    await expect(probeProcessGroup(4_242, "freebsd")).resolves.toBe("unknown");
+  });
+
+  it("on win32, reads the group's fate from the root: a Job Object dies with its launcher", async () => {
+    // A pid above every OS's ceiling is nobody's, so the cheap `kill(0)` says
+    // gone and the Job Object contract turns that into an EMPTY group — no
+    // PowerShell, no enumeration, and no `unknown` that would leave the
+    // record stranded.
+    await expect(probeProcessGroup(2_147_483_000, "win32")).resolves.toBe(
+      "empty",
+    );
+  });
+
+  it("parses the one line the Windows probe script prints", async () => {
+    const { parseWin32ProbeLine } = await import("../process-identity.js");
+    expect(parseWin32ProbeLine("133721234567890123|node\r\n")).toEqual({
+      fileTime: "133721234567890123",
+      name: "node",
+    });
+    expect(parseWin32ProbeLine("133721234567890123|mcpjam-job-launcher")).toEqual({
+      fileTime: "133721234567890123",
+      name: "mcpjam-job-launcher",
+    });
+    expect(parseWin32ProbeLine("")).toBeNull();
+    expect(parseWin32ProbeLine("not-a-filetime|node")).toBeNull();
+    expect(parseWin32ProbeLine("1337|")).toBeNull();
   });
 
   it("rejects an implausible pid without claiming the group is empty", async () => {

--- a/mcpjam-inspector/server/utils/harness/local/__tests__/session-env.test.ts
+++ b/mcpjam-inspector/server/utils/harness/local/__tests__/session-env.test.ts
@@ -280,3 +280,64 @@ describe("preconditions", () => {
     ]);
   });
 });
+
+describe("the vendor CLI's shell on Windows", () => {
+  const WIN_HOME = "C:\\state\\sessions\\s1\\home";
+  const WIN_ROOT = "C:\\Users\\dev\\project";
+
+  it("names Git Bash for the child only when the provider resolved one", () => {
+    const without = buildLocalHarnessEnv({
+      syntheticHome: WIN_HOME,
+      sessionRoot: WIN_ROOT,
+      platform: "win32",
+      base: {},
+    });
+    expect(without.CLAUDE_CODE_GIT_BASH_PATH).toBeUndefined();
+
+    const withBash = buildLocalHarnessEnv({
+      syntheticHome: WIN_HOME,
+      sessionRoot: WIN_ROOT,
+      platform: "win32",
+      base: {},
+      gitBashPath: "C:\\Program Files\\Git\\bin\\bash.exe",
+    });
+    expect(withBash.CLAUDE_CODE_GIT_BASH_PATH).toBe(
+      "C:\\Program Files\\Git\\bin\\bash.exe",
+    );
+  });
+
+  it("ignores it off Windows, where the CLI has a real shell", () => {
+    const env = buildLocalHarnessEnv({
+      syntheticHome: HOME,
+      sessionRoot: ROOT,
+      platform: "linux",
+      base: {},
+      gitBashPath: "/usr/bin/bash",
+    });
+    expect(env.CLAUDE_CODE_GIT_BASH_PATH).toBeUndefined();
+  });
+
+  it("refuses a relative shell path", () => {
+    expect(() =>
+      buildLocalHarnessEnv({
+        syntheticHome: WIN_HOME,
+        sessionRoot: WIN_ROOT,
+        platform: "win32",
+        base: {},
+        gitBashPath: "Git\\bin\\bash.exe",
+      }),
+    ).toThrow(LocalHarnessEnvError);
+  });
+
+  it("will not let a scoped value point the CLI at a different shell", () => {
+    expect(() =>
+      buildLocalHarnessEnv({
+        syntheticHome: WIN_HOME,
+        sessionRoot: WIN_ROOT,
+        platform: "win32",
+        base: {},
+        scoped: { CLAUDE_CODE_GIT_BASH_PATH: "C:\\evil\\bash.exe" },
+      }),
+    ).toThrow(/not allowed/);
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/local/adapter-path.ts
+++ b/mcpjam-inspector/server/utils/harness/local/adapter-path.ts
@@ -1,0 +1,103 @@
+/**
+ * The path the ADAPTER sees versus the path the OS sees.
+ *
+ * ── Why two shapes exist ─────────────────────────────────────────────────
+ * `@ai-sdk/harness` and its adapters compose every path with POSIX string
+ * operations — `posix.resolve`, `${dir}/.agent-runs/${id}`, `shellQuote` —
+ * on every platform, because in their model the sandbox is a remote Linux
+ * machine and the path is text sent over a wire. They never hand the value to
+ * a native filesystem call themselves.
+ *
+ * That is exactly what makes a native Windows path fatal there: `posix.resolve`
+ * does not recognise `C:\Users\…` as absolute, so it resolves it against the
+ * process cwd and emits a hybrid — `/a/inspector/C:\Users\…\work/.harness-…` —
+ * that the command translator then correctly refuses, because a backslash in
+ * an operand is a shell escape on the platform the adapters were written for.
+ *
+ * The fix is NOT to teach the translator about backslashes. That check is a
+ * security boundary and it is right as written. The fix is to give the adapter
+ * what it was written for: a POSIX-shaped absolute path. On Windows the
+ * session's roots are presented as `/c/Users/…` — the MSYS convention, which
+ * is a bijection on drive-letter paths and is what Git Bash and `cygpath -u`
+ * already print on that machine — and mapped back to the native path at the
+ * ONE place every operand crosses into a real OS call, which is the
+ * provider's `confine`.
+ *
+ * ── What this does not do ────────────────────────────────────────────────
+ * It is not path normalisation and it is not confinement. `fromAdapterPath`
+ * turns `/c/x` into `C:\x` and hands everything else back untouched, so a path
+ * that was never one of ours is judged by `confinePath` against the session's
+ * roots exactly as before. A UNC path (`\\server\share`) has no POSIX shape
+ * this module is willing to invent, and `toAdapterPath` refuses it rather than
+ * producing something the adapter would then feed back to us.
+ *
+ * On darwin and linux both functions are the identity.
+ */
+import { posix, win32 } from "node:path";
+
+export class AdapterPathError extends Error {}
+
+/** `/c/Users/x` — the MSYS spelling of `C:\Users\x`. */
+const MSYS_DRIVE_PATH = /^\/([A-Za-z])(?:\/(.*))?$/;
+/** `C:\Users\x` or `C:/Users/x`. */
+const NATIVE_DRIVE_PATH = /^([A-Za-z]):[\\/]/;
+
+/**
+ * The POSIX-shaped path the adapter is given for a native path we own.
+ *
+ * Identity off Windows. On Windows the input must be a drive-letter absolute
+ * path; the result is `/<drive>/<segments>` with forward slashes and no
+ * trailing separator.
+ */
+export function toAdapterPath(
+  nativePath: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform !== "win32") return nativePath;
+  const normalized = win32.normalize(nativePath);
+  const drive = NATIVE_DRIVE_PATH.exec(normalized);
+  if (drive === null) {
+    // `\\server\share`, a relative path, or a bare `C:` with no separator. None
+    // of these have a POSIX shape this module is willing to invent.
+    throw new AdapterPathError(
+      `cannot present ${JSON.stringify(nativePath)} to the adapter: only a ` +
+        `drive-letter absolute path has a POSIX-shaped spelling`,
+    );
+  }
+  const rest = normalized
+    .slice(drive[0].length)
+    .split(win32.sep)
+    .filter((segment) => segment.length > 0)
+    .join("/");
+  return rest.length === 0
+    ? `/${drive[1]!.toLowerCase()}`
+    : `/${drive[1]!.toLowerCase()}/${rest}`;
+}
+
+/**
+ * The native path behind an adapter-facing one.
+ *
+ * Identity off Windows. On Windows an MSYS drive path becomes the native
+ * spelling; anything else is returned unchanged, so a path that is not one of
+ * ours is still refused by confinement rather than reinterpreted here.
+ */
+export function fromAdapterPath(
+  adapterPath: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform !== "win32") return adapterPath;
+  const match = MSYS_DRIVE_PATH.exec(adapterPath);
+  if (match === null) return adapterPath;
+  const drive = `${match[1]!.toUpperCase()}:`;
+  const rest = match[2] ?? "";
+  // `posix.normalize` first so `..` is resolved in the shape the adapter wrote
+  // it, then re-seated on the drive. A path that climbs above the drive root
+  // normalises to the root itself; it is confinement's job to refuse it.
+  const normalizedRest = posix.normalize(`/${rest}`);
+  return win32.normalize(`${drive}${normalizedRest}`);
+}
+
+/** Is this a path `fromAdapterPath` would translate on win32? */
+export function isAdapterShapedWindowsPath(path: string): boolean {
+  return MSYS_DRIVE_PATH.test(path);
+}

--- a/mcpjam-inspector/server/utils/harness/local/command-translation.ts
+++ b/mcpjam-inspector/server/utils/harness/local/command-translation.ts
@@ -58,7 +58,14 @@
  * are re-confined to the session root by `confine`, so a shape that matches
  * still cannot address a path outside the grant.
  */
-import { isAbsolute, normalize, sep } from "node:path";
+// `posix` for every string the ADAPTER wrote, `normalize`/`sep` for every
+// path this module composes for the OS. The adapters emit POSIX text on every
+// platform — `posix.resolve`, forward slashes, `shellQuote` — because in their
+// model the sandbox is a remote Linux machine; on Windows the provider presents
+// the session's roots in that shape too (`adapter-path.ts`). So an operand is
+// judged as POSIX text everywhere, and the host's own path flavour only enters
+// when a result is mapped onto the managed bundle or the session overlay.
+import { normalize, posix, sep } from "node:path";
 import { assertArgvAllowed } from "./argv-policy.js";
 import type { SupportedLocalHarnessId } from "./targets.js";
 
@@ -289,7 +296,7 @@ function assertPlainPathOperand(path: string, command: string): void {
       command,
     );
   }
-  if (!isAbsolute(path)) {
+  if (!posix.isAbsolute(path)) {
     throw new CommandTranslationError(
       `path operand ${JSON.stringify(path)} is not absolute`,
       command,
@@ -306,8 +313,8 @@ function assertPlainPathOperand(path: string, command: string): void {
  * and the command is rejected rather than silently remapped.
  */
 function underBootstrapDir(path: string, bootstrapDir: string): boolean {
-  const p = normalize(path);
-  const root = normalize(bootstrapDir);
+  const p = posix.normalize(path);
+  const root = posix.normalize(bootstrapDir);
   return p === root || p.startsWith(root + "/");
 }
 
@@ -315,8 +322,8 @@ function remapBootstrapPath(
   path: string,
   ctx: CommandTranslationContext,
 ): string {
-  const root = normalize(ctx.adapterBootstrapDir);
-  const normalizedPath = normalize(path);
+  const root = posix.normalize(ctx.adapterBootstrapDir);
+  const normalizedPath = posix.normalize(path);
   // Containment is checked on the NORMALIZED path before any slicing. Slicing
   // first would clamp `/tmp/harness/claude-code/../../etc` (which normalizes
   // to `/tmp/etc`) back onto the bundle root and swallow the traversal
@@ -387,8 +394,8 @@ export function classifyBootstrapPath(
   path: string,
   ctx: CommandTranslationContext,
 ): BootstrapFileTarget {
-  const root = normalize(ctx.adapterBootstrapDir);
-  const normalized = normalize(path);
+  const root = posix.normalize(ctx.adapterBootstrapDir);
+  const normalized = posix.normalize(path);
   if (!underBootstrapDir(normalized, root)) return { kind: "workspace" };
 
   const relative = normalized.slice(root.length).replace(/^\//, "");
@@ -428,8 +435,8 @@ function assertUnderSyntheticHome(
   ctx: CommandTranslationContext,
   command: string,
 ): void {
-  const home = normalize(ctx.syntheticHome);
-  const p = normalize(path);
+  const home = posix.normalize(ctx.syntheticHome);
+  const p = posix.normalize(path);
   if (p === home || !p.startsWith(home + "/")) {
     throw new CommandTranslationError(
       `path operand ${JSON.stringify(path)} is outside the session's synthetic ` +
@@ -500,7 +507,7 @@ async function translateMkdir(
   const paths: string[] = [];
   for (const path of raw) {
     assertPlainPathOperand(path, command);
-    if (underBootstrapDir(path, normalize(ctx.adapterBootstrapDir))) {
+    if (underBootstrapDir(path, posix.normalize(ctx.adapterBootstrapDir))) {
       // The bundle already exists and is read-only by design; creating it is
       // a no-op rather than an error so the adapter's bootstrap sequence
       // completes unchanged.
@@ -583,7 +590,7 @@ async function matchBridgeLaunch(
   const bridgeToken = tokens[0]!;
   assertPlainPathOperand(bridgeToken, command);
   const expectedBridge = `${ctx.adapterBootstrapDir}/bridge.mjs`;
-  if (normalize(bridgeToken) !== normalize(expectedBridge)) {
+  if (posix.normalize(bridgeToken) !== posix.normalize(expectedBridge)) {
     throw new CommandTranslationError(
       `bridge launch names ${JSON.stringify(bridgeToken)}, but the only ` +
         `bridge this session may run is the one in its managed bundle`,
@@ -676,7 +683,7 @@ export async function translateAdapterCommand(
       );
     }
     assertPlainPathOperand(target, command);
-    if (underBootstrapDir(target, normalize(ctx.adapterBootstrapDir))) {
+    if (underBootstrapDir(target, posix.normalize(ctx.adapterBootstrapDir))) {
       return {
         kind: "noop",
         reason:
@@ -695,7 +702,7 @@ export async function translateAdapterCommand(
     const cwd = invocation.workingDirectory;
     if (
       cwd !== undefined &&
-      normalize(cwd) !== normalize(ctx.adapterBootstrapDir)
+      posix.normalize(cwd) !== posix.normalize(ctx.adapterBootstrapDir)
     ) {
       throw new CommandTranslationError(
         `a bootstrap command was issued from ${JSON.stringify(cwd)} rather ` +

--- a/mcpjam-inspector/server/utils/harness/local/compatibility.ts
+++ b/mcpjam-inspector/server/utils/harness/local/compatibility.ts
@@ -214,23 +214,22 @@ export const LOCAL_HARNESS_MANIFEST: Readonly<
       // off on a host.
     },
     // Native eligibility is per platform. macOS and Linux have POSIX process
-    // groups, which is what whole-tree cleanup is built on.
+    // groups, which is what whole-tree cleanup is built on there.
     //
-    // Windows is still absent, and deliberately so even though the Job Object
-    // launcher now exists (`tools/mcpjam-job-launcher`, in this package). Two
-    // things have to be true before `win32` is added here, and neither is yet:
+    // Windows has no process group; its whole-tree guarantee is a Job Object
+    // with KILL_ON_JOB_CLOSE, created by `tools/mcpjam-job-launcher`, which
+    // ships INSIDE the Windows pack so its bytes are covered by the tree
+    // digest. Listing `win32` here is necessary but not sufficient:
+    // `supportsOwnershipProof('win32')` still answers false until runtime
+    // resolution has verified that launcher, so a pack without one keeps the
+    // platform refused exactly as before.
     //
-    //   1. the launcher ships inside the Windows pack, so its bytes are covered
-    //      by the tree digest — `supportsOwnershipProof('win32')` answers false
-    //      until runtime resolution has verified one;
-    //   2. the conformance suite passes on `windows-latest`, which is what
-    //      turns "we wrote a Job Object" into evidence that stopping a session
-    //      stops everything it started.
-    //
-    // An unenforced cleanup promise is worse than no Windows support: a user
-    // told their session stopped, whose 376 MB agent is still running, has been
-    // lied to.
-    nativePlatforms: ["darwin", "linux"],
+    // Earned, not asserted: the conformance suite's `windows-latest` leg runs
+    // the full scenario and the abort scenario against the real pack and the
+    // real vendor CLI, and its survivor scan is what turns "we wrote a Job
+    // Object" into evidence that stopping a session stops everything it
+    // started. That leg is gating; the day it goes red, this entry is wrong.
+    nativePlatforms: ["darwin", "linux", "win32"],
     // Empty until a backend's escape probes actually pass (I6).
     isolatedBackends: {},
     lifecycleConformanceVersion: "",

--- a/mcpjam-inspector/server/utils/harness/local/conformance/run-lifecycle.ts
+++ b/mcpjam-inspector/server/utils/harness/local/conformance/run-lifecycle.ts
@@ -20,7 +20,7 @@ import { getLocalMachineId, grantLocalHarnessConsent, localHarnessStateRoot, reg
 import { computeTreeDigest, resolveManagedBundle } from "../runtime-identity.js";
 import { resolveNodeLauncher } from "../node-launcher.js";
 import { LOCAL_HARNESS_MANIFEST } from "../compatibility.js";
-import { localPackTarget, LOCAL_HARNESS_POLICY_VERSION } from "../targets.js";
+import { localPackTarget, LOCAL_HARNESS_POLICY_VERSION, type LocalPlatform } from "../targets.js";
 import { listProcessRecords } from "../process-registry.js";
 import { installedAdapterVersion } from "./adapter-version.js";
 
@@ -28,7 +28,8 @@ import { installedAdapterVersion } from "./adapter-version.js";
 const execFileP = promisify(execFile);
 const ROOT = process.env.CONFORMANCE_ROOT!;
 /** The pack is per platform, and so is the digest that admits it. */
-const PLATFORM = process.platform as "darwin" | "linux";
+// `LocalPlatform`, which includes win32 — the windows leg runs this script too.
+const PLATFORM = process.platform as LocalPlatform;
 /**
  * …and per ARCHITECTURE, which is the key the digest table actually uses. The
  * pack the build step produced is for this machine, so this is the entry the
@@ -90,7 +91,20 @@ function assert(condition: boolean, message: string): void {
  * for a zombie on both macOS and Linux; an empty answer means the pid is gone
  * outright.
  */
+/** Windows arms, for the same reason as in `run-native-turn.ts`: no `ps`, no
+ *  `pgrep`, and the MSYS `ps` Git Bash ships cannot see native processes. */
+const WIN = process.platform === "win32";
+const powershell = (script: string) =>
+  execFileP("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], { windowsHide: true });
+
 async function running(pid: number): Promise<boolean> {
+  if (WIN) {
+    try {
+      return (await execFileP("tasklist", ["/FI", `PID eq ${pid}`, "/NH", "/FO", "CSV"])).stdout.includes(`"${pid}"`);
+    } catch {
+      return false;
+    }
+  }
   let state: string;
   try {
     state = (await execFileP("ps", ["-o", "stat=", "-p", String(pid)])).stdout.trim();
@@ -110,8 +124,13 @@ async function stillRunning(pids: readonly number[]): Promise<number[]> {
 async function descendants(pid: number): Promise<number[]> {
   const out: number[] = [];
   const walk = async (p: number) => {
-    let kids = ""; try { kids = (await execFileP("pgrep", ["-P", String(p)])).stdout; } catch { return; }
-    for (const k of kids.split("\n").map((s) => Number(s.trim())).filter(Boolean)) { out.push(k); await walk(k); }
+    let kids = "";
+    try {
+      kids = WIN
+        ? (await powershell(`Get-CimInstance Win32_Process -Filter "ParentProcessId=${p}" | ForEach-Object { $_.ProcessId }`)).stdout
+        : (await execFileP("pgrep", ["-P", String(p)])).stdout;
+    } catch { return; }
+    for (const k of kids.split(/\r?\n/).map((s) => Number(s.trim())).filter(Boolean)) { out.push(k); await walk(k); }
   };
   await walk(pid); return out;
 }
@@ -262,7 +281,7 @@ async function setup() {
   const digest = await computeTreeDigest(BUNDLE);
   const bridgeBytes = await readFile(join(BUNDLE, "bridge.mjs"));
   const base = LOCAL_HARNESS_MANIFEST["claude-code"];
-  const manifest = { ...base, runtime: { ...(base.runtime as any), bundleDigest: { [PACK_TARGET]: digest }, launcherRelativePath: "launcher.mjs" }, lifecycleConformanceVersion: CONFORMANCE_VERSION, bridgeBundleDigest: `sha256:${createHash("sha256").update(bridgeBytes).digest("hex")}` } as typeof base;
+  const manifest = { ...base, runtime: { ...(base.runtime as any), bundleDigest: { [PACK_TARGET]: digest }, launcherRelativePath: "launcher.mjs" }, /* THIS scenario's manifest admits the platform it runs on; the shipped one keeps refusing win32 until this leg is green — same rule as run-native-turn. */ nativePlatforms: [...new Set([...base.nativePlatforms, PLATFORM])], lifecycleConformanceVersion: CONFORMANCE_VERSION, bridgeBundleDigest: `sha256:${createHash("sha256").update(bridgeBytes).digest("hex")}` } as typeof base;
   const rt = await resolveManagedBundle({ manifest, runtimeRoot: RUNTIME_ROOT, platform: PLATFORM }); if (!rt.ok) throw new Error(rt.message);
   const machineId = await getLocalMachineId();
   const target = { kind: "local-native" as const, machineId, workspaceGrantId: ws.grant.workspaceGrantId, harnessId: "claude-code" as const, runtimeId: rt.runtime.runtimeId, permissionProfile: "workspace-edits" as const, policyVersion: LOCAL_HARNESS_POLICY_VERSION };

--- a/mcpjam-inspector/server/utils/harness/local/conformance/run-lifecycle.ts
+++ b/mcpjam-inspector/server/utils/harness/local/conformance/run-lifecycle.ts
@@ -95,7 +95,7 @@ function assert(condition: boolean, message: string): void {
  *  `pgrep`, and the MSYS `ps` Git Bash ships cannot see native processes. */
 const WIN = process.platform === "win32";
 const powershell = (script: string) =>
-  execFileP("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], { windowsHide: true });
+  execFileP("powershell.exe", ["-NoProfile", "-NonInteractive", "-InputFormat", "None", "-Command", script], { windowsHide: true });
 
 async function running(pid: number): Promise<boolean> {
   if (WIN) {

--- a/mcpjam-inspector/server/utils/harness/local/conformance/run-native-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/local/conformance/run-native-turn.ts
@@ -700,8 +700,13 @@ async function main() {
     const link = join(sessionStateDir, "work", "project");
     pwdSpellings.push(toAdapterPath(plan.workspacePath, "win32"), link, toAdapterPath(link, "win32"));
   }
-  const pwdText = WIN ? turn2.text.toLowerCase() : turn2.text;
-  if (!pwdSpellings.some((p) => pwdText.includes(WIN ? p.toLowerCase() : p))) failures.push(`turn2's approved Bash did not run in the granted workspace (no pwd output came back through the model; accepted ${JSON.stringify(pwdSpellings)})`);
+  // Windows paths are case-insensitive and the vendor CLI's shell tool hands
+  // back a MIXED spelling (`D:\a/_temp/…` — a drive-native prefix with the
+  // shell's forward slashes after it), so there the comparison folds case and
+  // separators. POSIX stays exact.
+  const foldWin = (s: string) => s.toLowerCase().replace(/\//g, "\\");
+  const pwdText = WIN ? foldWin(turn2.text) : turn2.text;
+  if (!pwdSpellings.some((p) => pwdText.includes(WIN ? foldWin(p) : p))) failures.push(`turn2's approved Bash did not run in the granted workspace (no pwd output came back through the model; accepted ${JSON.stringify(pwdSpellings)})`);
 
   gw.child.kill("SIGTERM");
   await new Promise((r) => setTimeout(r, 200));

--- a/mcpjam-inspector/server/utils/harness/local/conformance/run-native-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/local/conformance/run-native-turn.ts
@@ -295,7 +295,7 @@ const freePort = () =>
  */
 const WIN = process.platform === "win32";
 const powershell = (script: string) =>
-  execFileP("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], {
+  execFileP("powershell.exe", ["-NoProfile", "-NonInteractive", "-InputFormat", "None", "-Command", script], {
     windowsHide: true,
   });
 
@@ -587,7 +587,11 @@ async function main() {
   const upstreamKeyInEnv = envDump.includes(UPSTREAM_KEY_CANARY);
   note(`upstream key in any child env: ${upstreamKeyInEnv ? "LEAKED" : "absent (good)"}`);
   note(`session capability in child env: ${envDump.includes(CAPABILITY) ? "present (env delivery fallback, as designed)" : "absent"}`);
-  const bridgeListeners = await listeners(bridgePid);
+  // The whole supervised tree, not the root alone. On Windows the root is the
+  // Job Object launcher and the socket belongs to the node process under it;
+  // on POSIX the union is a superset of the old check and stricter for it —
+  // any listener anywhere in the tree that is off loopback fails the run.
+  const bridgeListeners = (await Promise.all([bridgePid, ...kids].map(listeners))).flat();
   note(`bridge listeners: ${JSON.stringify(bridgeListeners)}`);
   const homeLeak = envDump.match(/HOME=([^\s]+)/g)?.slice(0, 2);
   note(`child HOME values: ${JSON.stringify(homeLeak)}`);

--- a/mcpjam-inspector/server/utils/harness/local/conformance/run-native-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/local/conformance/run-native-turn.ts
@@ -688,7 +688,20 @@ async function main() {
   // the workspace path coming back is `pwd`'s own output making the whole round
   // trip — request, approval, execution, result, model.
   if ((turn2.parts["tool-result"] ?? 0) < 1) failures.push(`turn2 produced no tool-result, so the approved Bash never ran (parts=${JSON.stringify(turn2.parts)})`);
-  if (!turn2.text.includes(plan.workspacePath)) failures.push("turn2's approved Bash did not run in the granted workspace (no pwd output came back through the model)");
+  // Where `pwd` ran, in every spelling it can legitimately come back in. On
+  // POSIX the CLI's cwd resolves through the `project` symlink to the
+  // canonical workspace and that is what `pwd` prints. Windows resolves no
+  // junction in a cwd, and Git Bash prints `/d/a/…` — so there the answer is
+  // the workspace or the session's `work\project` junction, in native or
+  // MSYS form. All four name the granted directory and nothing else.
+  const pwdSpellings = [plan.workspacePath];
+  if (WIN) {
+    const { toAdapterPath } = await import("../adapter-path.js");
+    const link = join(sessionStateDir, "work", "project");
+    pwdSpellings.push(toAdapterPath(plan.workspacePath, "win32"), link, toAdapterPath(link, "win32"));
+  }
+  const pwdText = WIN ? turn2.text.toLowerCase() : turn2.text;
+  if (!pwdSpellings.some((p) => pwdText.includes(WIN ? p.toLowerCase() : p))) failures.push(`turn2's approved Bash did not run in the granted workspace (no pwd output came back through the model; accepted ${JSON.stringify(pwdSpellings)})`);
 
   gw.child.kill("SIGTERM");
   await new Promise((r) => setTimeout(r, 200));

--- a/mcpjam-inspector/server/utils/harness/local/conformance/run-native-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/local/conformance/run-native-turn.ts
@@ -284,7 +284,30 @@ const freePort = () =>
  * for a zombie on both macOS and Linux; an empty answer means the pid is gone
  * outright.
  */
+/**
+ * Windows has none of `ps`, `pgrep` or `lsof`, and Git Bash's MSYS `ps` only
+ * sees MSYS processes — so on the windows leg these helpers would answer
+ * "nothing running, nothing listening" for a tree that is very much alive,
+ * and the verdicts below would either pass vacuously or fail by construction.
+ * Each helper therefore has a Windows arm that asks the OS directly:
+ * `tasklist` for liveness, `netstat -ano` for listeners, and CIM for the
+ * parent/child tree. Still deliberately NOT the code under test.
+ */
+const WIN = process.platform === "win32";
+const powershell = (script: string) =>
+  execFileP("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], {
+    windowsHide: true,
+  });
+
 async function running(pid: number): Promise<boolean> {
+  if (WIN) {
+    try {
+      const { stdout } = await execFileP("tasklist", ["/FI", `PID eq ${pid}`, "/NH", "/FO", "CSV"]);
+      return stdout.includes(`"${pid}"`);
+    } catch {
+      return false;
+    }
+  }
   let state: string;
   try {
     state = (await execFileP("ps", ["-o", "stat=", "-p", String(pid)])).stdout.trim();
@@ -305,11 +328,13 @@ async function descendants(pid: number): Promise<number[]> {
   const walk = async (p: number) => {
     let kids = "";
     try {
-      kids = (await execFileP("pgrep", ["-P", String(p)])).stdout;
+      kids = WIN
+        ? (await powershell(`Get-CimInstance Win32_Process -Filter "ParentProcessId=${p}" | ForEach-Object { $_.ProcessId }`)).stdout
+        : (await execFileP("pgrep", ["-P", String(p)])).stdout;
     } catch {
       return;
     }
-    for (const k of kids.split("\n").map((s) => Number(s.trim())).filter(Boolean)) {
+    for (const k of kids.split(/\r?\n/).map((s) => Number(s.trim())).filter(Boolean)) {
       out.push(k);
       await walk(k);
     }
@@ -326,6 +351,20 @@ async function psLine(pid: number, withEnv = false) {
   }
 }
 async function listeners(pid: number) {
+  if (WIN) {
+    // `  TCP    127.0.0.1:53123    0.0.0.0:0    LISTENING    1234`, for v4 and
+    // v6 alike (`[::1]:53123`). Shaped like the lsof answer below so the
+    // loopback verdict's regex reads both.
+    try {
+      return (await execFileP("netstat", ["-ano"])).stdout
+        .split(/\r?\n/)
+        .map((l) => l.trim().split(/\s+/))
+        .filter((f) => f[0] === "TCP" && f[3] === "LISTENING" && f[4] === String(pid))
+        .map((f) => `${f[1]} (LISTEN)`);
+    } catch {
+      return [];
+    }
+  }
   try {
     return (await execFileP("lsof", ["-nP", "-a", "-p", String(pid), "-iTCP", "-sTCP:LISTEN"])).stdout
       .split("\n").slice(1).filter(Boolean).map((l) => l.split(/\s+/).slice(-2).join(" "));

--- a/mcpjam-inspector/server/utils/harness/local/process-identity.ts
+++ b/mcpjam-inspector/server/utils/harness/local/process-identity.ts
@@ -24,7 +24,7 @@
  * liveness stands in for the group's, and `supportsOwnershipProof('win32')`
  * answers true only once runtime resolution has verified that launcher.
  */
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -245,31 +245,6 @@ function win32PowerShellPath(): string {
   );
 }
 
-/** What PowerShell needs to start at all, and nothing from the user's session
- *  beyond that: the probe reads the process table, not configuration. */
-function win32ProbeEnv(): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {};
-  for (const name of [
-    "SYSTEMROOT",
-    "SYSTEMDRIVE",
-    "WINDIR",
-    "TEMP",
-    "TMP",
-    "PATHEXT",
-    "COMSPEC",
-  ]) {
-    const value = process.env[name];
-    if (value) env[name] = value;
-  }
-  const root = win32SystemRoot();
-  env.PATH = [
-    root,
-    join(root, "System32"),
-    join(root, "System32", "WindowsPowerShell", "v1.0"),
-  ].join(";");
-  return env;
-}
-
 /** Parse the one line the probe script prints: `<filetime>|<process name>`. */
 export function parseWin32ProbeLine(
   raw: string,
@@ -304,45 +279,76 @@ async function probeWin32(pid: number): Promise<ProcessProbe> {
     "try { $t = $p.StartTime.ToFileTimeUtc() } catch { exit 3 }",
     "Write-Output ('{0}|{1}' -f $t, $p.ProcessName)",
   ].join("; ");
-  const result = await new Promise<
+  type ProbeResult =
     | { ok: true; stdout: string }
-    | { ok: false; exitCode: number | null; reason: string }
-  >((resolve) => {
-    execFile(
-      win32PowerShellPath(),
-      [
-        "-NoProfile",
-        "-NonInteractive",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-Command",
-        script,
-      ],
-      {
-        timeout: WIN32_PROBE_TIMEOUT_MS,
-        maxBuffer: 16 * 1024,
-        encoding: "utf8",
-        env: win32ProbeEnv(),
-        windowsHide: true,
-      },
-      (error, out) => {
-        if (!error) {
-          resolve({ ok: true, stdout: typeof out === "string" ? out : "" });
-          return;
-        }
-        const err = error as NodeJS.ErrnoException & {
-          code?: number | string;
-          killed?: boolean;
-        };
-        resolve({
-          ok: false,
-          exitCode: typeof err.code === "number" ? err.code : null,
-          reason: err.killed
-            ? "Get-Process timed out"
-            : `Get-Process failed (${String(err.code ?? "unknown")})`,
-        });
-      },
+    | { ok: false; exitCode: number | null; reason: string };
+  const result = await new Promise<ProbeResult>((resolve) => {
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+    const done = (value: ProbeResult) => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      resolve(value);
+    };
+    // The PARENT's environment, on purpose. The `ps`/`/proc` probes pass an
+    // empty one because they need nothing; PowerShell is different — started
+    // without `USERPROFILE`, `LOCALAPPDATA` and friends it stalls on its own
+    // startup for longer than this probe's timeout. Nothing here reaches a
+    // vendor process: this is the Inspector reading its own OS's process
+    // table. Stdin is closed rather than piped, which is the other documented
+    // way `powershell -Command` waits forever.
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(
+        win32PowerShellPath(),
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-InputFormat",
+          "None",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-Command",
+          script,
+        ],
+        { stdio: ["ignore", "pipe", "pipe"], env: process.env, windowsHide: true },
+      );
+    } catch (error) {
+      done({
+        ok: false,
+        exitCode: null,
+        reason: `PowerShell failed to start (${String(
+          (error as NodeJS.ErrnoException).code ?? "unknown",
+        )})`,
+      });
+      return;
+    }
+    let stdout = "";
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      if (stdout.length < 16 * 1024) stdout += chunk;
+    });
+    child.stderr?.resume();
+    timer = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      done({ ok: false, exitCode: null, reason: "Get-Process timed out" });
+    }, WIN32_PROBE_TIMEOUT_MS);
+    child.on("error", (error: NodeJS.ErrnoException) =>
+      done({
+        ok: false,
+        exitCode: null,
+        reason: `PowerShell failed (${String(error.code ?? "unknown")})`,
+      }),
     );
+    child.on("close", (code) => {
+      if (code === 0) done({ ok: true, stdout });
+      else done({ ok: false, exitCode: code, reason: `Get-Process exited ${code}` });
+    });
   });
   if (!result.ok) {
     if (result.exitCode === 1) return { state: "gone" };

--- a/mcpjam-inspector/server/utils/harness/local/process-identity.ts
+++ b/mcpjam-inspector/server/utils/harness/local/process-identity.ts
@@ -15,15 +15,18 @@
  * Linux reads `/proc/<pid>/stat` — exact, cheap, no subprocess. macOS shells
  * out to `/bin/ps` for the start time, which is second-granular; combined with
  * the process's own argv-derived name that is good enough to refuse a wrong
- * kill, which is the property that matters. Windows has neither, and the Job
- * Object work that would give it a real answer is not implemented here, so
- * `readProcessBirthIdentity` returns null and every ownership question answers
- * "cannot prove" — which fails closed: nothing is adopted, nothing is killed
- * by the janitor, and Windows is not offered as a native platform in the
- * compatibility manifest.
+ * kill, which is the property that matters. Windows has neither `/proc` nor
+ * `ps`, so it asks PowerShell's `Get-Process` for the kernel's creation time
+ * (100 ns resolution), after a cheap `kill(pid, 0)` has said the process is
+ * there at all. Windows has no process GROUP either: the whole-tree guarantee
+ * there is a Job Object with `KILL_ON_JOB_CLOSE`, created by the verified
+ * launcher the supervisor puts in front of every root — so the root's own
+ * liveness stands in for the group's, and `supportsOwnershipProof('win32')`
+ * answers true only once runtime resolution has verified that launcher.
  */
 import { execFile } from "node:child_process";
 import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
 
 /** Opaque, comparable string identifying "this exact process instance". */
 export type ProcessBirthIdentity = string;
@@ -214,6 +217,147 @@ async function probeDarwin(pid: number): Promise<ProcessProbe> {
   };
 }
 
+/**
+ * Windows.
+ *
+ * PowerShell is slow to start — hundreds of milliseconds warm, seconds on a
+ * cold CI runner — so liveness is asked first through `process.kill(pid, 0)`,
+ * which libuv answers from the process object without a subprocess. That call
+ * reports an EXITED process as ESRCH even while a handle to it is still open
+ * (it checks the exit code, not the handle), so a child the supervisor has not
+ * released yet is still reported gone. Only a live pid pays for PowerShell,
+ * whose `StartTime` is the kernel's own creation time as a FILETIME — a far
+ * stronger discriminator than darwin's second-granular `lstart`.
+ */
+const WIN32_PROBE_TIMEOUT_MS = 15_000;
+
+function win32SystemRoot(): string {
+  return process.env.SYSTEMROOT ?? process.env.WINDIR ?? "C:\\Windows";
+}
+
+function win32PowerShellPath(): string {
+  return join(
+    win32SystemRoot(),
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+}
+
+/** What PowerShell needs to start at all, and nothing from the user's session
+ *  beyond that: the probe reads the process table, not configuration. */
+function win32ProbeEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const name of [
+    "SYSTEMROOT",
+    "SYSTEMDRIVE",
+    "WINDIR",
+    "TEMP",
+    "TMP",
+    "PATHEXT",
+    "COMSPEC",
+  ]) {
+    const value = process.env[name];
+    if (value) env[name] = value;
+  }
+  const root = win32SystemRoot();
+  env.PATH = [
+    root,
+    join(root, "System32"),
+    join(root, "System32", "WindowsPowerShell", "v1.0"),
+  ].join(";");
+  return env;
+}
+
+/** Parse the one line the probe script prints: `<filetime>|<process name>`. */
+export function parseWin32ProbeLine(
+  raw: string,
+): { fileTime: string; name: string } | null {
+  const line = raw.trim();
+  const match = /^(\d+)\|(.+)$/.exec(line);
+  if (match === null) return null;
+  return { fileTime: match[1]!, name: match[2]! };
+}
+
+async function probeWin32(pid: number): Promise<ProcessProbe> {
+  try {
+    process.kill(pid, 0);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") return { state: "gone" };
+    // EPERM is "exists, and not ours to signal" — still alive. Anything else
+    // is a failure to look.
+    if (code !== "EPERM") {
+      return {
+        state: "unknown",
+        reason: `kill(0) failed (${code ?? "unknown"})`,
+      };
+    }
+  }
+  // `exit 1` is the process being absent — an answer. `exit 3` is a process
+  // whose start time could not be read (a protected process, or one that left
+  // between the two calls), which is not.
+  const script = [
+    `$p = Get-Process -Id ${pid} -ErrorAction SilentlyContinue`,
+    "if ($null -eq $p) { exit 1 }",
+    "try { $t = $p.StartTime.ToFileTimeUtc() } catch { exit 3 }",
+    "Write-Output ('{0}|{1}' -f $t, $p.ProcessName)",
+  ].join("; ");
+  const result = await new Promise<
+    | { ok: true; stdout: string }
+    | { ok: false; exitCode: number | null; reason: string }
+  >((resolve) => {
+    execFile(
+      win32PowerShellPath(),
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        script,
+      ],
+      {
+        timeout: WIN32_PROBE_TIMEOUT_MS,
+        maxBuffer: 16 * 1024,
+        encoding: "utf8",
+        env: win32ProbeEnv(),
+        windowsHide: true,
+      },
+      (error, out) => {
+        if (!error) {
+          resolve({ ok: true, stdout: typeof out === "string" ? out : "" });
+          return;
+        }
+        const err = error as NodeJS.ErrnoException & {
+          code?: number | string;
+          killed?: boolean;
+        };
+        resolve({
+          ok: false,
+          exitCode: typeof err.code === "number" ? err.code : null,
+          reason: err.killed
+            ? "Get-Process timed out"
+            : `Get-Process failed (${String(err.code ?? "unknown")})`,
+        });
+      },
+    );
+  });
+  if (!result.ok) {
+    if (result.exitCode === 1) return { state: "gone" };
+    return { state: "unknown", reason: result.reason };
+  }
+  const parsed = parseWin32ProbeLine(result.stdout);
+  if (parsed === null) {
+    return { state: "unknown", reason: "unparseable Get-Process output" };
+  }
+  return {
+    state: "alive",
+    identity: `win32:${parsed.fileTime}|${parsed.name}`,
+  };
+}
+
 /** Probe a pid, distinguishing gone from unprovable. */
 export async function probeProcess(
   pid: number,
@@ -224,6 +368,7 @@ export async function probeProcess(
   }
   if (platform === "linux") return probeLinux(pid);
   if (platform === "darwin") return probeDarwin(pid);
+  if (platform === "win32") return probeWin32(pid);
   return { state: "unknown", reason: `no liveness primitive on ${platform}` };
 }
 
@@ -454,6 +599,21 @@ export async function probeProcessGroup(
   if (!Number.isInteger(pid) || pid <= 0) return "unknown";
   if (platform === "linux") return probeLinuxGroup(pid);
   if (platform === "darwin") return probeDarwinGroup(pid);
+  if (platform === "win32") {
+    // No process groups. The root was started through the Job Object launcher
+    // — the supervisor refuses a win32 root any other way — and its job has
+    // KILL_ON_JOB_CLOSE: the launcher exiting, however it exits, closes the
+    // last handle and the kernel terminates every member. So the root's
+    // liveness IS the group's liveness, and no member can outlive it.
+    //
+    // That is an OS guarantee, not an enumeration, which is why the windows
+    // conformance leg asserts it empirically with a survivor scan after every
+    // run rather than trusting this comment.
+    const root = await probeProcess(pid, platform);
+    if (root.state === "gone") return "empty";
+    if (root.state === "alive") return "live";
+    return "unknown";
+  }
   return "unknown";
 }
 
@@ -631,10 +791,13 @@ export function signalProcessGroup(
   if (!Number.isInteger(pid) || pid <= 0) return false;
   try {
     if (platform === "win32") {
-      // No process groups. The supervisor does not offer Windows native mode;
-      // this arm exists so a caller on Windows gets `false` rather than a
-      // silently-succeeded no-op it might mistake for a kill.
-      return false;
+      // No process groups; `pid` is the Job Object launcher, and Node maps any
+      // signal here to `TerminateProcess`. The launcher dying closes its job
+      // handle and KILL_ON_JOB_CLOSE takes the tree with it — so there is no
+      // graceful phase on Windows, only the kill, delivered on the first
+      // signal.
+      process.kill(pid, signal);
+      return true;
     }
     process.kill(-pid, signal);
     return true;

--- a/mcpjam-inspector/server/utils/harness/local/session-env.ts
+++ b/mcpjam-inspector/server/utils/harness/local/session-env.ts
@@ -98,6 +98,15 @@ export interface LocalHarnessEnvOptions {
    * that (see `configStrategy` in the manifest).
    */
   scoped?: Readonly<Record<string, string>>;
+  /**
+   * Windows only: the Git Bash the vendor CLI's shell tool runs through.
+   * Claude Code on Windows executes Bash commands via Git for Windows and
+   * looks for it on PATH — which the child does not have, by design — or in
+   * `CLAUDE_CODE_GIT_BASH_PATH`. The provider resolves a real, existing
+   * `bash.exe` and names it here; absent, the CLI reports the missing shell
+   * itself. Ignored on every other platform.
+   */
+  gitBashPath?: string;
   platform?: NodeJS.Platform;
   base?: NodeJS.ProcessEnv;
 }
@@ -134,6 +143,10 @@ const SCOPED_NAME_DENYLIST = new Set([
   "APPDATA",
   "LOCALAPPDATA",
   "PWD",
+  // Names the shell the vendor CLI runs commands through. A scoped override
+  // would point it at any executable; the provider sets it from a path it
+  // has verified exists.
+  "CLAUDE_CODE_GIT_BASH_PATH",
 ]);
 
 export class LocalHarnessEnvError extends Error {}
@@ -185,6 +198,12 @@ export function buildLocalHarnessEnv(
     env.LOCALAPPDATA = path.join(opts.syntheticHome, "AppData", "Local");
     env.TEMP = env.TMPDIR;
     env.TMP = env.TMPDIR;
+    if (opts.gitBashPath !== undefined) {
+      if (!path.isAbsolute(opts.gitBashPath)) {
+        throw new LocalHarnessEnvError("gitBashPath must be an absolute path");
+      }
+      env.CLAUDE_CODE_GIT_BASH_PATH = opts.gitBashPath;
+    }
   }
   // Vendor CLIs treat a TTY as permission to draw interactive UI and, in some
   // builds, to prompt. A supervised child has no terminal.

--- a/mcpjam-inspector/server/utils/harness/local/supervised-provider.ts
+++ b/mcpjam-inspector/server/utils/harness/local/supervised-provider.ts
@@ -58,6 +58,7 @@ import {
   localBridgeUrl,
 } from "./bridge-endpoint.js";
 import { confinePath } from "./confine.js";
+import { fromAdapterPath, toAdapterPath } from "./adapter-path.js";
 import {
   classifyBootstrapPath,
   translateAdapterCommand,
@@ -111,6 +112,8 @@ export interface SupervisedLocalHarnessProviderOptions {
   onBridgeStarted?: (args: { pid: number; port: number }) => Promise<void>;
   /** Maximum bytes one file API operation may read or write. */
   maxFileBytes?: number;
+  /** Test seam. Production is always the host platform. */
+  platform?: NodeJS.Platform;
 }
 
 /** The `SandboxProcess` shape, synthesized for translations that need no
@@ -395,6 +398,32 @@ export function createSupervisedLocalHarnessProvider(
   // the two roots the file API allows.
   const workRoot = join(opts.sessionStateDir, "work");
   const WORKSPACE_LINK_NAME = "project";
+  const platform = opts.platform ?? process.platform;
+  // What the ADAPTER is told the roots are. On POSIX these are the native
+  // paths; on Windows they are the MSYS spelling (`/c/Users/…`) the framework's
+  // unconditional POSIX composition can work on, and `confine` maps every
+  // operand back to native before anything touches the disk. The child's own
+  // environment (`HOME`, `PWD`, cwd) stays native: the OS reads that, not the
+  // adapter. See `adapter-path.ts`.
+  const adapterWorkRoot = toAdapterPath(workRoot, platform);
+  const adapterHome = toAdapterPath(syntheticHome, platform);
+
+  /**
+   * Point `<work>/project` at the granted workspace.
+   *
+   * A symlink on POSIX. On Windows a JUNCTION: creating a real symlink there
+   * needs Developer Mode or elevation, which a user running an npx server
+   * does not have, while a junction is an ordinary user's operation — and
+   * `lstat().isSymbolicLink()`, `readlink` and `realpath` all treat it as the
+   * link it is, so confinement is unchanged.
+   */
+  const linkWorkspace = async (link: string): Promise<void> => {
+    await symlink(
+      opts.workspacePath,
+      link,
+      platform === "win32" ? "junction" : undefined,
+    );
+  };
 
   const buildSession = async (
     sessionId: string,
@@ -403,7 +432,7 @@ export function createSupervisedLocalHarnessProvider(
     // Session state first: the synthetic home must exist before a vendor CLI's
     // first write, and it must be owner-only from the moment it exists rather
     // than tightened afterwards.
-    for (const dir of syntheticHomeDirectories(syntheticHome)) {
+    for (const dir of syntheticHomeDirectories(syntheticHome, platform)) {
       await mkdir(dir, { recursive: true, mode: 0o700 });
     }
     await mkdir(bootstrapOverlay, { recursive: true, mode: 0o700 });
@@ -436,16 +465,23 @@ export function createSupervisedLocalHarnessProvider(
           throw error;
         },
       );
-      if (current !== opts.workspacePath || resolved !== opts.workspacePath) {
+      // On Windows the link is a junction, and `readlink` reports its target
+      // in whatever spelling the reparse point holds (a `\??\` prefix, a
+      // trailing separator, the case it was created with). Only the resolved
+      // path is a reliable comparison there; the text check stays on POSIX,
+      // where it catches a link whose target was itself replaced by a link.
+      const textAgrees =
+        platform === "win32" ? true : current === opts.workspacePath;
+      if (!textAgrees || resolved !== opts.workspacePath) {
         logger.warn("[local-harness] repointing a stale workspace link", {
           sessionStateDir: opts.sessionStateDir,
         });
         await rm(workspaceLink, { force: true });
-        await symlink(opts.workspacePath, workspaceLink);
+        await linkWorkspace(workspaceLink);
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-      await symlink(opts.workspacePath, workspaceLink);
+      await linkWorkspace(workspaceLink);
     }
 
     // The two roots the Inspector file API will touch, and nothing else.
@@ -457,7 +493,13 @@ export function createSupervisedLocalHarnessProvider(
     // is realpath'd when its grant is issued; the state directory is resolved
     // here, after the directories above exist.
     const roots = [await realpath(opts.sessionStateDir), opts.workspacePath];
-    const confine = (path: string) => confinePath(path, { roots });
+    // The ONE place an adapter-facing path becomes a native one. Everything
+    // the translator confines — every operand, the bridge's own argv, the
+    // file API's paths — comes through here, so the mapping cannot be
+    // forgotten at a call site. A path that is not in the adapter's shape
+    // passes through unchanged and is judged by `confinePath` as before.
+    const confine = (path: string) =>
+      confinePath(fromAdapterPath(path, platform), { roots });
 
     const env = {
       ...buildLocalHarnessEnv({
@@ -474,7 +516,7 @@ export function createSupervisedLocalHarnessProvider(
       // default working directory — so the translator matches the string the
       // adapters will actually emit.
       adapterBootstrapDir: posix.resolve(
-        workRoot,
+        adapterWorkRoot,
         opts.manifest.adapterBootstrapDir,
       ),
       managedBundleRoot: opts.runtime.rootPath,
@@ -484,9 +526,10 @@ export function createSupervisedLocalHarnessProvider(
       // Launch the pack's loopback wrapper rather than the remapped
       // `bridge.mjs`, which stays byte-identical so the recipe compare holds.
       bridgeLauncherPath: opts.runtime.launcherPath,
-      // The framework's default working directory (and the bridge's cwd).
-      sessionRoot: workRoot,
-      syntheticHome,
+      // The framework's default working directory (and the bridge's cwd), in
+      // the shape the adapter composes with. `confine` turns it native.
+      sessionRoot: adapterWorkRoot,
+      syntheticHome: adapterHome,
       // The same symlink-aware check the file API uses. The translator awaits
       // it for every session-scoped operand, including the bridge's own
       // `--workdir` and `--bridge-state-dir`, which nothing downstream would
@@ -670,6 +713,9 @@ export function createSupervisedLocalHarnessProvider(
             workspaceGrantId: opts.workspaceGrantId,
             targetKind: opts.targetKind,
             sessionStateDir: opts.sessionStateDir,
+            ...(opts.runtime.jobLauncherPath !== undefined
+              ? { jobLauncherPath: opts.runtime.jobLauncherPath }
+              : {}),
             role: "helper",
             ...(abort ? { abortSignal: abort } : {}),
           });
@@ -694,7 +740,7 @@ export function createSupervisedLocalHarnessProvider(
       // session's artefacts stay identifiable inside the user's own checkout.
       // Staged materialization with diff-based apply-back is a separate step
       // and is not pretended here.
-      defaultWorkingDirectory: workRoot,
+      defaultWorkingDirectory: adapterWorkRoot,
       description:
         `Supervised local ${opts.harnessId} process on this machine. ` +
         `Working directory ${opts.workspacePath}. Bridge on loopback port ` +
@@ -843,6 +889,9 @@ export function createSupervisedLocalHarnessProvider(
             workspaceGrantId: opts.workspaceGrantId,
             targetKind: opts.targetKind,
             sessionStateDir: opts.sessionStateDir,
+            ...(opts.runtime.jobLauncherPath !== undefined
+              ? { jobLauncherPath: opts.runtime.jobLauncherPath }
+              : {}),
             // The first spawned process is the session's root: killing it must
             // take the whole tree, and it is the record the janitor reclaims.
             role: isBridge ? "root" : "helper",

--- a/mcpjam-inspector/server/utils/harness/local/supervised-provider.ts
+++ b/mcpjam-inspector/server/utils/harness/local/supervised-provider.ts
@@ -392,6 +392,73 @@ async function resolveGitBashPath(
   return undefined;
 }
 
+/**
+ * Up to `maxBytes` from the front of a stream, giving up after `budgetMs`.
+ *
+ * For a process that has already been stopped: its streams hold whatever it
+ * said before it died and close behind it, so this drains quickly. The
+ * budget is for the other case, where nothing is coming.
+ */
+async function readHead(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number,
+  budgetMs: number,
+): Promise<string> {
+  const decoder = new TextDecoder();
+  let head = "";
+  const deadline = Date.now() + budgetMs;
+  const reader = stream.getReader();
+  try {
+    while (head.length < maxBytes) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      const next = await Promise.race([
+        reader.read(),
+        new Promise<{ done: true; value?: undefined }>((resolveRace) =>
+          setTimeout(() => resolveRace({ done: true }), remaining),
+        ),
+      ]);
+      if (next.done || next.value === undefined) break;
+      head += decoder.decode(next.value, { stream: true });
+    }
+  } catch {
+    /* nothing more to say */
+  } finally {
+    reader.releaseLock();
+  }
+  return head.slice(0, maxBytes);
+}
+
+/**
+ * What a bridge that never came up has to say for itself.
+ *
+ * Called AFTER the session was stopped, so the process is dead and its
+ * streams are closed: `wait()` resolves at once and the heads drain. A
+ * readiness timeout with no diagnosis was every early Windows failure — a
+ * bridge that crashed on import and one that hung before binding looked
+ * identical from the outside, thirty seconds apart from nothing.
+ */
+async function describeFailedBridge(handle: {
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  wait: () => Promise<{ exitCode: number }>;
+}): Promise<string> {
+  const exit = await Promise.race([
+    handle.wait().then((r) => `exit code ${r.exitCode}`),
+    new Promise<string>((resolveRace) =>
+      setTimeout(() => resolveRace("still running"), 500),
+    ),
+  ]);
+  const [out, err] = await Promise.all([
+    readHead(handle.stdout, 1024, 500),
+    readHead(handle.stderr, 2048, 500),
+  ]);
+  const parts = [exit];
+  if (err.trim().length > 0) parts.push(`stderr: ${JSON.stringify(err.trim())}`);
+  if (out.trim().length > 0) parts.push(`stdout: ${JSON.stringify(out.trim())}`);
+  return parts.join("; ");
+}
+
 /** Text view of a byte stream — for process output, never for file content. */
 async function collectStream(
   stream: ReadableStream<Uint8Array>,
@@ -981,6 +1048,15 @@ export function createSupervisedLocalHarnessProvider(
             // release the claim, so a retry is checked as a bridge again.
             releaseBridgeClaim();
             await opts.supervisor.stopSession(sessionId).catch(() => {});
+            // Then, with the process dead and its streams closed, say what it
+            // said. The message is amended in place so the error's TYPE — what
+            // callers and tests distinguish on — survives.
+            if (error instanceof Error) {
+              const said = await describeFailedBridge(handle).catch(
+                () => "no diagnosis could be read",
+              );
+              error.message = `${error.message} (bridge: ${said})`;
+            }
             throw error;
           }
         }

--- a/mcpjam-inspector/server/utils/harness/local/supervised-provider.ts
+++ b/mcpjam-inspector/server/utils/harness/local/supervised-provider.ts
@@ -438,25 +438,31 @@ async function readHead(
  * bridge that crashed on import and one that hung before binding looked
  * identical from the outside, thirty seconds apart from nothing.
  */
-async function describeFailedBridge(handle: {
-  stdout: ReadableStream<Uint8Array>;
-  stderr: ReadableStream<Uint8Array>;
-  wait: () => Promise<{ exitCode: number }>;
-  stderrHead?: () => string;
-}): Promise<string> {
-  const exit = await Promise.race([
-    handle.wait().then((r) => `exit code ${r.exitCode}`),
-    new Promise<string>((resolveRace) =>
-      setTimeout(() => resolveRace("still running"), 500),
-    ),
-  ]);
-  // The supervisor's own copy first: the adapter holds the stream's reader
-  // lock from the moment it is handed the process, so a read here finds
+async function describeFailedBridge(
+  handle: {
+    stdout: ReadableStream<Uint8Array>;
+    stderr: ReadableStream<Uint8Array>;
+    stderrHead?: () => string;
+    stdoutHead?: () => string;
+  },
+  /** The exit recorded BEFORE the session was stopped, or null if it was
+   *  still running then. A stop on Windows is `TerminateProcess`, which
+   *  reports exit code 1 — indistinguishable from the process's own, so it
+   *  is not read afterwards. */
+  exitBeforeStop: { exitCode: number } | null,
+): Promise<string> {
+  const exit =
+    exitBeforeStop !== null
+      ? `exited on its own with code ${exitBeforeStop.exitCode}`
+      : "was still running when the session was stopped";
+  // The supervisor's own copies first: the adapter holds the streams' reader
+  // locks from the moment it is handed the process, so a read here finds
   // nothing even when the bridge died with a full stack trace on stderr.
-  const kept = handle.stderrHead?.() ?? "";
+  const keptErr = handle.stderrHead?.() ?? "";
+  const keptOut = handle.stdoutHead?.() ?? "";
   const [out, err] = await Promise.all([
-    readHead(handle.stdout, 1024, 500),
-    kept.length > 0 ? Promise.resolve(kept) : readHead(handle.stderr, 2048, 500),
+    keptOut.length > 0 ? Promise.resolve(keptOut) : readHead(handle.stdout, 1024, 500),
+    keptErr.length > 0 ? Promise.resolve(keptErr) : readHead(handle.stderr, 2048, 500),
   ]);
   const parts = [exit];
   if (err.trim().length > 0) parts.push(`stderr: ${JSON.stringify(err.trim())}`);
@@ -1052,14 +1058,17 @@ export function createSupervisedLocalHarnessProvider(
             // caller has no handle to it, so nothing else would stop it. And
             // release the claim, so a retry is checked as a bridge again.
             releaseBridgeClaim();
+            // Whether it was alive is only knowable BEFORE the stop.
+            const exitBeforeStop = handle.exited?.() ?? null;
             await opts.supervisor.stopSession(sessionId).catch(() => {});
             // Then, with the process dead and its streams closed, say what it
             // said. The message is amended in place so the error's TYPE — what
             // callers and tests distinguish on — survives.
             if (error instanceof Error) {
-              const said = await describeFailedBridge(handle).catch(
-                () => "no diagnosis could be read",
-              );
+              const said = await describeFailedBridge(
+                handle,
+                exitBeforeStop,
+              ).catch(() => "no diagnosis could be read");
               error.message = `${error.message} (bridge: ${said})`;
             }
             throw error;

--- a/mcpjam-inspector/server/utils/harness/local/supervised-provider.ts
+++ b/mcpjam-inspector/server/utils/harness/local/supervised-provider.ts
@@ -45,7 +45,15 @@ import {
   stat,
   symlink,
 } from "node:fs/promises";
-import { basename, dirname, join, posix, resolve, sep } from "node:path";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  posix,
+  resolve,
+  sep,
+} from "node:path";
 import type {
   HarnessV1NetworkSandboxSession,
   HarnessV1SandboxProvider,
@@ -351,6 +359,39 @@ async function writeBytesAtomically(
   }
 }
 
+/**
+ * Windows: the Git Bash the vendor CLI's shell tool runs through.
+ *
+ * The child's PATH is System32 only, on purpose, so the CLI cannot find a
+ * shell by searching it. This names one explicitly — the parent's own
+ * `CLAUDE_CODE_GIT_BASH_PATH` if set, else the default Git for Windows
+ * install — and only when that file actually exists. Nothing is guessed into
+ * the child: absent, the CLI reports the missing shell itself.
+ */
+async function resolveGitBashPath(
+  platform: NodeJS.Platform,
+): Promise<string | undefined> {
+  if (platform !== "win32") return undefined;
+  const configured = process.env.CLAUDE_CODE_GIT_BASH_PATH;
+  const candidates = [
+    ...(configured && isAbsolute(configured) ? [configured] : []),
+    join(
+      process.env.ProgramFiles ?? "C:\\Program Files",
+      "Git",
+      "bin",
+      "bash.exe",
+    ),
+  ];
+  for (const candidate of candidates) {
+    try {
+      if ((await stat(candidate)).isFile()) return candidate;
+    } catch {
+      /* not there; next */
+    }
+  }
+  return undefined;
+}
+
 /** Text view of a byte stream — for process output, never for file content. */
 async function collectStream(
   stream: ReadableStream<Uint8Array>,
@@ -501,11 +542,14 @@ export function createSupervisedLocalHarnessProvider(
     const confine = (path: string) =>
       confinePath(fromAdapterPath(path, platform), { roots });
 
+    const gitBashPath = await resolveGitBashPath(platform);
     const env = {
       ...buildLocalHarnessEnv({
         syntheticHome,
         sessionRoot: opts.workspacePath,
+        platform,
         ...(opts.scopedEnv ? { scoped: opts.scopedEnv } : {}),
+        ...(gitBashPath !== undefined ? { gitBashPath } : {}),
       }),
       ...opts.launcher.requiredEnv,
     };

--- a/mcpjam-inspector/server/utils/harness/local/supervised-provider.ts
+++ b/mcpjam-inspector/server/utils/harness/local/supervised-provider.ts
@@ -442,6 +442,7 @@ async function describeFailedBridge(handle: {
   stdout: ReadableStream<Uint8Array>;
   stderr: ReadableStream<Uint8Array>;
   wait: () => Promise<{ exitCode: number }>;
+  stderrHead?: () => string;
 }): Promise<string> {
   const exit = await Promise.race([
     handle.wait().then((r) => `exit code ${r.exitCode}`),
@@ -449,9 +450,13 @@ async function describeFailedBridge(handle: {
       setTimeout(() => resolveRace("still running"), 500),
     ),
   ]);
+  // The supervisor's own copy first: the adapter holds the stream's reader
+  // lock from the moment it is handed the process, so a read here finds
+  // nothing even when the bridge died with a full stack trace on stderr.
+  const kept = handle.stderrHead?.() ?? "";
   const [out, err] = await Promise.all([
     readHead(handle.stdout, 1024, 500),
-    readHead(handle.stderr, 2048, 500),
+    kept.length > 0 ? Promise.resolve(kept) : readHead(handle.stderr, 2048, 500),
   ]);
   const parts = [exit];
   if (err.trim().length > 0) parts.push(`stderr: ${JSON.stringify(err.trim())}`);

--- a/mcpjam-inspector/server/utils/harness/local/supervisor.ts
+++ b/mcpjam-inspector/server/utils/harness/local/supervisor.ts
@@ -104,6 +104,13 @@ export interface SupervisedProcessHandle {
   stderr: ReadableStream<Uint8Array>;
   wait: () => Promise<{ exitCode: number }>;
   kill: () => Promise<void>;
+  /**
+   * The first bytes the process wrote to stderr, kept by the supervisor
+   * regardless of who is reading the stream. `stderr` above is handed to the
+   * adapter, which takes the reader lock; a provider diagnosing a bridge that
+   * died cannot read it again, and this is what it reads instead.
+   */
+  stderrHead: () => string;
 }
 
 export class SupervisorError extends Error {}
@@ -740,6 +747,7 @@ export class LocalHarnessSupervisor {
         await killTree();
         await exited;
       },
+      stderrHead: () => stderrHead,
     };
   }
 

--- a/mcpjam-inspector/server/utils/harness/local/supervisor.ts
+++ b/mcpjam-inspector/server/utils/harness/local/supervisor.ts
@@ -88,6 +88,14 @@ export interface SupervisedSpawnRequest {
    *  root is written to the durable registry; short-lived helpers are tracked
    *  in memory, because a record we cannot outlive is noise. */
   role: "root" | "helper";
+  /**
+   * Windows only: the digest-verified Job Object launcher from the resolved
+   * runtime (`ResolvedRuntime.jobLauncherPath`). Spawned in FRONT of
+   * `executable`, so the process and everything it starts land in a job that
+   * dies with the launcher. Ignored on every other platform; required for a
+   * win32 root.
+   */
+  jobLauncherPath?: string;
 }
 
 export interface SupervisedProcessHandle {
@@ -294,6 +302,29 @@ export class LocalHarnessSupervisor {
     }
     assertArgvAllowed(request.args);
 
+    // Windows: the verified Job Object launcher goes in front of the process.
+    // `supportsOwnershipProof('win32')` only answers true once runtime
+    // resolution has verified one, so a root reaching here without a path is
+    // a wiring fault rather than a policy outcome — refused all the same,
+    // because the alternative is a tree that "stop" cannot reach.
+    const jobLauncher =
+      this.platform === "win32" ? request.jobLauncherPath : undefined;
+    if (this.platform === "win32" && jobLauncher === undefined) {
+      if (request.role === "root") {
+        throw new SupervisorError(
+          "refusing to start a root process on win32 without the verified " +
+            "Job Object launcher: without it, stopping the session could not " +
+            "be guaranteed to stop everything it started",
+        );
+      }
+    }
+    if (jobLauncher !== undefined && !isAbsolute(jobLauncher)) {
+      throw new SupervisorError(
+        "the Job Object launcher must be an absolute path inside the " +
+          "verified runtime pack",
+      );
+    }
+
     // Read SYNCHRONOUSLY, before anything can yield: this is the value a stop
     // landing mid-launch will change.
     const stopGenerationAtEntry =
@@ -391,7 +422,14 @@ export class LocalHarnessSupervisor {
       );
     }
 
-    const child = spawn(request.executable, [...request.args], {
+    // On Windows the launcher is the process we hold and record: its pid is
+    // the root, its birth identity is the one verified before a kill, and its
+    // exit — by any route — is what takes the job down.
+    const [spawnExecutable, spawnArgs] =
+      jobLauncher !== undefined
+        ? [jobLauncher, [request.executable, ...request.args]]
+        : [request.executable, [...request.args]];
+    const child = spawn(spawnExecutable, spawnArgs, {
       cwd: request.workingDirectory,
       env: request.env,
       stdio: ["ignore", "pipe", "pipe"],

--- a/mcpjam-inspector/server/utils/harness/local/supervisor.ts
+++ b/mcpjam-inspector/server/utils/harness/local/supervisor.ts
@@ -429,10 +429,16 @@ export class LocalHarnessSupervisor {
       jobLauncher !== undefined
         ? [jobLauncher, [request.executable, ...request.args]]
         : [request.executable, [...request.args]];
+    // The launcher's stdin is a LIFELINE, not an input: it exits — closing
+    // its job, which kills the tree — the moment stdin reaches EOF. That is
+    // the property that makes an Inspector crash leave no orphans on Windows.
+    // So it gets a pipe this process holds open and never writes to; `ignore`
+    // would hand it the NUL device, which is EOF at once, and the tree would
+    // die before it could be identified (exit 143, nothing on stderr).
     const child = spawn(spawnExecutable, spawnArgs, {
       cwd: request.workingDirectory,
       env: request.env,
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: [jobLauncher !== undefined ? "pipe" : "ignore", "pipe", "pipe"],
       // POSIX: become a process-group leader so the whole tree can be signalled.
       detached: this.platform !== "win32",
       // Belt and braces — the default is already false, but this is the single

--- a/mcpjam-inspector/server/utils/harness/local/supervisor.ts
+++ b/mcpjam-inspector/server/utils/harness/local/supervisor.ts
@@ -111,6 +111,12 @@ export interface SupervisedProcessHandle {
    * died cannot read it again, and this is what it reads instead.
    */
   stderrHead: () => string;
+  /** Likewise for stdout, where some bridges put their startup complaints. */
+  stdoutHead: () => string;
+  /** The recorded exit, or null while the process is still running. Read it
+   *  BEFORE stopping the process: a stop on Windows is `TerminateProcess`,
+   *  which reports exit code 1 and would be mistaken for the process's own. */
+  exited: () => { exitCode: number } | null;
 }
 
 export class SupervisorError extends Error {}
@@ -464,9 +470,17 @@ export class LocalHarnessSupervisor {
     // slot that the promise, built later, reads or subscribes to.
     const out = bufferedStream(this.limits.maxOutputBytesPerStream);
     const err = bufferedStream(this.limits.maxOutputBytesPerStream);
-    child.stdout?.on("data", (chunk: Buffer) =>
-      out.push(new Uint8Array(chunk)),
-    );
+    let stdoutHead = "";
+    child.stdout?.on("data", (chunk: Buffer) => {
+      if (stdoutHead.length < 1024) {
+        stdoutHead += chunk.toString(
+          "utf8",
+          0,
+          Math.min(chunk.length, 1024 - stdoutHead.length),
+        );
+      }
+      out.push(new Uint8Array(chunk));
+    });
     // The first bytes of stderr, kept aside for the one error below that most
     // needs them: a root that cannot be identified is usually a root that
     // died at once, and its own last words are the diagnosis. Without this,
@@ -748,6 +762,8 @@ export class LocalHarnessSupervisor {
         await exited;
       },
       stderrHead: () => stderrHead,
+      stdoutHead: () => stdoutHead,
+      exited: () => exitResult,
     };
   }
 

--- a/mcpjam-inspector/server/utils/harness/local/supervisor.ts
+++ b/mcpjam-inspector/server/utils/harness/local/supervisor.ts
@@ -454,9 +454,22 @@ export class LocalHarnessSupervisor {
     child.stdout?.on("data", (chunk: Buffer) =>
       out.push(new Uint8Array(chunk)),
     );
-    child.stderr?.on("data", (chunk: Buffer) =>
-      err.push(new Uint8Array(chunk)),
-    );
+    // The first bytes of stderr, kept aside for the one error below that most
+    // needs them: a root that cannot be identified is usually a root that
+    // died at once, and its own last words are the diagnosis. Without this,
+    // every early bridge crash on a platform whose identity probe takes a few
+    // seconds reads as "could not read the birth identity".
+    let stderrHead = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      if (stderrHead.length < 2048) {
+        stderrHead += chunk.toString(
+          "utf8",
+          0,
+          Math.min(chunk.length, 2048 - stderrHead.length),
+        );
+      }
+      err.push(new Uint8Array(chunk));
+    });
 
     let exitResult: { exitCode: number } | null = null;
     let notifyExit: ((result: { exitCode: number }) => void) | null = null;
@@ -554,15 +567,34 @@ export class LocalHarnessSupervisor {
     // Read the birth identity immediately: this is the value that later proves
     // a pid still belongs to us. Reading it after any further await would race
     // a fast exit and a pid reuse.
-    const birthIdentity = await readProcessBirthIdentity(pid, this.platform);
+    const probe = await probeProcess(pid, this.platform);
+    const birthIdentity = probe.state === "alive" ? probe.identity : null;
     entry.birthIdentity = birthIdentity;
     if (request.role === "root" && birthIdentity === null) {
       // Started, but unidentifiable — we could not guarantee cleanup, so we
-      // refuse rather than run a tree we cannot prove we own.
+      // refuse rather than run a tree we cannot prove we own. Say WHY: "gone"
+      // and "could not look" are different failures with different fixes,
+      // and a root that exited before it could be identified has usually
+      // said something on stderr.
       await abandon();
+      const recordedExit = (): { exitCode: number } | null => exitResult;
+      const exit = recordedExit();
+      const why =
+        probe.state === "gone"
+          ? "the process had already exited"
+          : probe.state === "unknown"
+            ? `the probe could not look (${probe.reason})`
+            : "the process could not be identified";
+      const exited =
+        exit !== null ? `exit code ${exit.exitCode}` : "no exit recorded yet";
+      const said =
+        stderrHead.trim().length > 0
+          ? `; stderr: ${JSON.stringify(stderrHead.trim().slice(0, 1024))}`
+          : "";
       throw new SupervisorError(
-        "could not read the process birth identity for the harness root; " +
-          "refusing to run a tree this Inspector cannot prove it owns",
+        `could not read the process birth identity for the harness root — ` +
+          `${why} (${exited})${said}; refusing to run a tree this Inspector ` +
+          `cannot prove it owns`,
       );
     }
 

--- a/mcpjam-inspector/tools/mcpjam-job-launcher/main.go
+++ b/mcpjam-inspector/tools/mcpjam-job-launcher/main.go
@@ -91,6 +91,20 @@ func run(exe string, args []string) int {
 	// Stdio is inherited rather than piped. The supervisor already captures and
 	// bounds the streams on its side; relaying them here would add a buffer
 	// that can fill and a copy loop that can deadlock, for nothing.
+	// The child's stdin is NUL, not this process's. Stdin here is the
+	// supervisor's LIFELINE — a pipe it holds open and never writes to, whose
+	// EOF means the supervisor is gone — and it belongs to this launcher
+	// alone. Handed to the bridge as well, two readers block on one silent
+	// pipe: the bridge never sees the EOF a `/dev/null` stdin gives it on
+	// POSIX, and a bridge that reads stdin before it listens hangs until the
+	// readiness timeout kills it, saying nothing.
+	nul, err := os.OpenFile("NUL", os.O_RDONLY, 0)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mcpjam-job-launcher: open NUL: %v\n", err)
+		return 1
+	}
+	defer nul.Close()
+
 	attr := &syscall.ProcAttr{
 		// Explicit, because this is the low-level `syscall.StartProcess`, not
 		// `os.StartProcess`: here a nil Env is an EMPTY environment block, not
@@ -100,7 +114,7 @@ func run(exe string, args []string) int {
 		// supervisor built this environment for the child; pass it through.
 		Env: os.Environ(),
 		Files: []uintptr{
-			os.Stdin.Fd(),
+			nul.Fd(),
 			os.Stdout.Fd(),
 			os.Stderr.Fd(),
 		},

--- a/mcpjam-inspector/tools/mcpjam-job-launcher/main.go
+++ b/mcpjam-inspector/tools/mcpjam-job-launcher/main.go
@@ -92,6 +92,13 @@ func run(exe string, args []string) int {
 	// bounds the streams on its side; relaying them here would add a buffer
 	// that can fill and a copy loop that can deadlock, for nothing.
 	attr := &syscall.ProcAttr{
+		// Explicit, because this is the low-level `syscall.StartProcess`, not
+		// `os.StartProcess`: here a nil Env is an EMPTY environment block, not
+		// an inherited one. The child then starts with no SYSTEMROOT, and a
+		// Node binary dies inside OpenSSL's random-number init before it runs
+		// a line of JavaScript ("Assertion failed: ncrypto::CSPRNG"). The
+		// supervisor built this environment for the child; pass it through.
+		Env: os.Environ(),
 		Files: []uintptr{
 			os.Stdin.Fd(),
 			os.Stdout.Fd(),


### PR DESCRIPTION
## Local Claude Code on Windows

**Status:** the `windows-latest` conformance leg is green (run 33916710448: full turn, abort scenario, survivor scan). Per the workflow's own rule, that earns `win32` in `nativePlatforms` and the end of `continue-on-error`, and those are the same change; the last commit makes it. The leg now gates and the conformance-version stamp needs it.

### The thesis, now proven

`docs/local-harness.md` said Windows was blocked on an upstream `@ai-sdk/harness` fix because it resolves paths with POSIX semantics everywhere. It was not: the provider supplies `defaultWorkingDirectory` itself, and upstream never hands that value to a native OS call, only concatenates onto it. The provider presents the session's roots in the MSYS spelling (`/c/Users/…`), every derived path stays forward-slashed, the translator's metacharacter check is untouched, and `confine()` (the one chokepoint every operand already passes through, bridge argv included) maps back to native.

### What the Windows leg actually surfaced, one round each

1. PowerShell identity probe stalled on a stripped environment.
2. The Job Object launcher exits 143 when its stdin hits EOF (a deliberate lifeline); the supervisor was handing it `ignore`, which is the NUL device.
3. The launcher used the low-level `syscall.StartProcess` with a nil `Env`, which is an empty environment block, so the bridge's `node.exe` aborted in OpenSSL init with no `SYSTEMROOT`.
4. The launcher inherited the lifeline pipe into the bridge, which then never saw stdin EOF and never bound its port.
5. The runner's verdicts leaned on `lsof`, `ps`, `pgrep`; an empty listener list was a hard failure. Windows-native helpers added; `pwd` comes back with mixed separators and is folded.

Along the way the supervisor and provider gained real diagnostics: a root that cannot be identified now reports the probe's verdict, the exit code, and stderr; a bridge that never listens reports its exit status read *before* the stop and its output from the supervisor's own copy.

### Also in this PR

- `-buildvcs=false` on the launcher build in the pack workflow, so the win32 pack digest stops changing per commit (the reason the 3.3.6 digest table was unshipped).
- `docs/local-harness.md`: "What blocks Windows" is now "What Windows needed", with the remaining gaps.

### Known gaps (documented, follow-up)

- OS-level loopback corroboration and the gateway peer-pid check return null on Windows; the enforcing TCP probe still runs.
- Runner env-leak check reads `ps -E`, vacuous on Windows.
- Child PATH is System32 only; Bash tool calls needing `git` or a runtime will not find one until PATH policy for Windows is decided.
- PowerShell cold start on the first probe; launcher built by the runner image's Go toolchain (no pin).

### Not in this PR

Main's `pack-digests.generated.ts` is empty, so the harness ships inert on every platform until a pack run is dispatched and its table committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPYwQhHbPE9W9gufR2QmDL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes process-tree ownership, termination, and path confinement on a new native platform; mistakes could leave orphan agents or weaken spawn/stop guarantees, though conformance and unit tests target those paths heavily.
> 
> **Overview**
> **Windows is now a gating native platform** for supervised local Claude Code: `win32` joins `nativePlatforms`, the `windows-latest` conformance job no longer uses `continue-on-error`, and the conformance version stamp depends on that leg alongside POSIX runners.
> 
> The fix for adapter path composition is **provider-side MSYS-shaped roots** (`adapter-path.ts`): session roots are presented as `/c/Users/…` so `@ai-sdk/harness` POSIX string ops work unchanged; **`confine`** maps operands back to native paths. Command translation now treats adapter operands as POSIX text everywhere.
> 
> **Process supervision on Windows** uses the digest-verified **`mcpjam-job-launcher.exe`** (Job Object + `KILL_ON_JOB_CLOSE`) in front of the bridge, with a **stdin lifeline** on the launcher; the Go launcher gives the child **`NUL` stdin** and passes through **`Env`**. Identity uses **`kill(0)`** then PowerShell **`Get-Process` FILETIME**; group liveness follows the launcher root. The provider adds **junction** workspace links, optional **`CLAUDE_CODE_GIT_BASH_PATH`**, and richer bridge/root failure diagnostics; conformance runners gain Windows-native **tasklist / netstat / CIM** helpers.
> 
> Pack CI builds the launcher with **`go build -buildvcs=false`** so the win32 tree digest is not tied to every commit. Docs describe what Windows needed and remaining gaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72a82018768cd75ea025fc290e0ca840e9dfbb9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->