### PR TITLE
Bound the spilled-payload fetch by origin, size and a shared deadline

### DIFF
--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-evidence-reader.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-evidence-reader.test.ts
@@ -6,7 +6,7 @@
  * complete is indistinguishable from a turn with fewer tool calls, and that is
  * the one confusion the whole protocol is built to avoid.
  */
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   readTurnEvidence,
   type EvidenceReadTransport,
@@ -16,6 +16,8 @@ const scope = { iterationId: "iter_1", turnId: "turn_1" };
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
 });
 
 function page(
@@ -231,14 +233,21 @@ describe("row parsing", () => {
 });
 
 describe("payloads the backend spilled to storage", () => {
+  // The reader only fetches from the deployment it is configured against, so
+  // every URL here has to look like one the backend would actually hand back.
+  const STORE = "https://convex.example.test";
   const spilledRow = {
     ...settledRow,
     requestId: "spilled",
     argumentsJson: null,
-    argumentsUrl: "https://storage.example/args",
+    argumentsUrl: `${STORE}/args`,
     responseJson: null,
-    responseUrl: "https://storage.example/response",
+    responseUrl: `${STORE}/response`,
   };
+
+  beforeEach(() => {
+    vi.stubEnv("CONVEX_HTTP_URL", STORE);
+  });
 
   test("fetches a spilled payload and hands the merge an inline one", async () => {
     // The merge never learns a payload was spilled: it reads `argumentsJson`
@@ -303,7 +312,7 @@ describe("payloads the backend spilled to storage", () => {
     const fetchMock = vi.fn(async () => new Response("from-storage"));
     vi.stubGlobal("fetch", fetchMock);
     const transport: EvidenceReadTransport = async () =>
-      page([{ ...settledRow, argumentsUrl: "https://storage.example/args" }]);
+      page([{ ...settledRow, argumentsUrl: `${STORE}/args` }]);
 
     const result = await readTurnEvidence({ ...scope, transport });
 
@@ -332,5 +341,133 @@ describe("payloads the backend spilled to storage", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(result.rows[0].payloadsReadable).toBe(true);
+  });
+
+  test("a SETTLED row with no payload and no URL is unreadable, not empty", async () => {
+    // Inline JSON and spill URL are written by one backend in one mutation,
+    // so neither being present means version skew or a truncated write. Read
+    // as an empty response it would grade as a call that succeeded and
+    // returned nothing — a false record rather than a missing one.
+    const fetchMock = vi.fn(async () => new Response("x"));
+    vi.stubGlobal("fetch", fetchMock);
+    const transport: EvidenceReadTransport = async () =>
+      page([{ ...settledRow, responseJson: null }]);
+
+    const result = await readTurnEvidence({ ...scope, transport });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.rows[0].payloadsReadable).toBe(false);
+  });
+
+  test("refuses a URL that is not the configured deployment", async () => {
+    // The URL arrives over an authenticated channel, so this is defence in
+    // depth — but it is still a server-side fetch of a URL that came over the
+    // wire, and the reader should not be the thing that follows it anywhere.
+    const fetchMock = vi.fn(async () => new Response("secret"));
+    vi.stubGlobal("fetch", fetchMock);
+    const transport: EvidenceReadTransport = async () =>
+      page([
+        {
+          ...spilledRow,
+          argumentsUrl: "http://169.254.169.254/latest/meta-data/",
+          responseUrl: "https://convex.example.test.evil.test/response",
+        },
+      ]);
+
+    const result = await readTurnEvidence({ ...scope, transport });
+
+    // Neither the link-local address nor the origin that merely PREFIXES the
+    // trusted one is fetched, and the row degrades instead.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.rows[0].payloadsReadable).toBe(false);
+  });
+
+  test("refuses to follow a redirect away from the checked origin", async () => {
+    const fetchMock = vi.fn(async () => new Response('{"q":"x"}'));
+    vi.stubGlobal("fetch", fetchMock);
+    const transport: EvidenceReadTransport = async () => page([spilledRow]);
+
+    await readTurnEvidence({ ...scope, transport });
+
+    // The origin was checked on the URL in hand; a 302 would move the fetch
+    // somewhere that check never saw.
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: "error" });
+  });
+
+  test("a payload whose DECLARED size is over the cap is refused", async () => {
+    // A fresh Response per call, deliberately: one shared Response fails the
+    // second read on an already-consumed body, which would make this test
+    // pass with no cap in place at all.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("x".repeat(1024), {
+            headers: { "content-length": String(64 * 1024 * 1024) },
+          }),
+      ),
+    );
+    const transport: EvidenceReadTransport = async () => page([spilledRow]);
+
+    const result = await readTurnEvidence({ ...scope, transport });
+
+    expect(result.rows[0].payloadsReadable).toBe(false);
+    expect(result.rows[0].argumentsJson).toBeNull();
+  });
+
+  test("a payload that runs over the cap mid-stream is cancelled, not buffered", async () => {
+    // The case a content-length check cannot catch: a chunked body that only
+    // reveals its size as it arrives. `response.text()` would decode all of it
+    // before anything could object, so the stream has to be abandoned in
+    // flight — and abandoning it is the assertion.
+    const chunk = new Uint8Array(2 * 1024 * 1024);
+    let cancelled = false;
+    const makeResponse = () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            controller.enqueue(chunk);
+          },
+          cancel() {
+            cancelled = true;
+          },
+        }),
+      );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => makeResponse()),
+    );
+    const transport: EvidenceReadTransport = async () => page([spilledRow]);
+
+    const result = await readTurnEvidence({ ...scope, transport });
+
+    expect(cancelled).toBe(true);
+    expect(result.rows[0].payloadsReadable).toBe(false);
+  });
+
+  test("stops resolving once the whole pass runs out of time", async () => {
+    // Resolution is sequential, so the per-fetch timeout multiplies across a
+    // high-fan-out turn: only a shared deadline keeps the pass inside the
+    // iteration watchdog it is blocking.
+    const realNow = Date.now;
+    let clock = realNow.call(Date);
+    vi.spyOn(Date, "now").mockImplementation(() => clock);
+    const fetchMock = vi.fn(async () => {
+      clock += 30_000; // each fetch burns half the budget
+      return new Response('{"q":"x"}');
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const rows = Array.from({ length: 8 }, (_, i) => ({
+      ...spilledRow,
+      requestId: `spilled-${i}`,
+    }));
+    const transport: EvidenceReadTransport = async () => page(rows);
+
+    const result = await readTurnEvidence({ ...scope, transport });
+
+    // It gave up well short of 16 fetches, and every row it could not resolve
+    // is reported unreadable rather than silently empty.
+    expect(fetchMock.mock.calls.length).toBeLessThan(8);
+    expect(result.rows.some((r) => r.payloadsReadable === false)).toBe(true);
   });
 });

