### PR TITLE
Stop translated portals taking the whole app down

### DIFF
--- a/design-system/src/components/alert-dialog.tsx
+++ b/design-system/src/components/alert-dialog.tsx
@@ -51,8 +51,9 @@ function AlertDialogContent({
       <AlertDialogOverlay />
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
+        translate="no"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "notranslate bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className,
         )}
         {...props}

--- a/design-system/src/components/context-menu.tsx
+++ b/design-system/src/components/context-menu.tsx
@@ -82,8 +82,9 @@ function ContextMenuSubContent({
   return (
     <ContextMenuPrimitive.SubContent
       data-slot="context-menu-sub-content"
+      translate="no"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        "notranslate bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
         className,
       )}
       {...props}
@@ -99,8 +100,9 @@ function ContextMenuContent({
     <ContextMenuPrimitive.Portal>
       <ContextMenuPrimitive.Content
         data-slot="context-menu-content"
+        translate="no"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "notranslate bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
           className,
         )}
         {...props}

--- a/design-system/src/components/dialog.tsx
+++ b/design-system/src/components/dialog.tsx
@@ -57,8 +57,12 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
+        // Browser translators rewrite text nodes in place, so React can no
+        // longer find the nodes it must remove when a portaled surface
+        // unmounts. Every portaled surface in this package opts out.
+        translate="no"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "notranslate bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className,
         )}
         {...props}

--- a/design-system/src/components/dropdown-menu.tsx
+++ b/design-system/src/components/dropdown-menu.tsx
@@ -38,9 +38,10 @@ function DropdownMenuContent({
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
         data-slot="dropdown-menu-content"
+        translate="no"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "notranslate bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
           className,
         )}
         {...props}
