### PR TITLE
Reconcile compare presets against the user's own clients

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -77,6 +77,7 @@ import {
   demoteMcpjamHosts,
   dropPresetsShadowedByLiveHosts,
   isPresetHostId,
+  remapShadowedSelection,
 } from "./host-compare-presets";
 import { resolveClientDisplayNames } from "@/lib/client-display-name";
 import {
@@ -409,12 +410,19 @@ export function HostConfigCompareView({
       : parseHostsParam(searchParams.get(HOSTS_QUERY_PARAM));
     urlConsumedRef.current = true;
     setSelectedHostIds((previous) => {
+      // Point any selected preset at the live host that shadowed it BEFORE
+      // reconciling. A dropped preset is no longer selectable, so the default
+      // ChatGPT + Claude pair — or a selection stored before the user created
+      // the client — would otherwise reconcile the column away entirely.
+      // Owning the real client should upgrade that column, not delete it.
       const next = resolveInitialHostCompareSelection({
         projectId: selectionScopeId,
         liveHostIds: defaultHostIds,
         knownHostIds,
         previousSelection: previous,
         urlSelection,
+        remapSelection: (ids) =>
+          remapShadowedSelection(ids, liveHosts, subjectsByHost),
       });
       return sameStringArray(previous, next) ? previous : next;
     });
@@ -422,10 +430,12 @@ export function HostConfigCompareView({
     defaultHostIds,
     knownHostIds,
     listLoading,
+    liveHosts,
     presetOnly,
     projectId,
     searchParams,
     selectionScopeId,
+    subjectsByHost,
   ]);
 
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -75,7 +75,10 @@ import {
 import {
   buildPresetCompareEntries,
   demoteMcpjamHosts,
+  dropPresetsShadowedByLiveHosts,
+  isPresetHostId,
 } from "./host-compare-presets";
+import { resolveClientDisplayNames } from "@/lib/client-display-name";
 import {
   clientCompareFieldsWithData,
   getCaniuseCapabilityBySlug,
@@ -295,10 +298,41 @@ export function HostConfigCompareView({
   // land is what let it back in once live hosts joined the list.
   const hosts = useMemo(() => {
     const orderedPresets = sortCaniusePresetHosts(presets.hosts);
-    const ordered = presetOnly
-      ? orderedPresets
-      : [...liveHosts, ...orderedPresets];
-    return demoteMcpjamHosts(ordered, subjectsByHost);
+    if (presetOnly) return demoteMcpjamHosts(orderedPresets, subjectsByHost);
+
+    // A preset is a read-only stand-in for a client you do NOT have, so drop
+    // the ones the user already owns before combining. Without this a project
+    // with an MCPJam client showed it twice, same name and logo both times.
+    const ordered = demoteMcpjamHosts(
+      [
+        ...liveHosts,
+        ...dropPresetsShadowedByLiveHosts(
+          liveHosts,
+          orderedPresets,
+          subjectsByHost,
+        ),
+      ],
+      subjectsByHost,
+    );
+
+    // Number whatever collisions survive. `useHostList` already does this for
+    // live hosts, but it cannot see presets, so a live host colliding with a
+    // preset by NAME rather than by style used to render as two identical
+    // rows. Presets sort last here so the user's own client keeps the
+    // unsuffixed name and the stand-in takes the "#2".
+    const displayNames = resolveClientDisplayNames(
+      ordered.map((host) => ({
+        hostId: host.hostId,
+        name: host.name,
+        createdAt: isPresetHostId(host.hostId)
+          ? Number.MAX_SAFE_INTEGER
+          : host.createdAt,
+      })),
+    );
+    return ordered.map((host) => ({
+      ...host,
+      displayName: displayNames.get(host.hostId) ?? host.displayName,
+    }));
   }, [liveHosts, presetOnly, presets.hosts, subjectsByHost]);
   const [searchParams, setSearchParams] = useSearchParams();
   const [selectedHostIds, setSelectedHostIds] = useState<string[]>([]);

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-presets.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-presets.test.ts
@@ -344,6 +344,29 @@ describe("remapShadowedSelection", () => {
     ).toEqual(["h_mine"]);
   });
 
+  it("picks the host that owns the unsuffixed name, not the first in the array", () => {
+    // The list query returns rows in index order, while display names are
+    // allocated oldest-first. When the two disagree, taking the array's first
+    // host pointed the upgraded column at the client labeled "Claude #2".
+    const outOfOrder = [
+      { hostId: "h_new", name: "Claude", hostStyle: "claude", createdAt: 200 },
+      { hostId: "h_old", name: "Claude", hostStyle: "claude", createdAt: 100 },
+    ];
+    expect(
+      remapShadowedSelection([`${PRESET_HOST_ID_PREFIX}claude`], outOfOrder),
+    ).toEqual(["h_old"]);
+  });
+
+  it("breaks a createdAt tie by id, the same way display names do", () => {
+    const tied = [
+      { hostId: "h_b", name: "Claude", hostStyle: "claude", createdAt: 100 },
+      { hostId: "h_a", name: "Claude", hostStyle: "claude", createdAt: 100 },
+    ];
+    expect(
+      remapShadowedSelection([`${PRESET_HOST_ID_PREFIX}claude`], tied),
+    ).toEqual(["h_a"]);
+  });
+
   it("is a no-op when the user owns nothing", () => {
     const selection = [`${PRESET_HOST_ID_PREFIX}claude`];
     expect(remapShadowedSelection(selection, [])).toEqual(selection);

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-presets.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-presets.test.ts
@@ -10,6 +10,7 @@ import {
   demoteMcpjamHosts,
   dropPresetsShadowedByLiveHosts,
   isPresetHostId,
+  remapShadowedSelection,
   resolveCompareHostStyle,
 } from "../host-compare-presets";
 
@@ -289,5 +290,62 @@ describe("dropPresetsShadowedByLiveHosts", () => {
     const live = [{ hostId: "h_a", name: "Untitled thing" }];
     const presets = [{ hostId: `${PRESET_HOST_ID_PREFIX}claude`, name: "C" }];
     expect(dropPresetsShadowedByLiveHosts(live, presets)).toHaveLength(1);
+  });
+});
+
+describe("resolveCompareHostStyle signal order", () => {
+  it("prefers the list query's own hostStyle over subject and name", () => {
+    // The stored style is available for EVERY host, selected or not, which is
+    // what makes shadowing independent of selection.
+    expect(
+      resolveCompareHostStyle(
+        { hostId: "h_a", name: "Claude", hostStyle: "agentcore" },
+        { h_a: { hostStyle: "cursor" } },
+      ),
+    ).toBe("agentcore");
+  });
+
+  it("resolves an exact style name the hint table never lists", () => {
+    // `codex`, `agentcore` and `n8n` are absent from LOGO_NAME_HINTS; only the
+    // exact-name pass places them, and the logo resolver has always run both.
+    expect(resolveCompareHostStyle({ hostId: "h_a", name: "Codex" })).toBe(
+      "codex",
+    );
+    expect(resolveCompareHostStyle({ hostId: "h_b", name: "AgentCore" })).toBe(
+      "agentcore",
+    );
+  });
+});
+
+describe("remapShadowedSelection", () => {
+  const live = [{ hostId: "h_mine", name: "Claude", hostStyle: "claude" }];
+
+  it("points a selected preset at the live host that shadowed it", () => {
+    expect(
+      remapShadowedSelection(
+        [`${PRESET_HOST_ID_PREFIX}chatgpt`, `${PRESET_HOST_ID_PREFIX}claude`],
+        live,
+      ),
+    ).toEqual([`${PRESET_HOST_ID_PREFIX}chatgpt`, "h_mine"]);
+  });
+
+  it("leaves presets with no live counterpart alone", () => {
+    expect(
+      remapShadowedSelection([`${PRESET_HOST_ID_PREFIX}cursor`], live),
+    ).toEqual([`${PRESET_HOST_ID_PREFIX}cursor`]);
+  });
+
+  it("does not duplicate a live host already in the selection", () => {
+    expect(
+      remapShadowedSelection(
+        ["h_mine", `${PRESET_HOST_ID_PREFIX}claude`],
+        live,
+      ),
+    ).toEqual(["h_mine"]);
+  });
+
+  it("is a no-op when the user owns nothing", () => {
+    const selection = [`${PRESET_HOST_ID_PREFIX}claude`];
+    expect(remapShadowedSelection(selection, [])).toEqual(selection);
   });
 });

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-presets.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-presets.test.ts
@@ -8,7 +8,9 @@ import {
   PRESET_HOST_ID_PREFIX,
   buildPresetCompareEntries,
   demoteMcpjamHosts,
+  dropPresetsShadowedByLiveHosts,
   isPresetHostId,
+  resolveCompareHostStyle,
 } from "../host-compare-presets";
 
 const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
@@ -211,5 +213,81 @@ describe("demoteMcpjamHosts", () => {
     const out = demoteMcpjamHosts(hosts);
     expect(out).not.toBe(hosts);
     expect(hosts.map((h) => h.hostId)).toEqual(["h_a", "h_b"]);
+  });
+});
+
+describe("resolveCompareHostStyle", () => {
+  it("reads a preset's style straight off its id", () => {
+    expect(
+      resolveCompareHostStyle({ hostId: `${PRESET_HOST_ID_PREFIX}claude` }),
+    ).toBe("claude");
+  });
+
+  it("prefers a loaded subject's style over the name", () => {
+    // A host named "Claude" running the cursor style is the case where the
+    // name lies; the subject is authoritative once it exists.
+    expect(
+      resolveCompareHostStyle(
+        { hostId: "h_a", name: "Claude" },
+        { h_a: { hostStyle: "cursor" } },
+      ),
+    ).toBe("cursor");
+  });
+
+  it("falls back to the name when no subject has loaded", () => {
+    expect(resolveCompareHostStyle({ hostId: "h_a", name: "MCPJam" })).toBe(
+      "mcpjam",
+    );
+  });
+
+  it("returns null when nothing identifies the host", () => {
+    expect(
+      resolveCompareHostStyle({ hostId: "h_a", name: "Untitled thing" }),
+    ).toBeNull();
+  });
+});
+
+describe("dropPresetsShadowedByLiveHosts", () => {
+  // The two lists are built independently and then concatenated, so nothing
+  // reconciled them: a project with an MCPJam client showed both it and
+  // `preset:mcpjam`, same name and same logo.
+  it("drops the preset a live host already covers", () => {
+    const live = [{ hostId: "h_mine", name: "MCPJam" }];
+    const presets = [
+      { hostId: `${PRESET_HOST_ID_PREFIX}mcpjam`, name: "MCPJam" },
+      { hostId: `${PRESET_HOST_ID_PREFIX}claude`, name: "Claude" },
+    ];
+    expect(
+      dropPresetsShadowedByLiveHosts(live, presets).map((h) => h.hostId),
+    ).toEqual([`${PRESET_HOST_ID_PREFIX}claude`]);
+  });
+
+  it("keeps every preset when the user owns none of them", () => {
+    const presets = [
+      { hostId: `${PRESET_HOST_ID_PREFIX}mcpjam`, name: "MCPJam" },
+      { hostId: `${PRESET_HOST_ID_PREFIX}claude`, name: "Claude" },
+    ];
+    expect(dropPresetsShadowedByLiveHosts([], presets)).toHaveLength(2);
+  });
+
+  it("matches on the live host's STYLE, not its name", () => {
+    // A client named "My Editor" running the cursor style still shadows the
+    // Cursor preset. The name would never have matched.
+    const live = [{ hostId: "h_a", name: "My Editor" }];
+    const presets = [
+      { hostId: `${PRESET_HOST_ID_PREFIX}cursor`, name: "Cursor" },
+      { hostId: `${PRESET_HOST_ID_PREFIX}claude`, name: "Claude" },
+    ];
+    expect(
+      dropPresetsShadowedByLiveHosts(live, presets, {
+        h_a: { hostStyle: "cursor" },
+      }).map((h) => h.hostId),
+    ).toEqual([`${PRESET_HOST_ID_PREFIX}claude`]);
+  });
+
+  it("leaves presets alone when a live host identifies as nothing", () => {
+    const live = [{ hostId: "h_a", name: "Untitled thing" }];
+    const presets = [{ hostId: `${PRESET_HOST_ID_PREFIX}claude`, name: "C" }];
+    expect(dropPresetsShadowedByLiveHosts(live, presets)).toHaveLength(1);
   });
 });

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-selection.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-selection.test.ts
@@ -166,3 +166,18 @@ describe("host-compare-selection", () => {
     ).toEqual([...DEFAULT_COMPARE_HOST_IDS]);
   });
 });
+
+describe("reconcileHostCompareSelection deduplicates", () => {
+  // A selection renders one column per id, so a repeat is a duplicated column.
+  it("keeps the first occurrence and drops repeats", () => {
+    expect(
+      reconcileHostCompareSelection(["h_a", "h_b", "h_a"], new Set(["h_a", "h_b"])),
+    ).toEqual(["h_a", "h_b"]);
+  });
+
+  it("still filters ids that are not selectable", () => {
+    expect(
+      reconcileHostCompareSelection(["h_a", "h_gone", "h_a"], new Set(["h_a"])),
+    ).toEqual(["h_a"]);
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-presets.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-presets.ts
@@ -151,14 +151,26 @@ export function demoteMcpjamHosts<
  * uses, so what a row looks like and what it is treated as cannot disagree.
  */
 export function resolveCompareHostStyle(
-  host: Pick<HostListItem, "hostId"> & { name?: string },
+  host: Pick<HostListItem, "hostId"> & {
+    name?: string;
+    hostStyle?: string | null;
+  },
   subjectsByHost: Readonly<Record<string, { hostStyle?: string }>> = {},
 ): string | null {
   if (isPresetHostId(host.hostId)) {
     return host.hostId.slice(PRESET_HOST_ID_PREFIX.length);
   }
+  // The list query's own value, present for every host whether or not it is
+  // selected. This is what keeps the answer stable: reading the style from a
+  // loaded subject alone made it depend on selection, so a host named "Claude"
+  // but styled `agentcore` shadowed the Claude preset until you selected it,
+  // and stopped shadowing once you did.
+  if (host.hostStyle) return host.hostStyle;
   const style = subjectsByHost[host.hostId]?.hostStyle;
   if (style) return style;
+  // Last resort, for a backend too old to send `hostStyle`. Wrong for a host
+  // whose name does not match its style, which is precisely why it ranks below
+  // both real signals rather than above them.
   return host.name ? resolveHostStyleByName(host.name) : null;
 }
 
@@ -191,4 +203,48 @@ export function dropPresetsShadowedByLiveHosts<
   return presets.filter(
     (preset) => !covered.has(resolveCompareHostStyle(preset, subjectsByHost)!),
   );
+}
+
+/**
+ * Rewrite selected preset ids onto the live hosts that shadowed them.
+ *
+ * Dropping a preset the user already owns removes it from the selectable set,
+ * so any selection naming it — the ChatGPT + Claude default, or a stored one
+ * from before they created the client — reconciles it away and the column just
+ * disappears. The user asked to compare that client; owning a real one should
+ * upgrade the column, not delete it.
+ *
+ * Ids with no live counterpart pass through untouched, and a live host already
+ * in the selection does not get added twice.
+ */
+export function remapShadowedSelection<
+  T extends Pick<HostListItem, "hostId"> & {
+    name?: string;
+    hostStyle?: string | null;
+  },
+>(
+  selection: ReadonlyArray<string>,
+  liveHosts: ReadonlyArray<T>,
+  subjectsByHost: Readonly<Record<string, { hostStyle?: string }>> = {},
+): string[] {
+  const liveByStyle = new Map<string, string>();
+  for (const host of liveHosts) {
+    const style = resolveCompareHostStyle(host, subjectsByHost);
+    // First live host of a style wins, matching the order the chips render in.
+    if (style && !liveByStyle.has(style)) liveByStyle.set(style, host.hostId);
+  }
+  if (liveByStyle.size === 0) return [...selection];
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const hostId of selection) {
+    const style = isPresetHostId(hostId)
+      ? hostId.slice(PRESET_HOST_ID_PREFIX.length)
+      : null;
+    const mapped = (style && liveByStyle.get(style)) || hostId;
+    if (seen.has(mapped)) continue;
+    seen.add(mapped);
+    out.push(mapped);
+  }
+  return out;
 }

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-presets.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-presets.ts
@@ -1,5 +1,6 @@
 import type { HostConfigDtoWithCatalogFacts } from "@/lib/host-config-field-schema";
 import type { HostListItem } from "@/hooks/useClients";
+import { resolveHostStyleByName } from "@/lib/host-logo";
 import type { HostComparisonSubject } from "@/lib/host-config-field-schema";
 import {
   getCatalogHosts,
@@ -137,4 +138,57 @@ export function demoteMcpjamHosts<
   const rest = hosts.filter((host) => !isMcpjam(host));
   if (rest.length === hosts.length) return [...hosts];
   return [...rest, ...hosts.filter(isMcpjam)];
+}
+
+/**
+ * The catalog host id a compare entry stands for, or `null` when nothing
+ * identifies it.
+ *
+ * Three signals, strongest first. A preset carries the id in its own hostId. A
+ * live host's style is authoritative but only exists once its subject has
+ * loaded, and subjects load for SELECTED hosts only. The name is the fallback
+ * that covers the gap — and it is the same signal the chip's own logo lookup
+ * uses, so what a row looks like and what it is treated as cannot disagree.
+ */
+export function resolveCompareHostStyle(
+  host: Pick<HostListItem, "hostId"> & { name?: string },
+  subjectsByHost: Readonly<Record<string, { hostStyle?: string }>> = {},
+): string | null {
+  if (isPresetHostId(host.hostId)) {
+    return host.hostId.slice(PRESET_HOST_ID_PREFIX.length);
+  }
+  const style = subjectsByHost[host.hostId]?.hostStyle;
+  if (style) return style;
+  return host.name ? resolveHostStyleByName(host.name) : null;
+}
+
+/**
+ * Drop the catalog preset for any host style the user already has a real client
+ * for.
+ *
+ * The two lists are built independently — `useHostList` for live hosts,
+ * `buildPresetCompareEntries` for the catalog — and then concatenated, so
+ * nothing reconciled them. A project with an MCPJam client got both it and
+ * `preset:mcpjam`, two rows with the same name and logo and no way to tell them
+ * apart.
+ *
+ * The live host wins: it is the one the user can edit, select and verify
+ * against. The preset is a read-only stand-in for a client you do NOT have.
+ */
+export function dropPresetsShadowedByLiveHosts<
+  T extends Pick<HostListItem, "hostId"> & { name?: string },
+>(
+  liveHosts: ReadonlyArray<T>,
+  presets: ReadonlyArray<T>,
+  subjectsByHost: Readonly<Record<string, { hostStyle?: string }>> = {},
+): T[] {
+  const covered = new Set(
+    liveHosts
+      .map((host) => resolveCompareHostStyle(host, subjectsByHost))
+      .filter((style): style is string => style !== null),
+  );
+  if (covered.size === 0) return [...presets];
+  return presets.filter(
+    (preset) => !covered.has(resolveCompareHostStyle(preset, subjectsByHost)!),
+  );
 }

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-presets.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-presets.ts
@@ -1,6 +1,7 @@
 import type { HostConfigDtoWithCatalogFacts } from "@/lib/host-config-field-schema";
 import type { HostListItem } from "@/hooks/useClients";
 import { resolveHostStyleByName } from "@/lib/host-logo";
+import { stableClientOrder } from "@/lib/client-display-name";
 import type { HostComparisonSubject } from "@/lib/host-config-field-schema";
 import {
   getCatalogHosts,
@@ -221,16 +222,27 @@ export function remapShadowedSelection<
   T extends Pick<HostListItem, "hostId"> & {
     name?: string;
     hostStyle?: string | null;
+    createdAt?: number;
   },
 >(
   selection: ReadonlyArray<string>,
   liveHosts: ReadonlyArray<T>,
   subjectsByHost: Readonly<Record<string, { hostStyle?: string }>> = {},
 ): string[] {
+  // Oldest first, by the SAME comparator that allocates display names. Taking
+  // whatever the list query returned first would disagree with it whenever the
+  // two orders differ, and the upgraded column would read "Claude #2" with
+  // plain "Claude" sitting beside it.
+  const byNameOwnership = [...liveHosts].sort((left, right) =>
+    stableClientOrder(
+      { hostId: left.hostId, createdAt: left.createdAt ?? 0 },
+      { hostId: right.hostId, createdAt: right.createdAt ?? 0 },
+    ),
+  );
+
   const liveByStyle = new Map<string, string>();
-  for (const host of liveHosts) {
+  for (const host of byNameOwnership) {
     const style = resolveCompareHostStyle(host, subjectsByHost);
-    // First live host of a style wins, matching the order the chips render in.
     if (style && !liveByStyle.has(style)) liveByStyle.set(style, host.hostId);
   }
   if (liveByStyle.size === 0) return [...selection];

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-selection.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-selection.ts
@@ -99,22 +99,37 @@ export function resolveInitialHostCompareSelection(args: {
    * when omitted (no presets in play).
    */
   knownHostIds?: ReadonlyArray<string>;
+  /**
+   * Rewrite ids before they are reconciled. Compare uses it to point a
+   * selected preset at the live host that shadowed it: owning the real client
+   * drops the preset from the selectable set, and without this every source
+   * below — url, storage, the previous selection, and the default pair —
+   * would silently lose that column instead of upgrading it.
+   *
+   * Applied to each source rather than to the result, because reconciling
+   * happens first and would already have discarded the id.
+   */
+  remapSelection?: (ids: ReadonlyArray<string>) => string[];
 }): string[] {
   const known = new Set(args.knownHostIds ?? args.liveHostIds);
+  const remap = args.remapSelection ?? ((ids) => [...ids]);
 
   if (args.urlSelection && args.urlSelection.length > 0) {
-    const fromUrl = reconcileHostCompareSelection(args.urlSelection, known);
+    const fromUrl = reconcileHostCompareSelection(
+      remap(args.urlSelection),
+      known,
+    );
     if (fromUrl.length > 0) return fromUrl;
   }
 
   const stored = readHostCompareSelection(args.projectId);
   if (stored) {
-    const fromStorage = reconcileHostCompareSelection(stored, known);
+    const fromStorage = reconcileHostCompareSelection(remap(stored), known);
     if (fromStorage.length > 0) return fromStorage;
   }
 
   const fromPrevious = reconcileHostCompareSelection(
-    args.previousSelection,
+    remap(args.previousSelection),
     known,
   );
   if (fromPrevious.length > 0) return fromPrevious;
@@ -123,7 +138,7 @@ export function resolveInitialHostCompareSelection(args: {
   // "all live hosts" — falls through to live hosts only if the catalog ever
   // stops offering those two preset ids.
   const fromDefaultPresets = reconcileHostCompareSelection(
-    DEFAULT_COMPARE_HOST_IDS,
+    remap(DEFAULT_COMPARE_HOST_IDS),
     known,
   );
   if (fromDefaultPresets.length > 0) return fromDefaultPresets;

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-selection.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-selection.ts
@@ -52,7 +52,18 @@ export function reconcileHostCompareSelection(
   hostIds: ReadonlyArray<string>,
   liveHostIds: ReadonlySet<string>,
 ): string[] {
-  return hostIds.filter((id) => liveHostIds.has(id));
+  // Deduplicated as well as filtered. A selection is rendered as one column
+  // per id, so a repeat is a visibly duplicated column. Two sources can
+  // produce one: storage, which is only as clean as whatever wrote it, and
+  // `remapSelection`, which rewrites ids and can therefore collapse two onto
+  // the same host. Guaranteeing it here covers every path — url, stored,
+  // previous and default — instead of trusting each caller.
+  const seen = new Set<string>();
+  return hostIds.filter((id) => {
+    if (!liveHostIds.has(id) || seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
 }
 
 /** Toggle one host; always keeps at least `minSelected` ids. */

--- a/mcpjam-inspector/client/src/hooks/useClients.ts
+++ b/mcpjam-inspector/client/src/hooks/useClients.ts
@@ -23,6 +23,14 @@ export interface HostListItem {
   displayName?: string;
   hostConfigId: string;
   modelId: string;
+  /**
+   * The emulated client this host is, from the list query's own config read.
+   * Additive: older backends omit it, so readers must treat absent as unknown
+   * rather than as "no style". Available for EVERY host, which is what lets
+   * Compare reconcile the live list against the catalog presets without
+   * depending on which rows happen to be selected.
+   */
+  hostStyle?: string | null;
   serverCount: number;
   // Additive (PR: standalone hosts). Older backends omit these; readers must
   // treat absent as null/false rather than assume presence.

--- a/mcpjam-inspector/client/src/lib/client-display-name.ts
+++ b/mcpjam-inspector/client/src/lib/client-display-name.ts
@@ -8,9 +8,20 @@ function nameKey(name: string): string {
   return name.trim().toLowerCase();
 }
 
-function stableClientOrder(
-  left: ClientDisplayNameSource,
-  right: ClientDisplayNameSource,
+/**
+ * The order display names are allocated in: oldest first, ties broken by id.
+ * The first client of a name group keeps it unsuffixed and later ones take
+ * `#2`, `#3`, …
+ *
+ * Exported because anything that has to AGREE with the resulting labels has to
+ * agree on this order. Compare rewrites a selected preset onto the live host
+ * that shadows it, and picking that host by array order — the order the list
+ * query happens to return — would sometimes land on the client labeled
+ * "Claude #2" while "Claude" sat next to it.
+ */
+export function stableClientOrder(
+  left: Pick<ClientDisplayNameSource, "hostId" | "createdAt">,
+  right: Pick<ClientDisplayNameSource, "hostId" | "createdAt">,
 ): number {
   return (
     left.createdAt - right.createdAt || left.hostId.localeCompare(right.hostId)

--- a/mcpjam-inspector/client/src/lib/host-logo.ts
+++ b/mcpjam-inspector/client/src/lib/host-logo.ts
@@ -46,12 +46,27 @@ const LOGO_NAME_HINTS: Array<[RegExp, string]> = [
   [/mistral/i, "mistral"],
 ];
 
+/**
+ * The host id a free-text client name points at, or `null` when nothing in the
+ * hint table matches.
+ *
+ * Extracted from {@link resolveHostLogoByName} so callers that need the ID
+ * rather than the pixels — deduping a live host against its catalog preset, for
+ * instance — read the same table instead of copying the patterns. Ordering
+ * matters and is documented on the table itself; a second copy would drift.
+ */
+export function resolveHostStyleByName(name: string): string | null {
+  for (const [pattern, hostId] of LOGO_NAME_HINTS) {
+    if (pattern.test(name)) return hostId;
+  }
+  return null;
+}
+
 export function resolveHostLogoByName(
   name: string,
   themeMode?: HostThemeMode | null,
 ): string {
-  for (const [pattern, hostId] of LOGO_NAME_HINTS) {
-    if (pattern.test(name)) return getHostLogoSrc(hostId, themeMode);
-  }
+  const hostId = resolveHostStyleByName(name);
+  if (hostId) return getHostLogoSrc(hostId, themeMode);
   return resolveHostLogoByDisplayName(name, themeMode) ?? UNKNOWN_HOST_LOGO;
 }

--- a/mcpjam-inspector/client/src/lib/host-logo.ts
+++ b/mcpjam-inspector/client/src/lib/host-logo.ts
@@ -53,10 +53,15 @@ const LOGO_NAME_HINTS: Array<[RegExp, string]> = [
  * The host id a free-text client name points at, or `null` when nothing in the
  * hint table matches.
  *
- * Extracted from {@link resolveHostLogoByName} so callers that need the ID
- * rather than the pixels — deduping a live host against its catalog preset, for
- * instance — read the same table instead of copying the patterns. Ordering
- * matters and is documented on the table itself; a second copy would drift.
+ * Runs the same two passes {@link resolveHostLogoByName} does, in the same
+ * order, for callers that need the ID rather than the pixels — deduping a live
+ * host against its catalog preset, for instance. Sharing the hint table matters
+ * because its ordering is load-bearing (`claude-code` before `claude`) and a
+ * second copy would drift.
+ *
+ * The two functions cannot share a body: a logo has to come from the registry
+ * for a custom style and from static metadata for a built-in, while an ID is
+ * just an ID.
  */
 export function resolveHostStyleByName(name: string): string | null {
   for (const [pattern, hostId] of LOGO_NAME_HINTS) {
@@ -72,7 +77,15 @@ export function resolveHostLogoByName(
   name: string,
   themeMode?: HostThemeMode | null,
 ): string {
-  const hostId = resolveHostStyleByName(name);
-  if (hostId) return getHostLogoSrc(hostId, themeMode);
+  // Deliberately NOT `resolveHostStyleByName` here, even though it runs these
+  // same two passes. The passes resolve to ids from different places and only
+  // one of them is in this module's static metadata: the hint table lists
+  // built-ins, while the exact-name pass also matches CUSTOM registered
+  // styles, whose logos live in the style registry. Routing those through
+  // `getHostLogoSrc` finds nothing and renders the generic MCP mark, so each
+  // pass keeps the lookup that can actually serve it.
+  for (const [pattern, hostId] of LOGO_NAME_HINTS) {
+    if (pattern.test(name)) return getHostLogoSrc(hostId, themeMode);
+  }
   return resolveHostLogoByDisplayName(name, themeMode) ?? UNKNOWN_HOST_LOGO;
 }

--- a/mcpjam-inspector/client/src/lib/host-logo.ts
+++ b/mcpjam-inspector/client/src/lib/host-logo.ts
@@ -1,5 +1,8 @@
 import type { HostThemeMode } from "@/lib/client-styles";
-import { resolveHostLogoByDisplayName } from "@/lib/scenario-client-style";
+import {
+  resolveHostLogoByDisplayName,
+  resolveHostStyleByDisplayName,
+} from "@/lib/scenario-client-style";
 import { getHostLogoSrc, UNKNOWN_HOST_LOGO } from "@/lib/host-ui-metadata";
 
 export { UNKNOWN_HOST_LOGO };
@@ -59,7 +62,10 @@ export function resolveHostStyleByName(name: string): string | null {
   for (const [pattern, hostId] of LOGO_NAME_HINTS) {
     if (pattern.test(name)) return hostId;
   }
-  return null;
+  // BOTH passes, in the same order the logo resolver runs them. The hint table
+  // alone misses every id it never listed — `codex`, `agentcore`, `n8n` — so a
+  // host named exactly "Codex" resolved to null and matched nothing.
+  return resolveHostStyleByDisplayName(name);
 }
 
 export function resolveHostLogoByName(

--- a/mcpjam-inspector/client/src/lib/scenario-client-style.ts
+++ b/mcpjam-inspector/client/src/lib/scenario-client-style.ts
@@ -72,10 +72,18 @@ export function getHostLogoSrc(
     : chatUi.logoSrc;
 }
 
-/** Match a saved host's display name to a built-in style logo when config is unavailable. */
-export function resolveHostLogoByDisplayName(
-  displayName: string,
-  themeMode?: HostThemeMode | null
+/**
+ * Match a saved host's display name to a built-in style ID when config is
+ * unavailable.
+ *
+ * The ID-returning half of {@link resolveHostLogoByDisplayName}, split out so
+ * callers that need to KNOW the style — not just draw it — run the same
+ * comparison. It places ids the logo hint table never lists (`codex`,
+ * `agentcore`, `n8n`), which is exactly the set a hint-table-only resolver
+ * silently misses.
+ */
+export function resolveHostStyleByDisplayName(
+  displayName: string
 ): string | null {
   const needle = displayName.trim().toLowerCase().replace(/\s+/g, "");
   if (!needle) return null;
@@ -87,10 +95,19 @@ export function resolveHostLogoByDisplayName(
       .toLowerCase()
       .replace(/\s+/g, "");
     if (needle === id || needle === label || needle === shortLabel) {
-      return getScenarioHostLogo(style.id, undefined, themeMode);
+      return style.id;
     }
   }
   return null;
+}
+
+/** Match a saved host's display name to a built-in style logo when config is unavailable. */
+export function resolveHostLogoByDisplayName(
+  displayName: string,
+  themeMode?: HostThemeMode | null
+): string | null {
+  const styleId = resolveHostStyleByDisplayName(displayName);
+  return styleId ? getScenarioHostLogo(styleId, undefined, themeMode) : null;
 }
 
 /**


### PR DESCRIPTION
Two symptoms reported on Compare, one cause.

A project with an MCPJam client rendered **two** MCPJam rows — same name, same logo, nothing to tell them apart — and neither got a `#2`.

Live hosts come from `useHostList`, presets from `buildPresetCompareEntries`, and the two lists were concatenated without ever being compared. `resolveClientDisplayNames` (the thing that produces "Claude #2") runs *inside* `useHostList`, so it cannot see a preset. Nothing reconciled the boundary in either direction.

## Both halves now reconcile

**`dropPresetsShadowedByLiveHosts`** removes the preset for any style the user already owns. The live host wins — it is the one they can edit, select and verify against, while a preset is a read-only stand-in for a client you do *not* have.

Matching is on **style**, not name: a client named "My Editor" running `cursor` still shadows the Cursor preset, which a name comparison would have missed.

**`resolveClientDisplayNames` over the combined list** numbers whatever collision survives — a live host colliding with a preset by name rather than style. Presets sort last for that pass, so the user's own client keeps the unsuffixed name and the stand-in takes the `#2`.

## One helper, one hint table

`resolveCompareHostStyle` centralizes the three signals, strongest first:

1. a preset's own `hostId`
2. a loaded subject's `hostStyle` — authoritative, but subjects load for **selected** hosts only
3. the name — the fallback covering exactly that gap

For (3), `resolveHostStyleByName` is extracted out of `resolveHostLogoByName` rather than copied, so the name pass reads the same hint table the chip's logo does. What a row looks like and what it is treated as cannot drift apart — and that table's ordering (`claude-code` before `claude`, `cursor-cli` before `cursor`) already carries hard-won comments about exactly that.

## Verification

9 new tests on the two helpers, including the two cases that make this more than cosmetic: style beating a misleading name, and a live host that identifies as nothing leaving presets untouched.

`typecheck:client` clean, 3535 tests across `client/src/lib` and `client/src/components/hosts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate rows on Compare when a live host and a catalog preset share a client style, stops selected columns from disappearing when a preset is removed, and restores custom-style logos that had regressed to the generic MCP mark.

**Bug Fixes**
- `dropPresetsShadowedByLiveHosts` removes a preset when the user already owns a client with that style, matching on style rather than name.
- `resolveCompareHostStyle` prefers the list query's `hostStyle`, so shadowing no longer depends on which hosts are selected; its name fallback runs the same hint and exact-name passes as the logo lookup.
- `resolveClientDisplayNames` numbers surviving name collisions over the combined list, with the preset taking the `#2`.
- `remapShadowedSelection` upgrades a selected preset to the live host that replaced it, picking the host that owns the unsuffixed name, and applies to url, stored, previous, and default selections.
- `reconcileHostCompareSelection` deduplicates ids so a rewritten selection never renders two columns for the same host.
- `resolveHostLogoByName` runs its hint and exact-name passes separately again so custom-style logos keep drawing from the style registry.

<sup>Written for commit 0bd4ace250320be3603d73f126eb65d252b38585. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