--- a/mcpjam-inspector/server/utils/harness/harness-evidence-reader.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-evidence-reader.ts
@@ -27,6 +27,29 @@ const MAX_PAGES = 50;
 const PAGE_SIZE = 25;
 /** A spilled payload's fetch, bounded so one huge blob cannot hang a turn. */
 const PAYLOAD_FETCH_TIMEOUT_MS = 15_000;
+/**
+ * The whole resolution pass, across every row and both payloads.
+ *
+ * The per-fetch timeout does not bound this: resolution is sequential (see
+ * {@link resolveSpilledPayloads}), so a turn with pathological fan-out and an
+ * unavailable store multiplies it — 50 pages x 25 rows x 2 payloads x 15 s is
+ * on the order of ten hours, against an iteration watchdog measured in
+ * minutes. This is the bound that actually holds, and hitting it degrades the
+ * turn to narration grading rather than hanging the iteration that is waiting
+ * on it.
+ */
+const PAYLOAD_RESOLUTION_BUDGET_MS = 60_000;
+/**
+ * Largest spilled payload accepted into memory.
+ *
+ * `response.text()` buffers whatever arrives, and the timeout bounds duration,
+ * not size — a large or chunked object can exhaust the inspector before it
+ * ever completes. Comfortably above the backend's own inline threshold, so a
+ * payload that legitimately spilled still fits; a payload beyond it is
+ * reported unreadable, which is the honest answer and the same one a failed
+ * fetch gives.
+ */
+const MAX_SPILLED_PAYLOAD_BYTES = 24 * 1024 * 1024;
 
 export type EvidenceReadResult = {
   rows: EvidenceRow[];
@@ -142,27 +165,100 @@ function readRows(payload: Record<string, unknown> | null): {
   return { rows, dropped };
 }
 
+/** Whether a spill URL points at the deployment this inspector serves. */
+function isTrustedPayloadUrl(url: string): boolean {
+  const base = process.env.CONVEX_HTTP_URL?.trim();
+  if (!base) return false;
+  try {
+    const target = new URL(url);
+    // HTTPS only, and only the deployment this inspector is configured
+    // against. The URL arrives in a service-token-authenticated response from
+    // our own backend, so this is not the primary control — but it is a
+    // server-side fetch of a URL that came over the wire, and pinning the
+    // origin costs nothing. Compared on origin, not prefix: a `startsWith`
+    // check treats `https://convex.example.evil.test` as a match.
+    if (target.protocol !== "https:") return false;
+    return target.origin === new URL(base).origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read a body with a hard ceiling, without buffering past it.
+ *
+ * `response.text()` would decode whatever arrives before this function could
+ * object, so the stream is consumed chunk by chunk and abandoned the moment it
+ * exceeds the cap.
+ */
+async function readCappedText(response: Response): Promise<string | null> {
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > MAX_SPILLED_PAYLOAD_BYTES) {
+    return null;
+  }
+  const body = response.body;
+  if (!body) return null;
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > MAX_SPILLED_PAYLOAD_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(value);
+    }
+  } catch {
+    return null;
+  }
+  const joined = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(joined);
+}
+
 /**
  * Fetch a payload the backend spilled to storage.
  *
  * Large payloads travel as URLs rather than inline because a page is bounded
  * by row count: inlining them made a turn with a few multi-megabyte tool
  * results exceed the response ceiling and become unreadable at ANY page size.
- * Fetching here is the cost of that, and it is bounded — a stalled blob must
- * degrade the turn to narration grading, not hang it.
+ * Fetching here is the cost of that, and it is bounded three ways — origin,
+ * size and the pass's shared deadline — because a stalled or oversized blob
+ * must degrade the turn to narration grading, not hang or exhaust the process
+ * that is waiting on it.
  *
- * A failed fetch returns null, which the caller turns into
+ * Every refusal returns null, which the caller turns into
  * `payloadsReadable: false`: a payload that cannot be read back is not
  * complete evidence, and reading it as empty would be the silent version of
  * exactly the loss this protocol makes visible.
  */