@@ -239,8 +240,9 @@ function DropdownMenuSubContent({
   return (
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
+      translate="no"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        "notranslate bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
         className,
       )}
       {...props}

--- a/design-system/src/components/hover-card.tsx
+++ b/design-system/src/components/hover-card.tsx
@@ -27,10 +27,11 @@ function HoverCardContent({
     <HoverCardPrimitive.Portal data-slot="hover-card-portal">
       <HoverCardPrimitive.Content
         data-slot="hover-card-content"
+        translate="no"
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          "notranslate bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
           className,
         )}
         {...props}

--- a/design-system/src/components/menubar.tsx
+++ b/design-system/src/components/menubar.tsx
@@ -73,11 +73,12 @@ function MenubarContent({
     <MenubarPortal>
       <MenubarPrimitive.Content
         data-slot="menubar-content"
+        translate="no"
         align={align}
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md",
+          "notranslate bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md",
           className,
         )}
         {...props}
@@ -245,8 +246,9 @@ function MenubarSubContent({
   return (
     <MenubarPrimitive.SubContent
       data-slot="menubar-sub-content"
+      translate="no"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        "notranslate bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
         className,
       )}
       {...props}

--- a/design-system/src/components/popover.tsx
+++ b/design-system/src/components/popover.tsx
@@ -32,10 +32,11 @@ function PopoverContent({
   const content = (
     <PopoverPrimitive.Content
       data-slot="popover-content"
+      translate="no"
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+        "notranslate bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
         className,
       )}
       {...props}

--- a/design-system/src/components/select.tsx
+++ b/design-system/src/components/select.tsx
@@ -58,8 +58,9 @@ function SelectContent({
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
         data-slot="select-content"
+        translate="no"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "notranslate bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,

--- a/design-system/src/components/sheet.tsx
+++ b/design-system/src/components/sheet.tsx
@@ -55,8 +55,9 @@ function SheetContent({
       <SheetOverlay />
       <SheetPrimitive.Content
         data-slot="sheet-content"
+        translate="no"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "notranslate bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&

--- a/design-system/src/components/tooltip.tsx
+++ b/design-system/src/components/tooltip.tsx
@@ -54,9 +54,10 @@ function TooltipContent({
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
+        translate="no"
         sideOffset={sideOffset}
         className={cn(
-          "animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "notranslate animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           isMuted
             ? "border border-border bg-popover text-popover-foreground shadow-md"
             : "bg-primary text-primary-foreground",

--- a/mcpjam-inspector/client/src/components/__tests__/design-system-portal-translate.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/design-system-portal-translate.test.tsx
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+} from "@mcpjam/design-system/alert-dialog";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+} from "@mcpjam/design-system/context-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from "@mcpjam/design-system/dropdown-menu";
+import { HoverCard, HoverCardContent } from "@mcpjam/design-system/hover-card";
+import {
+  Menubar,
+  MenubarContent,
+  MenubarItem,
+  MenubarMenu,
+  MenubarSub,
+  MenubarSubContent,
+  MenubarSubTrigger,
+} from "@mcpjam/design-system/menubar";
+import { Popover, PopoverContent } from "@mcpjam/design-system/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+} from "@mcpjam/design-system/select";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+} from "@mcpjam/design-system/sheet";
+import { Tooltip, TooltipContent } from "@mcpjam/design-system/tooltip";
+
+// Browser translators rewrite text nodes in-place. React then cannot remove
+// the portaled surface it still has a reference to, and the whole app falls
+// through to the route error screen. See Sentry INSPECTOR-CLIENT-27X.
+function expectOptedOutOfTranslation(slot: string) {
+  const element = document.querySelector(`[data-slot="${slot}"]`);
+  expect(
+    element,
+    `no element rendered for [data-slot="${slot}"]`,
+  ).not.toBeNull();
+  expect(element).toHaveAttribute("translate", "no");
+  expect(element).toHaveClass("notranslate");
+}
+
+describe("portaled design-system surfaces opt out of browser translation", () => {
+  it("marks dialog content", () => {
+    render(
+      <Dialog defaultOpen>
+        <DialogContent>
+          <DialogTitle>Title</DialogTitle>
+          <DialogDescription>Description</DialogDescription>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expectOptedOutOfTranslation("dialog-content");
+  });
+
+  it("marks alert dialog content", () => {
+    render(
+      <AlertDialog defaultOpen>
+        <AlertDialogContent>
+          <AlertDialogTitle>Title</AlertDialogTitle>
+          <AlertDialogDescription>Description</AlertDialogDescription>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+
+    expectOptedOutOfTranslation("alert-dialog-content");
+  });
+
+  it("marks sheet content", () => {
+    render(
+      <Sheet defaultOpen>
+        <SheetContent>
+          <SheetTitle>Title</SheetTitle>
+          <SheetDescription>Description</SheetDescription>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    expectOptedOutOfTranslation("sheet-content");
+  });
+
+  it("marks popover content", () => {
+    render(
+      <Popover defaultOpen>
+        <PopoverContent>Body</PopoverContent>
+      </Popover>,
+    );
+
+    expectOptedOutOfTranslation("popover-content");
+  });
+
+  it("marks dropdown menu content", () => {
+    render(
+      <DropdownMenu defaultOpen>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Item</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    expectOptedOutOfTranslation("dropdown-menu-content");
+  });
+
+  it("marks select content", () => {
+    render(
+      <Select defaultOpen>
+        <SelectContent>
+          <SelectItem value="a">A</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+
+    expectOptedOutOfTranslation("select-content");
+  });
+
+  it("marks tooltip content", () => {
+    render(
+      <Tooltip defaultOpen>
+        <TooltipContent>Hint</TooltipContent>
+      </Tooltip>,
+    );
+
+    expectOptedOutOfTranslation("tooltip-content");
+  });
+
+  it("marks hover card content", () => {
+    render(
+      <HoverCard defaultOpen>
+        <HoverCardContent>Body</HoverCardContent>
+      </HoverCard>,
+    );
+
+    expectOptedOutOfTranslation("hover-card-content");
+  });
+
+  it("marks context menu content", () => {
+    render(
+      <ContextMenu>
+        <ContextMenuTrigger>Target</ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem>Item</ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>,
+    );
+    fireEvent.contextMenu(screen.getByText("Target"));
+
+    expectOptedOutOfTranslation("context-menu-content");
+  });
+
+  it("marks menubar content", () => {
+    render(
+      <Menubar defaultValue="file">
+        <MenubarMenu value="file">
+          <MenubarContent>
+            <MenubarItem>Item</MenubarItem>
+          </MenubarContent>
+        </MenubarMenu>
+      </Menubar>,
+    );
+
+    expectOptedOutOfTranslation("menubar-content");
+  });
+  it("marks dropdown menu sub content", () => {
+    render(
+      <DropdownMenu defaultOpen>
+        <DropdownMenuContent>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>More</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem>Item</DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    fireEvent.click(screen.getByText("More"));
+
+    expectOptedOutOfTranslation("dropdown-menu-sub-content");
+  });
+
+  it("marks context menu sub content", () => {
+    render(
+      <ContextMenu>
+        <ContextMenuTrigger>Target</ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>More</ContextMenuSubTrigger>
+            <ContextMenuSubContent>
+              <ContextMenuItem>Item</ContextMenuItem>
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+        </ContextMenuContent>
+      </ContextMenu>,
+    );
+    fireEvent.contextMenu(screen.getByText("Target"));
+    fireEvent.click(screen.getByText("More"));
+
+    expectOptedOutOfTranslation("context-menu-sub-content");
+  });
+
+  it("marks menubar sub content", () => {
+    render(
+      <Menubar defaultValue="file">
+        <MenubarMenu value="file">
+          <MenubarContent>
+            <MenubarSub>
+              <MenubarSubTrigger>More</MenubarSubTrigger>
+              <MenubarSubContent>
+                <MenubarItem>Item</MenubarItem>
+              </MenubarSubContent>
+            </MenubarSub>
+          </MenubarContent>
+        </MenubarMenu>
+      </Menubar>,
+    );
+    fireEvent.click(screen.getByText("More"));
+
+    expectOptedOutOfTranslation("menubar-sub-content");
+  });
+});

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -531,9 +531,6 @@ export function ServerDetailModal({
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent
-        // Browser translators rewrite text nodes in-place. React then cannot
-        // safely remove this portaled dialog after its close animation.
-        translate="no"
         // The `sm:` prefix is load-bearing. DialogContent's base carries
         // `sm:max-w-lg`, and tailwind-merge only collapses classes that
         // share a variant — so an unprefixed `max-w-2xl` never conflicts
@@ -543,7 +540,7 @@ export function ServerDetailModal({
         // spares the base `max-w-[calc(100%-2rem)]`, which tailwind-merge
         // used to drop as a same-variant conflict — that's the guard that
         // keeps the dialog off both screen edges below 640px.
-        className="notranslate sm:max-w-2xl max-h-[85vh] flex flex-col outline-none focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0"
+        className="sm:max-w-2xl max-h-[85vh] flex flex-col outline-none focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0"
         onOpenAutoFocus={(event) => {
           event.preventDefault();
         }}


### PR DESCRIPTION
## What broke

A browser translator rewrites text nodes in place. React then holds references to nodes that are no longer children of their parent, and tearing down a portaled surface throws `NotFoundError`. React Router catches it at the global `errorElement` ([router.tsx:508-515](../blob/main/mcpjam-inspector/client/src/router.tsx#L508-L515)), so the user loses the whole app to the "Something went wrong" screen — mid-chat, on the Playground.

## Evidence

[INSPECTOR-CLIENT-27X](https://mcpjam-gh.sentry.io/issues/INSPECTOR-CLIENT-27X) is the alerted case: Safari 26.6.2 on an English UI, `NotFoundError: The object can not be found here.` (DOMException code 8), `release: 3.3.5`.

Breadcrumbs from that session:

```
14:44:04  3 x POST /api/web/chat-v2      chat streaming
14:44:34  click
14:44:34  Warning: Missing `Description` ... for {DialogContent}    a Radix dialog opened
14:44:36  clicks + typing in two inputs
14:44:41  NotFoundError -> React Router caught it
```

The stack is entirely React internals, ending in `commitDeletionEffectsOnFiber` → `recursivelyTraverseDeletionEffects` → native `removeChild`, with the frame that enters `case 4` / `containerInfo`. Fiber tag 4 is `HostPortal`: React was deleting a subtree containing a portal and the node was gone from the container.

54 prod events over 30 days, ~17 users, releases 2.35.1 → 3.3.6 — chronic, not a regression. Browsers: Chrome, Chrome Mobile, Chrome Mobile iOS, Safari, Mobile Safari, Edge. Not one Firefox, the only browser of those without translation offered by default.

`f4009ba17` ("Prevent translated server dialog teardown crash", #4056) already diagnosed this in August and named the mechanism in a code comment — but fixed exactly one dialog.

## The change

Move the opt-out to the shared primitives, so all 89 `DialogContent` call sites and every other portaled surface are covered in one place: dialog, alert-dialog, sheet, popover, dropdown-menu, select, tooltip, hover-card, context-menu, menubar — plus the three sub-menu contents, which portal separately and so do not inherit the parent surface's opt-out.

`ServerDetailModal`'s local copy goes with it: the primitive supplies it now, and keeping both emitted `notranslate` twice in the DOM. Its August test still passes, and now proves the primitive covers a component that passes its own `className`.

## What this does not fix

The `insertBefore` variant ([27Y](https://mcpjam-gh.sentry.io/issues/INSPECTOR-CLIENT-27Y), [289](https://mcpjam-gh.sentry.io/issues/INSPECTOR-CLIENT-289), [25Y](https://mcpjam-gh.sentry.io/issues/INSPECTOR-CLIENT-25Y)), where React places a conditional child (`Toaster`, `MCPJamLimitDialog`, `PlanLimitDialog`, `SessionRefreshBanner`) into the `#root` container. Closing that needs `<html translate="no">`, which turns off translation for the whole app — a product call, so it is deliberately not in this PR.

Also out of scope, tracked separately: sonner's `Toaster` (accepts classes only, and a bare `notranslate` does not protect Safari), and three structural defects that throw the same exception with no translator involved — `widget-surface-host` reparenting a portal container outside React, `HostsTab`'s `AnimatePresence mode="sync"` wrapping both a portal container and its portal source, and `key={i}` over the streaming message-parts list.

## Testing

13 new tests in `design-system-portal-translate.test.tsx`, written first and watched fail for the right reason (element renders, attribute is `null`) before the fix.

```
design-system typecheck    clean
typecheck:client           clean (includes check:renderer-tier-b)
client suite               3 failed / 1093 passed files, 12306 tests passed
```

Those 3 failures are pre-existing: `score-run-resume`, `scenario-chat-transcript` and `eval-live-chat-panel` fail identically on a stashed clean tree. All storage/filesystem tests, unrelated to this diff.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops browser translators from crashing the app when portaled surfaces unmount by moving the `translate="no"` opt-out to every portaled primitive in `@mcpjam/design-system`.

- Covers all dialog, alert-dialog, sheet, popover, dropdown-menu, select, tooltip, hover-card, context-menu, and menubar surfaces, including sub-menus.
- Removes the one-off opt-out from `ServerDetailModal` and its duplicate `notranslate` class.
- Adds tests verifying every surface renders with both `translate="no"` and `notranslate`.

<sup>Written for commit 45e3be1768ec12605213784cec6deee94de177ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

