### PR TITLE
Simple eval case editor on the user-value chain (flag-gated)

### DIFF
--- a/.changeset/quick-run-chain.md
+++ b/.changeset/quick-run-chain.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": minor
+---
+
+Quick-run trials now show the same per-trial chain as suite runs. The stage projection lives in the SDK so the client and server share one whitelist.

--- a/.changeset/simple-case-form.md
+++ b/.changeset/simple-case-form.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Flag-gated simple case editor: three questions, capability/regression over matchOptions, and an authored rubric. Multi-turn and app cases still open the deep step list.

--- a/.changeset/simple-case-kind.md
+++ b/.changeset/simple-case-kind.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": minor
+---
+
+Persist authored case kind through the suite file and save payload. Deploy the backend `testCase.kind` argument first — Convex rejects unknown args until that ships.

--- a/.changeset/simple-case-model-rubric.md
+++ b/.changeset/simple-case-model-rubric.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+The case editor now keeps an authored `expectedOutput` rubric on save instead of dropping it. The simple-case model (kind derivation, shape detection, read/write) lands behind a flag constant with no UI yet.

--- a/.changeset/simple-case-new-entry.md
+++ b/.changeset/simple-case-new-entry.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Flag-gated new-case entry is Generate, Record, then Write. Record opens a run-once-then-adopt draft; the sidebar plus stays Write.

--- a/.changeset/simple-case-route-rollup.md
+++ b/.changeset/simple-case-route-rollup.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": minor
+---
+
+Observational route rollup across a case's latest trial batch, plus "Use this trial's route" to adopt observed tools as the expected path.