-async function fetchSpilledPayload(url: string): Promise<string | null> {
+async function fetchSpilledPayload(
+  url: string,
+  deadlineAtMs: number,
+): Promise<string | null> {
+  if (!isTrustedPayloadUrl(url)) return null;
+  const remaining = deadlineAtMs - Date.now();
+  if (remaining <= 0) return null;
   try {
     const response = await fetch(url, {
-      signal: AbortSignal.timeout(PAYLOAD_FETCH_TIMEOUT_MS),
+      // Never follow a redirect: the origin was checked on THIS url, and a
+      // 302 would move the fetch somewhere that check never saw.
+      redirect: "error",
+      signal: AbortSignal.timeout(
+        Math.min(PAYLOAD_FETCH_TIMEOUT_MS, remaining),
+      ),
     });
     if (!response.ok) return null;
-    return await response.text();
+    return await readCappedText(response);
   } catch {
     return null;
   }
@@ -178,17 +274,29 @@ async function fetchSpilledPayload(url: string): Promise<string | null> {
  */
 async function resolveSpilledPayloads(
   rows: EvidenceRow[],
+  deadlineAtMs: number,
 ): Promise<EvidenceRow[]> {
   const resolved: EvidenceRow[] = [];
   for (const row of rows) {
     let { argumentsJson, responseJson, payloadsReadable } = row;
     if (argumentsJson === null && row.argumentsUrl) {
-      argumentsJson = await fetchSpilledPayload(row.argumentsUrl);
+      argumentsJson = await fetchSpilledPayload(row.argumentsUrl, deadlineAtMs);
       if (argumentsJson === null) payloadsReadable = false;
     }
     if (responseJson === null && row.responseUrl) {
-      responseJson = await fetchSpilledPayload(row.responseUrl);
+      responseJson = await fetchSpilledPayload(row.responseUrl, deadlineAtMs);
       if (responseJson === null) payloadsReadable = false;
+    }
+    // A SETTLED row with no payload and no URL to fetch one from. Both are
+    // written by the same backend in the same mutation, so this is version
+    // skew or a truncated write — and reading it as a successful call with an
+    // empty response is precisely the silent loss this protocol exists to
+    // make visible. Unreadable is the honest answer.
+    //
+    // Only `responseJson`: a settled call always produced one, whereas
+    // `argumentsJson` is legitimately absent for a no-argument tool.
+    if (row.status === "settled" && responseJson === null && !row.responseUrl) {
+      payloadsReadable = false;
     }
     resolved.push({ ...row, argumentsJson, responseJson, payloadsReadable });
   }
@@ -211,6 +319,9 @@ export async function readTurnEvidence(args: {
   const rows: EvidenceRow[] = [];
   let unparseableRows = 0;
   let cursor: string | null = null;
+  // One deadline for the whole pass, set before the first request: payload
+  // resolution is sequential, so only a shared budget bounds it.
+  const deadlineAtMs = Date.now() + PAYLOAD_RESOLUTION_BUDGET_MS;
 
   for (let page = 0; page < MAX_PAGES; page += 1) {
     let response: Awaited<ReturnType<EvidenceReadTransport>>;
@@ -251,7 +362,7 @@ export async function readTurnEvidence(args: {
         },
       );
     }
-    rows.push(...(await resolveSpilledPayloads(page.rows)));
+    rows.push(...(await resolveSpilledPayloads(page.rows, deadlineAtMs)));
 
     if (response.body?.isDone === true) {
       return { rows, exhausted: true, unparseableRows };


### PR DESCRIPTION
Four review findings on the evidence reader's spill handling that arrived on [#4534](https://github.com/MCPJam/inspector/pull/4534) shortly before it merged and were not addressed. All four are on `main` now. None is reachable until harness evidence capture is turned on.

Context: large evidence payloads travel as storage URLs rather than inline, because a page is bounded by row count and a few multi-megabyte tool results made a turn unreadable at any page size. `fetchSpilledPayload` is the cost of that — and it went in bounded only by a per-fetch timeout.

## 1. No size ceiling

`response.text()` buffers whatever arrives. The timeout bounds duration, not bytes, so a large or chunked object could exhaust the process before the fetch ever completed.

The body is now read chunk by chunk against a ceiling and abandoned the moment it goes over: a declared `content-length` is rejected up front, and a stream that only reveals its size as it arrives is cancelled in flight. Over-limit reads report the row unreadable — the same answer a failed fetch gives, and the honest one.

## 2. No bound on the pass as a whole

Resolution is sequential on purpose, so a turn does not stampede storage from every concurrent iteration at once. That makes the per-fetch timeout multiply rather than bound: 50 pages × 25 rows × 2 payloads × 15 s is on the order of **ten hours**, against an iteration watchdog measured in minutes.

One deadline now covers the whole pass, set before the first request. Expiring degrades the turn to narration grading instead of hanging the iteration waiting on it.

## 3. The fetch trusted any URL in a row

The URL arrives from our own backend over a service-token-authenticated channel, so it is not attacker-controlled on the normal path — but it is still a server-side fetch of a URL that came over the wire, and pinning it costs nothing.

It is now restricted to the configured deployment's origin over HTTPS, compared as an **origin** rather than a prefix (a `startsWith` check treats `https://convex.example.evil.test` as a match), and redirects are refused with `redirect: "error"` because the origin was checked against the URL in hand.

## 4. A settled row with no payload read as an empty success

Inline JSON and spill URL are written by one backend in one mutation, so neither being present means version skew or a truncated write. Read as an empty response it graded as a call that succeeded and returned nothing — a false record rather than a missing one, which is exactly the silent loss this protocol exists to make visible. It now reads as unreadable.

Scoped to `responseJson` only: a settled call always produced one, whereas absent `argumentsJson` is legitimate for a no-argument tool.

## Testing

`npm run typecheck` clean, SDK builds, and **3,161 tests pass** across all 202 files in `server/utils/harness`, `server/services/evals` and `shared/__tests__` (run after `npm run pretest`, which generates the bundles those suites import).

Each fix is pinned by a test checked to fail against its own reversion:

| Reverted | Failing test |
|---|---|
| origin allowlist | refuses a URL that is not the configured deployment |
| size cap | a payload whose DECLARED size is over the cap is refused **and** a payload that runs over the cap mid-stream is cancelled |
| shared deadline | stops resolving once the whole pass runs out of time |
| missing-payload guard | a SETTLED row with no payload and no URL is unreadable, not empty |

Worth flagging one of these, because it nearly slipped through: the first version of the size-cap test passed *even with the cap removed*. It reused a single `Response` object across both fetches, so the second read failed on an already-consumed body and produced the expected `payloadsReadable: false` for entirely the wrong reason. It now builds a fresh response per call, and the mid-stream case doesn't merely fail without the cap — it takes eighty-five seconds to do so, which is the defect demonstrating itself.

## Rollout

No behaviour change to any path that is not resolving a spilled payload, and no change to what the merge sees: it still reads `argumentsJson` / `responseJson` either way, so digest matching stays identical on both sides of the size threshold. Pairs with [MCPJam/mcpjam-backend#1250](https://github.com/MCPJam/mcpjam-backend/pull/1250), which fixes the purge and write-side halves; the two are independent and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xifFZtXpcJ1usDaXZu97p

---
_Generated by [Claude Code](https://claude.ai/code/session_011xifFZtXpcJ1usDaXZu97p)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Server-side fetches and evidence completeness semantics change on the spill path; impact is scoped to harness evidence when enabled, but wrong bounds could mark turns unreadable or leave residual SSRF risk if origin checks regress.
> 
> **Overview**
> Hardens **spilled payload resolution** in the harness evidence reader so oversized, untrusted, or slow storage fetches cannot hang iterations or be misread as successful empty tool results.
> 
> Spill URLs are only fetched when they are **HTTPS** and match the **`CONVEX_HTTP_URL` origin** (not prefix); **`redirect: "error"`** blocks redirect-based origin bypass. Bodies are read with a **24MB cap** via streaming (`readCappedText`) instead of `response.text()`, rejecting oversized `content-length` and cancelling mid-stream overruns. A **60s shared deadline** caps the entire sequential resolution pass (not just per-fetch 15s timeouts). **Settled** rows missing both inline `responseJson` and `responseUrl` are marked **`payloadsReadable: false`** rather than grading as empty success.
> 
> Tests stub `CONVEX_HTTP_URL`, tighten teardown, and add cases for each guard (SSRF-style URLs, redirects, size limits, deadline exhaustion, missing settled payloads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ec606fef03a1b5726ab216af83bde1a0781ef40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the evidence reader's spilled-payload fetch in four ways so an oversized, slow, or misdirected fetch degrades a turn to narration grading instead of exhausting or hanging the process. No path is affected until harness evidence capture is enabled.

**Bug Fixes**
- Rejects payloads over 24 MB by declared size and cancels streams that exceed the cap mid-flight.
- Applies one 60-second deadline across the whole pass, since per-fetch timeouts multiply across sequential resolution.
- Restricts fetches to the configured deployment's HTTPS origin and refuses redirects.
- Treats a settled row with no payload and no spill URL as unreadable rather than a successful empty call.

<sup>Written for commit 6ec606fef03a1b5726ab216af83bde1a0781ef40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