--- a/cli/src/lib/eval-run-file.ts
+++ b/cli/src/lib/eval-run-file.ts
@@ -106,6 +106,7 @@ export function fileCaseToCreateBody(
     id: testCase.id,
     title: testCase.title,
     ...(testCase.intent !== undefined ? { intent: testCase.intent } : {}),
+    ...(testCase.kind !== undefined ? { kind: testCase.kind } : {}),
     steps: testCase.steps,
     iterations: testCase.repetitions,
     repetitions: testCase.repetitions,
@@ -140,6 +141,7 @@ export function fileCaseToUpdateBody(
     // A file re-sync is authoritative: unlike an ordinary PATCH, a missing
     // label must clear the old one rather than preserve stale attribution.
     intent: testCase.intent ?? null,
+    kind: testCase.kind ?? null,
     steps: testCase.steps,
     iterations: testCase.repetitions,
     repetitions: testCase.repetitions,

--- a/cli/tests/eval-suite-file.test.ts
+++ b/cli/tests/eval-suite-file.test.ts
@@ -3044,6 +3044,16 @@ describe("file-owned case bodies and idempotency", () => {
     assert.equal(fileCaseToUpdateBody(loaded.resolved.cases[0]).intent, null);
   });
 
+  test("case bodies preserve an authored kind and clear a removed one", () => {
+    const loaded = loadEvalSuiteFile(VALID_SUITE_FILE);
+    assert.equal(loaded.ok, true);
+    if (!loaded.ok) return;
+    const labelled = { ...loaded.resolved.cases[0], kind: "regression" as const };
+    assert.equal(fileCaseToCreateBody(labelled).kind, "regression");
+    assert.equal(fileCaseToUpdateBody(labelled).kind, "regression");
+    assert.equal(fileCaseToUpdateBody(loaded.resolved.cases[0]).kind, null);
+  });
+
   test("derived idempotency keys differ when run knobs differ", () => {
     const shared = {
       sourceHash: "a".repeat(64),

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -12381,7 +12381,7 @@
           },
           "kind": {
             "type": ["string", "null"],
-            "enum": ["capability", "regression"],
+            "enum": ["capability", "regression", null],
             "description": "Authored case kind. Omitted leaves the stored value unchanged; null clears it."
           },
           "models": {

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -11784,6 +11784,11 @@
             "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
             "description": "Optional authored analytics grouping label. Must be already trimmed; absent means unlabelled."
           },
+          "kind": {
+            "type": "string",
+            "enum": ["capability", "regression"],
+            "description": "Authored case kind for the simple editor. Absent means the editor derives it from matchOptions."
+          },
           "models": {
             "type": "array",
             "items": {
@@ -12007,6 +12012,11 @@
             "maxLength": 64,
             "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
             "description": "Optional authored analytics grouping label. Must be already trimmed."
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["capability", "regression"],
+            "description": "Authored case kind for the simple editor. Absent means the editor derives it from matchOptions."
           },
           "models": {
             "type": "array",
@@ -12368,6 +12378,11 @@
             "maxLength": 64,
             "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
             "description": "Optional authored analytics grouping label. Must be already trimmed; omitted leaves the stored value unchanged and null clears it."
+          },
+          "kind": {
+            "type": ["string", "null"],
+            "enum": ["capability", "regression"],
+            "description": "Authored case kind. Omitted leaves the stored value unchanged; null clears it."
           },
           "models": {
             "type": "array",

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -1160,6 +1160,9 @@ function EvalsTabContent({
           onCreateTestCase={async () =>
             handlers.handleCreateTestCase(selectedSuite._id)
           }
+          onRecordTestCase={() =>
+            handlers.handleRecordTestCase(selectedSuite._id)
+          }
           onGenerateTestCases={() => void handleGenerateMore()}
           canGenerateTestCases={generateState.canGenerate}
           generateTestCasesDisabledReason={generateState.disabledReason}

--- a/mcpjam-inspector/client/src/components/EvaluateTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvaluateTab.tsx
@@ -1169,6 +1169,9 @@ function EvaluateTabContent({
           onCreateTestCase={async () =>
             handlers.handleCreateTestCase(selectedSuite._id)
           }
+          onRecordTestCase={() =>
+            handlers.handleRecordTestCase(selectedSuite._id)
+          }
           onGenerateTestCases={() => void handleGenerateMore()}
           canGenerateTestCases={generateState.canGenerate}
           generateTestCasesDisabledReason={generateState.disabledReason}

--- a/mcpjam-inspector/client/src/components/evals/__tests__/draft-test-case.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/draft-test-case.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  draftTestCaseId,
+  isDraftTestCaseId,
+  parseDraftTestCaseId,
+} from "../draft-test-case";
+
+describe("draft-test-case", () => {
+  it("round-trips prompt and record sentinels", () => {
+    expect(draftTestCaseId("prompt")).toBe("draft:prompt");
+    expect(draftTestCaseId("record")).toBe("draft:record");
+    expect(parseDraftTestCaseId("draft:prompt")).toBe("prompt");
+    expect(parseDraftTestCaseId("draft:record")).toBe("record");
+    expect(isDraftTestCaseId("draft:record")).toBe(true);
+  });
+
+  it("rejects unknown or real ids", () => {
+    expect(parseDraftTestCaseId("draft:widget")).toBeNull();
+    expect(parseDraftTestCaseId("case-1")).toBeNull();
+    expect(parseDraftTestCaseId(null)).toBeNull();
+    expect(isDraftTestCaseId("draft:")).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/quick-run-chain.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/quick-run-chain.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { STAGE_ANALYZER_VERSION } from "@mcpjam/sdk/contract";
+import type { EvalIteration } from "../types";
+import { chainForQuickRunIteration } from "../simple-case/quick-run-chain";
+
+const verifiedRows = [
+  { stage: "connection", state: "passed" },
+  { stage: "discovery", state: "passed" },
+  { stage: "selection", state: "passed" },
+  { stage: "call", state: "failed", reason: "argumentMismatch" },
+  { stage: "response", state: "notReached", reason: "earlierStageFailed" },
+  { stage: "userValue", state: "notReached", reason: "earlierStageFailed" },
+] as const;
+
+function iteration(metadata: Record<string, unknown>): EvalIteration {
+  return {
+    _id: "iter-1",
+    testCaseId: "case-1",
+    createdBy: "u1",
+    createdAt: 1,
+    updatedAt: 2,
+    iterationNumber: 1,
+    status: "completed",
+    result: "failed",
+    actualToolCalls: [{ toolName: "search", arguments: {} }],
+    tokensUsed: 10,
+    testCaseSnapshot: {
+      title: "T",
+      query: "Q",
+      provider: "openai",
+      model: "gpt-4",
+      expectedToolCalls: [{ toolName: "search", arguments: {} }],
+    },
+    metadata,
+  };
+}
+
+describe("chainForQuickRunIteration", () => {
+  it("assembles a verified chain from valid stageResults", () => {
+    const chain = chainForQuickRunIteration(
+      iteration({
+        stageResults: verifiedRows,
+        firstFailedStage: "call",
+        failureCategory: "arguments",
+        stageAnalyzerVersion: STAGE_ANALYZER_VERSION,
+      }),
+    );
+    expect(chain.status).toBe("verified");
+    if (chain.status === "verified") {
+      expect(chain.firstFailedStage).toBe("call");
+    }
+  });
+
+  it("assembles an unverified chain when the rows do not validate", () => {
+    const chain = chainForQuickRunIteration(
+      iteration({
+        stageResults: [{ stage: "call", state: "failed" }],
+        stageAnalyzerVersion: 7,
+      }),
+    );
+    expect(chain.status).toBe("unverified");
+  });
+
+  it("assembles an absent chain for pre-D1 metadata", () => {
+    const chain = chainForQuickRunIteration(iteration({ turnCount: 1 }));
+    expect(chain.status).toBe("absent");
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/route-rollup.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/route-rollup.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { NO_TOOL_PATH_KEY } from "../../../../../../sdk/src/tool-path";
+import type { EvalIteration } from "../types";
+import {
+  toolsFromIteration,
+  summarizeRoutes,
+} from "../simple-case/route-rollup";
+
+function iteration(
+  id: string,
+  tools: string[],
+  createdAt = 1,
+): EvalIteration {
+  return {
+    _id: id,
+    testCaseId: "case-1",
+    createdBy: "u1",
+    createdAt,
+    updatedAt: createdAt,
+    iterationNumber: Number(id.replace(/\D/g, "") || 1),
+    status: "completed",
+    result: "passed",
+    actualToolCalls: tools.map((toolName) => ({ toolName, arguments: {} })),
+    metadata: { compareRunId: "cmp_latest" },
+    tokensUsed: 1,
+    testCaseSnapshot: {
+      title: "T",
+      query: "Q",
+      provider: "openai",
+      model: "gpt-4",
+      expectedToolCalls: [],
+    },
+  };
+}
+
+describe("summarizeRoutes", () => {
+  it("counts the same collapsed route across the latest batch", () => {
+    const rollup = summarizeRoutes([
+      iteration("1", ["search", "search", "get"], 10),
+      iteration("2", ["search", "get"], 11),
+      iteration("3", ["list"], 12),
+    ]);
+    expect(rollup.total).toBe(3);
+    expect(rollup.routes[0]?.count).toBe(2);
+    expect(rollup.routes[0]?.pathKey).toBe("search→get");
+    expect(rollup.routes[1]?.pathKey).toBe("list");
+  });
+
+  it("keeps arguments on a regression adopt and drops them for capability", () => {
+    const trial = iteration("9", ["search", "search", "get"]);
+    trial.actualToolCalls = [
+      { toolName: "search", arguments: { q: "a" } },
+      { toolName: "search", arguments: { q: "b" } },
+      { toolName: "get", arguments: { id: 1 } },
+    ];
+    expect(toolsFromIteration(trial, "capability")).toEqual([
+      { toolName: "search", arguments: {} },
+      { toolName: "get", arguments: {} },
+    ]);
+    expect(toolsFromIteration(trial, "regression")).toEqual([
+      { toolName: "search", arguments: { q: "a" } },
+      { toolName: "search", arguments: { q: "b" } },
+      { toolName: "get", arguments: { id: 1 } },
+    ]);
+  });
+
+  it("uses the no-tools sentinel when a trial called nothing", () => {
+    const rollup = summarizeRoutes([
+      iteration("1", [], 10),
+      iteration("2", [], 11),
+    ]);
+    expect(rollup.routes[0]?.pathKey).toBe(NO_TOOL_PATH_KEY);
+    expect(rollup.routes[0]?.count).toBe(2);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/route-rollup.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/route-rollup.test.ts
@@ -1,16 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { NO_TOOL_PATH_KEY } from "../../../../../../sdk/src/tool-path";
+import { NO_TOOL_PATH_KEY } from "@mcpjam/sdk/contract";
 import type { EvalIteration } from "../types";
 import {
   toolsFromIteration,
   summarizeRoutes,
 } from "../simple-case/route-rollup";
 
-function iteration(
-  id: string,
-  tools: string[],
-  createdAt = 1,
-): EvalIteration {
+function iteration(id: string, tools: string[], createdAt = 1): EvalIteration {
   return {
     _id: id,
     testCaseId: "case-1",

--- a/mcpjam-inspector/client/src/components/evals/__tests__/simple-case-form.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/simple-case-form.test.tsx
@@ -9,6 +9,8 @@ import {
   matchOptionsForKind,
   UNSET_TOOLS_BLOCK_REASON,
 } from "../simple-case/simple-case-model";
+import { adoptRouteFromIteration } from "../simple-case/route-rollup";
+import type { EvalIteration } from "../types";
 
 const promptOnly: TestStep[] = [
   { id: "turn-1", kind: "prompt", prompt: "Find the latest incidents" },
@@ -30,14 +32,18 @@ const withTool: TestStep[] = [
 function StatefulForm(
   props: Partial<ComponentProps<typeof SimpleCaseForm>> = {},
 ) {
+  const [steps, setSteps] = useState(props.steps ?? promptOnly);
   const [matchOptions, setMatchOptions] = useState(props.matchOptions);
   const [expectedOutput, setExpectedOutput] = useState(
     props.expectedOutput ?? "",
   );
   return (
     <SimpleCaseForm
-      steps={props.steps ?? promptOnly}
-      onStepsChange={props.onStepsChange ?? vi.fn()}
+      steps={steps}
+      onStepsChange={(next) => {
+        setSteps(next);
+        props.onStepsChange?.(next);
+      }}
       matchOptions={matchOptions}
       onMatchOptionsChange={(next) => {
         setMatchOptions(next);
@@ -159,4 +165,94 @@ describe("SimpleCaseForm", () => {
     await user.click(screen.getByRole("button", { name: "Steps" }));
     expect(onOpenDeepEditor).toHaveBeenCalled();
   });
+
+  it("adopts a capability route as deduped names without arguments", () => {
+    const adopted = adoptRouteFromIteration(
+      promptOnly,
+      {
+        actualToolCalls: [
+          { toolName: "search", arguments: { q: "incidents" } },
+          { toolName: "search", arguments: { q: "again" } },
+          { toolName: "get", arguments: { id: "1" } },
+        ],
+      } as EvalIteration,
+      "capability",
+    );
+    expect(
+      adopted.flatMap((step) => {
+        if (step.kind !== "assert" || step.assertion.type !== "toolCalledWith") {
+          return [];
+        }
+        return [
+          {
+            toolName: step.assertion.toolName,
+            arguments: step.assertion.args.args,
+          },
+        ];
+      }),
+    ).toEqual([
+      { toolName: "search", arguments: {} },
+      { toolName: "get", arguments: {} },
+    ]);
+  });
+
+  it("adopts a regression route with arguments and clears the unset gate", async () => {
+    const user = userEvent.setup();
+    render(
+      <AdoptHarness
+        kind="regression"
+        iteration={{
+          actualToolCalls: [
+            { toolName: "search", arguments: { q: "incidents" } },
+            { toolName: "get", arguments: { id: "42" } },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByTestId("simple-case-tools-unset")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Adopt route" }));
+    expect(screen.queryByTestId("simple-case-tools-unset")).not.toBeInTheDocument();
+    const rows = screen.getAllByTestId("simple-case-tool-row");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent("search");
+    expect(rows[1]).toHaveTextContent("get");
+  });
 });
+
+function AdoptHarness({
+  kind,
+  iteration,
+}: {
+  kind: "capability" | "regression";
+  iteration: Pick<EvalIteration, "actualToolCalls">;
+}) {
+  const [steps, setSteps] = useState(promptOnly);
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          setSteps(
+            adoptRouteFromIteration(
+              steps,
+              iteration as EvalIteration,
+              kind,
+            ),
+          )
+        }
+      >
+        Adopt route
+      </button>
+      <SimpleCaseForm
+        steps={steps}
+        onStepsChange={setSteps}
+        onMatchOptionsChange={vi.fn()}
+        onExpectedOutputChange={vi.fn()}
+        onPredicatesChange={vi.fn()}
+        onOpenDeepEditor={vi.fn()}
+        availableTools={["search", "get"]}
+        matchOptions={matchOptionsForKind(kind)}
+      />
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/__tests__/simple-case-form.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/simple-case-form.test.tsx
@@ -180,7 +180,10 @@ describe("SimpleCaseForm", () => {
     );
     expect(
       adopted.flatMap((step) => {
-        if (step.kind !== "assert" || step.assertion.type !== "toolCalledWith") {
+        if (
+          step.kind !== "assert" ||
+          step.assertion.type !== "toolCalledWith"
+        ) {
           return [];
         }
         return [
@@ -211,7 +214,9 @@ describe("SimpleCaseForm", () => {
     );
     expect(screen.getByTestId("simple-case-tools-unset")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Adopt route" }));
-    expect(screen.queryByTestId("simple-case-tools-unset")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("simple-case-tools-unset"),
+    ).not.toBeInTheDocument();
     const rows = screen.getAllByTestId("simple-case-tool-row");
     expect(rows).toHaveLength(2);
     expect(rows[0]).toHaveTextContent("search");
@@ -233,11 +238,7 @@ function AdoptHarness({
         type="button"
         onClick={() =>
           setSteps(
-            adoptRouteFromIteration(
-              steps,
-              iteration as EvalIteration,
-              kind,
-            ),
+            adoptRouteFromIteration(steps, iteration as EvalIteration, kind),
           )
         }
       >

--- a/mcpjam-inspector/client/src/components/evals/__tests__/simple-case-form.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/simple-case-form.test.tsx
@@ -1,0 +1,162 @@
+import { useState, type ComponentProps } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MATCH_OPTIONS_DEFAULTS } from "@/shared/eval-matching";
+import type { TestStep } from "@/shared/steps";
+import { SimpleCaseForm } from "../simple-case/simple-case-form";
+import {
+  matchOptionsForKind,
+  UNSET_TOOLS_BLOCK_REASON,
+} from "../simple-case/simple-case-model";
+
+const promptOnly: TestStep[] = [
+  { id: "turn-1", kind: "prompt", prompt: "Find the latest incidents" },
+];
+
+const withTool: TestStep[] = [
+  { id: "turn-1", kind: "prompt", prompt: "Find the latest incidents" },
+  {
+    id: "a1",
+    kind: "assert",
+    assertion: {
+      type: "toolCalledWith",
+      toolName: "list_incidents",
+      args: { args: {} },
+    },
+  },
+];
+
+function StatefulForm(
+  props: Partial<ComponentProps<typeof SimpleCaseForm>> = {},
+) {
+  const [matchOptions, setMatchOptions] = useState(props.matchOptions);
+  const [expectedOutput, setExpectedOutput] = useState(
+    props.expectedOutput ?? "",
+  );
+  return (
+    <SimpleCaseForm
+      steps={props.steps ?? promptOnly}
+      onStepsChange={props.onStepsChange ?? vi.fn()}
+      matchOptions={matchOptions}
+      onMatchOptionsChange={(next) => {
+        setMatchOptions(next);
+        props.onMatchOptionsChange?.(next);
+      }}
+      expectedOutput={expectedOutput}
+      onExpectedOutputChange={(next) => {
+        setExpectedOutput(next);
+        props.onExpectedOutputChange?.(next);
+      }}
+      onPredicatesChange={props.onPredicatesChange ?? vi.fn()}
+      onOpenDeepEditor={props.onOpenDeepEditor ?? vi.fn()}
+      onToolsChoiceBlockReasonChange={props.onToolsChoiceBlockReasonChange}
+      availableTools={["list_incidents", "get_incident"]}
+      isNegativeTest={props.isNegativeTest}
+    />
+  );
+}
+
+function renderForm(
+  overrides: Partial<ComponentProps<typeof SimpleCaseForm>> = {},
+) {
+  const onStepsChange = vi.fn();
+  const onMatchOptionsChange = vi.fn();
+  const onExpectedOutputChange = vi.fn();
+  const onPredicatesChange = vi.fn();
+  const onOpenDeepEditor = vi.fn();
+  const onToolsChoiceBlockReasonChange = vi.fn();
+  render(
+    <StatefulForm
+      {...overrides}
+      onStepsChange={overrides.onStepsChange ?? onStepsChange}
+      onMatchOptionsChange={onMatchOptionsChange}
+      onExpectedOutputChange={onExpectedOutputChange}
+      onPredicatesChange={onPredicatesChange}
+      onOpenDeepEditor={onOpenDeepEditor}
+      onToolsChoiceBlockReasonChange={onToolsChoiceBlockReasonChange}
+    />,
+  );
+  return {
+    onStepsChange,
+    onMatchOptionsChange,
+    onExpectedOutputChange,
+    onOpenDeepEditor,
+    onToolsChoiceBlockReasonChange,
+  };
+}
+
+describe("SimpleCaseForm", () => {
+  it("writes the capability and regression matchOptions trios", async () => {
+    const user = userEvent.setup();
+    const { onMatchOptionsChange } = renderForm({
+      steps: withTool,
+      isNegativeTest: false,
+    });
+
+    await user.click(screen.getByRole("radio", { name: "Regression" }));
+    expect(onMatchOptionsChange).toHaveBeenCalledWith(
+      matchOptionsForKind("regression"),
+    );
+
+    await user.click(screen.getByRole("radio", { name: "Capability" }));
+    expect(onMatchOptionsChange).toHaveBeenCalledWith(MATCH_OPTIONS_DEFAULTS);
+  });
+
+  it("drops toolCalledWith asserts when no tool is chosen", async () => {
+    const user = userEvent.setup();
+    const { onStepsChange } = renderForm({
+      steps: withTool,
+      isNegativeTest: false,
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "No tool should be called" }),
+    );
+    const next = onStepsChange.mock.calls.at(-1)?.[0] as TestStep[];
+    expect(next).toEqual([
+      { id: "turn-1", kind: "prompt", prompt: "Find the latest incidents" },
+    ]);
+  });
+
+  it("reports the unset-tools block reason", async () => {
+    const { onToolsChoiceBlockReasonChange } = renderForm({
+      isNegativeTest: false,
+    });
+    await waitFor(() => {
+      expect(onToolsChoiceBlockReasonChange).toHaveBeenCalledWith(
+        UNSET_TOOLS_BLOCK_REASON,
+      );
+    });
+    expect(screen.getByTestId("simple-case-tools-unset")).toHaveTextContent(
+      UNSET_TOOLS_BLOCK_REASON,
+    );
+  });
+
+  it("round-trips the rubric", async () => {
+    const user = userEvent.setup();
+    const { onExpectedOutputChange } = renderForm({
+      steps: withTool,
+      isNegativeTest: false,
+      expectedOutput: "",
+    });
+    await user.type(
+      screen.getByLabelText("What does a good answer accomplish?"),
+      "Names the latest incident",
+    );
+    expect(onExpectedOutputChange).toHaveBeenCalled();
+    expect(onExpectedOutputChange.mock.calls.at(-1)?.[0]).toBe(
+      "Names the latest incident",
+    );
+  });
+
+  it("opens the deep editor from the Steps link", async () => {
+    const user = userEvent.setup();
+    const { onOpenDeepEditor } = renderForm({
+      steps: withTool,
+      isNegativeTest: false,
+    });
+    await user.click(screen.getByRole("button", { name: "Steps" }));
+    expect(onOpenDeepEditor).toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/simple-case-model.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/simple-case-model.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from "vitest";
+import {
+  MATCH_OPTIONS_DEFAULTS,
+  resolveMatchOptions,
+} from "@/shared/eval-matching";
+import { type TestStep } from "@/shared/steps";
+import {
+  deriveCaseKind,
+  isSimpleCaseShape,
+  matchOptionsForKind,
+  readSimpleCase,
+  writeSimpleCase,
+} from "../simple-case/simple-case-model";
+
+const prompt = (id: string, text: string): TestStep => ({
+  id,
+  kind: "prompt",
+  prompt: text,
+});
+
+const toolCalledWith = (
+  id: string,
+  toolName: string,
+  args: Record<string, unknown> = {},
+): TestStep => ({
+  id,
+  kind: "assert",
+  assertion: {
+    type: "toolCalledWith",
+    toolName,
+    args: { args },
+  },
+});
+
+describe("deriveCaseKind", () => {
+  it("reads capability from SDK defaults (no matchOptions, no migration)", () => {
+    expect(deriveCaseKind(MATCH_OPTIONS_DEFAULTS)).toBe("capability");
+    expect(deriveCaseKind(resolveMatchOptions())).toBe("capability");
+  });
+
+  it("reads regression from the strict-order + zero-extras pair", () => {
+    expect(
+      deriveCaseKind({
+        toolCallOrder: "strict",
+        maxExtraToolCalls: 0,
+      }),
+    ).toBe("regression");
+  });
+
+  it("does not treat argumentMatching as part of the discriminant", () => {
+    expect(
+      deriveCaseKind({
+        toolCallOrder: "strict",
+        maxExtraToolCalls: 0,
+      }),
+    ).toBe("regression");
+    expect(
+      deriveCaseKind({
+        toolCallOrder: "ignore",
+        maxExtraToolCalls: 0,
+      }),
+    ).toBe("capability");
+    expect(
+      deriveCaseKind({
+        toolCallOrder: "strict",
+        maxExtraToolCalls: null,
+      }),
+    ).toBe("capability");
+  });
+
+  it("resolves through suite defaults then case override", () => {
+    expect(
+      deriveCaseKind(
+        resolveMatchOptions(
+          { toolCallOrder: "strict", maxExtraToolCalls: 0 },
+          undefined,
+        ),
+      ),
+    ).toBe("regression");
+    expect(
+      deriveCaseKind(
+        resolveMatchOptions(
+          { toolCallOrder: "strict", maxExtraToolCalls: 0 },
+          { toolCallOrder: "ignore" },
+        ),
+      ),
+    ).toBe("capability");
+    expect(
+      deriveCaseKind(
+        resolveMatchOptions(undefined, {
+          toolCallOrder: "strict",
+          maxExtraToolCalls: 0,
+        }),
+      ),
+    ).toBe("regression");
+  });
+});
+
+describe("matchOptionsForKind", () => {
+  it("writes capability as byte-identical MATCH_OPTIONS_DEFAULTS", () => {
+    expect(matchOptionsForKind("capability")).toEqual(MATCH_OPTIONS_DEFAULTS);
+  });
+
+  it("writes regression as strict order, 0 extras, partial args", () => {
+    expect(matchOptionsForKind("regression")).toEqual({
+      toolCallOrder: "strict",
+      maxExtraToolCalls: 0,
+      argumentMatching: "partial",
+    });
+  });
+});
+
+describe("isSimpleCaseShape", () => {
+  it("accepts a prompt-only case", () => {
+    expect(isSimpleCaseShape([prompt("p1", "What is the status?")])).toBe(
+      true,
+    );
+  });
+
+  it("accepts a prompt plus toolCalledWith asserts", () => {
+    expect(
+      isSimpleCaseShape([
+        prompt("p1", "List incidents"),
+        toolCalledWith("a1", "list_incidents"),
+        toolCalledWith("a2", "get_incident", { id: "1" }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("rejects empty steps", () => {
+    expect(isSimpleCaseShape([])).toBe(false);
+  });
+
+  it("rejects a toolCall step", () => {
+    expect(
+      isSimpleCaseShape([
+        prompt("p1", "go"),
+        {
+          id: "c1",
+          kind: "toolCall",
+          serverName: "srv",
+          toolName: "list_incidents",
+          arguments: {},
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it("rejects an interact step", () => {
+    expect(
+      isSimpleCaseShape([
+        prompt("p1", "go"),
+        {
+          id: "i1",
+          kind: "interact",
+          toolName: "create_view",
+          action: { kind: "click", target: { testId: "canvas" } },
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it("rejects a widget assert", () => {
+    expect(
+      isSimpleCaseShape([
+        prompt("p1", "go"),
+        {
+          id: "w1",
+          kind: "assert",
+          assertion: { kind: "textVisible", text: "ok" },
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it("rejects a non-toolCalledWith inline predicate", () => {
+    expect(
+      isSimpleCaseShape([
+        prompt("p1", "go"),
+        {
+          id: "a1",
+          kind: "assert",
+          assertion: { type: "responseContains", needle: "ok" },
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it("rejects a second prompt", () => {
+    expect(
+      isSimpleCaseShape([
+        prompt("p1", "first"),
+        toolCalledWith("a1", "search"),
+        prompt("p2", "second"),
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("readSimpleCase / writeSimpleCase", () => {
+  it("round-trips prompt, tool ids, and args", () => {
+    const steps: TestStep[] = [
+      prompt("p1", "Find the latest incidents"),
+      toolCalledWith("a1", "list_incidents", { limit: 5 }),
+      toolCalledWith("a2", "get_incident", { id: "abc" }),
+    ];
+    const view = readSimpleCase(steps);
+    expect(view).toEqual({
+      prompt: "Find the latest incidents",
+      noTool: false,
+      tools: [
+        { id: "a1", toolName: "list_incidents", arguments: { limit: 5 } },
+        { id: "a2", toolName: "get_incident", arguments: { id: "abc" } },
+      ],
+    });
+    expect(writeSimpleCase(steps, view)).toEqual(steps);
+  });
+
+  it("keeps step 0's id when rewriting the prompt", () => {
+    const next = writeSimpleCase([prompt("turn-1", "old")], {
+      prompt: "new",
+      tools: [],
+      noTool: false,
+    });
+    expect(next[0]).toEqual({ id: "turn-1", kind: "prompt", prompt: "new" });
+  });
+
+  it("noTool drops only toolCalledWith asserts", () => {
+    const steps: TestStep[] = [
+      prompt("p1", "Do not call anything"),
+      toolCalledWith("a1", "search"),
+      {
+        id: "extra",
+        kind: "assert",
+        assertion: { type: "responseContains", needle: "ok" },
+      },
+    ];
+    const next = writeSimpleCase(steps, {
+      prompt: "Do not call anything",
+      tools: [{ id: "a1", toolName: "search", arguments: {} }],
+      noTool: true,
+    });
+    expect(next).toEqual([
+      prompt("p1", "Do not call anything"),
+      {
+        id: "extra",
+        kind: "assert",
+        assertion: { type: "responseContains", needle: "ok" },
+      },
+    ]);
+    expect(next.some((s) => s.id === "a1")).toBe(false);
+  });
+
+  it("reuses existing tool assert ids by index when ids are omitted", () => {
+    const prev: TestStep[] = [
+      prompt("p1", "go"),
+      toolCalledWith("a1", "search", { q: "old" }),
+    ];
+    const next = writeSimpleCase(prev, {
+      prompt: "go",
+      noTool: false,
+      tools: [{ toolName: "search", arguments: { q: "new" } }],
+    });
+    expect(next[1]).toEqual(
+      toolCalledWith("a1", "search", { q: "new" }),
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/simple-case-model.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/simple-case-model.test.ts
@@ -3,13 +3,16 @@ import {
   MATCH_OPTIONS_DEFAULTS,
   resolveMatchOptions,
 } from "@/shared/eval-matching";
+import { PREDICATE_KIND_LABELS } from "@/shared/predicate-kinds";
 import { type TestStep } from "@/shared/steps";
 import {
   deriveCaseKind,
   displayCaseKind,
+  EXCLUDED_FROM_MORE_CHECKS,
   initialToolsChoice,
   isSimpleCaseShape,
   matchOptionsForKind,
+  MORE_CHECK_GROUPS,
   readSimpleCase,
   writeSimpleCase,
 } from "../simple-case/simple-case-model";
@@ -98,14 +101,14 @@ describe("deriveCaseKind", () => {
   });
 
   it("lets a persisted kind win over derived matchOptions", () => {
+    expect(displayCaseKind("regression", MATCH_OPTIONS_DEFAULTS)).toBe(
+      "regression",
+    );
     expect(
-      displayCaseKind("regression", MATCH_OPTIONS_DEFAULTS),
-    ).toBe("regression");
-    expect(
-      displayCaseKind(
-        "capability",
-        { toolCallOrder: "strict", maxExtraToolCalls: 0 },
-      ),
+      displayCaseKind("capability", {
+        toolCallOrder: "strict",
+        maxExtraToolCalls: 0,
+      }),
     ).toBe("capability");
     expect(displayCaseKind(undefined, MATCH_OPTIONS_DEFAULTS)).toBe(
       "capability",
@@ -151,9 +154,7 @@ describe("matchOptionsForKind", () => {
 
 describe("isSimpleCaseShape", () => {
   it("accepts a prompt-only case", () => {
-    expect(isSimpleCaseShape([prompt("p1", "What is the status?")])).toBe(
-      true,
-    );
+    expect(isSimpleCaseShape([prompt("p1", "What is the status?")])).toBe(true);
   });
 
   it("accepts a prompt plus toolCalledWith asserts", () => {
@@ -300,8 +301,53 @@ describe("readSimpleCase / writeSimpleCase", () => {
       noTool: false,
       tools: [{ toolName: "search", arguments: { q: "new" } }],
     });
-    expect(next[1]).toEqual(
-      toolCalledWith("a1", "search", { q: "new" }),
-    );
+    expect(next[1]).toEqual(toolCalledWith("a1", "search", { q: "new" }));
+  });
+});
+
+describe("matchOptionsForKind carries argument matching over", () => {
+  it("keeps an authored exact when the kind flips", () => {
+    expect(
+      matchOptionsForKind("regression", { argumentMatching: "exact" }),
+    ).toEqual({
+      toolCallOrder: "strict",
+      maxExtraToolCalls: 0,
+      argumentMatching: "exact",
+    });
+    expect(
+      matchOptionsForKind("capability", { argumentMatching: "exact" }),
+    ).toEqual({ ...MATCH_OPTIONS_DEFAULTS, argumentMatching: "exact" });
+  });
+
+  it("falls back to the SDK default without a current value", () => {
+    expect(matchOptionsForKind("capability")).toEqual(MATCH_OPTIONS_DEFAULTS);
+  });
+});
+
+describe("More checks groups partition the predicate catalog", () => {
+  it("files every predicate kind exactly once, or excludes it on purpose", () => {
+    const filed = new Map<string, string[]>();
+    for (const group of MORE_CHECK_GROUPS) {
+      for (const kind of group.kinds) {
+        filed.set(kind, [...(filed.get(kind) ?? []), group.id]);
+      }
+    }
+    for (const kind of Object.keys(PREDICATE_KIND_LABELS)) {
+      const groups = filed.get(kind) ?? [];
+      const excluded = EXCLUDED_FROM_MORE_CHECKS.has(
+        kind as Parameters<typeof EXCLUDED_FROM_MORE_CHECKS.has>[0],
+      );
+      expect(
+        { kind, groups, excluded },
+        `predicate kind "${kind}" must be in exactly one More checks group or excluded on purpose`,
+      ).toSatisfy(
+        (entry: { groups: string[]; excluded: boolean }) =>
+          (entry.groups.length === 1 && !entry.excluded) ||
+          (entry.groups.length === 0 && entry.excluded),
+      );
+    }
+    for (const kind of EXCLUDED_FROM_MORE_CHECKS) {
+      expect(kind in PREDICATE_KIND_LABELS).toBe(true);
+    }
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/simple-case-model.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/simple-case-model.test.ts
@@ -6,6 +6,7 @@ import {
 import { type TestStep } from "@/shared/steps";
 import {
   deriveCaseKind,
+  initialToolsChoice,
   isSimpleCaseShape,
   matchOptionsForKind,
   readSimpleCase,
@@ -93,6 +94,28 @@ describe("deriveCaseKind", () => {
         }),
       ),
     ).toBe("regression");
+  });
+});
+
+describe("initialToolsChoice", () => {
+  it("is unset for a prompt-only unfinished case", () => {
+    expect(initialToolsChoice({ tools: [], isNegativeTest: false })).toBe(
+      "unset",
+    );
+  });
+
+  it("is noTool when the saved case is already negative", () => {
+    expect(initialToolsChoice({ tools: [], isNegativeTest: true })).toBe(
+      "noTool",
+    );
+  });
+
+  it("is tools when toolCalledWith asserts exist", () => {
+    expect(
+      initialToolsChoice({
+        tools: [{ id: "a1", toolName: "search", arguments: {} }],
+      }),
+    ).toBe("tools");
   });
 });
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/simple-case-model.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/simple-case-model.test.ts
@@ -6,6 +6,7 @@ import {
 import { type TestStep } from "@/shared/steps";
 import {
   deriveCaseKind,
+  displayCaseKind,
   initialToolsChoice,
   isSimpleCaseShape,
   matchOptionsForKind,
@@ -94,6 +95,21 @@ describe("deriveCaseKind", () => {
         }),
       ),
     ).toBe("regression");
+  });
+
+  it("lets a persisted kind win over derived matchOptions", () => {
+    expect(
+      displayCaseKind("regression", MATCH_OPTIONS_DEFAULTS),
+    ).toBe("regression");
+    expect(
+      displayCaseKind(
+        "capability",
+        { toolCallOrder: "strict", maxExtraToolCalls: 0 },
+      ),
+    ).toBe("capability");
+    expect(displayCaseKind(undefined, MATCH_OPTIONS_DEFAULTS)).toBe(
+      "capability",
+    );
   });
 });
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-cases-overview.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-cases-overview.test.tsx
@@ -11,6 +11,7 @@ import { TestCasesOverview } from "../test-cases-overview";
 
 const useConvexMock = vi.hoisted(() => vi.fn());
 const useQueryMock = vi.hoisted(() => vi.fn());
+const flagMock = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("posthog-js", () => ({
   default: {
@@ -30,6 +31,10 @@ vi.mock("@/lib/PosthogUtils", () => ({
 vi.mock("convex/react", () => ({
   useConvex: useConvexMock,
   useQuery: useQueryMock,
+}));
+
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: flagMock,
 }));
 
 describe("TestCasesOverview", () => {
@@ -73,6 +78,7 @@ describe("TestCasesOverview", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    flagMock.mockReturnValue(false);
   });
 
   it("hydrates saved quick runs from fresh case metadata and iteration queries", async () => {
@@ -635,5 +641,62 @@ describe("TestCasesOverview", () => {
     expect(secondEvent.defaultPrevented).toBe(true);
     expect(checkbox).not.toBeChecked();
     expect(onTestCaseClick).not.toHaveBeenCalled();
+  });
+
+  it("keeps Generate and New case when the simple editor flag is off", () => {
+    useConvexMock.mockReturnValue({ query: vi.fn() });
+    useQueryMock.mockReturnValue(undefined);
+    renderWithProviders(
+      <TestCasesOverview
+        suite={suite}
+        cases={[]}
+        allIterations={[]}
+        runsViewMode="test-cases"
+        onViewModeChange={vi.fn()}
+        onTestCaseClick={vi.fn()}
+        hideViewModeSelect
+        onGenerateTestCases={vi.fn()}
+        canGenerateTestCases
+        onCreateTestCase={vi.fn()}
+        onRecordTestCase={vi.fn()}
+        runTrendData={[]}
+        modelStats={[]}
+        runsLoading={false}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Generate" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "New case" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Record" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Write" })).not.toBeInTheDocument();
+    expect(screen.queryByText(/mcpjam cloud eval/)).not.toBeInTheDocument();
+  });
+
+  it("shows Generate, Record, and Write plus a CLI import pointer when the flag is on", () => {
+    flagMock.mockReturnValue(true);
+    useConvexMock.mockReturnValue({ query: vi.fn() });
+    useQueryMock.mockReturnValue(undefined);
+    renderWithProviders(
+      <TestCasesOverview
+        suite={suite}
+        cases={[]}
+        allIterations={[]}
+        runsViewMode="test-cases"
+        onViewModeChange={vi.fn()}
+        onTestCaseClick={vi.fn()}
+        hideViewModeSelect
+        onGenerateTestCases={vi.fn()}
+        canGenerateTestCases
+        onCreateTestCase={vi.fn()}
+        onRecordTestCase={vi.fn()}
+        runTrendData={[]}
+        modelStats={[]}
+        runsLoading={false}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Generate" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Record" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Write" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "New case" })).not.toBeInTheDocument();
+    expect(screen.getByText(/mcpjam cloud eval/)).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -6,6 +6,7 @@ import { PreferencesStoreProvider } from "@/stores/preferences/preferences-provi
 import { TestTemplateEditor } from "../test-template-editor";
 import type { EvalIteration } from "../types";
 import { SIMPLE_CASE_EDITOR_FLAG } from "../simple-case/simple-case-model";
+import { STAGE_ANALYZER_VERSION } from "@mcpjam/sdk/contract";
 
 function renderWithProviders(
   ui: ReactElement,
@@ -1019,6 +1020,125 @@ describe("TestTemplateEditor run view from route", () => {
       expect(screen.getByText("User prompt")).toBeInTheDocument();
     });
     expect(screen.queryByTestId("simple-case-form")).not.toBeInTheDocument();
+  });
+
+  it("shows the quick-run chain in the latest-traced pane", async () => {
+    flagMock.mockReturnValue(true);
+    const quickRun: EvalIteration = {
+      ...baseIteration,
+      _id: "quick-1",
+      suiteRunId: undefined,
+      blob: "trace",
+      metadata: {
+        stageResults: [
+          { stage: "connection", state: "passed" },
+          { stage: "discovery", state: "passed" },
+          { stage: "selection", state: "passed" },
+          { stage: "call", state: "failed", reason: "argumentMismatch" },
+          { stage: "response", state: "notReached", reason: "earlierStageFailed" },
+          { stage: "userValue", state: "notReached", reason: "earlierStageFailed" },
+        ],
+        firstFailedStage: "call",
+        failureCategory: "arguments",
+        stageAnalyzerVersion: STAGE_ANALYZER_VERSION,
+      },
+    };
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteIterations={[quickRun]}
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        projectId={null}
+        trialChainEnabled
+        availableModels={[
+          {
+            provider: "openai",
+            model: "gpt-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("trial-chain-panel")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("iteration-trial-chain")).toBeInTheDocument();
+  });
+
+  it("shows the quick-run chain in RunColumn after a just-finished run", async () => {
+    const user = userEvent.setup();
+    flagMock.mockReturnValue(true);
+    streamEvalTestCaseMock.mockImplementation(
+      async (
+        _request: unknown,
+        onEvent: (event: {
+          type: "complete";
+          iterationId: string;
+          iteration: EvalIteration;
+        }) => void,
+      ) => {
+        onEvent({
+          type: "complete",
+          iterationId: "quick-run-1",
+          iteration: {
+            ...baseIteration,
+            _id: "quick-run-1",
+            suiteRunId: undefined,
+            blob: "trace",
+            metadata: {
+              stageResults: [
+                { stage: "connection", state: "passed" },
+                { stage: "discovery", state: "passed" },
+                { stage: "selection", state: "passed" },
+                { stage: "call", state: "failed", reason: "argumentMismatch" },
+                {
+                  stage: "response",
+                  state: "notReached",
+                  reason: "earlierStageFailed",
+                },
+                {
+                  stage: "userValue",
+                  state: "notReached",
+                  reason: "earlierStageFailed",
+                },
+              ],
+              firstFailedStage: "call",
+              failureCategory: "arguments",
+              stageAnalyzerVersion: STAGE_ANALYZER_VERSION,
+            },
+          },
+        });
+      },
+    );
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteIterations={[]}
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        projectId={null}
+        trialChainEnabled
+        availableModels={[
+          {
+            provider: "openai",
+            model: "gpt-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button", { name: /run$/i })[0],
+      ).toBeInTheDocument();
+    });
+    await user.click(screen.getAllByRole("button", { name: /run$/i })[0]!);
+    await waitFor(() => {
+      expect(screen.getByTestId("trial-chain-panel")).toBeInTheDocument();
+    });
   });
 
   it("runs compare across case-configured models and reuses the compare session id for per-model retry", async () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { PreferencesStoreProvider } from "@/stores/preferences/preferences-provider";
 import { TestTemplateEditor } from "../test-template-editor";
 import type { EvalIteration } from "../types";
+import { SIMPLE_CASE_EDITOR_FLAG } from "../simple-case/simple-case-model";
 
 function renderWithProviders(
   ui: ReactElement,
@@ -35,6 +36,7 @@ const updateTestCaseMutationMock = vi.hoisted(() => vi.fn());
 const streamEvalTestCaseMock = vi.hoisted(() => vi.fn());
 const runEvalTestCaseMock = vi.hoisted(() => vi.fn());
 const mockTraceViewer = vi.hoisted(() => vi.fn());
+const flagMock = vi.hoisted(() => vi.fn(() => false));
 const getGuestBearerTokenMock = vi.hoisted(() =>
   vi.fn().mockResolvedValue("guest-token"),
 );
@@ -157,6 +159,10 @@ vi.mock("posthog-js", () => ({
   default: { capture: vi.fn() },
 }));
 
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: flagMock,
+}));
+
 vi.mock("@/lib/PosthogUtils", () => ({
   detectEnvironment: () => "test",
   detectPlatform: () => "web",
@@ -178,6 +184,7 @@ vi.mock("convex/react", () => ({
   useQuery: (name: unknown, args: unknown) => useQueryMock(name, args),
   useAction: () => vi.fn(),
   useConvexAuth: () => useConvexAuthMock,
+  useConvex: () => ({ query: vi.fn() }),
 }));
 
 describe("TestTemplateEditor run view from route", () => {
@@ -299,6 +306,7 @@ describe("TestTemplateEditor run view from route", () => {
   beforeEach(() => {
     activeCaseDoc = caseDoc;
     vi.clearAllMocks();
+    flagMock.mockReturnValue(false);
     mockTraceViewer.mockReset();
     useMutationMock.mockImplementation((name: string) => {
       if (name === "testSuites:updateTestCase") {
@@ -830,6 +838,187 @@ describe("TestTemplateEditor run view from route", () => {
 
     expect(screen.getByText("Steps")).toBeInTheDocument();
     expect(screen.queryByText("Prompt steps")).not.toBeInTheDocument();
+  });
+
+  it("renders the simple form for a single-turn case when the flag is on", async () => {
+    flagMock.mockReturnValue(true);
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteIterations={[baseIteration]}
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        projectId={null}
+        availableModels={[
+          {
+            provider: "openai",
+            model: "gpt-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+        onExportDraft={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("simple-case-form")).toBeInTheDocument();
+    });
+    expect(flagMock).toHaveBeenCalledWith(SIMPLE_CASE_EDITOR_FLAG);
+    expect(screen.getByText("What does the user ask?")).toBeInTheDocument();
+    expect(screen.queryByText("User prompt")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the flat step-list editor for a multi-turn case even with the flag on", async () => {
+    flagMock.mockReturnValue(true);
+    activeCaseDoc = {
+      ...caseDoc,
+      steps: [
+        { id: "p1", kind: "prompt", prompt: "first" },
+        { id: "p2", kind: "prompt", prompt: "second" },
+      ],
+    };
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteIterations={[baseIteration]}
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        projectId={null}
+        availableModels={[
+          {
+            provider: "openai",
+            model: "gpt-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+        onExportDraft={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText("User prompt").length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByTestId("simple-case-form")).not.toBeInTheDocument();
+    expect(screen.getByText("Steps")).toBeInTheDocument();
+  });
+
+  it("saves a no-tool simple case as a negative test", async () => {
+    const user = userEvent.setup();
+    flagMock.mockReturnValue(true);
+    activeCaseDoc = {
+      ...caseDoc,
+      isNegativeTest: false,
+      steps: [
+        { id: "turn-1", kind: "prompt", prompt: "Find the latest incidents" },
+        {
+          id: "a1",
+          kind: "assert",
+          assertion: {
+            type: "toolCalledWith",
+            toolName: "list_incidents",
+            args: { args: {} },
+          },
+        },
+      ],
+    };
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteIterations={[]}
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        projectId={null}
+        availableModels={[
+          {
+            provider: "openai",
+            model: "gpt-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("simple-case-form")).toBeInTheDocument();
+    });
+    await user.click(
+      screen.getByRole("button", { name: "No tool should be called" }),
+    );
+    await user.click(screen.getAllByRole("button", { name: /save/i })[0]!);
+    await waitFor(() => {
+      expect(updateTestCaseMutationMock).toHaveBeenCalled();
+    });
+    expect(updateTestCaseMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isNegativeTest: true,
+        expectedToolCalls: [],
+      }),
+    );
+  });
+
+  it("blocks Run while the simple-form tools choice is unset", async () => {
+    flagMock.mockReturnValue(true);
+    activeCaseDoc = {
+      ...caseDoc,
+      isNegativeTest: false,
+      query: "Find the latest incidents",
+      steps: [
+        { id: "turn-1", kind: "prompt", prompt: "Find the latest incidents" },
+      ],
+    };
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteIterations={[]}
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        projectId={null}
+        availableModels={[
+          {
+            provider: "openai",
+            model: "gpt-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("simple-case-tools-unset")).toBeInTheDocument();
+    });
+    expect(
+      screen.getAllByRole("button", { name: /run$/i })[0],
+    ).toBeDisabled();
+  });
+
+  it("mounts the step list from the simple form Steps link", async () => {
+    const user = userEvent.setup();
+    flagMock.mockReturnValue(true);
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteIterations={[baseIteration]}
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        projectId={null}
+        availableModels={[
+          {
+            provider: "openai",
+            model: "gpt-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("simple-case-form")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: "Steps" }));
+    await waitFor(() => {
+      expect(screen.getByText("User prompt")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("simple-case-form")).not.toBeInTheDocument();
   });
 
   it("runs compare across case-configured models and reuses the compare session id for per-model retry", async () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -1294,6 +1294,7 @@ describe("TestTemplateEditor run view from route", () => {
       expectedToolCalls: [],
       lastMessageRun: undefined,
       expectedOutput: "Names the latest incident and its status",
+      kind: "capability" as const,
     };
 
     useQueryMock.mockImplementation((name: string) => {
@@ -1350,6 +1351,7 @@ describe("TestTemplateEditor run view from route", () => {
         expectedToolCalls: [],
         isNegativeTest: true,
         expectedOutput: "Names the latest incident and its status",
+        kind: "capability",
         steps: [
           expect.objectContaining({
             id: "turn-1",

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -1141,6 +1141,73 @@ describe("TestTemplateEditor run view from route", () => {
     });
   });
 
+  it("shows the observational route rollup for a multi-trial quick run", async () => {
+    flagMock.mockReturnValue(true);
+    const metadata = { compareRunId: "cmp_rollup" };
+    const trials: EvalIteration[] = [
+      {
+        ...baseIteration,
+        _id: "t1",
+        suiteRunId: undefined,
+        blob: "trace",
+        createdAt: 10,
+        actualToolCalls: [
+          { toolName: "search", arguments: {} },
+          { toolName: "get", arguments: {} },
+        ],
+        metadata,
+      },
+      {
+        ...baseIteration,
+        _id: "t2",
+        suiteRunId: undefined,
+        blob: "trace",
+        createdAt: 11,
+        actualToolCalls: [
+          { toolName: "search", arguments: {} },
+          { toolName: "get", arguments: {} },
+        ],
+        metadata,
+      },
+      {
+        ...baseIteration,
+        _id: "t3",
+        suiteRunId: undefined,
+        blob: "trace",
+        createdAt: 12,
+        actualToolCalls: [{ toolName: "list", arguments: {} }],
+        metadata,
+      },
+    ];
+    activeCaseDoc = { ...caseDoc, lastMessageRun: "t3" };
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteIterations={trials}
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        projectId={null}
+        trialChainEnabled
+        availableModels={[
+          {
+            provider: "openai",
+            model: "gpt-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("route-rollup-card")).toBeInTheDocument();
+    });
+    const card = screen.getByTestId("route-rollup-card");
+    expect(card).toHaveTextContent("Across 3 trials");
+    expect(card).toHaveTextContent("same route in 2 of 3");
+    expect(card).toHaveTextContent("Observational");
+    expect(card).not.toHaveTextContent(/pass|fail|verdict/i);
+  });
+
   it("runs compare across case-configured models and reuses the compare session id for per-model retry", async () => {
     const user = userEvent.setup();
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -917,6 +917,7 @@ describe("TestTemplateEditor run view from route", () => {
       promptTurns: undefined,
       expectedToolCalls: [],
       lastMessageRun: undefined,
+      expectedOutput: "Names the latest incident and its status",
     };
 
     useQueryMock.mockImplementation((name: string) => {
@@ -972,6 +973,7 @@ describe("TestTemplateEditor run view from route", () => {
         runs: 1,
         expectedToolCalls: [],
         isNegativeTest: true,
+        expectedOutput: "Names the latest incident and its status",
         steps: [
           expect.objectContaining({
             id: "turn-1",

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-validation.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-validation.test.tsx
@@ -38,6 +38,10 @@ vi.mock("posthog-js", () => ({
   default: { capture: vi.fn() },
 }));
 
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => false,
+}));
+
 vi.mock("@/lib/PosthogUtils", () => ({
   detectEnvironment: () => "test",
   detectPlatform: () => "web",
@@ -53,6 +57,7 @@ vi.mock("convex/react", () => ({
   useQuery: (name: unknown, args: unknown) => useQueryMock(name, args),
   useAction: () => vi.fn(),
   useConvexAuth: () => ({ isAuthenticated: false, isLoading: false }),
+  useConvex: () => ({ query: vi.fn() }),
 }));
 
 describe("getStepsBlockReason", () => {

--- a/mcpjam-inspector/client/src/components/evals/checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/checks-section.tsx
@@ -582,7 +582,7 @@ function ToolNameField({
   );
 }
 
-function ToolCalledWithFields({
+export function ToolCalledWithFields({
   predicate,
   onChange,
   availableTools,

--- a/mcpjam-inspector/client/src/components/evals/draft-test-case.ts
+++ b/mcpjam-inspector/client/src/components/evals/draft-test-case.ts
@@ -6,16 +6,20 @@
  * time someone opens the New case menu.
  *
  * The draft kind is carried inside the `test-edit` route's `testId` as an opaque
- * sentinel (e.g. `draft:prompt`), so no route/navigation plumbing has to learn a
- * new field — every consumer keeps treating `testId` as a string. The sentinel
- * is not a real Convex id, so it must never be handed to a Convex query.
+ * sentinel (e.g. `draft:prompt` or `draft:record`), so no route/navigation
+ * plumbing has to learn a new field — every consumer keeps treating `testId`
+ * as a string. The sentinel is not a real Convex id, so it must never be
+ * handed to a Convex query.
+ *
+ * `record` is run-once-then-adopt (Quick Run, then use the observed route),
+ * not the widget recorder.
  */
 
-// Render checks were unified into pinned prompt turns (created inside the
-// editor), so the only top-level draft kind is a prompt test case.
-export type DraftCaseKind = "prompt";
+export type DraftCaseKind = "prompt" | "record";
 
 const DRAFT_TEST_CASE_PREFIX = "draft:";
+
+const DRAFT_KINDS = new Set<DraftCaseKind>(["prompt", "record"]);
 
 /** Route `testId` sentinel for an unsaved case of the given kind. */
 export function draftTestCaseId(kind: DraftCaseKind): string {
@@ -30,7 +34,9 @@ export function parseDraftTestCaseId(
     return null;
   }
   const kind = id.slice(DRAFT_TEST_CASE_PREFIX.length);
-  return kind === "prompt" ? kind : null;
+  return DRAFT_KINDS.has(kind as DraftCaseKind)
+    ? (kind as DraftCaseKind)
+    : null;
 }
 
 export function isDraftTestCaseId(id: string | null | undefined): boolean {

--- a/mcpjam-inspector/client/src/components/evals/simple-case/case-suite-chips.tsx
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/case-suite-chips.tsx
@@ -1,0 +1,74 @@
+import { Button } from "@mcpjam/design-system/button";
+import { cn } from "@/lib/utils";
+
+export type CaseSuiteChipsProps = {
+  models: string[];
+  trials: number;
+  hostLabel: string;
+  onOpenSuiteSettings?: () => void;
+};
+
+function Chip({
+  label,
+  value,
+  onOpen,
+}: {
+  label: string;
+  value: string;
+  onOpen?: () => void;
+}) {
+  const body = (
+    <>
+      <span className="text-muted-foreground">{label}</span>
+      <span className="truncate text-foreground">{value}</span>
+    </>
+  );
+  const className = cn(
+    "inline-flex max-w-[14rem] items-center gap-1.5 rounded-md border border-border bg-muted/40 px-2 py-1 text-[11px]",
+  );
+  if (!onOpen) {
+    return <span className={className}>{body}</span>;
+  }
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      className={cn(className, "h-auto hover:bg-muted")}
+      onClick={onOpen}
+    >
+      {body}
+    </Button>
+  );
+}
+
+export function CaseSuiteChips({
+  models,
+  trials,
+  hostLabel,
+  onOpenSuiteSettings,
+}: CaseSuiteChipsProps) {
+  const modelValue =
+    models.length === 0
+      ? "Suite default"
+      : models.length === 1
+        ? models[0]
+        : `${models[0]} +${models.length - 1}`;
+  return (
+    <div
+      className="flex flex-wrap items-center gap-1.5"
+      data-testid="case-suite-chips"
+    >
+      <Chip
+        label="Model"
+        value={modelValue}
+        onOpen={onOpenSuiteSettings}
+      />
+      <Chip
+        label="Trials"
+        value={String(trials)}
+        onOpen={onOpenSuiteSettings}
+      />
+      <Chip label="Host" value={hostLabel} onOpen={onOpenSuiteSettings} />
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/simple-case/case-suite-chips.tsx
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/case-suite-chips.tsx
@@ -58,11 +58,7 @@ export function CaseSuiteChips({
       className="flex flex-wrap items-center gap-1.5"
       data-testid="case-suite-chips"
     >
-      <Chip
-        label="Model"
-        value={modelValue}
-        onOpen={onOpenSuiteSettings}
-      />
+      <Chip label="Model" value={modelValue} onOpen={onOpenSuiteSettings} />
       <Chip
         label="Trials"
         value={String(trials)}

--- a/mcpjam-inspector/client/src/components/evals/simple-case/quick-run-chain.ts
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/quick-run-chain.ts
@@ -1,0 +1,29 @@
+import {
+  assembleEvalRunDecisionChain,
+  projectStageDerivation,
+  type EvalRunDecisionChain,
+} from "@mcpjam/sdk/contract";
+import type { EvalIteration } from "../types";
+
+/**
+ * Assemble a decision chain from a quick-run iteration the client already
+ * holds. Uses the same projection + assembler as the server so the
+ * verified/unverified/absent discriminant is not re-derived from raw
+ * `metadata.stageResults`.
+ */
+export function chainForQuickRunIteration(
+  iteration: EvalIteration,
+): EvalRunDecisionChain {
+  return assembleEvalRunDecisionChain({
+    id: iteration._id,
+    iterationNumber: iteration.iterationNumber,
+    status: iteration.status,
+    result: iteration.result,
+    testCaseId: iteration.testCaseId,
+    title: iteration.testCaseSnapshot?.title,
+    expectedToolCalls: iteration.testCaseSnapshot?.expectedToolCalls,
+    actualToolCalls: iteration.actualToolCalls,
+    error: iteration.error,
+    ...projectStageDerivation(iteration.metadata),
+  });
+}

--- a/mcpjam-inspector/client/src/components/evals/simple-case/route-rollup-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/route-rollup-card.tsx
@@ -23,28 +23,31 @@ export function RouteRollupCard({
   onAdoptTrialRoute,
   adoptPrimary = false,
 }: RouteRollupCardProps) {
-  if (rollup.total < 2) return null;
+  if (rollup.total < 2 && !onAdoptTrialRoute) return null;
   const top = rollup.routes[0];
+  const showSummary = rollup.total >= 2;
   return (
     <div
       className="space-y-2 rounded-md border border-border bg-muted/20 p-3"
       data-testid="route-rollup-card"
     >
-      <div className="flex items-start justify-between gap-2">
-        <div>
-          <p className="text-[11px] font-medium text-foreground">
-            Across {rollup.total} trials
-          </p>
-          {top ? (
-            <p className="text-[11px] text-muted-foreground">
-              same route in {top.count} of {rollup.total}
+      {showSummary ? (
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <p className="text-[11px] font-medium text-foreground">
+              Across {rollup.total} trials
             </p>
-          ) : null}
+            {top ? (
+              <p className="text-[11px] text-muted-foreground">
+                same route in {top.count} of {rollup.total}
+              </p>
+            ) : null}
+          </div>
+          <span className="rounded-md border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+            Observational
+          </span>
         </div>
-        <span className="rounded-md border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-          Observational
-        </span>
-      </div>
+      ) : null}
       {expectedPathKey ? (
         <p className="text-[11px] text-muted-foreground">
           Expected route: {formatPath(expectedPathKey)}

--- a/mcpjam-inspector/client/src/components/evals/simple-case/route-rollup-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/route-rollup-card.tsx
@@ -1,8 +1,5 @@
 import { Button } from "@mcpjam/design-system/button";
-import {
-  NO_TOOL_PATH_KEY,
-  PATH_SEPARATOR,
-} from "../../../../../../sdk/src/tool-path";
+import { NO_TOOL_PATH_KEY, PATH_SEPARATOR } from "@mcpjam/sdk/contract";
 import type { RouteRollup } from "./route-rollup";
 
 export type RouteRollupCardProps = {

--- a/mcpjam-inspector/client/src/components/evals/simple-case/route-rollup-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/route-rollup-card.tsx
@@ -1,0 +1,78 @@
+import { Button } from "@mcpjam/design-system/button";
+import {
+  NO_TOOL_PATH_KEY,
+  PATH_SEPARATOR,
+} from "../../../../../../sdk/src/tool-path";
+import type { RouteRollup } from "./route-rollup";
+
+export type RouteRollupCardProps = {
+  rollup: RouteRollup;
+  expectedPathKey?: string;
+  onAdoptTrialRoute?: () => void;
+  adoptPrimary?: boolean;
+};
+
+function formatPath(pathKey: string): string {
+  if (pathKey === NO_TOOL_PATH_KEY) return "no tools";
+  return pathKey.split(PATH_SEPARATOR).join(` ${PATH_SEPARATOR} `);
+}
+
+export function RouteRollupCard({
+  rollup,
+  expectedPathKey,
+  onAdoptTrialRoute,
+  adoptPrimary = false,
+}: RouteRollupCardProps) {
+  if (rollup.total < 2) return null;
+  const top = rollup.routes[0];
+  return (
+    <div
+      className="space-y-2 rounded-md border border-border bg-muted/20 p-3"
+      data-testid="route-rollup-card"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="text-[11px] font-medium text-foreground">
+            Across {rollup.total} trials
+          </p>
+          {top ? (
+            <p className="text-[11px] text-muted-foreground">
+              same route in {top.count} of {rollup.total}
+            </p>
+          ) : null}
+        </div>
+        <span className="rounded-md border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+          Observational
+        </span>
+      </div>
+      {expectedPathKey ? (
+        <p className="text-[11px] text-muted-foreground">
+          Expected route: {formatPath(expectedPathKey)}
+        </p>
+      ) : null}
+      <ul className="space-y-1">
+        {rollup.routes.map((route) => (
+          <li
+            key={route.pathKey}
+            className="text-[11px] text-foreground"
+            data-testid="route-rollup-row"
+          >
+            {formatPath(route.pathKey)}
+            <span className="text-muted-foreground"> · {route.count}</span>
+          </li>
+        ))}
+      </ul>
+      {onAdoptTrialRoute ? (
+        <Button
+          type="button"
+          variant={adoptPrimary ? "default" : "outline"}
+          size="sm"
+          className="h-7 text-xs"
+          onClick={onAdoptTrialRoute}
+        >
+          Use this trial&apos;s route as expected
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/simple-case/route-rollup.ts
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/route-rollup.ts
@@ -1,4 +1,4 @@
-import { buildPathKey } from "../../../../../../sdk/src/tool-path";
+import { buildPathKey } from "@mcpjam/sdk/contract";
 import type { TestStep } from "@/shared/steps";
 import { groupCaseIterations } from "../runs/group-case-iterations";
 import type { EvalIteration } from "../types";
@@ -26,8 +26,10 @@ export function toolsFromIteration(
   const calls = iteration.actualToolCalls ?? [];
   if (kind === "capability") {
     const seen = new Set<string>();
-    const tools: Array<{ toolName: string; arguments: Record<string, unknown> }> =
-      [];
+    const tools: Array<{
+      toolName: string;
+      arguments: Record<string, unknown>;
+    }> = [];
     for (const call of calls) {
       if (seen.has(call.toolName)) continue;
       seen.add(call.toolName);

--- a/mcpjam-inspector/client/src/components/evals/simple-case/route-rollup.ts
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/route-rollup.ts
@@ -1,0 +1,92 @@
+import { buildPathKey } from "../../../../../../sdk/src/tool-path";
+import type { TestStep } from "@/shared/steps";
+import { groupCaseIterations } from "../runs/group-case-iterations";
+import type { EvalIteration } from "../types";
+import {
+  readSimpleCase,
+  writeSimpleCase,
+  type CaseKind,
+} from "./simple-case-model";
+
+export type RouteSummary = {
+  pathKey: string;
+  count: number;
+  iterationIds: string[];
+};
+
+export type RouteRollup = {
+  total: number;
+  routes: RouteSummary[];
+};
+
+export function toolsFromIteration(
+  iteration: EvalIteration,
+  kind: "capability" | "regression",
+): Array<{ toolName: string; arguments: Record<string, unknown> }> {
+  const calls = iteration.actualToolCalls ?? [];
+  if (kind === "capability") {
+    const seen = new Set<string>();
+    const tools: Array<{ toolName: string; arguments: Record<string, unknown> }> =
+      [];
+    for (const call of calls) {
+      if (seen.has(call.toolName)) continue;
+      seen.add(call.toolName);
+      tools.push({ toolName: call.toolName, arguments: {} });
+    }
+    return tools;
+  }
+  return calls.map((call) => ({
+    toolName: call.toolName,
+    arguments: (call.arguments ?? {}) as Record<string, unknown>,
+  }));
+}
+
+/** Write this trial's observed route into the simple-case expected tools. */
+export function adoptRouteFromIteration(
+  steps: TestStep[],
+  iteration: EvalIteration,
+  kind: CaseKind,
+): TestStep[] {
+  const view = readSimpleCase(steps);
+  const tools = toolsFromIteration(iteration, kind);
+  return writeSimpleCase(steps, {
+    prompt: view.prompt,
+    tools,
+    noTool: tools.length === 0,
+  });
+}
+
+export function expectedPathKeyFromSteps(steps: TestStep[]): string {
+  return buildPathKey(readSimpleCase(steps).tools.map((tool) => tool.toolName));
+}
+
+export function pathKeyForIteration(iteration: EvalIteration): string {
+  return buildPathKey(
+    (iteration.actualToolCalls ?? []).map((call) => call.toolName),
+  );
+}
+
+/** Summarize routes over the latest batch of a case's iterations. */
+export function summarizeRoutes(iterations: EvalIteration[]): RouteRollup {
+  const batch = groupCaseIterations(iterations)[0];
+  const latest = batch?.iterations ?? [];
+  const byPath = new Map<string, RouteSummary>();
+  for (const iteration of latest) {
+    const pathKey = pathKeyForIteration(iteration);
+    const existing = byPath.get(pathKey);
+    if (existing) {
+      existing.count += 1;
+      existing.iterationIds.push(iteration._id);
+    } else {
+      byPath.set(pathKey, {
+        pathKey,
+        count: 1,
+        iterationIds: [iteration._id],
+      });
+    }
+  }
+  return {
+    total: latest.length,
+    routes: [...byPath.values()].sort((a, b) => b.count - a.count),
+  };
+}

--- a/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-form.tsx
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-form.tsx
@@ -94,6 +94,7 @@ export type SimpleCaseFormProps = {
   onOpenDeepEditor: () => void;
   onToolsChoiceBlockReasonChange?: (reason: string | null) => void;
   evalValidationBorderClass?: string;
+  autoFocusPrompt?: boolean;
 };
 
 export function SimpleCaseForm({
@@ -112,6 +113,7 @@ export function SimpleCaseForm({
   onOpenDeepEditor,
   onToolsChoiceBlockReasonChange,
   evalValidationBorderClass,
+  autoFocusPrompt = false,
 }: SimpleCaseFormProps) {
   const view = useMemo(() => readSimpleCase(steps), [steps]);
   const resolvedMatch = resolveMatchOptions(
@@ -262,6 +264,7 @@ export function SimpleCaseForm({
           onChange={(event) => setPrompt(event.target.value)}
           rows={4}
           placeholder="Enter the user prompt…"
+          autoFocus={autoFocusPrompt}
           aria-label="What does the user ask?"
           className={cn(
             "resize-none bg-background font-mono text-sm leading-relaxed",

--- a/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-form.tsx
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-form.tsx
@@ -135,6 +135,14 @@ export function SimpleCaseForm({
     return () => onToolsChoiceBlockReasonChange?.(null);
   }, [toolsChoice, onToolsChoiceBlockReasonChange]);
 
+  // Adopt / Generate / deep-editor writes can add tools while this form
+  // is mounted. Flip off "unset" so Save/Run unblock without a second click.
+  useEffect(() => {
+    if (view.tools.length > 0 && toolsChoice !== "tools") {
+      setToolsChoice("tools");
+    }
+  }, [view.tools, toolsChoice]);
+
   const resolvedPredicates =
     resolveCasePredicates(suiteDefaultPredicates, predicates) ?? [];
   const suiteToolCalledWithApplies =

--- a/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-form.tsx
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-form.tsx
@@ -1,0 +1,518 @@
+import { useEffect, useMemo, useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import { Textarea } from "@mcpjam/design-system/textarea";
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@mcpjam/design-system/toggle-group";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@mcpjam/design-system/collapsible";
+import { cn } from "@/lib/utils";
+import {
+  resolveCasePredicates,
+  resolveMatchOptions,
+  type CasePredicates,
+  type EvalMatchOptions,
+} from "@/shared/eval-matching";
+import type { Predicate } from "@/shared/eval-matching";
+import type { TestStep } from "@/shared/steps";
+import { ChecksSection, ToolCalledWithFields } from "../checks-section";
+import {
+  deriveCaseKind,
+  initialToolsChoice,
+  matchOptionsForKind,
+  readSimpleCase,
+  UNSET_TOOLS_BLOCK_REASON,
+  writeSimpleCase,
+  type CaseKind,
+  type SimpleCaseTool,
+  type ToolsChoice,
+} from "./simple-case-model";
+
+const MORE_CHECK_GROUPS: Array<{
+  id: "response" | "selection" | "call" | "appView";
+  label: string;
+  kinds: ReadonlyArray<Predicate["type"]>;
+}> = [
+  {
+    id: "response",
+    label: "Response",
+    kinds: [
+      "responseContains",
+      "responseMatches",
+      "finalAssistantMessageNonEmpty",
+      "noToolErrors",
+      "tokenBudgetUnder",
+      "turnCountUnder",
+    ],
+  },
+  {
+    id: "selection",
+    label: "Selection",
+    kinds: [
+      "toolCalledWith",
+      "toolCalledAtLeastOnce",
+      "toolNeverCalled",
+      "firstToolWas",
+    ],
+  },
+  {
+    id: "call",
+    label: "Call",
+    kinds: [],
+  },
+  {
+    id: "appView",
+    label: "App view",
+    kinds: [
+      "widgetRendered",
+      "widgetRenderLatencyUnder",
+      "widgetNoConsoleErrors",
+    ],
+  },
+];
+
+export type SimpleCaseFormProps = {
+  steps: TestStep[];
+  onStepsChange: (next: TestStep[]) => void;
+  matchOptions?: EvalMatchOptions;
+  onMatchOptionsChange: (next: EvalMatchOptions) => void;
+  suiteDefaultMatchOptions?: EvalMatchOptions;
+  expectedOutput?: string;
+  onExpectedOutputChange: (next: string) => void;
+  predicates?: CasePredicates;
+  onPredicatesChange: (next: CasePredicates | undefined) => void;
+  suiteDefaultPredicates?: Predicate[];
+  availableTools?: string[];
+  isNegativeTest?: boolean;
+  onOpenDeepEditor: () => void;
+  onToolsChoiceBlockReasonChange?: (reason: string | null) => void;
+  evalValidationBorderClass?: string;
+};
+
+export function SimpleCaseForm({
+  steps,
+  onStepsChange,
+  matchOptions,
+  onMatchOptionsChange,
+  suiteDefaultMatchOptions,
+  expectedOutput,
+  onExpectedOutputChange,
+  predicates,
+  onPredicatesChange,
+  suiteDefaultPredicates = [],
+  availableTools = [],
+  isNegativeTest,
+  onOpenDeepEditor,
+  onToolsChoiceBlockReasonChange,
+  evalValidationBorderClass,
+}: SimpleCaseFormProps) {
+  const view = useMemo(() => readSimpleCase(steps), [steps]);
+  const resolvedMatch = resolveMatchOptions(
+    suiteDefaultMatchOptions,
+    matchOptions,
+  );
+  const kind = deriveCaseKind(resolvedMatch);
+
+  const [toolsChoice, setToolsChoice] = useState<ToolsChoice>(() =>
+    initialToolsChoice({ tools: view.tools, isNegativeTest }),
+  );
+  const [stashedTools, setStashedTools] = useState<SimpleCaseTool[]>(
+    () => view.tools,
+  );
+  const [moreOpen, setMoreOpen] = useState(false);
+
+  useEffect(() => {
+    onToolsChoiceBlockReasonChange?.(
+      toolsChoice === "unset" ? UNSET_TOOLS_BLOCK_REASON : null,
+    );
+    return () => onToolsChoiceBlockReasonChange?.(null);
+  }, [toolsChoice, onToolsChoiceBlockReasonChange]);
+
+  const resolvedPredicates =
+    resolveCasePredicates(suiteDefaultPredicates, predicates) ?? [];
+  const suiteToolCalledWithApplies =
+    toolsChoice === "noTool" &&
+    resolvedPredicates.some((predicate) => predicate.type === "toolCalledWith");
+
+  const setKind = (next: CaseKind) => {
+    onMatchOptionsChange(matchOptionsForKind(next));
+  };
+
+  const setPrompt = (prompt: string) => {
+    onStepsChange(
+      writeSimpleCase(steps, {
+        prompt,
+        tools: view.tools,
+        noTool: toolsChoice === "noTool",
+      }),
+    );
+  };
+
+  const setTools = (tools: SimpleCaseTool[]) => {
+    setStashedTools(tools);
+    onStepsChange(
+      writeSimpleCase(steps, {
+        prompt: view.prompt,
+        tools,
+        noTool: false,
+      }),
+    );
+  };
+
+  const chooseNoTool = () => {
+    if (view.tools.length > 0) setStashedTools(view.tools);
+    setToolsChoice("noTool");
+    onStepsChange(
+      writeSimpleCase(steps, {
+        prompt: view.prompt,
+        tools: view.tools,
+        noTool: true,
+      }),
+    );
+  };
+
+  const chooseTools = () => {
+    setToolsChoice("tools");
+    const restored = view.tools.length > 0 ? view.tools : stashedTools;
+    onStepsChange(
+      writeSimpleCase(steps, {
+        prompt: view.prompt,
+        tools: restored,
+        noTool: false,
+      }),
+    );
+  };
+
+  const addTool = (toolName: string) => {
+    const name = toolName.trim();
+    if (!name) return;
+    setToolsChoice("tools");
+    setTools([
+      ...view.tools,
+      { id: `assert-${Date.now()}-${view.tools.length + 1}`, toolName: name, arguments: {} },
+    ]);
+  };
+
+  const caseList = predicates?.list ?? [];
+  const setCaseList = (list: Predicate[]) => {
+    onPredicatesChange(list.length === 0 ? undefined : { mode: "extend", list });
+  };
+
+  const predicatesByGroup = (kinds: ReadonlyArray<Predicate["type"]>) =>
+    caseList.filter((predicate) => kinds.includes(predicate.type));
+
+  return (
+    <div className="space-y-6" data-testid="simple-case-form">
+      <div className="flex items-start justify-between gap-3">
+        <ToggleGroup
+          type="single"
+          value={kind}
+          onValueChange={(value) => {
+            if (value === "capability" || value === "regression") {
+              setKind(value);
+            }
+          }}
+          className="gap-0.5"
+          aria-label="Case kind"
+        >
+          <ToggleGroupItem value="capability" className="h-7 px-2.5 text-xs">
+            Capability
+          </ToggleGroupItem>
+          <ToggleGroupItem value="regression" className="h-7 px-2.5 text-xs">
+            Regression
+          </ToggleGroupItem>
+        </ToggleGroup>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs text-muted-foreground"
+          onClick={onOpenDeepEditor}
+        >
+          Steps
+        </Button>
+      </div>
+      <p className="text-[11px] leading-snug text-muted-foreground">
+        {kind === "regression"
+          ? "This case must take one exact route — order and no extra calls."
+          : "This case should reach the right tool. Extra calls are allowed."}
+      </p>
+
+      <section className="space-y-2">
+        <Label className="text-[11px] font-medium text-foreground">
+          What does the user ask?
+        </Label>
+        <Textarea
+          value={view.prompt}
+          onChange={(event) => setPrompt(event.target.value)}
+          rows={4}
+          placeholder="Enter the user prompt…"
+          aria-label="What does the user ask?"
+          className={cn(
+            "resize-none bg-background font-mono text-sm leading-relaxed",
+            !view.prompt.trim() && evalValidationBorderClass,
+          )}
+        />
+      </section>
+
+      <section className="space-y-2">
+        <Label className="text-[11px] font-medium text-foreground">
+          {kind === "regression"
+            ? "Which route should it take?"
+            : "Which tool should handle it?"}
+        </Label>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant={toolsChoice === "noTool" ? "secondary" : "outline"}
+            size="sm"
+            className="h-7 text-xs"
+            onClick={chooseNoTool}
+          >
+            No tool should be called
+          </Button>
+          {toolsChoice === "noTool" ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs"
+              onClick={chooseTools}
+            >
+              Use tools instead
+            </Button>
+          ) : null}
+        </div>
+        {toolsChoice === "unset" ? (
+          <p
+            className="text-[11px] text-destructive"
+            data-testid="simple-case-tools-unset"
+          >
+            {UNSET_TOOLS_BLOCK_REASON}
+          </p>
+        ) : null}
+        {suiteToolCalledWithApplies ? (
+          <p
+            className="text-[11px] text-destructive"
+            data-testid="simple-case-negative-contradiction"
+          >
+            This case says no tool should be called, but a toolCalledWith check
+            still applies from the suite or this case. Those cannot both hold.
+          </p>
+        ) : null}
+
+        {toolsChoice !== "noTool" ? (
+          <div className="space-y-3">
+            {view.tools.map((tool, index) => (
+              <div
+                key={tool.id}
+                className="space-y-2 rounded-md border border-border bg-muted/20 p-3"
+                data-testid="simple-case-tool-row"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-[11px] font-medium text-muted-foreground">
+                    {kind === "regression" ? `Step ${index + 1}` : "Tool"}
+                  </p>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 w-7 p-0 text-muted-foreground"
+                    aria-label={`Remove ${tool.toolName || "tool"}`}
+                    onClick={() =>
+                      setTools(view.tools.filter((row) => row.id !== tool.id))
+                    }
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+                {kind === "regression" ? (
+                  <ToolCalledWithFields
+                    predicate={{
+                      type: "toolCalledWith",
+                      toolName: tool.toolName,
+                      args: { args: tool.arguments },
+                    }}
+                    onChange={(next) => {
+                      if (next.type !== "toolCalledWith") return;
+                      setTools(
+                        view.tools.map((row) =>
+                          row.id === tool.id
+                            ? {
+                                ...row,
+                                toolName: next.toolName,
+                                arguments: next.args.args ?? {},
+                              }
+                            : row,
+                        ),
+                      );
+                    }}
+                    availableTools={availableTools}
+                    readOnly={false}
+                  />
+                ) : (
+                  <ToolCalledWithFields
+                    predicate={{
+                      type: "toolCalledWith",
+                      toolName: tool.toolName,
+                      args: { args: {} },
+                    }}
+                    onChange={(next) => {
+                      if (next.type !== "toolCalledWith") return;
+                      setTools(
+                        view.tools.map((row) =>
+                          row.id === tool.id
+                            ? { ...row, toolName: next.toolName, arguments: {} }
+                            : row,
+                        ),
+                      );
+                    }}
+                    availableTools={availableTools}
+                    readOnly={false}
+                  />
+                )}
+              </div>
+            ))}
+            <AddToolRow
+              availableTools={availableTools}
+              onAdd={addTool}
+            />
+          </div>
+        ) : null}
+      </section>
+
+      <section className="space-y-2">
+        <Label
+          htmlFor="simple-case-rubric"
+          className="text-[11px] font-medium text-foreground"
+        >
+          What does a good answer accomplish?
+        </Label>
+        <Input
+          id="simple-case-rubric"
+          value={expectedOutput ?? ""}
+          onChange={(event) => onExpectedOutputChange(event.target.value)}
+          placeholder="One sentence the model grader can score against"
+          className="h-8 font-mono text-xs"
+        />
+        <p className="text-[11px] text-muted-foreground">
+          Model grader · advisory. Setting this changes what the judge grades
+          against.
+        </p>
+      </section>
+
+      <Collapsible open={moreOpen} onOpenChange={setMoreOpen}>
+        <CollapsibleTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-0 text-xs text-muted-foreground"
+          >
+            More checks
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="space-y-4 pt-3">
+          {MORE_CHECK_GROUPS.map((group) => {
+            const rows = predicatesByGroup(group.kinds);
+            const inherited = resolvedPredicates.filter(
+              (predicate) =>
+                group.kinds.includes(predicate.type) &&
+                !caseList.includes(predicate),
+            );
+            return (
+              <section key={group.id} className="space-y-2">
+                <h4 className="text-[11px] font-medium text-foreground">
+                  {group.label}
+                </h4>
+                {group.kinds.length === 0 ? (
+                  <p className="text-[11px] text-muted-foreground">
+                    Argument matching stays partial for both kinds. Nothing else
+                    is authorable at call today.
+                  </p>
+                ) : (
+                  <ChecksSection
+                    value={rows}
+                    onChange={(next) => {
+                      const kept = caseList.filter(
+                        (predicate) => !group.kinds.includes(predicate.type),
+                      );
+                      setCaseList([...kept, ...next]);
+                    }}
+                    availableTools={availableTools}
+                    title=""
+                    hideEmptyState
+                    allowedKinds={group.kinds}
+                  />
+                )}
+                {inherited.length > 0 ? (
+                  <p className="text-[11px] text-muted-foreground">
+                    {inherited.length} inherited from the suite
+                  </p>
+                ) : null}
+              </section>
+            );
+          })}
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+}
+
+function AddToolRow({
+  availableTools,
+  onAdd,
+}: {
+  availableTools: string[];
+  onAdd: (toolName: string) => void;
+}) {
+  const [name, setName] = useState("");
+  return (
+    <div className="flex items-center gap-2">
+      {availableTools.length > 0 ? (
+        <select
+          className="h-8 min-w-0 flex-1 rounded-md border border-input bg-background px-2 text-xs"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          aria-label="Add a tool"
+        >
+          <option value="">Pick a tool…</option>
+          {availableTools.map((tool) => (
+            <option key={tool} value={tool}>
+              {tool}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <Input
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="Tool name"
+          aria-label="Add a tool"
+          className="h-8 flex-1 text-xs"
+        />
+      )}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-8 gap-1 text-xs"
+        onClick={() => {
+          onAdd(name);
+          setName("");
+        }}
+        disabled={!name.trim()}
+      >
+        <Plus className="h-3.5 w-3.5" />
+        Add
+      </Button>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-form.tsx
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-form.tsx
@@ -27,6 +27,7 @@ import {
   displayCaseKind,
   initialToolsChoice,
   matchOptionsForKind,
+  MORE_CHECK_GROUPS,
   readSimpleCase,
   UNSET_TOOLS_BLOCK_REASON,
   writeSimpleCase,
@@ -34,49 +35,6 @@ import {
   type SimpleCaseTool,
   type ToolsChoice,
 } from "./simple-case-model";
-
-const MORE_CHECK_GROUPS: Array<{
-  id: "response" | "selection" | "call" | "appView";
-  label: string;
-  kinds: ReadonlyArray<Predicate["type"]>;
-}> = [
-  {
-    id: "response",
-    label: "Response",
-    kinds: [
-      "responseContains",
-      "responseMatches",
-      "finalAssistantMessageNonEmpty",
-      "noToolErrors",
-      "tokenBudgetUnder",
-      "turnCountUnder",
-    ],
-  },
-  {
-    id: "selection",
-    label: "Selection",
-    kinds: [
-      "toolCalledWith",
-      "toolCalledAtLeastOnce",
-      "toolNeverCalled",
-      "firstToolWas",
-    ],
-  },
-  {
-    id: "call",
-    label: "Call",
-    kinds: [],
-  },
-  {
-    id: "appView",
-    label: "App view",
-    kinds: [
-      "widgetRendered",
-      "widgetRenderLatencyUnder",
-      "widgetNoConsoleErrors",
-    ],
-  },
-];
 
 export type SimpleCaseFormProps = {
   steps: TestStep[];
@@ -157,7 +115,7 @@ export function SimpleCaseForm({
 
   const setKind = (next: CaseKind) => {
     onKindChange?.(next);
-    onMatchOptionsChange(matchOptionsForKind(next));
+    onMatchOptionsChange(matchOptionsForKind(next, resolvedMatch));
   };
 
   const setPrompt = (prompt: string) => {
@@ -211,13 +169,19 @@ export function SimpleCaseForm({
     setToolsChoice("tools");
     setTools([
       ...view.tools,
-      { id: `assert-${Date.now()}-${view.tools.length + 1}`, toolName: name, arguments: {} },
+      {
+        id: `assert-${Date.now()}-${view.tools.length + 1}`,
+        toolName: name,
+        arguments: {},
+      },
     ]);
   };
 
   const caseList = predicates?.list ?? [];
   const setCaseList = (list: Predicate[]) => {
-    onPredicatesChange(list.length === 0 ? undefined : { mode: "extend", list });
+    onPredicatesChange(
+      list.length === 0 ? undefined : { mode: "extend", list },
+    );
   };
 
   const predicatesByGroup = (kinds: ReadonlyArray<Predicate["type"]>) =>
@@ -396,10 +360,7 @@ export function SimpleCaseForm({
                 )}
               </div>
             ))}
-            <AddToolRow
-              availableTools={availableTools}
-              onAdd={addTool}
-            />
+            <AddToolRow availableTools={availableTools} onAdd={addTool} />
           </div>
         ) : null}
       </section>
@@ -448,26 +409,19 @@ export function SimpleCaseForm({
                 <h4 className="text-[11px] font-medium text-foreground">
                   {group.label}
                 </h4>
-                {group.kinds.length === 0 ? (
-                  <p className="text-[11px] text-muted-foreground">
-                    Argument matching stays partial for both kinds. Nothing else
-                    is authorable at call today.
-                  </p>
-                ) : (
-                  <ChecksSection
-                    value={rows}
-                    onChange={(next) => {
-                      const kept = caseList.filter(
-                        (predicate) => !group.kinds.includes(predicate.type),
-                      );
-                      setCaseList([...kept, ...next]);
-                    }}
-                    availableTools={availableTools}
-                    title=""
-                    hideEmptyState
-                    allowedKinds={group.kinds}
-                  />
-                )}
+                <ChecksSection
+                  value={rows}
+                  onChange={(next) => {
+                    const kept = caseList.filter(
+                      (predicate) => !group.kinds.includes(predicate.type),
+                    );
+                    setCaseList([...kept, ...next]);
+                  }}
+                  availableTools={availableTools}
+                  title=""
+                  hideEmptyState
+                  allowedKinds={group.kinds}
+                />
                 {inherited.length > 0 ? (
                   <p className="text-[11px] text-muted-foreground">
                     {inherited.length} inherited from the suite

--- a/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-form.tsx
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-form.tsx
@@ -24,7 +24,7 @@ import type { Predicate } from "@/shared/eval-matching";
 import type { TestStep } from "@/shared/steps";
 import { ChecksSection, ToolCalledWithFields } from "../checks-section";
 import {
-  deriveCaseKind,
+  displayCaseKind,
   initialToolsChoice,
   matchOptionsForKind,
   readSimpleCase,
@@ -83,6 +83,8 @@ export type SimpleCaseFormProps = {
   onStepsChange: (next: TestStep[]) => void;
   matchOptions?: EvalMatchOptions;
   onMatchOptionsChange: (next: EvalMatchOptions) => void;
+  kind?: CaseKind;
+  onKindChange?: (next: CaseKind) => void;
   suiteDefaultMatchOptions?: EvalMatchOptions;
   expectedOutput?: string;
   onExpectedOutputChange: (next: string) => void;
@@ -102,6 +104,8 @@ export function SimpleCaseForm({
   onStepsChange,
   matchOptions,
   onMatchOptionsChange,
+  kind: persistedKind,
+  onKindChange,
   suiteDefaultMatchOptions,
   expectedOutput,
   onExpectedOutputChange,
@@ -120,7 +124,7 @@ export function SimpleCaseForm({
     suiteDefaultMatchOptions,
     matchOptions,
   );
-  const kind = deriveCaseKind(resolvedMatch);
+  const kind = displayCaseKind(persistedKind, resolvedMatch);
 
   const [toolsChoice, setToolsChoice] = useState<ToolsChoice>(() =>
     initialToolsChoice({ tools: view.tools, isNegativeTest }),
@@ -152,6 +156,7 @@ export function SimpleCaseForm({
     resolvedPredicates.some((predicate) => predicate.type === "toolCalledWith");
 
   const setKind = (next: CaseKind) => {
+    onKindChange?.(next);
     onMatchOptionsChange(matchOptionsForKind(next));
   };
 

--- a/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-model.ts
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-model.ts
@@ -1,0 +1,160 @@
+/**
+ * Pure model for the flag-gated simple case editor.
+ *
+ * A case is "simple" when it is one prompt plus zero or more
+ * `toolCalledWith` asserts — the shape the three-question form can
+ * author without loss. Kind is derived from resolved matchOptions
+ * (PR1–PR5); a persisted `kind` field arrives later (PR7).
+ */
+
+import {
+  isAssertStep,
+  isPromptStep,
+  isWidgetAssertion,
+  type TestStep,
+} from "@/shared/steps";
+import {
+  MATCH_OPTIONS_DEFAULTS,
+  type EvalMatchOptions,
+} from "@/shared/eval-matching";
+
+export const SIMPLE_CASE_EDITOR_FLAG = "eval-simple-case-editor";
+
+export type CaseKind = "capability" | "regression";
+
+export type SimpleCaseTool = {
+  id: string;
+  toolName: string;
+  arguments: Record<string, unknown>;
+};
+
+export type SimpleCaseView = {
+  prompt: string;
+  tools: SimpleCaseTool[];
+  noTool: boolean;
+};
+
+export type WriteSimpleCaseView = {
+  prompt: string;
+  tools: Array<{
+    id?: string;
+    toolName: string;
+    arguments?: Record<string, unknown>;
+  }>;
+  noTool: boolean;
+};
+
+let stepIdCounter = 0;
+function newStepId(kind: string): string {
+  stepIdCounter += 1;
+  return `${kind}-${Date.now()}-${stepIdCounter}`;
+}
+
+export function isToolCalledWithAssert(step: TestStep): boolean {
+  return (
+    isAssertStep(step) &&
+    !isWidgetAssertion(step.assertion) &&
+    step.assertion.type === "toolCalledWith"
+  );
+}
+
+/**
+ * Regression is the strict-order + no-extras pair. `argumentMatching` is
+ * deliberately not part of the discriminant — both kinds keep `partial`.
+ */
+export function deriveCaseKind(
+  resolvedMatchOptions: Pick<
+    EvalMatchOptions,
+    "toolCallOrder" | "maxExtraToolCalls"
+  >,
+): CaseKind {
+  return resolvedMatchOptions.toolCallOrder === "strict" &&
+    resolvedMatchOptions.maxExtraToolCalls === 0
+    ? "regression"
+    : "capability";
+}
+
+export function matchOptionsForKind(kind: CaseKind): Required<
+  Omit<EvalMatchOptions, "allowExtraToolCalls">
+> {
+  if (kind === "regression") {
+    return {
+      toolCallOrder: "strict",
+      maxExtraToolCalls: 0,
+      argumentMatching: "partial",
+    };
+  }
+  return { ...MATCH_OPTIONS_DEFAULTS };
+}
+
+/**
+ * `steps[0]` is a prompt and every other step is a non-widget
+ * `toolCalledWith` assert. Prompt-only is simple. A second prompt,
+ * `toolCall`, `interact`, widget assert, or any other inline predicate
+ * is not.
+ */
+export function isSimpleCaseShape(steps: TestStep[]): boolean {
+  if (!Array.isArray(steps) || steps.length === 0) return false;
+  if (!isPromptStep(steps[0])) return false;
+  return steps.slice(1).every(isToolCalledWithAssert);
+}
+
+export function readSimpleCase(steps: TestStep[]): SimpleCaseView {
+  const prompt = isPromptStep(steps[0]) ? steps[0].prompt : "";
+  const tools: SimpleCaseTool[] = [];
+  for (const step of steps) {
+    if (!isToolCalledWithAssert(step) || !isAssertStep(step)) continue;
+    const assertion = step.assertion;
+    if (isWidgetAssertion(assertion) || assertion.type !== "toolCalledWith") {
+      continue;
+    }
+    tools.push({
+      id: step.id,
+      toolName: assertion.toolName,
+      arguments: assertion.args.args ?? {},
+    });
+  }
+  return { prompt, tools, noTool: tools.length === 0 };
+}
+
+/**
+ * Rewrite the simple-case slice of `prevSteps`. Keeps step 0's id when it
+ * is already a prompt, and reuses existing `toolCalledWith` assert ids by
+ * index (or an explicit `id` on the incoming tool). `noTool` drops only
+ * `toolCalledWith` asserts so flipping back can restore from caller state.
+ */
+export function writeSimpleCase(
+  prevSteps: TestStep[],
+  view: WriteSimpleCaseView,
+): TestStep[] {
+  const prevPrompt = isPromptStep(prevSteps[0]) ? prevSteps[0] : undefined;
+  const promptStep: TestStep = {
+    id: prevPrompt?.id ?? newStepId("prompt"),
+    kind: "prompt",
+    prompt: view.prompt,
+  };
+
+  const leftover = prevSteps
+    .slice(prevPrompt ? 1 : 0)
+    .filter((step) => !isToolCalledWithAssert(step));
+
+  if (view.noTool) {
+    return [promptStep, ...leftover];
+  }
+
+  const prevTools = prevSteps.filter(isToolCalledWithAssert);
+  const toolSteps: TestStep[] = view.tools.map((tool, index) => {
+    const prev = prevTools[index];
+    return {
+      id: tool.id ?? prev?.id ?? newStepId("assert"),
+      kind: "assert",
+      assertion: {
+        type: "toolCalledWith",
+        toolName: tool.toolName,
+        args: { args: tool.arguments ?? {} },
+      },
+    };
+  });
+
+  return [promptStep, ...toolSteps, ...leftover];
+}

--- a/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-model.ts
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-model.ts
@@ -76,6 +76,20 @@ export function isToolCalledWithAssert(step: TestStep): boolean {
  * Regression is the strict-order + no-extras pair. `argumentMatching` is
  * deliberately not part of the discriminant — both kinds keep `partial`.
  */
+/** Persisted kind wins; otherwise derive from resolved matchOptions. */
+export function displayCaseKind(
+  persisted: CaseKind | null | undefined,
+  resolvedMatchOptions: Pick<
+    EvalMatchOptions,
+    "toolCallOrder" | "maxExtraToolCalls"
+  >,
+): CaseKind {
+  if (persisted === "capability" || persisted === "regression") {
+    return persisted;
+  }
+  return deriveCaseKind(resolvedMatchOptions);
+}
+
 export function deriveCaseKind(
   resolvedMatchOptions: Pick<
     EvalMatchOptions,

--- a/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-model.ts
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-model.ts
@@ -16,9 +16,64 @@ import {
 import {
   MATCH_OPTIONS_DEFAULTS,
   type EvalMatchOptions,
+  type Predicate,
 } from "@/shared/eval-matching";
 
 export const SIMPLE_CASE_EDITOR_FLAG = "eval-simple-case-editor";
+
+export type MoreCheckGroupId = "response" | "selection" | "appView";
+
+/**
+ * The "More checks" groups, labelled by what a reader is checking rather
+ * than by the analyzer's stage (`PREDICATE_STAGE` files every response
+ * predicate at `userValue`, because no authorable grader measures the
+ * `response` link today).
+ *
+ * Partition rule, test-enforced: every kind in `PREDICATE_KIND_LABELS` is
+ * in exactly one group or in `EXCLUDED_FROM_MORE_CHECKS`. A kind added to
+ * the catalog fails that test until somebody files it — a group list that
+ * merely omits a kind would hide it silently.
+ */
+export const MORE_CHECK_GROUPS: ReadonlyArray<{
+  id: MoreCheckGroupId;
+  label: string;
+  kinds: ReadonlyArray<Predicate["type"]>;
+}> = [
+  {
+    id: "response",
+    label: "Response",
+    kinds: [
+      "responseContains",
+      "responseMatches",
+      "finalAssistantMessageNonEmpty",
+      "noToolErrors",
+      "tokenBudgetUnder",
+      "turnCountUnder",
+    ],
+  },
+  {
+    id: "selection",
+    label: "Selection and call",
+    kinds: ["toolCalledAtLeastOnce", "toolNeverCalled", "firstToolWas"],
+  },
+  {
+    id: "appView",
+    label: "App view",
+    kinds: [
+      "widgetRendered",
+      "widgetRenderLatencyUnder",
+      "widgetNoConsoleErrors",
+    ],
+  },
+];
+
+/**
+ * Owned by the tool question above the disclosure. Offering it again here
+ * would author the route twice, and on a no-tool case would create the
+ * contradiction the corpus guard rejects.
+ */
+export const EXCLUDED_FROM_MORE_CHECKS: ReadonlySet<Predicate["type"]> =
+  new Set<Predicate["type"]>(["toolCalledWith"]);
 
 export const UNSET_TOOLS_BLOCK_REASON =
   "Choose which tool should handle it, or that no tool should be called.";
@@ -102,17 +157,26 @@ export function deriveCaseKind(
     : "capability";
 }
 
-export function matchOptionsForKind(kind: CaseKind): Required<
-  Omit<EvalMatchOptions, "allowExtraToolCalls">
-> {
+/**
+ * The matchOptions a kind writes. `argumentMatching` is carried over from
+ * `current` (the RESOLVED options, suite defaults included) rather than
+ * reset: the toggle decides order and extras, and an authored `exact` must
+ * not silently become `partial` because the author flipped the kind.
+ */
+export function matchOptionsForKind(
+  kind: CaseKind,
+  current?: Pick<EvalMatchOptions, "argumentMatching">,
+): Required<Omit<EvalMatchOptions, "allowExtraToolCalls">> {
+  const argumentMatching =
+    current?.argumentMatching ?? MATCH_OPTIONS_DEFAULTS.argumentMatching;
   if (kind === "regression") {
     return {
       toolCallOrder: "strict",
       maxExtraToolCalls: 0,
-      argumentMatching: "partial",
+      argumentMatching,
     };
   }
-  return { ...MATCH_OPTIONS_DEFAULTS };
+  return { ...MATCH_OPTIONS_DEFAULTS, argumentMatching };
 }
 
 /**

--- a/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-model.ts
+++ b/mcpjam-inspector/client/src/components/evals/simple-case/simple-case-model.ts
@@ -20,7 +20,21 @@ import {
 
 export const SIMPLE_CASE_EDITOR_FLAG = "eval-simple-case-editor";
 
+export const UNSET_TOOLS_BLOCK_REASON =
+  "Choose which tool should handle it, or that no tool should be called.";
+
 export type CaseKind = "capability" | "regression";
+
+export type ToolsChoice = "unset" | "tools" | "noTool";
+
+export function initialToolsChoice(input: {
+  tools: SimpleCaseTool[];
+  isNegativeTest?: boolean;
+}): ToolsChoice {
+  if (input.tools.length > 0) return "tools";
+  if (input.isNegativeTest) return "noTool";
+  return "unset";
+}
 
 export type SimpleCaseTool = {
   id: string;

--- a/mcpjam-inspector/client/src/components/evals/suite-dashboard.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-dashboard.tsx
@@ -66,6 +66,7 @@ export interface SuiteDashboardProps {
   generateTestCasesDisabledReason?: string;
   isGeneratingTestCases?: boolean;
   onCreateTestCase?: () => void;
+  onRecordTestCase?: () => void;
   /**
    * When set, the results split shows this run's detail in its right pane
    * (the rail highlights the run). Drives the folded-in run-detail view; the
@@ -124,6 +125,7 @@ export function SuiteDashboard({
   generateTestCasesDisabledReason,
   isGeneratingTestCases,
   onCreateTestCase,
+  onRecordTestCase,
   selectedRunId,
   runDetailPane,
   onExitRun,
@@ -180,6 +182,7 @@ export function SuiteDashboard({
       generateTestCasesDisabledReason={generateTestCasesDisabledReason}
       isGeneratingTestCases={isGeneratingTestCases}
       onCreateTestCase={onCreateTestCase}
+      onRecordTestCase={onRecordTestCase}
       hostNamesById={hostNamesById}
       environments={environments}
     />

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -360,6 +360,7 @@ export function SuiteIterationsView({
   navigation,
   onSetupCi,
   onCreateTestCase,
+  onRecordTestCase,
   onGenerateTestCases,
   canGenerateTestCases = false,
   isGeneratingTestCases = false,
@@ -417,6 +418,7 @@ export function SuiteIterationsView({
   navigation: SuiteNavigation;
   onSetupCi?: () => void;
   onCreateTestCase?: () => void;
+  onRecordTestCase?: () => void;
   onGenerateTestCases?: () => void;
   canGenerateTestCases?: boolean;
   generateTestCasesDisabledReason?: string;
@@ -1259,6 +1261,7 @@ export function SuiteIterationsView({
       generateTestCasesDisabledReason={generateTestCasesDisabledReason}
       isGeneratingTestCases={isGeneratingTestCases}
       onCreateTestCase={onCreateTestCase}
+      onRecordTestCase={onRecordTestCase}
       hostNamesById={hostNamesById}
       environments={projectEnvironments}
       {...extra}
@@ -1800,6 +1803,7 @@ export function SuiteIterationsView({
                       }
                       isGeneratingTestCases={isGeneratingTestCases}
                       onCreateTestCase={onCreateTestCase}
+                      onRecordTestCase={onRecordTestCase}
                       hostNamesById={hostNamesById}
                       environments={projectEnvironments}
                     />

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -1474,6 +1474,9 @@ export function SuiteIterationsView({
                       replace: true,
                     })
                   }
+                  onOpenSuiteSettings={() =>
+                    navigation.toSuiteOverview(suite._id)
+                  }
                 />
               </motion.div>
             ) : viewMode === "test-detail" && selectedTestId ? (

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useConvex, useQuery } from "convex/react";
 import { track } from "@/lib/analytics";
-import { Loader2, Play, Plus, Puzzle, Sparkles, Trash2 } from "lucide-react";
+import { Circle, Loader2, Play, Plus, Puzzle, Sparkles, Trash2 } from "lucide-react";
+import { useFeatureFlagEnabled } from "posthog-js/react";
+import { SIMPLE_CASE_EDITOR_FLAG } from "./simple-case/simple-case-model";
 import { toast } from "sonner";
 import { Button } from "@mcpjam/design-system/button";
 import { Checkbox } from "@mcpjam/design-system/checkbox";
@@ -140,6 +142,8 @@ interface TestCasesOverviewProps {
   generateTestCasesDisabledReason?: string;
   isGeneratingTestCases?: boolean;
   onCreateTestCase?: () => void;
+  /** Run-once-then-adopt draft. Flag-gated; omitted keeps the two-button empty state. */
+  onRecordTestCase?: () => void;
   /**
    * `namedHostId` → display name for hosts with no suite attachment — the
    * resolved host of an environment-backed run, or a detached one. Owned by
@@ -185,10 +189,13 @@ export function TestCasesOverview({
   generateTestCasesDisabledReason,
   isGeneratingTestCases = false,
   onCreateTestCase,
+  onRecordTestCase,
   hostNamesById,
   environments,
   quickRunIterationOverride,
 }: TestCasesOverviewProps) {
+  const simpleCaseEditorEnabled =
+    useFeatureFlagEnabled(SIMPLE_CASE_EDITOR_FLAG) === true;
   const convex = useConvex();
   // A one-host matrix is pointless, so the cross-host view is only offered when
   // the suite has >=2 host attachments. Same source useCrossHostData reads.
@@ -648,64 +655,89 @@ export function TestCasesOverview({
                 ) : hideViewModeSelect ? (
                   <div className="flex min-h-[200px] flex-col items-center justify-center gap-4 px-4 py-12">
                     {onGenerateTestCases || onCreateTestCase ? (
-                      <div className="flex items-center gap-2">
-                        {onGenerateTestCases ? (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <span className="inline-flex">
-                                <Button
-                                  type="button"
-                                  variant="default"
-                                  className="h-11 gap-2 px-6 text-sm"
-                                  onClick={onGenerateTestCases}
-                                  disabled={
-                                    !canGenerateTestCases ||
-                                    isGeneratingTestCases
-                                  }
-                                  aria-busy={isGeneratingTestCases}
-                                >
-                                  {isGeneratingTestCases ? (
-                                    <Loader2
-                                      className="h-4 w-4 shrink-0 animate-spin"
-                                      aria-hidden
-                                    />
-                                  ) : (
-                                    <Sparkles
-                                      className="h-4 w-4 shrink-0"
-                                      aria-hidden
-                                    />
-                                  )}
-                                  Generate
-                                </Button>
-                              </span>
-                            </TooltipTrigger>
-                            <TooltipContent
-                              variant="muted"
-                              side="bottom"
-                              sideOffset={6}
+                      <div className="flex flex-col items-center gap-3">
+                        <div className="flex items-center gap-2">
+                          {onGenerateTestCases ? (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="inline-flex">
+                                  <Button
+                                    type="button"
+                                    variant="default"
+                                    className="h-11 gap-2 px-6 text-sm"
+                                    onClick={onGenerateTestCases}
+                                    disabled={
+                                      !canGenerateTestCases ||
+                                      isGeneratingTestCases
+                                    }
+                                    aria-busy={isGeneratingTestCases}
+                                  >
+                                    {isGeneratingTestCases ? (
+                                      <Loader2
+                                        className="h-4 w-4 shrink-0 animate-spin"
+                                        aria-hidden
+                                      />
+                                    ) : (
+                                      <Sparkles
+                                        className="h-4 w-4 shrink-0"
+                                        aria-hidden
+                                      />
+                                    )}
+                                    Generate
+                                  </Button>
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent
+                                variant="muted"
+                                side="bottom"
+                                sideOffset={6}
+                              >
+                                {isGeneratingTestCases
+                                  ? "Generating test cases…"
+                                  : !canGenerateTestCases
+                                    ? generateTestCasesDisabledReason ??
+                                      "Configure suite servers before generating cases."
+                                    : "Generate suggested cases from your server's tools."}
+                              </TooltipContent>
+                            </Tooltip>
+                          ) : null}
+                          {simpleCaseEditorEnabled && onRecordTestCase ? (
+                            <Button
+                              type="button"
+                              variant="outline"
+                              className="h-11 gap-2 px-6 text-sm"
+                              onClick={onRecordTestCase}
                             >
-                              {isGeneratingTestCases
-                                ? "Generating test cases…"
-                                : !canGenerateTestCases
-                                ? generateTestCasesDisabledReason ??
-                                  "Configure suite servers before generating cases."
-                                : "Generate suggested cases from your server's tools."}
-                            </TooltipContent>
-                          </Tooltip>
-                        ) : null}
-                        {onCreateTestCase ? (
-                          <Button
-                            type="button"
-                            variant="default"
-                            className="h-11 gap-2 px-6 text-sm"
-                            onClick={onCreateTestCase}
-                          >
-                            <Plus
-                              className="h-4 w-4 shrink-0"
-                              aria-hidden
-                            />
-                            New case
-                          </Button>
+                              <Circle
+                                className="h-4 w-4 shrink-0"
+                                aria-hidden
+                              />
+                              Record
+                            </Button>
+                          ) : null}
+                          {onCreateTestCase ? (
+                            <Button
+                              type="button"
+                              variant={
+                                simpleCaseEditorEnabled ? "outline" : "default"
+                              }
+                              className="h-11 gap-2 px-6 text-sm"
+                              onClick={onCreateTestCase}
+                            >
+                              <Plus
+                                className="h-4 w-4 shrink-0"
+                                aria-hidden
+                              />
+                              {simpleCaseEditorEnabled ? "Write" : "New case"}
+                            </Button>
+                          ) : null}
+                        </div>
+                        {simpleCaseEditorEnabled ? (
+                          <p className="text-[11px] text-muted-foreground">
+                            Or import a suite file with{" "}
+                            <code className="font-mono">mcpjam cloud eval</code>
+                            .
+                          </p>
                         ) : null}
                       </div>
                     ) : null}

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -241,6 +241,7 @@ interface TestTemplate {
   predicates?: CasePredicates;
   /** Authored rubric for the model judge. Empty string clears it. */
   expectedOutput?: string;
+  kind?: "capability" | "regression";
 }
 
 interface TestTemplateEditorProps {
@@ -1195,6 +1196,7 @@ export function TestTemplateEditor({
       matchOptions: currentTestCase.matchOptions,
       predicates: currentTestCase.predicates,
       expectedOutput: currentTestCase.expectedOutput ?? "",
+      kind: currentTestCase.kind,
     });
     // Seed the transient picker from the persisted runs so a user who saved
     // runs=N still sees N selected when the editor opens. Clamp to [1, 10]
@@ -1622,6 +1624,8 @@ export function TestTemplateEditor({
     const normalizedCurrentExpectedOutput = (
       currentTestCase.expectedOutput ?? ""
     ).trim();
+    const formKind = editForm.kind ?? null;
+    const currentKind = currentTestCase.kind ?? null;
 
     return (
       editForm.title !== currentTestCase.title ||
@@ -1632,6 +1636,7 @@ export function TestTemplateEditor({
       normalizedMatchOptions !== normalizedCurrentMatchOptions ||
       normalizedPredicates !== normalizedCurrentPredicates ||
       normalizedExpectedOutput !== normalizedCurrentExpectedOutput ||
+      formKind !== currentKind ||
       serverNegativeFlagMismatch
     );
   }, [editForm, currentAdvancedConfig, currentSteps, currentTestCase]);
@@ -1970,6 +1975,7 @@ export function TestTemplateEditor({
       advancedConfig: normalizeAdvancedConfig(form.advancedConfig),
       matchOptions: form.matchOptions,
       predicates: normalizedPredicates,
+      ...(form.kind !== undefined ? { kind: form.kind } : {}),
     };
   };
 
@@ -3513,6 +3519,12 @@ export function TestTemplateEditor({
                         steps={editForm.steps}
                         onStepsChange={setSteps}
                         matchOptions={editForm.matchOptions}
+                        kind={editForm.kind}
+                        onKindChange={(next) =>
+                          setEditForm((current) =>
+                            current ? { ...current, kind: next } : current,
+                          )
+                        }
                         onMatchOptionsChange={(next) =>
                           setEditForm((current) =>
                             current

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -1316,7 +1316,12 @@ export function TestTemplateEditor({
 
     const rollup = summarizeRoutes(recentIterations);
     const showRollup = simpleCaseEditorEnabled && rollup.total > 1;
-    if (!chain && !showRollup) return null;
+    const showRecordAdopt =
+      simpleCaseEditorEnabled &&
+      draftKind === "record" &&
+      !!iteration &&
+      rollup.total >= 1;
+    if (!chain && !showRollup && !showRecordAdopt) return null;
 
     const resolvedMatch = resolveMatchOptions(
       suite?.defaultMatchOptions,
@@ -1331,10 +1336,11 @@ export function TestTemplateEditor({
     return (
       <div className="space-y-2">
         {chain}
-        {showRollup ? (
+        {showRollup || showRecordAdopt ? (
           <RouteRollupCard
             rollup={rollup}
             expectedPathKey={expectedPathKey}
+            adoptPrimary={draftKind === "record"}
             onAdoptTrialRoute={
               iteration
                 ? () =>
@@ -3543,6 +3549,7 @@ export function TestTemplateEditor({
                           setToolsChoiceBlockReason
                         }
                         evalValidationBorderClass={evalValidationBorderClass}
+                        autoFocusPrompt={draftKind === "record"}
                       />
                     ) : editForm ? (
                       <StepListEditor

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -219,9 +219,16 @@ import { SimpleCaseForm } from "./simple-case/simple-case-form";
 import { CaseSuiteChips } from "./simple-case/case-suite-chips";
 import {
   SIMPLE_CASE_EDITOR_FLAG,
+  deriveCaseKind,
   isSimpleCaseShape,
 } from "./simple-case/simple-case-model";
 import { chainForQuickRunIteration } from "./simple-case/quick-run-chain";
+import { RouteRollupCard } from "./simple-case/route-rollup-card";
+import {
+  adoptRouteFromIteration,
+  expectedPathKeyFromSteps,
+  summarizeRoutes,
+} from "./simple-case/route-rollup";
 
 interface TestTemplate {
   title: string;
@@ -1290,17 +1297,64 @@ export function TestTemplateEditor({
    * the client already holds.
    */
   const trialChainSlotFor = (iteration: EvalIteration | null) => {
-    if (!iteration || !chainSlotEnabled) return null;
-    if (iteration.suiteRunId) {
-      const chain = trialChains.chains.get(iteration._id);
-      if (!chain) return null;
-      return <TrialChainPanel chain={chain} resetKey={iteration._id} />;
+    let chain: ReactNode = null;
+    if (iteration && chainSlotEnabled) {
+      if (iteration.suiteRunId) {
+        const assembled = trialChains.chains.get(iteration._id);
+        chain = assembled ? (
+          <TrialChainPanel chain={assembled} resetKey={iteration._id} />
+        ) : null;
+      } else {
+        chain = (
+          <TrialChainPanel
+            chain={chainForQuickRunIteration(iteration)}
+            resetKey={iteration._id}
+          />
+        );
+      }
     }
+
+    const rollup = summarizeRoutes(recentIterations);
+    const showRollup = simpleCaseEditorEnabled && rollup.total > 1;
+    if (!chain && !showRollup) return null;
+
+    const resolvedMatch = resolveMatchOptions(
+      suite?.defaultMatchOptions,
+      editForm?.matchOptions,
+    );
+    const kind = deriveCaseKind(resolvedMatch);
+    const expectedPathKey =
+      kind === "regression" && editForm
+        ? expectedPathKeyFromSteps(editForm.steps)
+        : undefined;
+
     return (
-      <TrialChainPanel
-        chain={chainForQuickRunIteration(iteration)}
-        resetKey={iteration._id}
-      />
+      <div className="space-y-2">
+        {chain}
+        {showRollup ? (
+          <RouteRollupCard
+            rollup={rollup}
+            expectedPathKey={expectedPathKey}
+            onAdoptTrialRoute={
+              iteration
+                ? () =>
+                    setEditForm((current) =>
+                      current
+                        ? {
+                            ...current,
+                            steps: adoptRouteFromIteration(
+                              current.steps,
+                              iteration,
+                              kind,
+                            ),
+                          }
+                        : current,
+                    )
+                : undefined
+            }
+          />
+        ) : null}
+      </div>
     );
   };
 

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   type KeyboardEvent,
+  type ReactNode,
 } from "react";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import { track } from "@/lib/analytics";
@@ -220,6 +221,7 @@ import {
   SIMPLE_CASE_EDITOR_FLAG,
   isSimpleCaseShape,
 } from "./simple-case/simple-case-model";
+import { chainForQuickRunIteration } from "./simple-case/quick-run-chain";
 
 interface TestTemplate {
   title: string;
@@ -1273,25 +1275,33 @@ export function TestTemplateEditor({
     suiteRuns,
   ]);
 
+  const chainSlotEnabled = trialChainEnabled || simpleCaseEditorEnabled;
   const trialChains = useEvalRunIterationChains({
     projectId,
     run: openTrialRun,
-    enabled: trialChainEnabled,
+    enabled: chainSlotEnabled,
   });
 
   /**
    * The chain panel for one opened trial, or nothing.
    *
-   * Built here and passed DOWN as a node: `IterationDetails` has five hosts
-   * and only this one can answer which run the trial belongs to.
+   * Run-backed trials come from the run-id keyed hook. Quick runs have no
+   * run id, so the same projection + assembler runs locally on the doc
+   * the client already holds.
    */
   const trialChainSlotFor = (iteration: EvalIteration | null) => {
-    if (!iteration) return null;
-    const chain = trialChains.chains.get(iteration._id);
-    // An absent KEY is "not loaded", which is not "no chain" — a trial the
-    // walk has not reached renders nothing rather than a false absence.
-    if (!chain) return null;
-    return <TrialChainPanel chain={chain} resetKey={iteration._id} />;
+    if (!iteration || !chainSlotEnabled) return null;
+    if (iteration.suiteRunId) {
+      const chain = trialChains.chains.get(iteration._id);
+      if (!chain) return null;
+      return <TrialChainPanel chain={chain} resetKey={iteration._id} />;
+    }
+    return (
+      <TrialChainPanel
+        chain={chainForQuickRunIteration(iteration)}
+        resetKey={iteration._id}
+      />
+    );
   };
 
   // The host a replayed iteration actually ran on (its suite run's
@@ -3616,6 +3626,9 @@ export function TestTemplateEditor({
                         record={previewRecord}
                         testCase={currentTestCase}
                         authoredSteps={editForm?.steps ?? currentSteps}
+                        trialChainSlot={trialChainSlotFor(
+                          previewRecord.iteration ?? null,
+                        )}
                         serverNames={connectedServerList}
                         projectId={projectId}
                         onContinueInChat={onContinueInChat}
@@ -3934,6 +3947,7 @@ function RunColumn({
   recorder,
   authoredSteps,
   onRenderedWidgetTargets,
+  trialChainSlot,
 }: {
   record: CompareRunRecord;
   testCase: any;
@@ -3968,6 +3982,7 @@ function RunColumn({
    * override. May be undefined when the suite hostConfig hasn't loaded.
    */
   baselineHostStyle: string | undefined;
+  trialChainSlot?: ReactNode;
 }) {
   const themeMode = usePreferencesStore((state) => state.themeMode);
   const globalPreferenceHostStyle = usePreferencesStore(
@@ -4476,6 +4491,7 @@ function RunColumn({
       </PreviewHeaderSlot>
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden px-3 pb-3 pt-1.5">
+        {trialChainSlot}
         {shouldRenderChatShell ? (
           <ScenarioHostStyleProvider value={hostStyle}>
             <ScenarioHostThemeProvider value={themeMode}>

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -1307,22 +1307,32 @@ export function TestTemplateEditor({
           <TrialChainPanel chain={assembled} resetKey={iteration._id} />
         ) : null;
       } else {
+        // The record handed in may be the SSE `complete` snapshot. A judge
+        // landing after that rewrites the chain's last link, and the Convex
+        // subscription carries the newer doc — so prefer it when present.
+        const live =
+          recentIterations.find((it) => it._id === iteration._id) ??
+          iteration;
         chain = (
           <TrialChainPanel
-            chain={chainForQuickRunIteration(iteration)}
+            chain={chainForQuickRunIteration(live)}
             resetKey={iteration._id}
           />
         );
       }
     }
 
-    const rollup = summarizeRoutes(recentIterations);
-    const showRollup = simpleCaseEditorEnabled && rollup.total > 1;
+    // The rollup's adopt action rewrites `steps` through the simple-case
+    // model, which assumes one prompt plus tool asserts. On a multi-turn or
+    // app case that rewrite would reorder turns, so neither is offered there.
+    const simpleShape = !!editForm && isSimpleCaseShape(editForm.steps);
+    const rollup =
+      simpleCaseEditorEnabled && simpleShape
+        ? summarizeRoutes(recentIterations)
+        : null;
+    const showRollup = !!rollup && rollup.total > 1;
     const showRecordAdopt =
-      simpleCaseEditorEnabled &&
-      draftKind === "record" &&
-      !!iteration &&
-      rollup.total >= 1;
+      !!rollup && draftKind === "record" && !!iteration && rollup.total >= 1;
     if (!chain && !showRollup && !showRecordAdopt) return null;
 
     const resolvedMatch = resolveMatchOptions(
@@ -1338,7 +1348,7 @@ export function TestTemplateEditor({
     return (
       <div className="space-y-2">
         {chain}
-        {showRollup || showRecordAdopt ? (
+        {rollup && (showRollup || showRecordAdopt) ? (
           <RouteRollupCard
             rollup={rollup}
             expectedPathKey={expectedPathKey}
@@ -3320,6 +3330,7 @@ export function TestTemplateEditor({
                       </TooltipContent>
                     </Tooltip>
                   )}
+                  {useSimpleForm ? null : (
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <label className="inline-flex cursor-pointer items-center">
@@ -3347,6 +3358,7 @@ export function TestTemplateEditor({
                       Iterations for the next run
                     </TooltipContent>
                   </Tooltip>
+                  )}
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
@@ -3515,7 +3527,12 @@ export function TestTemplateEditor({
 
                   <div className="space-y-4 pt-1">
                     {editForm && useSimpleForm ? (
+                      // Keyed by case: the form holds the tools tri-state and
+                      // the stashed tools in local state, and carrying either
+                      // across a case switch would let a fresh prompt-only
+                      // draft inherit "tools" and save as a negative test.
                       <SimpleCaseForm
+                        key={`simple-case:${currentTestCase?._id ?? "none"}`}
                         steps={editForm.steps}
                         onStepsChange={setSteps}
                         matchOptions={editForm.matchOptions}

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -223,6 +223,8 @@ interface TestTemplate {
   matchOptions?: EvalMatchOptions;
   /** Case-level predicate gate override; undefined ⇒ inherit suite defaults. */
   predicates?: CasePredicates;
+  /** Authored rubric for the model judge. Empty string clears it. */
+  expectedOutput?: string;
 }
 
 interface TestTemplateEditorProps {
@@ -1167,6 +1169,7 @@ export function TestTemplateEditor({
       advancedConfig: normalizeAdvancedConfig(currentTestCase.advancedConfig),
       matchOptions: currentTestCase.matchOptions,
       predicates: currentTestCase.predicates,
+      expectedOutput: currentTestCase.expectedOutput ?? "",
     });
     // Seed the transient picker from the persisted runs so a user who saved
     // runs=N still sees N selected when the editor opens. Clamp to [1, 10]
@@ -1528,6 +1531,10 @@ export function TestTemplateEditor({
     const normalizedCurrentPredicates = JSON.stringify(
       normalizeForComparison(currentTestCase.predicates ?? null),
     );
+    const normalizedExpectedOutput = (editForm.expectedOutput ?? "").trim();
+    const normalizedCurrentExpectedOutput = (
+      currentTestCase.expectedOutput ?? ""
+    ).trim();
 
     return (
       editForm.title !== currentTestCase.title ||
@@ -1537,6 +1544,7 @@ export function TestTemplateEditor({
       normalizedAdvancedConfig !== normalizedCurrentAdvancedConfig ||
       normalizedMatchOptions !== normalizedCurrentMatchOptions ||
       normalizedPredicates !== normalizedCurrentPredicates ||
+      normalizedExpectedOutput !== normalizedCurrentExpectedOutput ||
       serverNegativeFlagMismatch
     );
   }, [editForm, currentAdvancedConfig, currentSteps, currentTestCase]);
@@ -1849,10 +1857,9 @@ export function TestTemplateEditor({
       scenario: form.scenario?.trim() ? form.scenario.trim() : undefined,
       query,
       expectedToolCalls,
-      // No per-step `expectedOutput` in the steps model (the legacy per-turn
-      // field is gone); it stays undefined just as it already did for any
-      // steps-authored case.
-      expectedOutput: undefined as string | undefined,
+      // Authored rubric for the model judge. Send "" to clear — the backend
+      // preserves the field on omit, and the judge trims "" to absent.
+      expectedOutput: form.expectedOutput?.trim() ?? "",
       steps,
       isNegativeTest,
       advancedConfig: normalizeAdvancedConfig(form.advancedConfig),

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -213,6 +213,13 @@ import {
 import { resolveHostLogoByName } from "@/lib/host-logo";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { HostChipLogo } from "@/components/hosts/host-chip";
+import { useFeatureFlagEnabled } from "posthog-js/react";
+import { SimpleCaseForm } from "./simple-case/simple-case-form";
+import { CaseSuiteChips } from "./simple-case/case-suite-chips";
+import {
+  SIMPLE_CASE_EDITOR_FLAG,
+  isSimpleCaseShape,
+} from "./simple-case/simple-case-model";
 
 interface TestTemplate {
   title: string;
@@ -280,6 +287,8 @@ interface TestTemplateEditorProps {
    * one. Only relevant when `selectedTestCaseId` is a draft sentinel.
    */
   onDraftSaved?: (newTestCaseId: string) => void;
+  /** Open suite overview / settings from the simple-case read-only chips. */
+  onOpenSuiteSettings?: () => void;
 }
 
 function recorderDebug(message: string, details?: Record<string, unknown>) {
@@ -859,10 +868,17 @@ export function TestTemplateEditor({
   ensureServersReady,
   projectServers,
   onDraftSaved,
+  onOpenSuiteSettings,
 }: TestTemplateEditorProps) {
   // Resolves the WorkOS token for signed-in users and the guest bearer for
   // guests (project-owning guests included). See use-convex-access-token.
   const getAccessToken = useConvexAccessToken();
+  const simpleCaseEditorEnabled =
+    useFeatureFlagEnabled(SIMPLE_CASE_EDITOR_FLAG) === true;
+  const [deepEditor, setDeepEditor] = useState(false);
+  const [toolsChoiceBlockReason, setToolsChoiceBlockReason] = useState<
+    string | null
+  >(null);
   const [editForm, setEditForm] = useState<TestTemplate | null>(null);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   // Guards the first-Save insert of a prompt draft so a double-click can't
@@ -1175,6 +1191,7 @@ export function TestTemplateEditor({
     // runs=N still sees N selected when the editor opens. Clamp to [1, 10]
     // — the picker only exposes that range.
     setIterationOverride(Math.max(1, Math.min(10, currentTestCase.runs ?? 1)));
+    setDeepEditor(false);
   }, [currentTestCase?._id]);
 
   /**
@@ -1572,11 +1589,20 @@ export function TestTemplateEditor({
     return areAllChecksValid(editForm.predicates.list);
   }, [editForm?.predicates]);
 
+  const useSimpleForm = Boolean(
+    simpleCaseEditorEnabled &&
+      editForm &&
+      isSimpleCaseShape(editForm.steps) &&
+      !deepEditor,
+  );
+  const simpleToolsBlock = useSimpleForm ? toolsChoiceBlockReason : null;
+
   const savePrimaryDisabled =
     !arePromptTurnsValid ||
     !arePredicatesValid ||
     isRunningCompare ||
-    isSavingDraft;
+    isSavingDraft ||
+    Boolean(simpleToolsBlock);
 
   const saveDisabledTooltip = useMemo(() => {
     if (!savePrimaryDisabled) {
@@ -1584,6 +1610,9 @@ export function TestTemplateEditor({
     }
     if (isRunningCompare) {
       return "Wait for the current run to finish before saving.";
+    }
+    if (simpleToolsBlock) {
+      return simpleToolsBlock;
     }
     if (!arePromptTurnsValid && editForm) {
       return getStepsBlockReason(editForm.steps);
@@ -1598,6 +1627,7 @@ export function TestTemplateEditor({
     arePromptTurnsValid,
     arePredicatesValid,
     editForm,
+    simpleToolsBlock,
   ]);
 
   // Pre-run credit estimate for the editor's Run / Run compare button. Priced
@@ -1644,7 +1674,8 @@ export function TestTemplateEditor({
     selectedModelValues.length === 0 ||
     isRunningCompare ||
     !canRun ||
-    !arePromptTurnsValid;
+    !arePromptTurnsValid ||
+    Boolean(simpleToolsBlock);
 
   const runDisabledTooltip = useMemo(() => {
     if (!runPrimaryDisabled) {
@@ -1661,6 +1692,9 @@ export function TestTemplateEditor({
     }
     if (!canRun) {
       return "Configure suite servers before running.";
+    }
+    if (simpleToolsBlock) {
+      return simpleToolsBlock;
     }
     if (!arePromptTurnsValid && editForm) {
       return (
@@ -1691,6 +1725,7 @@ export function TestTemplateEditor({
     editForm,
     ensureServersReady,
     isDraft,
+    simpleToolsBlock,
   ]);
 
   // Bulk replace of all steps — the flat StepListEditor edits the `TestStep[]`
@@ -1896,6 +1931,11 @@ export function TestTemplateEditor({
   const handleCreateFromDraft = async () => {
     if (!editForm || isSavingDraft) return;
 
+    if (simpleToolsBlock) {
+      toast.error(simpleToolsBlock);
+      return;
+    }
+
     if (!validateSteps(editForm.steps)) {
       toast.error(
         getStepsBlockReason(editForm.steps) ??
@@ -1940,6 +1980,11 @@ export function TestTemplateEditor({
       return;
     }
     if (!editForm || !currentTestCase) return;
+
+    if (simpleToolsBlock) {
+      toast.error(simpleToolsBlock);
+      return;
+    }
 
     if (!validateSteps(editForm.steps)) {
       toast.error(
@@ -2254,6 +2299,11 @@ export function TestTemplateEditor({
     );
     if (runModelValues.length === 0) {
       toast.error("Select at least one model to run.");
+      return;
+    }
+
+    if (simpleToolsBlock) {
+      toast.error(simpleToolsBlock);
       return;
     }
 
@@ -3127,7 +3177,16 @@ export function TestTemplateEditor({
                     }}
                   />
                 ) : null}
-                {quickRunHostOptions.length > 0 ? (
+                {useSimpleForm ? (
+                  <CaseSuiteChips
+                    models={selectedModelValues}
+                    trials={editForm?.runs ?? 1}
+                    hostLabel={
+                      selectedQuickRunHostOption?.label ?? suiteHostLabel
+                    }
+                    onOpenSuiteSettings={onOpenSuiteSettings}
+                  />
+                ) : quickRunHostOptions.length > 0 ? (
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <label className="inline-flex cursor-pointer items-center">
@@ -3379,7 +3438,49 @@ export function TestTemplateEditor({
                   ) : null}
 
                   <div className="space-y-4 pt-1">
-                    {editForm ? (
+                    {editForm && useSimpleForm ? (
+                      <SimpleCaseForm
+                        steps={editForm.steps}
+                        onStepsChange={setSteps}
+                        matchOptions={editForm.matchOptions}
+                        onMatchOptionsChange={(next) =>
+                          setEditForm((current) =>
+                            current
+                              ? { ...current, matchOptions: next }
+                              : current,
+                          )
+                        }
+                        suiteDefaultMatchOptions={suite?.defaultMatchOptions}
+                        expectedOutput={editForm.expectedOutput}
+                        onExpectedOutputChange={(next) =>
+                          setEditForm((current) =>
+                            current
+                              ? { ...current, expectedOutput: next }
+                              : current,
+                          )
+                        }
+                        predicates={editForm.predicates}
+                        onPredicatesChange={(next) =>
+                          setEditForm((current) =>
+                            current
+                              ? { ...current, predicates: next }
+                              : current,
+                          )
+                        }
+                        suiteDefaultPredicates={
+                          (suite?.defaultPredicates ?? []) as Predicate[]
+                        }
+                        availableTools={assertableTools.map((tool) =>
+                          typeof tool === "string" ? tool : tool.name,
+                        )}
+                        isNegativeTest={currentTestCase.isNegativeTest}
+                        onOpenDeepEditor={() => setDeepEditor(true)}
+                        onToolsChoiceBlockReasonChange={
+                          setToolsChoiceBlockReason
+                        }
+                        evalValidationBorderClass={evalValidationBorderClass}
+                      />
+                    ) : editForm ? (
                       <StepListEditor
                         steps={editForm.steps}
                         onStepsChange={setSteps}

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -409,6 +409,8 @@ export type EvalCase = {
   isNegativeTest?: boolean; // When true, test passes if NO tools are called
   scenario?: string; // Description of why app should NOT trigger (negative tests only)
   expectedOutput?: string; // The output or experience expected from the MCP server
+  /** Authored case kind; absent means the editor derives it from matchOptions. */
+  kind?: "capability" | "regression";
   /**
    * Unified authored test steps — the source of truth for execution and the
    * "is this a render check?" detection (`isModelFree(steps)`). Replaces the

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -1492,6 +1492,20 @@ export function useEvalHandlers({
     [navigateAfterTestCaseMutation]
   );
 
+  // Record = run-once-then-adopt, not the widget recorder. Same unsaved
+  // draft path as Write; the editor focuses the prompt and surfaces adopt
+  // after the first Quick Run.
+  const handleRecordTestCase = useCallback(
+    (suiteId: string) => {
+      navigateAfterTestCaseMutation({
+        type: "test-edit",
+        suiteId,
+        testId: draftTestCaseId("record"),
+      });
+    },
+    [navigateAfterTestCaseMutation]
+  );
+
   // Handle delete test case - opens confirmation modal
   const handleDeleteTestCase = useCallback(
     (testCaseId: string, testCaseTitle: string) => {
@@ -1812,6 +1826,7 @@ export function useEvalHandlers({
     directDeleteRun,
     confirmDeleteRun,
     handleCreateTestCase,
+    handleRecordTestCase,
     handleDeleteTestCase,
     directDeleteTestCase,
     confirmDeleteTestCase,

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
@@ -2860,6 +2860,60 @@ describe("v1 eval-edit routes", () => {
   });
 
   /**
+   * `kind` rides the same three-way protocol as `intent`. The point of these
+   * is the silent-drop trap: a v1 body is non-strict on create, so a field
+   * the route forgets to forward vanishes with a 201 — and the CLI's
+   * `--file` sync would then claim a kind the case never got.
+   */
+  describe("per-case kind", () => {
+    const PROMPT_STEP = { id: "s1", kind: "prompt", prompt: "hi" };
+    const CASES_PATH = "/api/v1/projects/p1/eval-suites/suite_1/cases";
+    const CASE_PATH = `${CASES_PATH}/case_1`;
+
+    it("forwards a valid kind on create", async () => {
+      const res = await request("POST", CASES_PATH, {
+        title: "Refund flow",
+        steps: [PROMPT_STEP],
+        kind: "regression",
+      });
+
+      expect(res.status).toBe(201);
+      expect(authoredCaseArgs().kind).toBe("regression");
+    });
+
+    it("forwards a valid kind on PATCH", async () => {
+      const res = await request("PATCH", CASE_PATH, { kind: "capability" });
+
+      expect(res.status).toBe(200);
+      expect(updateArgs().kind).toBe("capability");
+    });
+
+    it("omits kind on PATCH when the caller leaves it untouched", async () => {
+      const res = await request("PATCH", CASE_PATH, { title: "Renamed" });
+
+      expect(res.status).toBe(200);
+      expect("kind" in updateArgs()).toBe(false);
+    });
+
+    it("forwards null on PATCH to clear kind", async () => {
+      const res = await request("PATCH", CASE_PATH, { kind: null });
+
+      expect(res.status).toBe(200);
+      expect(updateArgs().kind).toBeNull();
+    });
+
+    it.each(["", "smoke", "CAPABILITY"])(
+      "rejects invalid kind %j on PATCH before mutation",
+      async (kind) => {
+        const res = await request("PATCH", CASE_PATH, { kind });
+
+        expect(res.status).toBe(400);
+        expect(convexMutationMock).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  /**
    * The per-case IMPORT CLAIM, across every public write and read.
    *
    * Asserted at the TRANSPORT boundary — the exact Convex mutation argument and

--- a/mcpjam-inspector/server/routes/v1/eval-stage-projection.ts
+++ b/mcpjam-inspector/server/routes/v1/eval-stage-projection.ts
@@ -1,61 +1,12 @@
 /**
  * Public projection of an iteration's stage evidence.
  *
- * This is intentionally separate from `evals.ts` so its TEST exercises the
- * real metadata boundary. `metadata` is an open record carrying internal
- * signals and quarantined raw payloads; only this explicit whitelist may cross
- * into a public DTO.
+ * The body lives in the SDK contract so the inspector client can apply the
+ * same whitelist to a quick-run doc it already holds. This file stays the
+ * server's import path so `toIterationDto` and the existing test are
+ * untouched.
  */
 
-import { stageDerivationSchema } from "@mcpjam/sdk/contract";
+import { projectStageDerivation } from "@mcpjam/sdk/contract";
 
-/**
- * Project the verified stage derivation, or its quarantine marker.
- *
- * The whole derivation is validated together because `firstFailedStage` and
- * `failureCategory` are claims about the rows: if the rows do not validate,
- * neither claim can be checked against them. In that case the public contract
- * exposes only `stageResultsUnverified` and an independently valid version,
- * never the chain or either unverified claim.
- *
- * Fields are omitted rather than nulled, so iterations predating D1 remain
- * byte-identical to their former DTOs.
- */
-export function toStageProjection(metadata: unknown): Record<string, unknown> {
-  if (!metadata || typeof metadata !== "object") return {};
-  const record = metadata as Record<string, unknown>;
-  if (!("stageResults" in record)) return {};
-
-  const derivation = stageDerivationSchema.safeParse({
-    stageResults: record.stageResults,
-    ...(record.firstFailedStage !== undefined
-      ? { firstFailedStage: record.firstFailedStage }
-      : {}),
-    ...(record.failureCategory !== undefined
-      ? { failureCategory: record.failureCategory }
-      : {}),
-    stageAnalyzerVersion: record.stageAnalyzerVersion,
-  });
-  if (derivation.success) {
-    return {
-      stageResults: derivation.data.stageResults,
-      ...(derivation.data.firstFailedStage
-        ? { firstFailedStage: derivation.data.firstFailedStage }
-        : {}),
-      ...(derivation.data.failureCategory
-        ? { failureCategory: derivation.data.failureCategory }
-        : {}),
-      stageAnalyzerVersion: derivation.data.stageAnalyzerVersion,
-    };
-  }
-
-  const version = record.stageAnalyzerVersion;
-  return {
-    stageResultsUnverified: true,
-    ...(typeof version === "number" &&
-    Number.isInteger(version) &&
-    version >= 0
-      ? { stageAnalyzerVersion: version }
-      : {}),
-  };
-}
+export const toStageProjection = projectStageDerivation;

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -1828,6 +1828,9 @@ function toCaseDto(testCase: CaseDoc) {
         }
       : {}),
     ...(typeof testCase.intent === "string" ? { intent: testCase.intent } : {}),
+    ...(testCase.kind === "capability" || testCase.kind === "regression"
+      ? { kind: testCase.kind }
+      : {}),
     ...(importClaim ? { import: importClaim } : {}),
     createdAt: testCase.createdAt ?? null,
     updatedAt: testCase.updatedAt ?? null,
@@ -2142,6 +2145,12 @@ const publicCaseBodyShape = {
    * `createCaseSchema` narrows this to the stored (string-only) form below.
    */
   intent: caseIntentUpdateSchema.optional(),
+  /**
+   * Authored case kind (capability | regression). Same three-way protocol as
+   * `intent`: omitted preserves, `null` clears, a literal sets. Metadata plus
+   * an authoring default — nothing in the runner or verdict reads it.
+   */
+  kind: z.enum(["capability", "regression"]).nullable().optional(),
   models: z
     .array(
       z.object({
@@ -2194,6 +2203,8 @@ const createCaseSchema = z.strictObject({
   id: opaqueIdSchema.optional(),
   // A new case has nothing to clear: stored intent is a string or absent.
   intent: caseIntentSchema.optional(),
+  // Likewise for kind: `null` on create has nothing to clear.
+  kind: z.enum(["capability", "regression"]).optional(),
   /** The converter's claim for this case. See {@link publicCaseImportSchema}. */
   import: publicCaseImportSchema.optional(),
 });
@@ -2492,10 +2503,11 @@ const generateCasesSchema = z
  */
 type CaseMutationBody = Omit<
   z.infer<typeof createCaseSchema>,
-  "import" | "intent"
+  "import" | "intent" | "kind"
 > & {
   import?: z.infer<typeof publicCaseImportSchema> | null;
   intent?: z.infer<typeof caseIntentUpdateSchema>;
+  kind?: "capability" | "regression" | null;
 };
 
 function buildCaseMutationArgs(
@@ -2535,6 +2547,8 @@ function buildCaseMutationArgs(
   // clear; string = set. Never use a truthiness check here: it would collapse
   // the explicit clear into omission before Convex can apply it.
   if (body.intent !== undefined) args.intent = body.intent;
+  // Same definedness rule as intent: `null` must reach Convex as the clear.
+  if (body.kind !== undefined) args.kind = body.kind;
   if (body.expectedOutput !== undefined)
     args.expectedOutput = body.expectedOutput;
 

--- a/sdk/src/contract/eval-suite.schema.generated.ts
+++ b/sdk/src/contract/eval-suite.schema.generated.ts
@@ -255,6 +255,12 @@ export const evalSuiteFileJsonSchema: Record<string, unknown> = {
               { type: "null" },
             ],
           },
+          kind: {
+            anyOf: [
+              { type: "string", enum: ["capability", "regression"] },
+              { type: "null" },
+            ],
+          },
           steps: {
             minItems: 1,
             maxItems: 200,

--- a/sdk/src/contract/eval-suite.schema.json
+++ b/sdk/src/contract/eval-suite.schema.json
@@ -269,6 +269,12 @@
               { "type": "null" }
             ]
           },
+          "kind": {
+            "anyOf": [
+              { "type": "string", "enum": ["capability", "regression"] },
+              { "type": "null" }
+            ]
+          },
           "steps": {
             "minItems": 1,
             "maxItems": 200,

--- a/sdk/src/contract/index.ts
+++ b/sdk/src/contract/index.ts
@@ -567,3 +567,11 @@ export {
   evalRunMeasurementUnitSchema,
   measurementUnitLabel,
 } from "./decision-summary.js";
+
+export {
+  NO_TOOL_PATH_KEY,
+  PATH_SEPARATOR,
+  buildPathKey,
+  collapseImmediateRepeats,
+  toolNamesFromPathKey,
+} from "./tool-path.js";

--- a/sdk/src/contract/index.ts
+++ b/sdk/src/contract/index.ts
@@ -168,6 +168,7 @@ export {
   deriveStageResults,
   isPositiveToolCallPredicateKind,
   isSelectionPredicateKind,
+  projectStageDerivation,
   stageDerivationSchema,
   stageDerivationToMetadata,
   stageReasonSchema,

--- a/sdk/src/contract/stage-derivation.ts
+++ b/sdk/src/contract/stage-derivation.ts
@@ -1643,3 +1643,52 @@ export function stageDerivationToMetadata(
     stageAnalyzerVersion: derivation.stageAnalyzerVersion,
   };
 }
+
+/**
+ * Public projection of an iteration's stage evidence.
+ *
+ * `metadata` is an open record; only this whitelist may cross into a
+ * decision-chain assembly. Validated derivations pass through; invalid
+ * rows become `stageResultsUnverified`. Pre-D1 metadata (no
+ * `stageResults`) is omitted so those iterations stay byte-identical.
+ */
+export function projectStageDerivation(
+  metadata: unknown,
+): Record<string, unknown> {
+  if (!metadata || typeof metadata !== "object") return {};
+  const record = metadata as Record<string, unknown>;
+  if (!("stageResults" in record)) return {};
+
+  const derivation = stageDerivationSchema.safeParse({
+    stageResults: record.stageResults,
+    ...(record.firstFailedStage !== undefined
+      ? { firstFailedStage: record.firstFailedStage }
+      : {}),
+    ...(record.failureCategory !== undefined
+      ? { failureCategory: record.failureCategory }
+      : {}),
+    stageAnalyzerVersion: record.stageAnalyzerVersion,
+  });
+  if (derivation.success) {
+    return {
+      stageResults: derivation.data.stageResults,
+      ...(derivation.data.firstFailedStage
+        ? { firstFailedStage: derivation.data.firstFailedStage }
+        : {}),
+      ...(derivation.data.failureCategory
+        ? { failureCategory: derivation.data.failureCategory }
+        : {}),
+      stageAnalyzerVersion: derivation.data.stageAnalyzerVersion,
+    };
+  }
+
+  const version = record.stageAnalyzerVersion;
+  return {
+    stageResultsUnverified: true,
+    ...(typeof version === "number" &&
+    Number.isInteger(version) &&
+    version >= 0
+      ? { stageAnalyzerVersion: version }
+      : {}),
+  };
+}

--- a/sdk/src/contract/stage-derivation.ts
+++ b/sdk/src/contract/stage-derivation.ts
@@ -1653,7 +1653,7 @@ export function stageDerivationToMetadata(
  * `stageResults`) is omitted so those iterations stay byte-identical.
  */
 export function projectStageDerivation(
-  metadata: unknown,
+  metadata: unknown
 ): Record<string, unknown> {
   if (!metadata || typeof metadata !== "object") return {};
   const record = metadata as Record<string, unknown>;
@@ -1685,9 +1685,7 @@ export function projectStageDerivation(
   const version = record.stageAnalyzerVersion;
   return {
     stageResultsUnverified: true,
-    ...(typeof version === "number" &&
-    Number.isInteger(version) &&
-    version >= 0
+    ...(typeof version === "number" && Number.isInteger(version) && version >= 0
       ? { stageAnalyzerVersion: version }
       : {}),
   };

--- a/sdk/src/contract/suite-file.ts
+++ b/sdk/src/contract/suite-file.ts
@@ -429,6 +429,11 @@ export const evalSuiteFileCaseSchema = z
     /** Optional analytics grouping label. `null` explicitly clears it. */
     intent: caseIntentUpdateSchema.optional(),
     /**
+     * Authored case kind. Absent means the editor derives it from
+     * matchOptions. `null` explicitly clears it.
+     */
+    kind: z.enum(["capability", "regression"]).nullable().optional(),
+    /**
      * The authored steps, reused VERBATIM from the canonical step union — this
      * is not a suite-file dialect of steps. Step `id`s are therefore required
      * here too: they carry per-step history and make the round-trip exact.

--- a/sdk/src/contract/tool-path.ts
+++ b/sdk/src/contract/tool-path.ts
@@ -40,7 +40,7 @@ export function toolNamesFromPathKey(pathKey: string | undefined): string[] {
       pathKey
         .split(PATH_SEPARATOR)
         .map((name) => name.trim())
-        .filter(Boolean),
-    ),
+        .filter(Boolean)
+    )
   );
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1595,4 +1595,4 @@ export {
   buildPathKey,
   collapseImmediateRepeats,
   toolNamesFromPathKey,
-} from "./tool-path.js";
+} from "./contract/tool-path.js";

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1588,3 +1588,11 @@ export type {
   GetTaskExtResult,
   UpdateTaskExtResult,
 } from "./mcp-client-manager/index.js";
+
+export {
+  NO_TOOL_PATH_KEY,
+  PATH_SEPARATOR,
+  buildPathKey,
+  collapseImmediateRepeats,
+  toolNamesFromPathKey,
+} from "./tool-path.js";

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -4699,6 +4699,12 @@ const evalCaseInput = z.object({
     .describe(
       "Optional analytics grouping label for this case. It does not change scoring or verdicts."
     ),
+  kind: z
+    .enum(["capability", "regression"])
+    .optional()
+    .describe(
+      "Authored case kind for the simple editor. Absent means the editor derives it from matchOptions."
+    ),
   runs: z
     .number()
     .int()
@@ -4909,6 +4915,12 @@ const caseFieldsShape = {
     .optional()
     .describe(
       "Optional analytics grouping label for this case. It does not change scoring or verdicts."
+    ),
+  kind: z
+    .enum(["capability", "regression"])
+    .optional()
+    .describe(
+      "Authored case kind for the simple editor. Absent means the editor derives it from matchOptions."
     ),
   // The unified test-step model REPLACES the old kind / prompt / turns /
   // expectedToolCalls / renderCheck authoring fields (Phase 2.5 clean break).
@@ -5916,6 +5928,13 @@ const updateEvalCaseInput = z.object({
     .optional()
     .describe(
       "Analytics grouping label. Omit to preserve it; pass null to clear it. It never changes scoring or verdicts."
+    ),
+  kind: z
+    .enum(["capability", "regression"])
+    .nullable()
+    .optional()
+    .describe(
+      "Authored case kind. Omit to preserve it; pass null to clear it."
     ),
 });
 export type UpdateEvalCaseInput = z.infer<typeof updateEvalCaseInput>;

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -1574,6 +1574,8 @@ export interface PlatformEvalCase {
   title: string;
   /** Optional authored analytics grouping label; absent is unlabelled. */
   intent?: string;
+  /** Authored case kind; absent means the editor derives it from matchOptions. */
+  kind?: "capability" | "regression";
   /** Ordered test steps that define the case. */
   steps: PlatformEvalStep[];
   expectedOutput?: string;

--- a/sdk/src/suite-file-loader.ts
+++ b/sdk/src/suite-file-loader.ts
@@ -160,6 +160,8 @@ export type ResolvedEvalSuiteFileCase = {
   title: string;
   /** Authored analytics grouping label; absent remains unlabelled. */
   intent?: string;
+  /** Authored case kind; absent means derive from matchOptions. */
+  kind?: "capability" | "regression";
   steps: EvalSuiteFileCase["steps"];
   assertions: NonNullable<EvalSuiteFileCase["assertions"]>;
   expectedOutput?: string;
@@ -553,6 +555,9 @@ function resolveCase(
     ...(typeof authoredCase.intent === "string"
       ? { intent: authoredCase.intent }
       : {}),
+    ...(authoredCase.kind === "capability" || authoredCase.kind === "regression"
+      ? { kind: authoredCase.kind }
+      : {}),
     steps: authoredCase.steps,
     assertions: authoredCase.assertions ?? [],
     ...(authoredCase.expectedOutput === undefined
@@ -624,6 +629,7 @@ const CASE_KEY_ORDER = [
   "id",
   "title",
   "intent",
+  "kind",
   "disabled",
   "model",
   "repetitions",

--- a/sdk/src/tool-path.ts
+++ b/sdk/src/tool-path.ts
@@ -1,0 +1,46 @@
+/**
+ * Observational tool-route keys.
+ *
+ * Lifted from the backend usage-insights trajectory helper so evals can
+ * describe "the same route in k of N trials" without importing Convex.
+ * `search,search,get` collapses to `search→get`. The backend copy is a
+ * follow-up `check:mirrors` candidate.
+ */
+
+export const PATH_SEPARATOR = "→";
+
+/** Sentinel `pathKey` for a trial that never called a tool. */
+export const NO_TOOL_PATH_KEY = "no_tools";
+
+/** Collapse immediately-repeated names; `[]` in, `[]` out. */
+export function collapseImmediateRepeats(names: string[]): string[] {
+  const out: string[] = [];
+  for (const name of names) {
+    if (out[out.length - 1] === name) continue;
+    out.push(name);
+  }
+  return out;
+}
+
+/** `pathKey` for an already-ordered tool-name sequence. */
+export function buildPathKey(toolCallSequence: string[]): string {
+  const collapsed = collapseImmediateRepeats(toolCallSequence);
+  if (collapsed.length === 0) return NO_TOOL_PATH_KEY;
+  return collapsed.join(PATH_SEPARATOR);
+}
+
+/**
+ * Recover the distinct tool names from a stored `pathKey`.
+ * Returns `[]` for the no-tools sentinel.
+ */
+export function toolNamesFromPathKey(pathKey: string | undefined): string[] {
+  if (!pathKey || pathKey === NO_TOOL_PATH_KEY) return [];
+  return Array.from(
+    new Set(
+      pathKey
+        .split(PATH_SEPARATOR)
+        .map((name) => name.trim())
+        .filter(Boolean),
+    ),
+  );
+}

--- a/sdk/tests/stage-derivation-projection.test.ts
+++ b/sdk/tests/stage-derivation-projection.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  STAGE_ANALYZER_VERSION,
+  projectStageDerivation,
+  type StageResultRow,
+} from "../src/contract/index.js";
+
+const rows: StageResultRow[] = [
+  { stage: "connection", state: "passed" },
+  { stage: "discovery", state: "passed" },
+  { stage: "selection", state: "passed" },
+  { stage: "call", state: "failed", reason: "argumentMismatch" },
+  { stage: "response", state: "notReached", reason: "earlierStageFailed" },
+  { stage: "userValue", state: "notReached", reason: "earlierStageFailed" },
+];
+
+describe("projectStageDerivation", () => {
+  it("projects a validated derivation with an ahead version unchanged", () => {
+    expect(
+      projectStageDerivation({
+        stageResults: rows,
+        firstFailedStage: "call",
+        failureCategory: "arguments",
+        stageAnalyzerVersion: STAGE_ANALYZER_VERSION + 1,
+        internalOnly: "drop me",
+      }),
+    ).toEqual({
+      stageResults: rows,
+      firstFailedStage: "call",
+      failureCategory: "arguments",
+      stageAnalyzerVersion: STAGE_ANALYZER_VERSION + 1,
+    });
+  });
+
+  it("quarantines invalid rows and keeps only an independently valid version", () => {
+    expect(
+      projectStageDerivation({
+        stageResults: [{ stage: "call", state: "failed" }],
+        firstFailedStage: "call",
+        failureCategory: "arguments",
+        stageAnalyzerVersion: 7,
+      }),
+    ).toEqual({
+      stageResultsUnverified: true,
+      stageAnalyzerVersion: 7,
+    });
+    expect(
+      projectStageDerivation({
+        stageResults: [{ stage: "call", state: "failed" }],
+        stageAnalyzerVersion: -1,
+      }),
+    ).toEqual({ stageResultsUnverified: true });
+  });
+
+  it("omits pre-D1 metadata and does not project a version by itself", () => {
+    expect(projectStageDerivation({ turnCount: 1 })).toEqual({});
+    expect(projectStageDerivation({ stageAnalyzerVersion: 2 })).toEqual({});
+    expect(projectStageDerivation(null)).toEqual({});
+  });
+});

--- a/sdk/tests/stage-derivation-projection.test.ts
+++ b/sdk/tests/stage-derivation-projection.test.ts
@@ -23,7 +23,7 @@ describe("projectStageDerivation", () => {
         failureCategory: "arguments",
         stageAnalyzerVersion: STAGE_ANALYZER_VERSION + 1,
         internalOnly: "drop me",
-      }),
+      })
     ).toEqual({
       stageResults: rows,
       firstFailedStage: "call",
@@ -39,7 +39,7 @@ describe("projectStageDerivation", () => {
         firstFailedStage: "call",
         failureCategory: "arguments",
         stageAnalyzerVersion: 7,
-      }),
+      })
     ).toEqual({
       stageResultsUnverified: true,
       stageAnalyzerVersion: 7,
@@ -48,7 +48,7 @@ describe("projectStageDerivation", () => {
       projectStageDerivation({
         stageResults: [{ stage: "call", state: "failed" }],
         stageAnalyzerVersion: -1,
-      }),
+      })
     ).toEqual({ stageResultsUnverified: true });
   });
 

--- a/sdk/tests/suite-file-loader.test.ts
+++ b/sdk/tests/suite-file-loader.test.ts
@@ -367,6 +367,36 @@ describe("case intent", () => {
   });
 });
 
+describe("case kind", () => {
+  it("accepts capability and regression and omits when absent", () => {
+    const authored: EvalSuiteFile = {
+      ...MINIMAL,
+      cases: MINIMAL.cases.map((entry, index) =>
+        index === 0 ? { ...entry, kind: "regression" } : entry
+      ),
+    };
+    const loaded = loadOrThrow(serializeEvalSuiteFile(authored));
+    expect(loaded.authored.cases[0]?.kind).toBe("regression");
+    expect(loaded.resolved.cases[0]?.kind).toBe("regression");
+
+    const omitted = loadOrThrow(serializeEvalSuiteFile(MINIMAL));
+    expect(omitted.authored.cases[0]?.kind).toBeUndefined();
+    expect(omitted.resolved.cases[0]?.kind).toBeUndefined();
+  });
+
+  it("treats an explicit null kind as absent in the runner view", () => {
+    const authored: EvalSuiteFile = {
+      ...MINIMAL,
+      cases: MINIMAL.cases.map((entry, index) =>
+        index === 0 ? { ...entry, kind: null } : entry
+      ),
+    };
+    const loaded = loadOrThrow(asText(authored));
+    expect(loaded.authored.cases[0]?.kind).toBeNull();
+    expect(loaded.resolved.cases[0]?.kind).toBeUndefined();
+  });
+});
+
 describe("findings", () => {
   const duplicateCaseIds = asText(
     payload(findFixture(data.reject, "duplicate case ids"))

--- a/sdk/tests/tool-path.test.ts
+++ b/sdk/tests/tool-path.test.ts
@@ -5,7 +5,7 @@ import {
   buildPathKey,
   collapseImmediateRepeats,
   toolNamesFromPathKey,
-} from "../src/tool-path.js";
+} from "../src/contract/tool-path.js";
 
 describe("tool-path", () => {
   it("collapses immediate repeats so search,search,get becomes search→get", () => {
@@ -14,13 +14,13 @@ describe("tool-path", () => {
       "get",
     ]);
     expect(buildPathKey(["search", "search", "get"])).toBe(
-      `search${PATH_SEPARATOR}get`,
+      `search${PATH_SEPARATOR}get`
     );
   });
 
   it("keeps a genuine revisit (search→get→search)", () => {
     expect(buildPathKey(["search", "get", "search"])).toBe(
-      `search${PATH_SEPARATOR}get${PATH_SEPARATOR}search`,
+      `search${PATH_SEPARATOR}get${PATH_SEPARATOR}search`
     );
   });
 

--- a/sdk/tests/tool-path.test.ts
+++ b/sdk/tests/tool-path.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  NO_TOOL_PATH_KEY,
+  PATH_SEPARATOR,
+  buildPathKey,
+  collapseImmediateRepeats,
+  toolNamesFromPathKey,
+} from "../src/tool-path.js";
+
+describe("tool-path", () => {
+  it("collapses immediate repeats so search,search,get becomes search→get", () => {
+    expect(collapseImmediateRepeats(["search", "search", "get"])).toEqual([
+      "search",
+      "get",
+    ]);
+    expect(buildPathKey(["search", "search", "get"])).toBe(
+      `search${PATH_SEPARATOR}get`,
+    );
+  });
+
+  it("keeps a genuine revisit (search→get→search)", () => {
+    expect(buildPathKey(["search", "get", "search"])).toBe(
+      `search${PATH_SEPARATOR}get${PATH_SEPARATOR}search`,
+    );
+  });
+
+  it("uses the no-tools sentinel for an empty sequence", () => {
+    expect(buildPathKey([])).toBe(NO_TOOL_PATH_KEY);
+    expect(toolNamesFromPathKey(NO_TOOL_PATH_KEY)).toEqual([]);
+  });
+
+  it("recovers distinct names from a pathKey", () => {
+    expect(toolNamesFromPathKey(`search${PATH_SEPARATOR}get`)).toEqual([
+      "search",
+      "get",
+    ]);
+  });
+});


### PR DESCRIPTION
## What

A simpler default eval case editor, behind the new `eval-simple-case-editor` flag, built on the user-value chain and over UNCHANGED step, suite-file, and decision contracts. Flag off: the UI is byte-identical to today.

With the flag on, a single-turn case is three questions:

1. **Capability | Regression** — the first fork. Regression writes `matchOptions {strict, 0 extras}`; capability writes the SDK defaults. `argumentMatching` is carried over, never reset. Kind is derived from resolved `matchOptions` when no persisted `kind` exists.
2. **What does the user ask?** — `steps[0]` prompt.
3. **Which tool should handle it?** (capability) / **Which route should it take?** (regression: ordered, with arguments) — `toolCalledWith` assert steps, the existing gating `toolCalls:match` scorer. **No tool should be called** is now an authored choice (`isNegativeTest: true`), and the tools question is a required tri-state so an unfinished case cannot save as a negative test.
4. **What does a good answer accomplish?** — writes `expectedOutput`, which the goal-completion judge already reads first. The deep editor previously hardcoded it to `undefined` on save; it now round-trips.
5. **More checks** — one collapsed disclosure of the existing predicates, grouped Response / Selection and call / App view, with a partition test over the predicate catalog. `toolCalledWith` is excluded because the tool question owns it.

Model, trials, and host are read-only suite chips on the header. Multi-turn, app, and browser cases still open the existing step list, and "Steps" switches to it losslessly (both editors edit the same `editForm.steps`).

**Result pane.** Quick runs now show the same per-trial six-stage chain as suite runs. The server's stage projection moved into the SDK contract (`projectStageDerivation`) so the client applies the one whitelist to the doc it already holds, and `assembleEvalRunDecisionChain` still owns verified / unverified / absent. Multi-trial quick runs get an **Observational** route rollup ("same route in k of N") with "Use this trial's route as expected". No verdict, no pass^k.

**New case entry** (flag on): Generate → Record → Write. Record is run-once-then-adopt, not the widget recorder, which never synthesizes tool expectations.

**Persisted `kind`** (last step): suite file, SDK, CLI `--file`, v1 API body + DTO, and the save payload.

Design mock: https://claude.ai/code/artifact/40fb9f1d-8422-4b1b-9d4f-2e975787a603

## Commits are one per planned step

Six feature commits (steps 1–5 and 7 of the plan) plus three review fixups labelled with the steps they belong to. This ships as one PR rather than six serial ones because the whole feature is dark behind one flag and every intermediate step is inert on its own; prefer **rebase and merge** to keep the per-step history, or squash if that is house style.

## Deploy and flag ordering

Backend `testCase.kind` is MCPJam/mcpjam-backend#1252. Convex rejects unknown mutation args, but this PR only sends `kind` after a user toggles it in the flagged form or authors it in a suite file, so **merge order is free**. What must wait: **do not enable `eval-simple-case-editor` on a deployment until `npx convex function-spec` shows `kind` on `updateTestCase.args` there** (staging auto-deploys from backend main; prod needs a promotion).

## Review pointers

- `client/src/components/evals/simple-case/simple-case-model.ts` — pure model: kind derivation, kind→matchOptions, simple-shape detection, read/write of steps, More checks partition.
- `client/src/components/evals/simple-case/simple-case-form.tsx` — the form.
- `test-template-editor.tsx` — `useSimpleForm` mount (keyed by case), header chips, `trialChainSlotFor` (quick-run branch + rollup gated on simple shape), `buildSavePayload` (`expectedOutput`, `kind`).
- `sdk/src/contract/stage-derivation.ts` `projectStageDerivation` + `server/routes/v1/eval-stage-projection.ts` now an alias.
- `sdk/src/contract/tool-path.ts` — lifted from backend `usageInsights/trajectory.ts`; a `check:mirrors` candidate as follow-up.
- `server/routes/v1/evals.ts` — `kind` on the shared case body (nullable on PATCH), mutation args, DTO.

## Risks worth knowing

- Authoring a rubric flips the judge's `rubricSource` from `assertions` to `expected_output`, so `rubricHash` changes for that case and prior judge calibration for it no longer matches. Said inline in the form; never auto-filled.
- `deriveIsNegativeTestFromSteps` still treats "no tools yet" as negative; the form's required tri-state is what prevents that on the new path. The deep editor is unchanged.
- Toggling Capability on a suite with strict defaults writes an explicit case override (intended; the existing override badge shows it).

## Verification

- Client: the editor, form, model, rollup, chain, overview, sidebar, step-list, catalog (still 6/12), pass-criteria, cost-estimate, validation, and the 21-case compare-route suites pass, plus the new flagged cases in the compare-route file.
- Server: `eval-edit` (incl. new `kind` omit/null/literal/reject tests), `openapi-drift`, `openapi-types-parity`, `openapi-decision-vocabularies`, `eval-stage-projection` pass.
- SDK: `stage-derivation-projection`, `suite-file-loader`, `tool-path` pass; `tsc --noEmit` clean.
- Client typecheck clean for all touched files.
- **Not run:** a live flagged end-to-end against a dev server. `cli/tests/eval-suite-file.test.ts` was not runnable in a worktree (bare SDK import resolves to a stale dist); CI is the arbiter for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpeKSRZ9nNXFRHkA2tzdqM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches eval case authoring, save payloads, and API/schema contracts; enabling the flag before backend accepts `testCase.kind` can fail saves, and persisting `expectedOutput` changes judge rubric sourcing for affected cases.
> 
> **Overview**
> Adds a **PostHog-flagged** (`eval-simple-case-editor`) **simple case editor** for single-turn cases: capability vs regression (via `matchOptions`), user prompt, tool/route expectations, an **`expectedOutput` rubric** that now **survives save** (no longer forced to `undefined`), and grouped “More checks.” Multi-turn and app cases still use the step list; **Steps** toggles between the two without losing `editForm.steps`.
> 
> **Quick runs** show the same **six-stage trial chain** as suite runs by moving **`projectStageDerivation`** into the SDK and assembling quick-run chains client-side. Multi-trial quick runs get an **observational route rollup** and **“Use this trial’s route as expected”** (capability dedupes tool names; regression keeps arguments).
> 
> **Authoring UX when the flag is on:** empty-state actions become **Generate → Record → Write**; **Record** uses a `draft:record` route for run-once-then-adopt. **`kind`** (`capability` | `regression`) flows through suite files, OpenAPI/v1 API, CLI file sync, and save payloads (PATCH omit / null / set, same as `intent`).
> 
> **SDK:** shared **tool path keys** (`buildPathKey`, `NO_TOOL_PATH_KEY`) for route rollup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ef3defa9d9c71a831b46263f653d4fb1aa4e388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a flag-gated simple case editor that authors single-turn eval cases as three questions (capability/regression, the user ask, and the tool route) over the unchanged step contracts, and makes quick runs show the same per-trial decision chain as suite runs. With the flag off, the UI is byte-identical.

**Deployment**
- Backend must accept `testCase.kind` before enabling `eval-simple-case-editor`; Convex rejects unknown mutation args, so verify `kind` is on `updateTestCase.args` first.
- Merge order is free — `kind` is only sent after a user authors it in the flagged form or a suite file.

**Side effects**
- Authoring a rubric switches the judge's `rubricSource` from `assertions` to `expected_output`, changing `rubricHash` for that case and invalidating prior calibration.
- "No tool should be called" is now an explicit authored choice; the tools question is a required tri-state so an unfinished case cannot save as a negative test.
- `expectedOutput` now round-trips on save instead of being dropped by the deep editor.
- The multi-trial quick-run rollup has no verdict; adopting a trial's route writes the observed tools into the same steps the form grades.

<sup>Written for commit 5ef3defa9d9c71a831b46263f653d4fb1aa4e388. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

