### PR TITLE
feat(csp): correlate violations with applied policies

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/BlockedRequestCard.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/BlockedRequestCard.tsx
@@ -22,6 +22,8 @@ function pillClasses(klass: Diagnosis["class"]): string {
       return "bg-purple-500/10 text-purple-600 dark:text-purple-400";
     case "runtime-mismatch":
       return "bg-sky-500/10 text-sky-600 dark:text-sky-400";
+    case "policy-unavailable":
+      return "bg-muted text-muted-foreground";
     case "network":
       return "bg-muted text-muted-foreground";
     case "sandbox":
@@ -35,6 +37,8 @@ function pillLabel(klass: Diagnosis["class"]): string {
       return "HOST-STRIPPED";
     case "runtime-mismatch":
       return "MISMATCH";
+    case "policy-unavailable":
+      return "UNAVAILABLE";
     default:
       return klass.toUpperCase();
   }
@@ -87,10 +91,9 @@ export function BlockedRequestCard({
   };
 
   const handlePreviewHypothesis = () => {
-    toast(
-      "Hypothesis preview recorded · re-run flow coming soon",
-      { duration: 2200 },
-    );
+    toast("Hypothesis preview recorded · re-run flow coming soon", {
+      duration: 2200,
+    });
   };
 
   return (
@@ -166,28 +169,28 @@ export function BlockedRequestCard({
               <strong className="font-medium">
                 Adding this won&apos;t fix the current run.
               </strong>{" "}
-              The host stripped this entry before the browser ever received
-              the policy. Copy the declaration to document your portability
-              intent — and consider self-hosting the resource for this host.
+              The host stripped this entry before the browser ever received the
+              policy. Copy the declaration to document your portability intent —
+              and consider self-hosting the resource for this host.
             </div>
           )}
 
           {isRuntimeMismatch && (
             <div className="rounded-md border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-[11.5px] leading-relaxed">
-              <strong className="font-medium">effective ≠ observed.</strong>{" "}
-              The host reported this origin as allowed, but the browser still
-              blocked it. Possible causes: runtime restriction layered on top
-              of the iframe, browser/extension policy, or
-              evidence-collection lag. Adding to{" "}
-              <span className="font-mono">_meta.ui.csp</span> will not help —
-              investigate the host runtime or compare snapshots in Policy
+              <strong className="font-medium">effective ≠ observed.</strong> The
+              host reported this origin as allowed, but the browser still
+              blocked it. Possible causes: runtime restriction layered on top of
+              the iframe, browser/extension policy, or evidence-collection lag.
+              Adding to <span className="font-mono">_meta.ui.csp</span> will not
+              help — investigate the host runtime or compare snapshots in Policy
               Diff.
             </div>
           )}
 
           {diagnosis.class === "cors" && (
             <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-[11.5px] leading-relaxed">
-              This is a <strong className="font-medium">fetch / XHR CORS block</strong>,
+              This is a{" "}
+              <strong className="font-medium">fetch / XHR CORS block</strong>,
               not a CSP block. The remote origin must return an{" "}
               <span className="font-mono">Access-Control-Allow-Origin</span>{" "}
               header, or proxy the request through a server you control.
@@ -199,7 +202,9 @@ export function BlockedRequestCard({
               <span className="text-muted-foreground">{`csp: {`}</span>
               {"\n"}
               <span className="block -mx-3 px-3 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
-                {`+   ${diagnosis.patch!.field}: ${JSON.stringify(diagnosis.patch!.add)},`}
+                {`+   ${diagnosis.patch!.field}: ${JSON.stringify(
+                  diagnosis.patch!.add,
+                )},`}
               </span>
               <span className="text-muted-foreground">{`}`}</span>
             </pre>
@@ -224,25 +229,30 @@ export function BlockedRequestCard({
 
           <div className="flex flex-wrap items-center gap-2 pt-1">
             <span className="flex-1" />
-            {(isHostStripped || isRuntimeMismatch) && onViewPolicyDiff && (
-              <button
-                type="button"
-                className="inline-flex items-center gap-1 px-2 h-7 rounded text-[11px] text-sky-600 dark:text-sky-400 hover:bg-sky-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                onClick={() => onViewPolicyDiff(originOf(diagnosis.url))}
-              >
-                View policy diff <ExternalLink className="size-3" />
-              </button>
-            )}
-            {diagnosis.class !== "cors" && diagnosis.class !== "runtime-mismatch" && (
-              <button
-                type="button"
-                title="Coming soon"
-                onClick={handlePreviewHypothesis}
-                className="inline-flex items-center gap-1 px-2.5 h-7 rounded border border-border/60 text-[11px] text-muted-foreground hover:text-foreground hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                Preview hypothesis
-              </button>
-            )}
+            {(isHostStripped ||
+              isRuntimeMismatch ||
+              diagnosis.class === "policy-unavailable") &&
+              onViewPolicyDiff && (
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 px-2 h-7 rounded text-[11px] text-sky-600 dark:text-sky-400 hover:bg-sky-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onClick={() => onViewPolicyDiff(originOf(diagnosis.url))}
+                >
+                  View policy diff <ExternalLink className="size-3" />
+                </button>
+              )}
+            {diagnosis.class !== "cors" &&
+              diagnosis.class !== "runtime-mismatch" &&
+              diagnosis.class !== "policy-unavailable" && (
+                <button
+                  type="button"
+                  title="Coming soon"
+                  onClick={handlePreviewHypothesis}
+                  className="inline-flex items-center gap-1 px-2.5 h-7 rounded border border-border/60 text-[11px] text-muted-foreground hover:text-foreground hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  Preview hypothesis
+                </button>
+              )}
             {showPatch && (
               <button
                 type="button"

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/CspWorkbench.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/CspWorkbench.tsx
@@ -125,6 +125,9 @@ export function CspWorkbench({
             baseUriDomains: sandboxInfo?.baseUriDomains,
             source: "declared",
           },
+      appliedPoliciesByMount: isRecorded
+        ? undefined
+        : sandboxInfo?.appliedPoliciesByMount,
       widgetDeclared: isRecorded
         ? recordedDeclaration(recordedPolicy)
         : sandboxInfo?.widgetDeclared ?? null,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/FindingsTab.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/FindingsTab.tsx
@@ -48,7 +48,7 @@ export function FindingsTab({
           <div className="text-[11.5px] text-muted-foreground max-w-md">
             The widget loaded without tripping any{" "}
             <span className="font-mono">securitypolicyviolation</span> events.
-            Check Policy Diff to inspect the declared / effective allowlists.
+            Check Policy Diff to inspect the requested / Effective policies.
           </div>
         </div>
       </div>
@@ -72,6 +72,11 @@ export function FindingsTab({
       label: "mismatch",
       cls: "text-sky-600 dark:text-sky-400",
     },
+    {
+      count: summary.policyUnavailable,
+      label: "unavailable",
+      cls: "text-muted-foreground",
+    },
   ].filter((p) => p.count > 0);
 
   const fixesPart =
@@ -80,7 +85,9 @@ export function FindingsTab({
       : null;
   const declPart =
     summary.declarations > 0
-      ? `${summary.declarations} ${summary.declarations === 1 ? "declaration" : "declarations"}`
+      ? `${summary.declarations} ${
+          summary.declarations === 1 ? "declaration" : "declarations"
+        }`
       : null;
 
   return (

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/PolicyDiffTab.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/PolicyDiffTab.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
 import type { ClassifierInput, Diagnosis } from "./types";
 import { extractOrigin, originAllowedByAny } from "./match-source";
 
@@ -183,6 +188,7 @@ function PolicyColumn({
   jumpHost,
   forceOpen,
   unconfirmed,
+  info,
 }: {
   title: string;
   subtitle: string;
@@ -193,6 +199,7 @@ function PolicyColumn({
   /** Render the column as a guess rather than a reading. See the Effective
    *  column's two subtitles below. */
   unconfirmed?: boolean;
+  info?: string;
 }) {
   const [open, setOpen] = useState(false);
   const summary = summarize(rows);
@@ -218,7 +225,21 @@ function PolicyColumn({
       >
         <div className="min-w-0">
           <div className="flex items-baseline gap-2 flex-wrap">
-            <span className="text-[12px] font-medium">{title}</span>
+            <span className="inline-flex items-center gap-1 text-[12px] font-medium">
+              {title}
+              {info && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span aria-label={info} className="inline-flex cursor-help">
+                      <Info className="size-3 text-muted-foreground" />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent variant="muted" sideOffset={4}>
+                    {info}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </span>
             <span
               className={`font-mono text-[10.5px] ${
                 unconfirmed
@@ -389,12 +410,13 @@ export function PolicyDiffTab({
         />
         <PolicyColumn
           title="Effective"
-          subtitle={applied ? "proxy applied" : "widget asked · unverified"}
+          subtitle={applied ? "by client" : "widget asked · unverified"}
           rows={effectiveRows}
           emptyLabel={recorded ? "Not recorded" : "No allowlist captured"}
           jumpHost={jumpToHost}
           forceOpen={Boolean(jumpToHost)}
           unconfirmed={!applied}
+          info="The CSP the client applied to this widget."
         />
         <PolicyColumn
           title="Observed"
@@ -406,33 +428,13 @@ export function PolicyDiffTab({
         />
       </div>
 
-      <div className="rounded-md border border-dashed border-border/60 bg-card/50 px-3 py-2 text-[11.5px] text-muted-foreground leading-relaxed">
-        {applied ? (
-          <>
-            <span className="font-medium text-foreground">Effective</span> is
-            parsed from the CSP the sandbox proxy reported injecting for this
-            mount — the policy the browser is enforcing, not a prediction of it.
-          </>
-        ) : (
-          <>
-            <span className="font-medium text-amber-600 dark:text-amber-400">
-              Effective is unconfirmed.
-            </span>{" "}
-            The proxy did not report an applied CSP for this view (an offline
-            replay, a saved eval trace, or the mount is still in flight), so
-            this column repeats what the widget requested. It is not evidence of
-            what the browser allowed.
-          </>
-        )}
-      </div>
-
       {mismatchHosts.size > 0 && (
         <div className="rounded-md border border-dashed border-border/60 bg-card/50 px-3 py-2 text-[11.5px] text-muted-foreground leading-relaxed">
           Rows tagged{" "}
           <span className="font-mono text-sky-600 dark:text-sky-400">
             effective ≠ observed
           </span>{" "}
-          are where the host reported the origin as allowed but the browser
+          are where the Effective policy allowed the origin but the browser
           still blocked it. See Findings for the candidate causes.
         </div>
       )}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/__tests__/classify.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/__tests__/classify.test.ts
@@ -7,7 +7,7 @@ function v(
   blockedUri: string,
   directive: string,
   ts = 1000,
-  subtype?: CspViolation["subtype"]
+  subtype?: CspViolation["subtype"],
 ): CspViolation {
   return {
     directive,
@@ -108,6 +108,73 @@ describe("classifyDiagnoses", () => {
     expect(out[0].primarySource).toBe("inferred");
   });
 
+  it("never compares a violation with an Effective policy from another mount", () => {
+    const violation = {
+      ...v("https://js.stripe.com/v3", "frame-src"),
+      mountId: 1,
+    };
+    const out = classifyDiagnoses({
+      effective: {
+        ...EMPTY_EFFECTIVE,
+        frameDomains: ["https://js.stripe.com"],
+        source: "applied",
+      },
+      appliedPoliciesByMount: {
+        "2": {
+          headerString: "frame-src https://js.stripe.com",
+          mode: "widget-declared",
+        },
+      },
+      widgetDeclared: { frameDomains: ["https://js.stripe.com"] },
+      violations: [violation],
+    });
+
+    expect(out[0].class).toBe("policy-unavailable");
+    expect(out[0].patch).toBeNull();
+  });
+
+  it("renders legacy violations without comparing them to the latest policy", () => {
+    const out = classifyDiagnoses({
+      effective: {
+        ...EMPTY_EFFECTIVE,
+        frameDomains: ["https://js.stripe.com"],
+        source: "applied",
+      },
+      widgetDeclared: { frameDomains: ["https://js.stripe.com"] },
+      violations: [v("https://js.stripe.com/v3", "frame-src")],
+    });
+
+    expect(out[0].class).toBe("policy-unavailable");
+  });
+
+  it("uses the matching mount's Effective policy instead of the latest one", () => {
+    const violation = {
+      ...v("https://js.stripe.com/v3", "frame-src"),
+      mountId: 1,
+    };
+    const out = classifyDiagnoses({
+      effective: {
+        ...EMPTY_EFFECTIVE,
+        frameDomains: [],
+        source: "applied",
+      },
+      appliedPoliciesByMount: {
+        "1": {
+          headerString: "frame-src https://js.stripe.com",
+          mode: "widget-declared",
+        },
+        "2": {
+          headerString: "frame-src 'none'",
+          mode: "widget-declared",
+        },
+      },
+      widgetDeclared: { frameDomains: ["https://js.stripe.com"] },
+      violations: [violation],
+    });
+
+    expect(out[0].class).toBe("runtime-mismatch");
+  });
+
   it("classifies all false CSP subtypes as host-stripped without a patch", () => {
     const cases: Array<{
       subtype: NonNullable<CspViolation["subtype"]>;
@@ -164,7 +231,7 @@ describe("classifyDiagnoses", () => {
 
     expect(out[0].why).toContain("host does not support fetch requests");
     expect(out[0].evidence[0].note).toContain(
-      "the origin stays in the effective CSP"
+      "the origin stays in the effective CSP",
     );
   });
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/__tests__/csp-header.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/__tests__/csp-header.test.ts
@@ -1,9 +1,36 @@
 import { describe, expect, it } from "vitest";
 import {
+  compareCspPolicies,
   effectiveFromCspHeader,
   parseCspHeader,
   resolveDirective,
 } from "../csp-header";
+
+describe("compareCspPolicies", () => {
+  it("ignores directive order, source order, duplicates, and whitespace", () => {
+    expect(
+      compareCspPolicies(
+        "frame-src https://b.example https://a.example; default-src 'none'",
+        " default-src 'none'; frame-src https://a.example https://b.example https://a.example ",
+      ),
+    ).toEqual({ status: "matching", differingDirectives: [] });
+  });
+
+  it("reports changed directives", () => {
+    expect(
+      compareCspPolicies(
+        "default-src 'none'; frame-src https://a.example",
+        "default-src 'none'; frame-src https://b.example",
+      ),
+    ).toEqual({ status: "different", differingDirectives: ["frame-src"] });
+  });
+
+  it("reports unavailable when either policy was not captured", () => {
+    expect(compareCspPolicies(undefined, "default-src 'none'").status).toBe(
+      "unavailable",
+    );
+  });
+});
 
 // The two policies the sandbox proxy can actually apply, verbatim. The
 // widget-declared one is the output of `buildCSP` for a widget declaring only
@@ -69,13 +96,17 @@ describe("parseCspHeader", () => {
 
 describe("resolveDirective", () => {
   it("falls back to default-src when the directive is absent", () => {
-    const map = parseCspHeader("default-src 'self'; connect-src https://a.example");
+    const map = parseCspHeader(
+      "default-src 'self'; connect-src https://a.example",
+    );
     expect(resolveDirective(map, "connect-src")).toEqual(["https://a.example"]);
     expect(resolveDirective(map, "img-src")).toEqual(["'self'"]);
   });
 
   it("returns undefined — not an empty list — when nothing governs", () => {
-    expect(resolveDirective(parseCspHeader("script-src 'self'"), "img-src")).toBeUndefined();
+    expect(
+      resolveDirective(parseCspHeader("script-src 'self'"), "img-src"),
+    ).toBeUndefined();
   });
 
   it("prefers an explicitly empty directive over default-src", () => {
@@ -106,7 +137,9 @@ describe("effectiveFromCspHeader", () => {
   });
 
   it("applies the default-src fallback when a directive is missing", () => {
-    const e = effectiveFromCspHeader(parseCspHeader("default-src https://a.example"));
+    const e = effectiveFromCspHeader(
+      parseCspHeader("default-src https://a.example"),
+    );
     expect(e.connectDomains).toEqual(["https://a.example"]);
     expect(e.resourceDomains).toEqual(["https://a.example"]);
   });

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/__tests__/policy-diff.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/__tests__/policy-diff.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { PolicyDiffTab } from "../PolicyDiffTab";
+import type { ClassifierInput } from "../types";
+
+describe("PolicyDiffTab", () => {
+  it("keeps browser policy evidence out of the user-facing diff", async () => {
+    const input: ClassifierInput = {
+      effective: {
+        connectDomains: [],
+        resourceDomains: [],
+        frameDomains: ["https://js.stripe.com"],
+        source: "applied",
+      },
+      appliedPoliciesByMount: {
+        "1": {
+          headerString: "default-src 'none'; frame-src https://js.stripe.com",
+          mode: "widget-declared",
+        },
+        "2": {
+          headerString: "default-src 'none'; frame-src https://js.stripe.com",
+          mode: "widget-declared",
+        },
+      },
+      widgetDeclared: { frameDomains: ["https://js.stripe.com"] },
+      violations: [
+        {
+          directive: "frame-src",
+          blockedUri: "https://js.stripe.com/a",
+          mountId: 1,
+          originalPolicy: "frame-src https://js.stripe.com; default-src 'none'",
+          disposition: "enforce",
+          timestamp: 1,
+        },
+        {
+          directive: "frame-src",
+          blockedUri: "https://js.stripe.com/b",
+          mountId: 2,
+          originalPolicy: "default-src 'none'; frame-src 'none'",
+          disposition: "enforce",
+          timestamp: 2,
+        },
+        {
+          directive: "frame-src",
+          blockedUri: "https://js.stripe.com/c",
+          originalPolicy: "frame-src 'none'",
+          disposition: "report",
+          timestamp: 3,
+        },
+      ],
+    };
+
+    render(<PolicyDiffTab input={input} diagnoses={[]} />);
+
+    expect(screen.getAllByText("Effective").length).toBeGreaterThan(0);
+    expect(screen.getByText("by client")).toBeTruthy();
+    await userEvent.hover(
+      screen.getByLabelText("The CSP the client applied to this widget."),
+    );
+    expect(
+      (await screen.findAllByText("The CSP the client applied to this widget."))
+        .length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText(/Effective is parsed from/)).toBeNull();
+    expect(screen.queryByText("Violation policy evidence")).toBeNull();
+    expect(screen.queryByText(/Browser-reported policy/)).toBeNull();
+    expect(screen.queryByText("Client-applied policy")).toBeNull();
+    expect(screen.queryByRole("link", { name: "originalPolicy" })).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/classify.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/classify.ts
@@ -10,7 +10,11 @@
  */
 
 import type { CspViolation } from "@/stores/widget-debug-store";
-import { resolveDirective } from "./csp-header";
+import {
+  effectiveFromCspHeader,
+  parseCspHeader,
+  resolveDirective,
+} from "./csp-header";
 import type {
   ClassifierInput,
   CspField,
@@ -60,7 +64,7 @@ export function directiveToField(directive: string): CspField | null {
  *  (OpenAI Apps SDK shape) and camelCase (MCP Apps spec shape). */
 function readDeclared(
   declared: ClassifierInput["widgetDeclared"] | undefined,
-  field: CspField
+  field: CspField,
 ): string[] | undefined {
   if (!declared) return undefined;
   switch (field) {
@@ -113,7 +117,7 @@ function fieldDirective(field: CspField): string | undefined {
 
 function readEffective(
   effective: ClassifierInput["effective"],
-  field: CspField
+  field: CspField,
 ): string[] | undefined {
   // When the applied policy was captured, read the governing directive from it
   // (with the `default-src` fallback) rather than the flattened arrays: a
@@ -179,7 +183,7 @@ function isConnectSubtype(field: CspField | null): boolean {
 
 function subtypeIsFalse(
   input: ClassifierInput,
-  subtype: CspSubtype | undefined
+  subtype: CspSubtype | undefined,
 ): boolean {
   if (!subtype) return false;
   switch (subtype) {
@@ -203,7 +207,7 @@ function whyForClass(
   // True only when the injected guard did the blocking and the origin is
   // still in the effective CSP. See `guardEnforced` below — a resource
   // subtype really is stripped, so it keeps the stripped wording.
-  guardEnforced = false
+  guardEnforced = false,
 ): string {
   switch (klass) {
     case "csp":
@@ -214,6 +218,8 @@ function whyForClass(
         : `${directive} — host stripped this entry from effective CSP`;
     case "runtime-mismatch":
       return `Effective CSP allowed ${directive} for this origin; browser blocked anyway`;
+    case "policy-unavailable":
+      return `Effective policy for this iframe mount was not captured`;
     case "cors":
       return `CSP allowed the request; the remote refused`;
     case "network":
@@ -240,7 +246,7 @@ function extractRisks(
   klass: DiagnosisClass,
   field: CspField | null,
   origin: string,
-  declaredEntry: string | undefined
+  declaredEntry: string | undefined,
 ): string[] {
   const risks: string[] = [];
   if (field === "frameDomains") risks.push("nested iframe");
@@ -260,7 +266,7 @@ function extractRisks(
  *  risk extractor can decide if the developer's entry was a wildcard. */
 function findDeclaredEntry(
   origin: string,
-  declared: string[] | undefined
+  declared: string[] | undefined,
 ): string | undefined {
   if (!declared) return undefined;
   return declared.find((e) => originAllowedByAny(origin, [e]));
@@ -299,13 +305,37 @@ export function classifyDiagnoses(input: ClassifierInput): Diagnosis[] {
     const declared = field
       ? readDeclared(input.widgetDeclared, field)
       : undefined;
-    const effective = field ? readEffective(input.effective, field) : undefined;
+    const matchedPolicy =
+      v.mountId !== undefined
+        ? input.appliedPoliciesByMount?.[String(v.mountId)]
+        : undefined;
+    const matchedEffective = matchedPolicy
+      ? (() => {
+          const directives = parseCspHeader(matchedPolicy.headerString);
+          return {
+            ...effectiveFromCspHeader(directives),
+            directives,
+            source: "applied" as const,
+          };
+        })()
+      : undefined;
+    // Preserve the old classifier for callers that do not provide mount-aware
+    // data. Once the map exists, never fall back to the latest mount.
+    const comparisonAvailable =
+      matchedEffective !== undefined ||
+      (input.appliedPoliciesByMount === undefined &&
+        input.effective.source !== "applied");
+    const effective = field
+      ? readEffective(matchedEffective ?? input.effective, field)
+      : undefined;
 
     const inDeclared = originAllowedByAny(origin, declared);
     const inEffective = originAllowedByAny(origin, effective);
 
     let klass: DiagnosisClass;
-    if (blockedBySubtype && inDeclared) {
+    if (!comparisonAvailable) {
+      klass = "policy-unavailable";
+    } else if (blockedBySubtype && inDeclared) {
       klass = "host-stripped";
     } else if (inEffective) {
       klass = "runtime-mismatch";
@@ -391,7 +421,8 @@ export function summarize(diagnoses: Diagnosis[]) {
     hostStripped = 0,
     runtimeMismatch = 0,
     network = 0,
-    sandbox = 0;
+    sandbox = 0,
+    policyUnavailable = 0;
   let fixes = 0,
     declarations = 0;
 
@@ -411,6 +442,9 @@ export function summarize(diagnoses: Diagnosis[]) {
       case "runtime-mismatch":
         runtimeMismatch++;
         break;
+      case "policy-unavailable":
+        policyUnavailable++;
+        break;
       case "network":
         network++;
         break;
@@ -426,6 +460,7 @@ export function summarize(diagnoses: Diagnosis[]) {
     cors,
     hostStripped,
     runtimeMismatch,
+    policyUnavailable,
     network,
     sandbox,
     fixes,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/csp-header.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/csp-header.ts
@@ -18,6 +18,11 @@
 
 export type CspDirectiveMap = Record<string, string[]>;
 
+export interface CspPolicyComparison {
+  status: "matching" | "different" | "unavailable";
+  differingDirectives: string[];
+}
+
 /** Directives whose sources the workbench folds into one "resource" column. */
 const RESOURCE_DIRECTIVES = [
   "script-src",
@@ -49,6 +54,38 @@ export function parseCspHeader(header: string): CspDirectiveMap {
     map[name] = tokens.slice(1);
   }
   return map;
+}
+
+/**
+ * Compare policy semantics rather than serialization. Directive order,
+ * whitespace, duplicate sources, and source order do not change a policy.
+ */
+export function compareCspPolicies(
+  appliedPolicy: string | undefined,
+  violationPolicy: string | undefined,
+): CspPolicyComparison {
+  if (!appliedPolicy || !violationPolicy) {
+    return { status: "unavailable", differingDirectives: [] };
+  }
+
+  const applied = parseCspHeader(appliedPolicy);
+  const violation = parseCspHeader(violationPolicy);
+  const directives = Array.from(
+    new Set([...Object.keys(applied), ...Object.keys(violation)]),
+  ).sort();
+  const differingDirectives = directives.filter((directive) => {
+    const left = Array.from(new Set(applied[directive] ?? [])).sort();
+    const right = Array.from(new Set(violation[directive] ?? [])).sort();
+    return (
+      left.length !== right.length ||
+      left.some((value, i) => value !== right[i])
+    );
+  });
+
+  return {
+    status: differingDirectives.length === 0 ? "matching" : "different",
+    differingDirectives,
+  };
 }
 
 /**

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/types.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/types.ts
@@ -25,6 +25,9 @@ import type { CspViolation } from "@/stores/widget-debug-store";
  *                       (post-host) allows. Cause unknown from policy alone —
  *                       could be runtime restriction, browser/extension layer,
  *                       or evidence-collection lag. No CSP patch will help.
+ * `policy-unavailable`– the violation cannot be paired with an Effective policy
+ *                       from the same iframe mount. No policy conclusion is
+ *                       safe until that evidence exists.
  * `cors`              – CSP allowed it, network refused (Access-Control-*).
  *                       Server-side fix only. **Not classified yet** — we
  *                       have no signal source. Reserved for future use.
@@ -36,6 +39,7 @@ export type DiagnosisClass =
   | "csp"
   | "host-stripped"
   | "runtime-mismatch"
+  | "policy-unavailable"
   | "cors"
   | "network"
   | "sandbox";
@@ -140,6 +144,12 @@ export interface ClassifierInput {
     directives?: CspDirectiveMap;
     source?: "applied" | "declared";
   };
+  /** Applied policies indexed by sandbox mount. When present, violations are
+   * compared only with the policy carrying the same mount ID. */
+  appliedPoliciesByMount?: Record<
+    string,
+    { headerString: string; mode: "permissive" | "widget-declared" }
+  >;
   /** What the server originally declared in `_meta.ui.csp`. */
   widgetDeclared?: {
     connect_domains?: string[];

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -74,6 +74,7 @@ const {
     setWidgetDebugInfo: vi.fn(),
     setWidgetGlobals: vi.fn(),
     setWidgetCsp: vi.fn(),
+    setWidgetAppliedCsp: vi.fn(),
     addCspViolation: vi.fn(),
     clearCspViolations: vi.fn(),
     setWidgetModelContext: vi.fn(),
@@ -200,21 +201,27 @@ vi.mock("@/stores/traffic-log-store", () => ({
   extractMethod: vi.fn(),
 }));
 
-vi.mock("@/stores/widget-debug-store", () => ({
-  useWidgetDebugStore: (selector: any) =>
-    selector({
-      setWidgetDebugInfo: stableStoreFns.setWidgetDebugInfo,
-      setWidgetGlobals: stableStoreFns.setWidgetGlobals,
-      setWidgetCsp: stableStoreFns.setWidgetCsp,
-      addCspViolation: stableStoreFns.addCspViolation,
-      clearCspViolations: stableStoreFns.clearCspViolations,
-      setWidgetModelContext: stableStoreFns.setWidgetModelContext,
-      setWidgetHtml: stableStoreFns.setWidgetHtml,
-      setSandboxApplied: stableStoreFns.setSandboxApplied,
-      appendLifecycle: stableStoreFns.appendLifecycle,
-      recordMount: stableStoreFns.recordMount,
+vi.mock("@/stores/widget-debug-store", () => {
+  const state = {
+    setWidgetDebugInfo: stableStoreFns.setWidgetDebugInfo,
+    setWidgetGlobals: stableStoreFns.setWidgetGlobals,
+    setWidgetCsp: stableStoreFns.setWidgetCsp,
+    setWidgetAppliedCsp: stableStoreFns.setWidgetAppliedCsp,
+    addCspViolation: stableStoreFns.addCspViolation,
+    clearCspViolations: stableStoreFns.clearCspViolations,
+    setWidgetModelContext: stableStoreFns.setWidgetModelContext,
+    setWidgetHtml: stableStoreFns.setWidgetHtml,
+    setSandboxApplied: stableStoreFns.setSandboxApplied,
+    appendLifecycle: stableStoreFns.appendLifecycle,
+    recordMount: stableStoreFns.recordMount,
+    widgets: new Map(),
+  };
+  return {
+    useWidgetDebugStore: Object.assign((selector: any) => selector(state), {
+      getState: () => state,
     }),
-}));
+  };
+});
 
 vi.mock("@/lib/session-token", () => ({
   authFetch: vi
@@ -288,7 +295,7 @@ function HostedRenderer(props: React.ComponentProps<typeof MCPAppsRenderer>) {
 }
 
 function HostedSurfaceHost(
-  props: React.ComponentProps<typeof WidgetSurfaceHost>
+  props: React.ComponentProps<typeof WidgetSurfaceHost>,
 ) {
   return (
     <InspectorWidgetHostProvider>
@@ -429,12 +436,12 @@ describe("MCPAppsRenderer tool input streaming", () => {
           baseUriDomains: [],
         }}
         widgetPermissions={{ microphone: true } as any}
-      />
+      />,
     );
 
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>widget</body></html>"
+        "<html><body>widget</body></html>",
       );
     });
 
@@ -447,7 +454,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="claude">
         <HostedRenderer {...baseProps} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
 
     await vi.waitFor(() => {
@@ -456,7 +463,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
 
     // Should advertise Claude's preset, not the old empty literal.
     expect(appBridgeArgsRef.current?.hostCapabilities).toEqual(
-      expect.objectContaining(getHostCapabilitiesForStyle("claude"))
+      expect.objectContaining(getHostCapabilitiesForStyle("claude")),
     );
   });
 
@@ -477,7 +484,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         {...baseProps}
         toolCallId="call-2"
         toolOutput={{ content: [{ type: "text" as const, text: "next" }] }}
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -602,9 +609,9 @@ describe("MCPAppsRenderer tool input streaming", () => {
       expect(mockAppBridgeCtor).toHaveBeenCalledTimes(2);
       expect(sandboxedIframeMountsRef.current).toBe(2);
       const anchors = Array.from(
-        document.querySelectorAll("[data-mcp-app-surface-container]")
+        document.querySelectorAll("[data-mcp-app-surface-container]"),
       ).map((node) =>
-        node.parentElement?.getAttribute("data-mcp-app-surface-anchor")
+        node.parentElement?.getAttribute("data-mcp-app-surface-anchor"),
       );
       expect(anchors).toContain("call-1");
       expect(anchors).toContain("call-2");
@@ -628,7 +635,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
           toolOutput={{ content: [{ type: "text" as const, text: "next" }] }}
         />
         <HostedSurfaceHost />
-      </WidgetSurfaceHostProvider>
+      </WidgetSurfaceHostProvider>,
     );
 
     // Live-preferred path bypasses cached blob — both tool calls trigger a
@@ -657,7 +664,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
 
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>live-widget</body></html>"
+        "<html><body>live-widget</body></html>",
       );
     });
 
@@ -760,7 +767,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
           fullscreenWidgetId="call-1"
         />
         <HostedSurfaceHost />
-      </WidgetSurfaceHostProvider>
+      </WidgetSurfaceHostProvider>,
     );
 
     await vi.waitFor(() => {
@@ -768,7 +775,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     });
 
     expect(appBridgeArgsRef.current?.options?.hostContext?.displayMode).toBe(
-      "fullscreen"
+      "fullscreen",
     );
     expect(mockBridge.close).not.toHaveBeenCalled();
     expect(mockBridge.teardownResource).not.toHaveBeenCalled();
@@ -783,14 +790,14 @@ describe("MCPAppsRenderer tool input streaming", () => {
         cachedWidgetHtmlUrl="blob:cached"
         displayMode="fullscreen"
         fullscreenWidgetId="call-1"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.onMessage).toBeTypeOf("function");
     });
     expect(
-      screen.queryByRole("button", { name: "Open in test-server" })
+      screen.queryByRole("button", { name: "Open in test-server" }),
     ).not.toBeInTheDocument();
 
     act(() => {
@@ -810,7 +817,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(openSpy).toHaveBeenCalledWith(
       "https://app.example.com/trails/42",
       "_blank",
-      "noopener,noreferrer"
+      "noopener,noreferrer",
     );
     openSpy.mockRestore();
   });
@@ -828,7 +835,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         cachedWidgetHtmlUrl="blob:cached"
         displayMode="fullscreen"
         fullscreenWidgetId="call-1"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -846,7 +853,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     });
 
     expect(
-      screen.queryByRole("button", { name: "Open in test-server" })
+      screen.queryByRole("button", { name: "Open in test-server" }),
     ).not.toBeInTheDocument();
   });
 
@@ -867,7 +874,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         cachedWidgetHtmlUrl="blob:cached"
         displayMode="fullscreen"
         fullscreenWidgetId="call-1"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -884,7 +891,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
       } as MessageEvent);
     });
     expect(
-      screen.queryByRole("button", { name: "Open in test-server" })
+      screen.queryByRole("button", { name: "Open in test-server" }),
     ).not.toBeInTheDocument();
 
     rerender(
@@ -895,7 +902,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
           displayMode="fullscreen"
           fullscreenWidgetId="call-1"
         />
-      </ActiveMcpProfileProvider>
+      </ActiveMcpProfileProvider>,
     );
 
     await vi.waitFor(() => {
@@ -912,7 +919,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
       } as MessageEvent);
     });
     expect(
-      screen.queryByRole("button", { name: "Open in test-server" })
+      screen.queryByRole("button", { name: "Open in test-server" }),
     ).not.toBeInTheDocument();
   });
 
@@ -937,7 +944,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         <ScenarioHostThemeProvider value="dark">
           <HostedRenderer {...baseProps} />
         </ScenarioHostThemeProvider>
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
 
     await vi.waitFor(() => {
@@ -945,7 +952,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     });
 
     expect(appBridgeArgsRef.current?.hostCapabilities).toEqual(
-      expect.objectContaining(getHostCapabilitiesForStyle("chatgpt"))
+      expect.objectContaining(getHostCapabilitiesForStyle("chatgpt")),
     );
     const advertised = appBridgeArgsRef.current?.hostCapabilities;
     expect(advertised).toHaveProperty("serverResources");
@@ -963,7 +970,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="copilot">
         <HostedRenderer {...baseProps} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
 
     await vi.waitFor(() => {
@@ -988,7 +995,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="claude">
         <HostedRenderer {...baseProps} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
     await vi.waitFor(() => {
       expect(mockBridge.connect).toHaveBeenCalled();
@@ -998,7 +1005,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
       | undefined;
     expect(hostContext).toHaveProperty("toolInfo");
     expect(
-      (hostContext?.toolInfo as { tool: { name: string } }).tool.name
+      (hostContext?.toolInfo as { tool: { name: string } }).tool.name,
     ).toBe("test-tool");
   });
 
@@ -1009,7 +1016,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="copilot">
         <HostedRenderer {...baseProps} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
     await vi.waitFor(() => {
       expect(mockBridge.connect).toHaveBeenCalled();
@@ -1031,7 +1038,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="copilot">
         <HostedRenderer {...baseProps} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
     await vi.waitFor(() => {
       expect(mockBridge.connect).toHaveBeenCalled();
@@ -1051,7 +1058,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="copilot">
         <HostedRenderer {...baseProps} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
     await vi.waitFor(() => {
       expect(mockBridge.connect).toHaveBeenCalled();
@@ -1069,7 +1076,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="claude">
         <HostedRenderer {...baseProps} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
     await vi.waitFor(() => {
       expect(mockBridge.connect).toHaveBeenCalled();
@@ -1097,7 +1104,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="copilot">
         <HostedRenderer {...baseProps} displayMode="pip" pipWidgetId="call-1" />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
     await vi.waitFor(() => {
       expect(mockBridge.connect).toHaveBeenCalled();
@@ -1135,7 +1142,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
             fullscreenWidgetId="call-1"
           />
         </ScenarioHostStyleProvider>
-      </ActiveMcpProfileProvider>
+      </ActiveMcpProfileProvider>,
     );
     await vi.waitFor(() => {
       expect(mockBridge.connect).toHaveBeenCalled();
@@ -1178,7 +1185,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="copilot">
         <HostedRenderer {...baseProps} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.csp).toBeDefined();
@@ -1222,7 +1229,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="cursor">
         <HostedRenderer {...baseProps} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.csp).toBeDefined();
@@ -1239,7 +1246,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="chatgpt">
         <HostedRenderer {...baseProps} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.cspSubtypePolicy).toBeDefined();
@@ -1263,7 +1270,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     };
     expect(sandboxedIframePropsRef.current.cspSubtypePolicy).toEqual(expected);
     expect(mcpAppsModalPropsRef.current?.widgetCspSubtypePolicy).toEqual(
-      expected
+      expected,
     );
   });
 
@@ -1276,7 +1283,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ActiveMcpProfileProvider value={profile}>
         <HostedRenderer {...baseProps} />
-      </ActiveMcpProfileProvider>
+      </ActiveMcpProfileProvider>,
     );
     await vi.waitFor(() => {
       expect(mcpAppsModalPropsRef.current).not.toBeNull();
@@ -1287,7 +1294,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     const expected = { localStorage: false };
     expect(sandboxedIframePropsRef.current.browserStorage).toEqual(expected);
     expect(mcpAppsModalPropsRef.current?.widgetBrowserStorage).toEqual(
-      expected
+      expected,
     );
   });
 
@@ -1310,11 +1317,11 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="claude">
         <HostedRenderer {...baseProps} cachedWidgetHtmlUrl="blob:cached" />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>widget</body></html>"
+        "<html><body>widget</body></html>",
       );
     });
     expect(sandboxedIframePropsRef.current.cspSubtypePolicy).toEqual({
@@ -1338,11 +1345,11 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="goose">
         <HostedRenderer {...baseProps} cachedWidgetHtmlUrl="blob:cached" />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>widget</body></html>"
+        "<html><body>widget</body></html>",
       );
     });
     expect(sandboxedIframePropsRef.current.permissive).toBe(false);
@@ -1358,7 +1365,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         <ScenarioHostStyleProvider value="chatgpt">
           <HostedRenderer {...baseProps} />
         </ScenarioHostStyleProvider>
-      </WidgetSurfaceProvider>
+      </WidgetSurfaceProvider>,
     );
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.permissive).toBe(true);
@@ -1366,7 +1373,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     });
     expect(sandboxedIframePropsRef.current.cspSubtypePolicy).toBeUndefined();
     expect(
-      mcpAppsModalPropsRef.current?.widgetCspSubtypePolicy
+      mcpAppsModalPropsRef.current?.widgetCspSubtypePolicy,
     ).toBeUndefined();
   });
 
@@ -1397,17 +1404,17 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="copilot">
         <HostedRenderer {...baseProps} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>widget</body></html>"
+        "<html><body>widget</body></html>",
       );
     });
     // Permissions cleared on Copilot — matches what real Copilot does
     // (it doesn't honor the widget's permission declarations at all).
     expect(
-      sandboxedIframePropsRef.current?.permissions ?? undefined
+      sandboxedIframePropsRef.current?.permissions ?? undefined,
     ).toBeUndefined();
   });
 
@@ -1472,15 +1479,15 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ActiveMcpProfileProvider value={copilotPermissionsOff}>
         <HostedRenderer {...baseProps} />
-      </ActiveMcpProfileProvider>
+      </ActiveMcpProfileProvider>,
     );
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>widget</body></html>"
+        "<html><body>widget</body></html>",
       );
     });
     expect(
-      sandboxedIframePropsRef.current?.permissions ?? undefined
+      sandboxedIframePropsRef.current?.permissions ?? undefined,
     ).toBeUndefined();
   });
 
@@ -1507,11 +1514,11 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="claude">
         <HostedRenderer {...baseProps} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>widget</body></html>"
+        "<html><body>widget</body></html>",
       );
     });
     // Claude's matrix honors permissions → widget declaration
@@ -1532,7 +1539,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
           toolInput={{ query: "yellow" }}
           toolOutput={undefined}
         />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
 
     await vi.waitFor(() => {
@@ -1553,7 +1560,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
           toolOutput={undefined}
           toolMetadata={{ "openai/outputTemplate": "ui://widget/test.html" }}
         />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
 
     await act(async () => {
@@ -1575,7 +1582,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
           }}
           toolMetadata={{ "openai/outputTemplate": "ui://widget/test.html" }}
         />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
 
     await vi.waitFor(() => {
@@ -1607,7 +1614,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
           cachedWidgetHtmlUrl="blob:cached"
           liveFetchPreferred
         />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
 
     await act(async () => {
@@ -1632,7 +1639,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
           cachedWidgetHtmlUrl="blob:cached"
           liveFetchPreferred
         />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
 
     await vi.waitFor(() => {
@@ -1663,7 +1670,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostCapabilitiesOverrideProvider value={override}>
         <HostedRenderer {...baseProps} />
-      </ScenarioHostCapabilitiesOverrideProvider>
+      </ScenarioHostCapabilitiesOverrideProvider>,
     );
 
     await vi.waitFor(() => {
@@ -1681,7 +1688,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         <ScenarioHostThemeProvider value="dark">
           <HostedRenderer {...baseProps} />
         </ScenarioHostThemeProvider>
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
 
     await vi.waitFor(() => {
@@ -1691,11 +1698,11 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(
       appBridgeArgsRef.current?.options?.hostContext?.styles?.variables?.[
         "--color-background-primary"
-      ]
+      ],
     ).toBe(
       CHATGPT_HOST_STYLE.mcp.resolveStyleVariables("dark")[
         "--color-background-primary"
-      ]
+      ],
     );
 
     await act(async () => {
@@ -1718,7 +1725,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
               fonts: "",
             }),
           }),
-        })
+        }),
       );
     });
   });
@@ -1734,7 +1741,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         <ScenarioHostThemeProvider value="dark">
           <HostedRenderer {...baseProps} />
         </ScenarioHostThemeProvider>
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
 
     await vi.waitFor(() => {
@@ -1745,11 +1752,11 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(
       appBridgeArgsRef.current?.options?.hostContext?.styles?.variables?.[
         "--color-background-primary"
-      ]
+      ],
     ).toBe(
       CLAUDE_HOST_STYLE.mcp.resolveStyleVariables("dark")[
         "--color-background-primary"
-      ]
+      ],
     );
 
     await act(async () => {
@@ -1769,7 +1776,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
                 ],
             }),
           }),
-        })
+        }),
       );
     });
   });
@@ -1800,7 +1807,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
       expect(mockBridge.setHostContext).toHaveBeenLastCalledWith(
         expect.objectContaining({
           theme: "light",
-        })
+        }),
       );
     });
   });
@@ -1831,7 +1838,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
           availableDisplayModes: ["inline"],
           locale: "fr-FR",
           timeZone: "Europe/Paris",
-        })
+        }),
       );
     });
   });
@@ -1850,7 +1857,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="claude">
         <HostedRenderer {...baseProps} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
 
     await vi.waitFor(() => {
@@ -1858,7 +1865,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     });
 
     expect(
-      appBridgeArgsRef.current?.options?.hostContext?.styles?.variables
+      appBridgeArgsRef.current?.options?.hostContext?.styles?.variables,
     ).toEqual(
       expect.objectContaining({
         "--color-background-primary":
@@ -1866,13 +1873,13 @@ describe("MCPAppsRenderer tool input streaming", () => {
             "--color-background-primary"
           ],
         "--font-sans": "Custom Sans",
-      })
+      }),
     );
     expect(
-      appBridgeArgsRef.current?.options?.hostContext?.styles?.variables
+      appBridgeArgsRef.current?.options?.hostContext?.styles?.variables,
     ).not.toHaveProperty("--mcpjam-theme-preset");
     expect(
-      appBridgeArgsRef.current?.options?.hostContext?.styles?.variables
+      appBridgeArgsRef.current?.options?.hostContext?.styles?.variables,
     ).not.toHaveProperty("--totally-unknown");
 
     await act(async () => {
@@ -1892,7 +1899,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
               "--font-sans": "Custom Sans",
             }),
           }),
-        })
+        }),
       );
     });
   });
@@ -1901,7 +1908,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="claude">
         <HostedRenderer {...baseProps} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
 
     const iframe = await screen.findByTestId("sandboxed-iframe");
@@ -1911,7 +1918,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(sandboxedIframePropsRef.current?.style?.backgroundColor).toBe(
       CLAUDE_HOST_STYLE.mcp.resolveStyleVariables("light")[
         "--color-background-primary"
-      ]
+      ],
     );
     expect(sandboxedIframePropsRef.current?.colorScheme).toBe("light");
     expect(hostChrome).toHaveStyle({
@@ -1941,7 +1948,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <ScenarioHostStyleProvider value="claude">
         <HostedRenderer {...baseProps} prefersBorder={false} />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
 
     const iframe = await screen.findByTestId("sandboxed-iframe");
@@ -1950,7 +1957,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(iframe.className).toContain("bg-transparent");
     expect(iframe.className).not.toContain("border border-border/40");
     expect(sandboxedIframePropsRef.current?.style?.backgroundColor).toBe(
-      CLAUDE_HOST_STYLE.chatUi.resolveChatBackground("light")
+      CLAUDE_HOST_STYLE.chatUi.resolveChatBackground("light"),
     );
     expect(sandboxedIframePropsRef.current?.colorScheme).toBe("light");
   });
@@ -1969,7 +1976,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         cachedWidgetHtmlUrl="blob:cached"
         displayMode="pip"
         pipWidgetId="call-1"
-      />
+      />,
     );
 
     const iframe = await screen.findByTestId("sandboxed-iframe");
@@ -1995,7 +2002,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         cachedWidgetHtmlUrl="blob:cached"
         displayMode="fullscreen"
         fullscreenWidgetId="call-1"
-      />
+      />,
     );
 
     const iframe = await screen.findByTestId("sandboxed-iframe");
@@ -2030,7 +2037,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         cachedWidgetHtmlUrl="blob:cached"
         displayMode="fullscreen"
         fullscreenWidgetId="call-1"
-      />
+      />,
     );
 
     expect(sandboxedIframeElementRef.current).toBe(initialIframeElement);
@@ -2070,7 +2077,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         cachedWidgetHtmlUrl="blob:cached"
         displayMode="fullscreen"
         fullscreenWidgetId="call-1"
-      />
+      />,
     );
     expect(sandboxedIframePropsRef.current?.style?.height).toBe("100%");
 
@@ -2130,7 +2137,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         expect.objectContaining({
           locale: "en-US",
           timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        })
+        }),
       );
     });
 
@@ -2154,7 +2161,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
             hover: false,
             touch: true,
           },
-        })
+        }),
       );
     });
   });
@@ -2172,12 +2179,12 @@ describe("MCPAppsRenderer tool input streaming", () => {
         }}
         widgetPermissions={{ clipboardWrite: true } as any}
         widgetPermissive={false}
-      />
+      />,
     );
 
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>widget</body></html>"
+        "<html><body>widget</body></html>",
       );
     });
 
@@ -2199,12 +2206,12 @@ describe("MCPAppsRenderer tool input streaming", () => {
         }}
         widgetPermissions={{ geolocation: true } as any}
         widgetPermissive={true}
-      />
+      />,
     );
 
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>widget</body></html>"
+        "<html><body>widget</body></html>",
       );
     });
 
@@ -2218,7 +2225,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
 
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>live-widget</body></html>"
+        "<html><body>live-widget</body></html>",
       );
     });
 
@@ -2240,12 +2247,12 @@ describe("MCPAppsRenderer tool input streaming", () => {
         {...baseProps}
         cachedWidgetHtmlUrl="blob:cached"
         liveFetchPreferred
-      />
+      />,
     );
 
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>live-widget</body></html>"
+        "<html><body>live-widget</body></html>",
       );
     });
 
@@ -2266,7 +2273,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
           injectedOpenAiCompat={false}
           injectedOpenAiCompatCapabilities={{ callTool: false }}
         />
-      </ScenarioHostStyleProvider>
+      </ScenarioHostStyleProvider>,
     );
 
     await vi.waitFor(() => {
@@ -2286,7 +2293,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
 
   it("falls back to cached HTML when the live fetch throws (e.g. server disconnected)", async () => {
     vi.mocked(authFetch).mockRejectedValueOnce(
-      new Error('Hosted server not found for "server-1"')
+      new Error('Hosted server not found for "server-1"'),
     );
 
     render(
@@ -2294,12 +2301,12 @@ describe("MCPAppsRenderer tool input streaming", () => {
         {...baseProps}
         cachedWidgetHtmlUrl="blob:cached"
         liveFetchPreferred
-      />
+      />,
     );
 
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>widget</body></html>"
+        "<html><body>widget</body></html>",
       );
     });
 
@@ -2330,7 +2337,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     render(
       <WidgetSurfaceProvider value="playground">
         <HostedRenderer {...baseProps} />
-      </WidgetSurfaceProvider>
+      </WidgetSurfaceProvider>,
     );
 
     await vi.waitFor(() => {
@@ -2382,7 +2389,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         resourceUri="mcp-app://stale"
         cachedWidgetHtmlUrl="blob:cached"
         liveFetchPreferred
-      />
+      />,
     );
 
     // Wait for the stale fetch to start.
@@ -2399,13 +2406,13 @@ describe("MCPAppsRenderer tool input streaming", () => {
         resourceUri="mcp-app://fresh"
         cachedWidgetHtmlUrl="blob:cached"
         liveFetchPreferred
-      />
+      />,
     );
 
     // Wait for the fresh fetch to complete and paint the sandbox.
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>live-widget</body></html>"
+        "<html><body>live-widget</body></html>",
       );
     });
 
@@ -2432,10 +2439,10 @@ describe("MCPAppsRenderer tool input streaming", () => {
     });
 
     expect(sandboxedIframePropsRef.current?.html).toBe(
-      "<html><body>live-widget</body></html>"
+      "<html><body>live-widget</body></html>",
     );
     expect(sandboxedIframePropsRef.current?.html).not.toContain(
-      "STALE-CONTENT"
+      "STALE-CONTENT",
     );
   });
 
@@ -2465,7 +2472,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         {...baseProps}
         cachedWidgetHtmlUrl="blob:cached"
         liveFetchPreferred
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -2486,7 +2493,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
       () =>
         new Promise<void>((resolve) => {
           resolveConnect = resolve;
-        })
+        }),
     );
 
     render(<HostedRenderer {...baseProps} cachedWidgetHtmlUrl="blob:cached" />);
@@ -2504,7 +2511,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
 
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>widget</body></html>"
+        "<html><body>widget</body></html>",
       );
     });
   });
@@ -2525,7 +2532,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         "call-1",
         "<html><body>widget</body></html>",
         undefined,
-        undefined
+        undefined,
       );
     });
 
@@ -2543,7 +2550,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
 
     await vi.waitFor(() => {
       expect(sandboxedIframePropsRef.current?.html).toBe(
-        "<html><body>widget</body></html>"
+        "<html><body>widget</body></html>",
       );
     });
   });
@@ -2570,7 +2577,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         // hostInfo derived from activeMcpProfile.apps.uiInitialize.hostInfo;
         // null in the test environment because the default context value is
         // `undefined` (no ActiveMcpProfileProvider wrapping the renderer).
-        null
+        null,
       );
     });
 
@@ -2622,6 +2629,43 @@ describe("MCPAppsRenderer tool input streaming", () => {
         null,
       );
     });
+  });
+
+  it("records CSP intent from the proxy with its applied mount", async () => {
+    render(<HostedRenderer {...baseProps} cachedWidgetHtmlUrl="blob:cached" />);
+
+    await vi.waitFor(() => {
+      expect(sandboxedIframePropsRef.current?.onMessage).toBeTypeOf("function");
+    });
+
+    act(() => {
+      sandboxedIframePropsRef.current.onMessage({
+        data: {
+          type: "mcpjam:csp-applied",
+          mountId: "proxy-a:1",
+          csp: "frame-src https://js.stripe.com",
+          mode: "widget-declared",
+          intent: {
+            csp: { frameDomains: ["https://js.stripe.com"] },
+            permissive: false,
+          },
+        },
+      } as MessageEvent);
+    });
+
+    expect(stableStoreFns.setWidgetAppliedCsp).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        mountId: "proxy-a:1",
+        headerString: "frame-src https://js.stripe.com",
+        mode: "widget-declared",
+        intent: {
+          csp: { frameDomains: ["https://js.stripe.com"] },
+          cspDirectives: undefined,
+          permissive: false,
+        },
+      },
+    );
   });
 
   it("marks a srcdoc mount as a degraded view (no origin to allowlist)", async () => {
@@ -2703,7 +2747,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="input-streaming"
         toolInput={partialInput}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -2727,7 +2771,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="input-streaming"
         toolInput={undefined}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -2750,7 +2794,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="input-streaming"
         toolInput={partialInput}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -2776,7 +2820,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="input-streaming"
         toolInput={firstPartial}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -2793,7 +2837,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="input-streaming"
         toolInput={secondPartial}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
     await vi.waitFor(() => {
       expect(mockBridge.sendToolInputPartial).toHaveBeenCalledTimes(2);
@@ -2808,7 +2852,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="input-streaming"
         toolInput={{ ...secondPartial }}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
     expect(mockBridge.sendToolInputPartial).toHaveBeenCalledTimes(2);
   });
@@ -2822,7 +2866,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="input-streaming"
         toolInput={firstPartial}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -2842,7 +2886,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="input-streaming"
         toolInput={secondPartial}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -2862,7 +2906,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="input-streaming"
         toolInput={firstPartial}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -2882,7 +2926,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="input-streaming"
         toolInput={secondPartial}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -2900,7 +2944,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="input-streaming"
         toolInput={{ elements: '[{"type":"rectangle"' }}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -2918,7 +2962,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="input-available"
         toolInput={completeInput}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
     await vi.waitFor(() => {
       expect(mockBridge.sendToolInput).toHaveBeenCalledTimes(1);
@@ -2933,7 +2977,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="input-streaming"
         toolInput={{ elements: '[{"type":"triangle"' }}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
     await vi.waitFor(() => {
       expect(mockBridge.sendToolInput).toHaveBeenCalledTimes(1);
@@ -2946,7 +2990,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="output-available"
         toolInput={{ elements: '[{"type":"ellipse"}]' }}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
     await vi.waitFor(() => {
       expect(mockBridge.sendToolInput).toHaveBeenCalledTimes(2);
@@ -2964,14 +3008,14 @@ describe("MCPAppsRenderer tool input streaming", () => {
     await vi.waitFor(() => {
       expect(mockBridge.sendToolResult).toHaveBeenCalledTimes(1);
       expect(mockBridge.sendToolResult).toHaveBeenCalledWith(
-        baseProps.toolOutput
+        baseProps.toolOutput,
       );
     });
   });
 
   it("re-sends tool output when prop changes", async () => {
     const { rerender } = render(
-      <HostedRenderer {...baseProps} cachedWidgetHtmlUrl="blob:cached" />
+      <HostedRenderer {...baseProps} cachedWidgetHtmlUrl="blob:cached" />,
     );
 
     await vi.waitFor(() => {
@@ -2988,7 +3032,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         {...baseProps}
         toolOutput={newOutput}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -3004,7 +3048,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="output-available"
         toolInput={{ elements: '[{"type":"rectangle"}]' }}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -3025,7 +3069,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         toolState="output-available"
         toolInput={{ elements: '[{"type":"ellipse"}]' }}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -3067,7 +3111,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         {...baseProps}
         minimalMode={true}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -3088,7 +3132,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         {...baseProps}
         minimalMode={true}
         cachedWidgetHtmlUrl="blob:cached"
-      />
+      />,
     );
 
     await vi.waitFor(() => {
@@ -3163,7 +3207,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         <ActiveMcpProfileProvider value={declaredCspProfile()}>
           <HostedRenderer {...baseProps} />
         </ActiveMcpProfileProvider>
-      </WidgetSurfaceProvider>
+      </WidgetSurfaceProvider>,
     );
 
     await vi.waitFor(() => {
@@ -3206,7 +3250,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
         <ActiveMcpProfileProvider value={declaredCspProfile()}>
           <HostedRenderer {...baseProps} />
         </ActiveMcpProfileProvider>
-      </WidgetSurfaceProvider>
+      </WidgetSurfaceProvider>,
     );
 
     await vi.waitFor(() => {
@@ -3229,6 +3273,9 @@ describe("MCPAppsRenderer tool input streaming", () => {
           directive: "script-src-elem",
           effectiveDirective: "script-src-elem",
           blockedUri: "https://esm.sh/react@19",
+          mountId: "proxy-a:7",
+          originalPolicy: "default-src 'none'; script-src 'none'",
+          disposition: "enforce",
           ...overrides,
         },
       } as MessageEvent);
@@ -3245,6 +3292,14 @@ describe("MCPAppsRenderer tool input streaming", () => {
       });
 
       postCspViolation();
+      expect(stableStoreFns.addCspViolation).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          mountId: "proxy-a:7",
+          originalPolicy: "default-src 'none'; script-src 'none'",
+          disposition: "enforce",
+        }),
+      );
       // Grace period: the notice must not race a View that is merely slow.
       expect(screen.queryByTestId("mcp-app-csp-blocked-notice")).toBeNull();
 
@@ -3339,7 +3394,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
           {...baseProps}
           toolCallId="call-2"
           resourceUri="mcp-app://other"
-        />
+        />,
       );
 
       await act(async () => {
@@ -3492,7 +3547,7 @@ describe("MCPAppsRenderer host capability enforcement", () => {
     render(
       <ScenarioHostCapabilitiesOverrideProvider value={{}}>
         <HostedRenderer {...baseProps} />
-      </ScenarioHostCapabilitiesOverrideProvider>
+      </ScenarioHostCapabilitiesOverrideProvider>,
     );
 
     await vi.waitFor(() => {
@@ -3513,7 +3568,7 @@ describe("MCPAppsRenderer host capability enforcement", () => {
     render(
       <ScenarioHostCapabilitiesOverrideProvider value={{}}>
         <HostedRenderer {...baseProps} />
-      </ScenarioHostCapabilitiesOverrideProvider>
+      </ScenarioHostCapabilitiesOverrideProvider>,
     );
 
     await vi.waitFor(() => {
@@ -3545,7 +3600,7 @@ describe("MCPAppsRenderer host capability enforcement", () => {
       render(
         <ScenarioHostCapabilitiesOverrideProvider value={{ [cap]: {} }}>
           <HostedRenderer {...baseProps} />
-        </ScenarioHostCapabilitiesOverrideProvider>
+        </ScenarioHostCapabilitiesOverrideProvider>,
       );
 
       await vi.waitFor(() => {
@@ -3553,7 +3608,7 @@ describe("MCPAppsRenderer host capability enforcement", () => {
       });
 
       expect(mockBridge[handlerKey]).not.toBeNull();
-    }
+    },
   );
 
   it("reports widget-initiated server tool calls for transcript rendering", async () => {
@@ -3569,7 +3624,7 @@ describe("MCPAppsRenderer host capability enforcement", () => {
           onCallTool={onCallTool}
           onAppToolInvocationChange={onAppToolInvocationChange}
         />
-      </ScenarioHostCapabilitiesOverrideProvider>
+      </ScenarioHostCapabilitiesOverrideProvider>,
     );
 
     await vi.waitFor(() => {
@@ -3592,7 +3647,7 @@ describe("MCPAppsRenderer host capability enforcement", () => {
         toolName: "transparency-test",
         input: { value: 1 },
         status: "running",
-      })
+      }),
     );
     expect(onAppToolInvocationChange).toHaveBeenNthCalledWith(
       2,
@@ -3603,7 +3658,7 @@ describe("MCPAppsRenderer host capability enforcement", () => {
         input: { value: 1 },
         output: { content: [{ type: "text", text: "tool ok" }] },
         status: "success",
-      })
+      }),
     );
   });
 
@@ -3611,7 +3666,7 @@ describe("MCPAppsRenderer host capability enforcement", () => {
     render(
       <ScenarioHostCapabilitiesOverrideProvider value={{ serverResources: {} }}>
         <HostedRenderer {...baseProps} />
-      </ScenarioHostCapabilitiesOverrideProvider>
+      </ScenarioHostCapabilitiesOverrideProvider>,
     );
 
     await vi.waitFor(() => {
@@ -3627,7 +3682,7 @@ describe("MCPAppsRenderer host capability enforcement", () => {
     render(
       <ScenarioHostCapabilitiesOverrideProvider value={{ openLinks: {} }}>
         <HostedRenderer {...baseProps} />
-      </ScenarioHostCapabilitiesOverrideProvider>
+      </ScenarioHostCapabilitiesOverrideProvider>,
     );
 
     await vi.waitFor(() => {
@@ -3653,7 +3708,7 @@ describe("MCPAppsRenderer widgetDisplayModeRequests policy", () => {
   });
 
   const profileWith = (
-    policy: "accept" | "user-initiated-only" | "decline"
+    policy: "accept" | "user-initiated-only" | "decline",
   ): HostConfigMcpProfileV1 => ({
     profileVersion: 1,
     apps: { mcpAppsOverrides: { widgetDisplayModeRequests: policy } },
@@ -3665,7 +3720,7 @@ describe("MCPAppsRenderer widgetDisplayModeRequests policy", () => {
         <ScenarioHostStyleProvider value="claude">
           <HostedRenderer {...baseProps} />
         </ScenarioHostStyleProvider>
-      </ActiveMcpProfileProvider>
+      </ActiveMcpProfileProvider>,
     );
     await vi.waitFor(() => {
       expect(mockBridge.onrequestdisplaymode).not.toBeNull();
@@ -3683,7 +3738,7 @@ describe("MCPAppsRenderer widgetDisplayModeRequests policy", () => {
         <ScenarioHostStyleProvider value="claude">
           <HostedRenderer {...baseProps} />
         </ScenarioHostStyleProvider>
-      </ActiveMcpProfileProvider>
+      </ActiveMcpProfileProvider>,
     );
     await vi.waitFor(() => {
       expect(mockBridge.onrequestdisplaymode).not.toBeNull();
@@ -3705,7 +3760,7 @@ describe("MCPAppsRenderer widgetDisplayModeRequests policy", () => {
         <ScenarioHostStyleProvider value="claude">
           <HostedRenderer {...baseProps} />
         </ScenarioHostStyleProvider>
-      </ActiveMcpProfileProvider>
+      </ActiveMcpProfileProvider>,
     );
     await vi.waitFor(() => {
       expect(mockBridge.onrequestdisplaymode).not.toBeNull();
@@ -3845,21 +3900,21 @@ describe("MCPAppsRenderer display-mode requests after a user close", () => {
   }
 
   const profileWith = (
-    policy: "accept" | "user-initiated-only" | "decline"
+    policy: "accept" | "user-initiated-only" | "decline",
   ): HostConfigMcpProfileV1 => ({
     profileVersion: 1,
     apps: { mcpAppsOverrides: { widgetDisplayModeRequests: policy } },
   });
 
   async function mountControlled(
-    policy: "accept" | "user-initiated-only" | "decline"
+    policy: "accept" | "user-initiated-only" | "decline",
   ) {
     render(
       <ActiveMcpProfileProvider value={profileWith(policy)}>
         <ScenarioHostStyleProvider value="mcpjam">
           <ControlledHost />
         </ScenarioHostStyleProvider>
-      </ActiveMcpProfileProvider>
+      </ActiveMcpProfileProvider>,
     );
     await vi.waitFor(() => {
       expect(mockBridge.onrequestdisplaymode).not.toBeNull();
@@ -4009,7 +4064,7 @@ describe("MCPAppsRenderer display-mode requests after a user close", () => {
       availableDisplayModes: ["inline", "pip"],
     });
     const { requestMode, publishedDisplayMode } = await mountControlled(
-      "accept"
+      "accept",
     );
 
     expect(await requestMode("pip")).toBe("pip");
@@ -4094,7 +4149,7 @@ describe("MCPAppsRenderer requestTeardown policy", () => {
   });
 
   const profileWithRequestTeardown = (
-    requestTeardown: boolean
+    requestTeardown: boolean,
   ): HostConfigMcpProfileV1 => ({
     profileVersion: 1,
     apps: { mcpAppsOverrides: { requestTeardown } },
@@ -4110,7 +4165,7 @@ describe("MCPAppsRenderer requestTeardown policy", () => {
             onRequestTeardown={onRequestTeardown}
           />
         </ScenarioHostStyleProvider>
-      </ActiveMcpProfileProvider>
+      </ActiveMcpProfileProvider>,
     );
 
     await vi.waitFor(() => {
@@ -4139,7 +4194,7 @@ describe("MCPAppsRenderer requestTeardown policy", () => {
             <HostedSurfaceHost />
           </ScenarioHostStyleProvider>
         </ActiveMcpProfileProvider>
-      </WidgetSurfaceHostProvider>
+      </WidgetSurfaceHostProvider>,
     );
 
     await vi.waitFor(() => {
@@ -4166,7 +4221,7 @@ describe("MCPAppsRenderer requestTeardown policy", () => {
         <ScenarioHostStyleProvider value="claude">
           <HostedRenderer {...baseProps} />
         </ScenarioHostStyleProvider>
-      </ActiveMcpProfileProvider>
+      </ActiveMcpProfileProvider>,
     );
 
     await vi.waitFor(() => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/use-widget-host.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/use-widget-host.tsx
@@ -15,7 +15,7 @@
 // reads through `environment`/`resolvers` while keeping its derivation in place;
 // pre-resolving them into `WidgetHost.resolveEnvironment` is the Phase-3 target.
 
-import { useMemo, useRef, type ReactNode } from "react";
+import { useCallback, useMemo, useRef, type ReactNode } from "react";
 import {
   HOSTED_MODE,
   SANDBOX_ORIGIN,
@@ -37,6 +37,12 @@ import { useHostContextStore } from "@/stores/client-context-store";
 import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
 import { useTrafficLogStore } from "@/stores/traffic-log-store";
 import { useWidgetDebugStore } from "@/stores/widget-debug-store";
+import type { CspViolation } from "@/stores/widget-debug-store";
+import { compareCspPolicies } from "../csp-workbench/csp-header";
+import {
+  CspViolationTelemetryLimiter,
+  reportCspViolationToSentry,
+} from "@/lib/csp-violation-telemetry";
 import {
   resolveEffectiveCompatRuntime,
   resolveEffectiveHostCapabilities,
@@ -88,7 +94,12 @@ import type {
 // design-system <Dialog> and <CheckoutDialogV2>.
 
 /** WidgetModalProps → the inspector design-system <Dialog> (widget-modal sizing). */
-function WidgetModalChrome({ open, onClose, title, children }: WidgetModalProps) {
+function WidgetModalChrome({
+  open,
+  onClose,
+  title,
+  children,
+}: WidgetModalProps) {
   return (
     <Dialog
       open={open}
@@ -156,8 +167,8 @@ export function useWidgetHost(): WidgetHostImpl {
   const kind: WidgetSurfaceKind = isScenarioSurface
     ? "scenario"
     : widgetSurface === "playground"
-      ? "playground"
-      : "chat";
+    ? "playground"
+    : "chat";
 
   // Read into a ref so the memoized `services` object stays stable while the
   // listResourceTemplates guard still observes the live value (mirrors the
@@ -287,7 +298,10 @@ export function useWidgetHost(): WidgetHostImpl {
           profile: activeMcpProfileRef.current,
           hostStyle,
         }),
-      resolveEffectiveHostCapabilities: ({ hostStyle, hostCapabilitiesOverride }) =>
+      resolveEffectiveHostCapabilities: ({
+        hostStyle,
+        hostCapabilitiesOverride,
+      }) =>
         resolveEffectiveHostCapabilities({
           hostStyle,
           profile: activeMcpProfileRef.current,
@@ -311,9 +325,7 @@ export function useWidgetHost(): WidgetHostImpl {
   const setWidgetState = useWidgetDebugStore((s) => s.setWidgetState);
   const setWidgetGlobals = useWidgetDebugStore((s) => s.setWidgetGlobals);
   const setWidgetCsp = useWidgetDebugStore((s) => s.setWidgetCsp);
-  const setWidgetAppliedCsp = useWidgetDebugStore(
-    (s) => s.setWidgetAppliedCsp,
-  );
+  const setWidgetAppliedCsp = useWidgetDebugStore((s) => s.setWidgetAppliedCsp);
   const addCspViolation = useWidgetDebugStore((s) => s.addCspViolation);
   const clearCspViolations = useWidgetDebugStore((s) => s.clearCspViolations);
   const setWidgetModelContext = useWidgetDebugStore(
@@ -323,6 +335,45 @@ export function useWidgetHost(): WidgetHostImpl {
   const setSandboxApplied = useWidgetDebugStore((s) => s.setSandboxApplied);
   const appendLifecycle = useWidgetDebugStore((s) => s.appendLifecycle);
   const addTrafficLog = useTrafficLogStore((s) => s.addLog);
+  const cspTelemetryLimiterRef = useRef(new CspViolationTelemetryLimiter());
+  const reportCspViolation = useCallback(
+    (toolCallId: string, serverId: string, violation: CspViolation) => {
+      if (
+        !cspTelemetryLimiterRef.current.shouldReport(
+          toolCallId,
+          serverId,
+          violation,
+        )
+      ) {
+        return;
+      }
+      const applied =
+        violation.mountId === undefined
+          ? undefined
+          : useWidgetDebugStore.getState().widgets.get(toolCallId)?.csp
+              ?.appliedPoliciesByMount?.[String(violation.mountId)];
+      reportCspViolationToSentry({
+        toolCallId,
+        serverId,
+        violation,
+        appliedPolicy: applied?.headerString,
+        appliedMode: applied?.mode,
+        intent: applied?.intent,
+        comparison: compareCspPolicies(
+          applied?.headerString,
+          violation.originalPolicy,
+        ),
+      });
+    },
+    [],
+  );
+  const clearCspViolationsAndTelemetry = useCallback(
+    (toolCallId: string) => {
+      cspTelemetryLimiterRef.current.clearToolCall(toolCallId);
+      clearCspViolations(toolCallId);
+    },
+    [clearCspViolations],
+  );
 
   const debug = useMemo<WidgetDebugSink>(
     () => ({
@@ -333,7 +384,8 @@ export function useWidgetHost(): WidgetHostImpl {
       setWidgetCsp,
       setWidgetAppliedCsp,
       addCspViolation,
-      clearCspViolations,
+      reportCspViolation,
+      clearCspViolations: clearCspViolationsAndTelemetry,
       setWidgetModelContext,
       setWidgetHtml,
       setSandboxApplied,
@@ -348,7 +400,8 @@ export function useWidgetHost(): WidgetHostImpl {
       setWidgetCsp,
       setWidgetAppliedCsp,
       addCspViolation,
-      clearCspViolations,
+      reportCspViolation,
+      clearCspViolationsAndTelemetry,
       setWidgetModelContext,
       setWidgetHtml,
       setSandboxApplied,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
@@ -56,6 +56,7 @@ export type {
   WidgetLifecycleEvent,
   WidgetMount,
   CspViolation,
+  CspApplicationIntent,
   UiLogEvent,
   // chrome injection
   WidgetModalProps,

--- a/mcpjam-inspector/client/src/lib/__tests__/csp-violation-telemetry.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/csp-violation-telemetry.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { captureSentryMessage } from "../sentry";
+import {
+  CspViolationTelemetryLimiter,
+  failedToApplyCsp,
+  reportCspViolationToSentry,
+  sanitizeCspPolicy,
+} from "../csp-violation-telemetry";
+
+vi.mock("../sentry", () => ({ captureSentryMessage: vi.fn() }));
+
+const violation = {
+  directive: "frame-src",
+  effectiveDirective: "frame-src",
+  blockedUri: "https://user:secret@js.stripe.com/v3?token=secret#part",
+  mountId: 4,
+  originalPolicy:
+    "script-src 'nonce-secret' 'sha256-secret'; frame-src https://user:secret@js.stripe.com/v3?token=secret#part",
+  disposition: "enforce" as const,
+  sourceFile: "https://app.example/widget.js?session=secret#trace",
+  lineNumber: 12,
+  columnNumber: 8,
+  timestamp: 1,
+};
+
+describe("CSP violation telemetry", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("redacts secrets from policies", () => {
+    expect(sanitizeCspPolicy(violation.originalPolicy)?.value).toBe(
+      "script-src 'nonce-[redacted]' 'sha256-[redacted]'; frame-src https://js.stripe.com/v3",
+    );
+  });
+
+  it("deduplicates violations and caps each mount", () => {
+    const limiter = new CspViolationTelemetryLimiter(2);
+    expect(limiter.shouldReport("t1", "s1", violation)).toBe(true);
+    expect(limiter.shouldReport("t1", "s1", violation)).toBe(false);
+    expect(
+      limiter.shouldReport("t1", "s1", {
+        ...violation,
+        blockedUri: "https://two.example",
+      }),
+    ).toBe(true);
+    expect(
+      limiter.shouldReport("t1", "s1", {
+        ...violation,
+        blockedUri: "https://three.example",
+      }),
+    ).toBe(false);
+    expect(limiter.shouldReport("t1", "s1", { ...violation, mountId: 5 })).toBe(
+      true,
+    );
+    limiter.clearToolCall("t1");
+    expect(limiter.shouldReport("t1", "s1", violation)).toBe(true);
+  });
+
+  it("sends sanitized support details without making them page-worthy", () => {
+    reportCspViolationToSentry({
+      toolCallId: "tool-1",
+      serverId: "server-1",
+      violation,
+      appliedPolicy: "frame-src https://js.stripe.com/v3?key=secret",
+      appliedMode: "widget-declared",
+      comparison: { status: "different", differingDirectives: ["script-src"] },
+    });
+
+    expect(captureSentryMessage).toHaveBeenCalledWith(
+      "MCP App CSP violation",
+      expect.objectContaining({
+        level: "info",
+        fingerprint: ["mcp-app-csp-violation", "frame-src"],
+        extra: expect.objectContaining({
+          mountId: 4,
+          blockedOrigin: "https://js.stripe.com",
+          blockedUrl: "https://js.stripe.com/v3",
+          sourceFile: "https://app.example/widget.js",
+          appliedPolicy: "frame-src https://js.stripe.com/v3",
+          originalPolicy: expect.not.stringContaining("secret"),
+        }),
+      }),
+    );
+    expect(
+      JSON.stringify(vi.mocked(captureSentryMessage).mock.calls),
+    ).not.toContain("email");
+  });
+
+  it("identifies only a source MCPJam intended to allow but failed to inject", () => {
+    const intent = {
+      csp: { frameDomains: ["https://js.stripe.com"] },
+      permissive: false,
+    };
+    expect(
+      failedToApplyCsp({
+        violation,
+        appliedPolicy: "default-src 'none'; frame-src 'none'",
+        intent,
+      }),
+    ).toBe(true);
+    expect(
+      failedToApplyCsp({
+        violation,
+        appliedPolicy: "frame-src https://js.stripe.com",
+        intent,
+      }),
+    ).toBe(false);
+    expect(
+      failedToApplyCsp({
+        violation,
+        appliedPolicy: "frame-src 'none'",
+        intent: { csp: { frameDomains: [] }, permissive: false },
+      }),
+    ).toBe(false);
+  });
+
+  it("emits an error named Failed to apply CSP only for an MCPJam failure", () => {
+    reportCspViolationToSentry({
+      toolCallId: "tool-1",
+      serverId: "server-1",
+      violation,
+      appliedPolicy: "default-src 'none'; frame-src 'none'",
+      appliedMode: "widget-declared",
+      intent: {
+        csp: { frameDomains: ["https://js.stripe.com"] },
+        permissive: false,
+      },
+      comparison: { status: "matching", differingDirectives: [] },
+    });
+
+    expect(captureSentryMessage).toHaveBeenCalledWith(
+      "Failed to apply CSP",
+      expect.objectContaining({
+        level: "error",
+        fingerprint: ["failed-to-apply-csp", "frame-src"],
+        tags: expect.objectContaining({ mcpjam_csp_apply_failed: "true" }),
+      }),
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/lib/csp-violation-telemetry.ts
+++ b/mcpjam-inspector/client/src/lib/csp-violation-telemetry.ts
@@ -1,0 +1,279 @@
+import type { CspViolation } from "@/stores/widget-debug-store";
+import type { CspApplicationIntent } from "@mcpjam/widget-react";
+import type { CspPolicyComparison } from "@/components/chat-v2/thread/csp-workbench/csp-header";
+import {
+  parseCspHeader,
+  resolveDirective,
+} from "@/components/chat-v2/thread/csp-workbench/csp-header";
+import { captureSentryMessage } from "./sentry";
+
+const MAX_POLICY_LENGTH = 16_000;
+const REDACTED_SOURCE_RE = /^'?(nonce|sha256|sha384|sha512)-/i;
+
+function parentDirective(directive: string): string {
+  const normalized = directive.toLowerCase();
+  if (normalized === "script-src-elem" || normalized === "script-src-attr") {
+    return "script-src";
+  }
+  if (normalized === "style-src-elem" || normalized === "style-src-attr") {
+    return "style-src";
+  }
+  return normalized;
+}
+
+function intendedSources(
+  intent: CspApplicationIntent,
+  directive: string,
+): string[] {
+  const normalized = parentDirective(directive);
+  const sources = new Set<string>();
+  const csp = intent.csp;
+  if (normalized === "connect-src") {
+    csp?.connectDomains?.forEach((source) => sources.add(source));
+  } else if (normalized === "frame-src") {
+    csp?.frameDomains?.forEach((source) => sources.add(source));
+  } else if (normalized === "base-uri") {
+    csp?.baseUriDomains?.forEach((source) => sources.add(source));
+  } else if (
+    normalized === "script-src" ||
+    normalized === "style-src" ||
+    normalized === "img-src" ||
+    normalized === "font-src" ||
+    normalized === "media-src"
+  ) {
+    csp?.resourceDomains?.forEach((source) => sources.add(source));
+  }
+  intent.cspDirectives?.[normalized]?.forEach((source) => sources.add(source));
+  intent.cspDirectives?.[directive.toLowerCase()]?.forEach((source) =>
+    sources.add(source),
+  );
+  return [...sources];
+}
+
+/**
+ * Conservative allow check for paging. Path-scoped and ambiguous expressions
+ * intentionally return false: missing a page is safer than waking someone for
+ * a policy the app itself configured incorrectly.
+ */
+function clearlyAllowsUrl(value: string, sources: readonly string[]): boolean {
+  let blocked: URL;
+  try {
+    blocked = new URL(value);
+  } catch {
+    return false;
+  }
+
+  return sources.some((source) => {
+    const trimmed = source.trim();
+    if (trimmed === "*") return true;
+    if (trimmed === `${blocked.protocol}`) return true;
+    if (trimmed.startsWith("'")) return false;
+
+    try {
+      const allowed = new URL(trimmed);
+      if (allowed.pathname !== "/" || allowed.search || allowed.hash) {
+        return false;
+      }
+      if (allowed.protocol !== blocked.protocol) return false;
+      if (allowed.port && allowed.port !== blocked.port) return false;
+      if (allowed.hostname.startsWith("*.")) {
+        const suffix = allowed.hostname.slice(1).toLowerCase();
+        return blocked.hostname.toLowerCase().endsWith(suffix);
+      }
+      return allowed.origin === blocked.origin;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function hasAmbiguousUrlSource(sources: readonly string[]): boolean {
+  return sources.some((source) => {
+    const trimmed = source.trim();
+    if (
+      trimmed === "*" ||
+      trimmed === "'none'" ||
+      /^[a-zA-Z][a-zA-Z0-9+.-]*:$/.test(trimmed)
+    ) {
+      return false;
+    }
+    if (trimmed.startsWith("'")) return true;
+    try {
+      const parsed = new URL(trimmed);
+      return parsed.pathname !== "/" || Boolean(parsed.search || parsed.hash);
+    } catch {
+      return true;
+    }
+  });
+}
+
+export function failedToApplyCsp(args: {
+  violation: CspViolation;
+  appliedPolicy?: string;
+  intent?: CspApplicationIntent;
+}): boolean {
+  const { violation, appliedPolicy, intent } = args;
+  if (!intent || !appliedPolicy || violation.disposition !== "enforce") {
+    return false;
+  }
+  const directive = parentDirective(
+    violation.effectiveDirective || violation.directive,
+  );
+  const intendedAllows =
+    intent.permissive ||
+    clearlyAllowsUrl(violation.blockedUri, intendedSources(intent, directive));
+  if (!intendedAllows) return false;
+
+  const appliedSources = resolveDirective(
+    parseCspHeader(appliedPolicy),
+    directive,
+  );
+  if (hasAmbiguousUrlSource(appliedSources ?? [])) return false;
+  return !clearlyAllowsUrl(violation.blockedUri, appliedSources ?? []);
+}
+
+function sanitizeUrl(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return value.split(/[?#]/, 1)[0];
+  }
+}
+
+function sanitizedOrigin(value: string): string | undefined {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+export function sanitizeCspPolicy(
+  policy: string | undefined,
+): { value: string; truncated: boolean } | undefined {
+  if (!policy) return undefined;
+  const sanitized = policy
+    .split(/(\s+|;)/)
+    .map((token) => {
+      if (REDACTED_SOURCE_RE.test(token)) {
+        const quoted = token.startsWith("'");
+        const start = quoted ? 1 : 0;
+        const kind = token.slice(start, token.indexOf("-")).toLowerCase();
+        return `${quoted ? "'" : ""}${kind}-[redacted]${quoted ? "'" : ""}`;
+      }
+      return sanitizeUrl(token) ?? token;
+    })
+    .join("");
+  return {
+    value: sanitized.slice(0, MAX_POLICY_LENGTH),
+    truncated: sanitized.length > MAX_POLICY_LENGTH,
+  };
+}
+
+export class CspViolationTelemetryLimiter {
+  private readonly seen = new Map<string, Set<string>>();
+
+  constructor(private readonly limitPerMount = 10) {}
+
+  shouldReport(
+    toolCallId: string,
+    serverId: string,
+    violation: CspViolation,
+  ): boolean {
+    const mountKey = `${serverId}:${toolCallId}:${
+      violation.mountId ?? "legacy"
+    }`;
+    const entries = this.seen.get(mountKey) ?? new Set<string>();
+    const signature = [
+      violation.effectiveDirective || violation.directive,
+      violation.blockedUri,
+      violation.sourceFile ?? "",
+      violation.lineNumber ?? "",
+      violation.columnNumber ?? "",
+      violation.originalPolicy ?? "",
+    ].join("|");
+    if (entries.has(signature) || entries.size >= this.limitPerMount)
+      return false;
+    entries.add(signature);
+    this.seen.set(mountKey, entries);
+    return true;
+  }
+
+  clearToolCall(toolCallId: string): void {
+    for (const key of this.seen.keys()) {
+      if (key.includes(`:${toolCallId}:`)) this.seen.delete(key);
+    }
+  }
+}
+
+export function reportCspViolationToSentry(args: {
+  toolCallId: string;
+  serverId: string;
+  violation: CspViolation;
+  appliedPolicy?: string;
+  appliedMode?: "permissive" | "widget-declared";
+  intent?: CspApplicationIntent;
+  comparison: CspPolicyComparison;
+}): void {
+  const { toolCallId, serverId, violation, comparison } = args;
+  const directive = violation.effectiveDirective || violation.directive;
+  const applied = sanitizeCspPolicy(args.appliedPolicy);
+  const original = sanitizeCspPolicy(violation.originalPolicy);
+  const blockedUrl = sanitizeUrl(violation.blockedUri);
+  const applyFailed = failedToApplyCsp({
+    violation,
+    appliedPolicy: args.appliedPolicy,
+    intent: args.intent,
+  });
+  const intentSources = args.intent
+    ? intendedSources(args.intent, directive).map(
+        (source) => sanitizeUrl(source) ?? source,
+      )
+    : undefined;
+
+  try {
+    captureSentryMessage(
+      applyFailed ? "Failed to apply CSP" : "MCP App CSP violation",
+      {
+        // Ordinary violations are support evidence: keep them searchable, but
+        // reserve error-level events (and paging) for MCPJam application bugs.
+        level: applyFailed ? "error" : "info",
+        fingerprint: [
+          applyFailed ? "failed-to-apply-csp" : "mcp-app-csp-violation",
+          directive,
+        ],
+        tags: {
+          csp_directive: directive,
+          csp_disposition: violation.disposition ?? "unknown",
+          csp_policy_comparison: comparison.status,
+          csp_mode: args.appliedMode ?? "unknown",
+          mcpjam_csp_apply_failed: applyFailed ? "true" : "false",
+        },
+        extra: {
+          mountId: violation.mountId,
+          serverId,
+          toolCallId,
+          blockedOrigin: sanitizedOrigin(violation.blockedUri),
+          blockedUrl,
+          sourceFile: sanitizeUrl(violation.sourceFile),
+          lineNumber: violation.lineNumber,
+          columnNumber: violation.columnNumber,
+          appliedPolicy: applied?.value,
+          appliedPolicyTruncated: applied?.truncated,
+          originalPolicy: original?.value,
+          originalPolicyTruncated: original?.truncated,
+          differingDirectives: comparison.differingDirectives,
+          intendedSources: intentSources,
+        },
+      },
+    );
+  } catch {
+    // Telemetry must never affect widget rendering.
+  }
+}

--- a/mcpjam-inspector/client/src/lib/sentry.ts
+++ b/mcpjam-inspector/client/src/lib/sentry.ts
@@ -69,9 +69,10 @@ let sentryReplayStoppedByGuard = false;
 export function syncSentryReplayForPath(pathname: string): void {
   try {
     if (!isErrorCaptureSurface()) return;
-    const replay = Sentry.getClient()?.getIntegrationByName?.<
-      ReturnType<typeof Sentry.replayIntegration>
-    >("Replay");
+    const replay =
+      Sentry.getClient()?.getIntegrationByName?.<
+        ReturnType<typeof Sentry.replayIntegration>
+      >("Replay");
     if (!replay) return;
 
     if (isCredentialBearingPath(pathname)) {
@@ -106,7 +107,14 @@ export function syncSentryReplayForPath(pathname: string): void {
  */
 export function captureSentryException(
   error: Error,
-  context?: { tags?: Record<string, string> }
+  context?: { tags?: Record<string, string> },
 ): void {
   Sentry.captureException(error, context);
+}
+
+export function captureSentryMessage(
+  message: string,
+  context: Parameters<typeof Sentry.captureMessage>[1],
+): void {
+  Sentry.captureMessage(message, context);
 }

--- a/mcpjam-inspector/client/src/stores/__tests__/widget-debug-store-applied-csp.test.ts
+++ b/mcpjam-inspector/client/src/stores/__tests__/widget-debug-store-applied-csp.test.ts
@@ -30,6 +30,7 @@ describe("widget-debug-store — applied CSP", () => {
     } as never);
 
     useWidgetDebugStore.getState().setWidgetAppliedCsp("t1", {
+      mountId: 1,
       headerString: HEADER,
       mode: "widget-declared",
     });
@@ -48,9 +49,11 @@ describe("widget-debug-store — applied CSP", () => {
     store.setWidgetDebugInfo("t2", { toolName: "demo" });
     store.setWidgetCsp("t2", declared);
 
-    useWidgetDebugStore
-      .getState()
-      .setWidgetAppliedCsp("t2", { headerString: HEADER, mode: "permissive" });
+    useWidgetDebugStore.getState().setWidgetAppliedCsp("t2", {
+      mountId: 2,
+      headerString: HEADER,
+      mode: "permissive",
+    });
 
     expect(useWidgetDebugStore.getState().widgets.get("t2")!.csp!.mode).toBe(
       "permissive",
@@ -61,6 +64,7 @@ describe("widget-debug-store — applied CSP", () => {
     // A permissive widget declaring no csp/permissions/domain never reaches
     // setWidgetCsp at all, so this can be the first writer.
     useWidgetDebugStore.getState().setWidgetAppliedCsp("t3", {
+      mountId: 3,
       headerString: HEADER,
       mode: "permissive",
     });
@@ -76,6 +80,7 @@ describe("widget-debug-store — applied CSP", () => {
     const store = useWidgetDebugStore.getState();
     store.setWidgetDebugInfo("t4", { toolName: "demo" });
     store.setWidgetAppliedCsp("t4", {
+      mountId: 4,
       headerString: HEADER,
       mode: "widget-declared",
     });
@@ -88,5 +93,61 @@ describe("widget-debug-store — applied CSP", () => {
     expect(
       useWidgetDebugStore.getState().widgets.get("t4")!.csp!.headerString,
     ).toBeUndefined();
+  });
+
+  it("keeps policies from different mounts separate", () => {
+    const store = useWidgetDebugStore.getState();
+    store.setWidgetAppliedCsp("t5", {
+      mountId: 1,
+      headerString: "frame-src https://one.example",
+      mode: "widget-declared",
+    });
+    store.setWidgetAppliedCsp("t5", {
+      mountId: 2,
+      headerString: "frame-src https://two.example",
+      mode: "widget-declared",
+    });
+
+    const csp = useWidgetDebugStore.getState().widgets.get("t5")!.csp!;
+    expect(csp.activeMountId).toBe(2);
+    expect(csp.appliedPoliciesByMount).toEqual({
+      "1": {
+        headerString: "frame-src https://one.example",
+        mode: "widget-declared",
+      },
+      "2": {
+        headerString: "frame-src https://two.example",
+        mode: "widget-declared",
+      },
+    });
+  });
+
+  it("keeps first mounts from recreated proxies separate", () => {
+    const store = useWidgetDebugStore.getState();
+    store.setWidgetAppliedCsp("t6", {
+      mountId: "proxy-a:1",
+      headerString: "frame-src https://one.example",
+      mode: "widget-declared",
+    });
+    store.setWidgetAppliedCsp("t6", {
+      mountId: "proxy-b:1",
+      headerString: "frame-src https://two.example",
+      mode: "widget-declared",
+      intent: {
+        csp: { frameDomains: ["https://two.example"] },
+        permissive: false,
+      },
+    });
+
+    const csp = useWidgetDebugStore.getState().widgets.get("t6")!.csp!;
+    expect(csp.activeMountId).toBe("proxy-b:1");
+    expect(Object.keys(csp.appliedPoliciesByMount ?? {})).toEqual([
+      "proxy-a:1",
+      "proxy-b:1",
+    ]);
+    expect(csp.appliedPoliciesByMount?.["proxy-b:1"].intent).toEqual({
+      csp: { frameDomains: ["https://two.example"] },
+      permissive: false,
+    });
   });
 });

--- a/mcpjam-inspector/client/src/stores/widget-debug-store.ts
+++ b/mcpjam-inspector/client/src/stores/widget-debug-store.ts
@@ -13,6 +13,20 @@ import type {
   OpenAiAppsCapabilities,
 } from "@/lib/client-styles";
 
+/** New mounts use an opaque string; numbers remain valid for saved data. */
+export type CspMountId = string | number;
+
+export interface CspApplicationIntent {
+  csp?: {
+    connectDomains?: string[];
+    resourceDomains?: string[];
+    frameDomains?: string[];
+    baseUriDomains?: string[];
+  };
+  cspDirectives?: Record<string, string[]>;
+  permissive: boolean;
+}
+
 export interface CspViolation {
   /** The CSP directive that was violated (e.g., "script-src") */
   directive: string;
@@ -20,6 +34,11 @@ export interface CspViolation {
   effectiveDirective?: string;
   /** The URI that was blocked */
   blockedUri: string;
+  /** Id of the exact inner iframe mount that emitted this event. */
+  mountId?: CspMountId;
+  /** The policy that caused this specific violation. */
+  originalPolicy?: string;
+  disposition?: "enforce" | "report";
   /** Source file where the violation occurred */
   sourceFile?: string | null;
   /** Line number in source file */
@@ -118,6 +137,8 @@ export interface WidgetSandboxApplied {
    * `@mcpjam/widget-react`'s `widget-host.ts` — edit both.
    */
   viewMode?: "url" | "srcdoc" | "srcdoc-fallback";
+  /** Id of the currently displayed inner iframe mount. */
+  mountId?: CspMountId;
   /** The view's document URL as reported by the proxy. */
   viewUrl?: string;
   /**
@@ -190,6 +211,17 @@ export interface WidgetSandboxInfo {
   };
   /** Full CSP header string (for advanced users) */
   headerString?: string;
+  /** Latest proxy mount, retained for consumers that show current state. */
+  activeMountId?: CspMountId;
+  /** Applied policies keyed by proxy mount id so remounts cannot mix data. */
+  appliedPoliciesByMount?: Record<
+    string,
+    {
+      headerString: string;
+      mode: "permissive" | "widget-declared";
+      intent?: CspApplicationIntent;
+    }
+  >;
   /** List of CSP violations for this widget */
   violations: CspViolation[];
   /** Widget's actual CSP declaration (null if not declared) */
@@ -350,7 +382,12 @@ interface WidgetDebugStore {
    */
   setWidgetAppliedCsp: (
     toolCallId: string,
-    applied: { headerString: string; mode: CspMode },
+    applied: {
+      mountId: CspMountId;
+      headerString: string;
+      mode: CspMode;
+      intent?: CspApplicationIntent;
+    },
   ) => void;
 
   // Add a CSP violation for a widget
@@ -427,7 +464,7 @@ export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
         widgetState:
           info.widgetState !== undefined
             ? info.widgetState
-            : (existing?.widgetState ?? null),
+            : existing?.widgetState ?? null,
         globals: info.globals ??
           existing?.globals ?? {
             theme: "dark",
@@ -525,6 +562,8 @@ export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
           // assumption-presented-as-fact this panel exists to stop. Same
           // invariant as the `setFirstCspBlock(null)` reset alongside it.
           headerString: undefined,
+          activeMountId: undefined,
+          appliedPoliciesByMount: {},
         },
         updatedAt: Date.now(),
       });
@@ -550,6 +589,15 @@ export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
       const nextCsp = {
         ...currentCsp,
         headerString: applied.headerString,
+        activeMountId: applied.mountId,
+        appliedPoliciesByMount: {
+          ...(currentCsp.appliedPoliciesByMount ?? {}),
+          [String(applied.mountId)]: {
+            headerString: applied.headerString,
+            mode: applied.mode,
+            ...(applied.intent ? { intent: applied.intent } : {}),
+          },
+        },
         // The proxy is authoritative about which branch it took: in permissive
         // mode it never calls buildCSP at all.
         mode: applied.mode,
@@ -609,6 +657,9 @@ export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
         csp: {
           ...existing.csp,
           violations: [],
+          headerString: undefined,
+          activeMountId: undefined,
+          appliedPoliciesByMount: {},
         },
         updatedAt: Date.now(),
       });
@@ -676,8 +727,8 @@ export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
         injectedOpenAiCompatCapabilities:
           injectedOpenAiCompat === false
             ? undefined
-            : (injectedOpenAiCompatCapabilities ??
-              existing?.injectedOpenAiCompatCapabilities),
+            : injectedOpenAiCompatCapabilities ??
+              existing?.injectedOpenAiCompatCapabilities,
         updatedAt: Date.now(),
       });
       return { widgets };

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-mount.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-mount.test.ts
@@ -66,6 +66,9 @@ interface MountHarness {
     allowValue: string,
     colorScheme: unknown,
     mountMode?: "write" | "srcdoc",
+    appliedCsp?: string,
+    appliedCspMode?: "permissive" | "widget-declared",
+    cspIntent?: Record<string, unknown>,
   ) => "url" | "srcdoc" | "srcdoc-fallback";
   createInnerFrame: (
     sandboxValue: string,
@@ -82,7 +85,7 @@ interface MountHarness {
  * Rehydrate the proxy's mount helpers against a jsdom document, with the
  * top-level `inner` / `lastMount` bindings they close over.
  */
-function harness(): { dom: JSDOM; h: MountHarness } {
+function harness(proxyInstanceId = "proxy-a"): { dom: JSDOM; h: MountHarness } {
   const dom = new JSDOM(
     "<!doctype html><html><head></head><body></body></html>",
     {
@@ -101,9 +104,12 @@ function harness(): { dom: JSDOM; h: MountHarness } {
     "document",
     "window",
     "posted",
+    "proxyInstanceId",
     `
     const INNER_STYLE = "width:100%; height:100%; border:none;";
     let inner = null;
+    let mountSequence = 0;
+    let currentMountId = null;
     let lastMount = null;
     // Pinning is off in this harness; the view-mode post falls back to "*".
     let hostOrigin = null;
@@ -112,7 +118,8 @@ function harness(): { dom: JSDOM; h: MountHarness } {
     ${mountInnerSrc}
     ${remountLastSrc}
     return {
-      mountInner,
+      mountInner: (html, sandboxValue, allowValue, colorScheme, mountMode, appliedCsp = "default-src 'none'", appliedCspMode = "widget-declared", cspIntent) =>
+        mountInner(html, sandboxValue, allowValue, colorScheme, mountMode, appliedCsp, appliedCspMode, cspIntent),
       createInnerFrame,
       getInner: () => inner,
       getLastMount: () => lastMount,
@@ -124,8 +131,12 @@ function harness(): { dom: JSDOM; h: MountHarness } {
     document: Document,
     window: unknown,
     posted: Array<[unknown, string]>,
+    proxyInstanceId: string,
   ) => MountHarness;
-  return { dom, h: factory(dom.window.document, win, posted) };
+  return {
+    dom,
+    h: factory(dom.window.document, win, posted, proxyInstanceId),
+  };
 }
 
 const WIDGET = "<!doctype html><html><body><p id='w'>hi</p></body></html>";
@@ -193,6 +204,8 @@ describe("sandbox-proxy mountInner", () => {
       allowValue: "geolocation *",
       colorScheme: "dark",
       mountMode: undefined,
+      appliedCsp: "default-src 'none'",
+      appliedCspMode: "widget-declared",
     });
   });
 
@@ -205,7 +218,17 @@ describe("sandbox-proxy mountInner", () => {
     expect(h.posted).toEqual([
       [
         {
+          type: "mcpjam:csp-applied",
+          mountId: "proxy-a:1",
+          csp: "default-src 'none'",
+          mode: "widget-declared",
+        },
+        "*",
+      ],
+      [
+        {
           type: "mcpjam:view-mode",
+          mountId: "proxy-a:1",
           mode: "url",
           // jsdom's document.open() does not adopt the entry document's URL
           // (the browser e2e pins that); what matters here is that the proxy
@@ -221,8 +244,51 @@ describe("sandbox-proxy mountInner", () => {
     const { h } = harness();
     h.mountInner(WIDGET, "allow-scripts", "", "light", "srcdoc");
     expect(h.posted).toEqual([
-      [{ type: "mcpjam:view-mode", mode: "srcdoc", url: "about:srcdoc" }, "*"],
+      [
+        {
+          type: "mcpjam:csp-applied",
+          mountId: "proxy-a:1",
+          csp: "default-src 'none'",
+          mode: "widget-declared",
+        },
+        "*",
+      ],
+      [
+        {
+          type: "mcpjam:view-mode",
+          mountId: "proxy-a:1",
+          mode: "srcdoc",
+          url: "about:srcdoc",
+        },
+        "*",
+      ],
     ]);
+  });
+
+  it("reports the pre-injection CSP intent with the same mount id", () => {
+    const { h } = harness();
+    const intent = {
+      csp: { frameDomains: ["https://js.stripe.com"] },
+      permissive: false,
+    };
+    h.mountInner(
+      WIDGET,
+      "allow-same-origin allow-scripts",
+      "",
+      "light",
+      undefined,
+      "frame-src https://js.stripe.com",
+      "widget-declared",
+      intent,
+    );
+
+    expect(h.posted[0][0]).toEqual({
+      type: "mcpjam:csp-applied",
+      mountId: "proxy-a:1",
+      csp: "frame-src https://js.stripe.com",
+      mode: "widget-declared",
+      intent,
+    });
   });
 
   it("removes the previous frame and repoints `inner` on every mount", () => {
@@ -313,6 +379,54 @@ describe("sandbox-proxy blank-reload remount", () => {
     expect(before.isConnected).toBe(false);
     expect(after.getAttribute("allow")).toBe("camera *");
     expect(after.contentDocument!.querySelector("#w")!.textContent).toBe("hi");
+    expect(
+      h.posted.filter(
+        ([data]) => (data as { type?: string }).type === "mcpjam:csp-applied",
+      ),
+    ).toEqual([
+      [
+        {
+          type: "mcpjam:csp-applied",
+          mountId: "proxy-a:1",
+          csp: "default-src 'none'",
+          mode: "widget-declared",
+        },
+        "*",
+      ],
+      [
+        {
+          type: "mcpjam:csp-applied",
+          mountId: "proxy-a:2",
+          csp: "default-src 'none'",
+          mode: "widget-declared",
+        },
+        "*",
+      ],
+    ]);
+  });
+
+  it("does not reuse mount ids when the whole proxy is recreated", () => {
+    const firstProxy = harness("proxy-a").h;
+    const secondProxy = harness("proxy-b").h;
+
+    firstProxy.mountInner(
+      WIDGET,
+      "allow-same-origin allow-scripts",
+      "",
+      "light",
+    );
+    secondProxy.mountInner(
+      WIDGET,
+      "allow-same-origin allow-scripts",
+      "",
+      "light",
+    );
+
+    const firstApplied = firstProxy.posted[0][0] as { mountId: string };
+    const secondApplied = secondProxy.posted[0][0] as { mountId: string };
+    expect(firstApplied.mountId).toBe("proxy-a:1");
+    expect(secondApplied.mountId).toBe("proxy-b:1");
+    expect(firstApplied.mountId).not.toBe(secondApplied.mountId);
   });
 
   it("leaves the frame alone after its own write (href is the proxy URL)", () => {
@@ -360,6 +474,10 @@ describe("sandbox-proxy nested sandbox-proxy-ready guard", () => {
     expect(guard).toContain("remountLast();");
     expect(guard).toContain("return;");
     expect(guard).not.toContain("window.parent.postMessage");
+  });
+
+  it("stamps forwarded violations with the current mount id", () => {
+    expect(html).toContain("? { ...data, mountId: currentMountId }");
   });
 });
 
@@ -447,7 +565,7 @@ describe("sandbox-proxy host-origin pinning (source contract)", () => {
 
   it("relays to the locked origin rather than any window", () => {
     expect(html).toContain(
-      'window.parent.postMessage(data, hostOrigin || "*")',
+      'window.parent.postMessage(outgoing, hostOrigin || "*")',
     );
     // And the boot handshake, which happens before any host message, is the
     // only postMessage that can still be unaddressed.

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -74,6 +74,29 @@
       }
 
       /**
+       * Identify this outer proxy iframe for the lifetime of the document.
+       * The sequence alone is not enough: recreating the whole proxy starts
+       * it at 1 again, which could make a later mount collide with saved
+       * policy/violation evidence from the same tool call.
+       */
+      function createProxyInstanceId() {
+        const cryptoApi = globalThis.crypto;
+        if (typeof cryptoApi?.randomUUID === "function") {
+          return cryptoApi.randomUUID();
+        }
+        if (typeof cryptoApi?.getRandomValues === "function") {
+          const bytes = new Uint8Array(16);
+          cryptoApi.getRandomValues(bytes);
+          return Array.from(bytes, (byte) =>
+            byte.toString(16).padStart(2, "0"),
+          ).join("");
+        }
+        return `${Date.now().toString(36)}-${Math.random()
+          .toString(36)
+          .slice(2)}`;
+      }
+
+      /**
        * Build iframe allow attribute from permissions (SEP-1865)
        * @param {Object} permissions - Permissions metadata (camera, microphone, geolocation, clipboardWrite)
        * @returns {string} Permission Policy allow attribute string
@@ -204,7 +227,7 @@
             typeof cspDirectives === "object" &&
             Object.values(cspDirectives).some(
               (tokens) =>
-                Array.isArray(tokens) && tokens.some(cspDirectiveTokenSurvives)
+                Array.isArray(tokens) && tokens.some(cspDirectiveTokenSurvives),
             );
           if (hasCspOverrides) {
             // Helper: if cspDirectives names this directive, emit ONLY
@@ -286,7 +309,7 @@
           const keepDeclaredConnectDomains =
             !connectSubtypePolicy ||
             ["fetch", "xhr", "websocket"].some(
-              (subtype) => connectSubtypePolicy[subtype] !== false
+              (subtype) => connectSubtypePolicy[subtype] !== false,
             );
 
           // Keep the shared connect-src declaration whenever at least one API
@@ -409,7 +432,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
           cspSubtypePolicy && cspSubtypePolicy.cspConnectDomains;
         if (!connectPolicy || typeof connectPolicy !== "object") return "";
         const blocked = ["fetch", "xhr", "websocket"].filter(
-          (subtype) => connectPolicy[subtype] === false
+          (subtype) => connectPolicy[subtype] === false,
         );
         if (blocked.length === 0) return "";
 
@@ -653,14 +676,11 @@ document.addEventListener('securitypolicyviolation', function(e) {
       function buildBrowserStorageGuardScript(browserStorage) {
         if (!browserStorage || typeof browserStorage !== "object") return "";
         const blocked = ["localStorage", "sessionStorage", "indexedDB"].filter(
-          (api) => browserStorage[api] === false
+          (api) => browserStorage[api] === false,
         );
         if (blocked.length === 0) return "";
 
-        const configJson = JSON.stringify({ blocked }).replace(
-          /</g,
-          "\\u003c"
-        );
+        const configJson = JSON.stringify({ blocked }).replace(/</g, "\\u003c");
 
         return `<script>
 (function() {
@@ -806,7 +826,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
         if (extraScript) {
           html = html.replace(
             /<meta[^>]+http-equiv\s*=\s*["']?content-security-policy["']?[^>]*>/gi,
-            ""
+            "",
           );
         }
         const cspMeta =
@@ -837,7 +857,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
           // Insert after doctype
           return html.replace(
             /(<!DOCTYPE[^>]*>|<!doctype[^>]*>)/i,
-            "$1<head>" + injection + "</head>"
+            "$1<head>" + injection + "</head>",
           );
         } else {
           // Prepend CSP meta tag and listener
@@ -917,6 +937,9 @@ document.addEventListener('securitypolicyviolation', function(e) {
        * @param {string} allowValue - Final inner `allow=` value ("" for none)
        * @param {unknown} colorScheme - Host theme for applyColorScheme
        * @param {"write" | "srcdoc" | undefined} mountMode - Mount strategy
+       * @param {string} appliedCsp - CSP injected into this mount
+       * @param {"permissive" | "widget-declared"} appliedCspMode - CSP branch
+       * @param {object | undefined} cspIntent - pre-injection policy input
        * @returns {"url" | "srcdoc" | "srcdoc-fallback"} How the view was mounted
        */
       function mountInner(
@@ -925,7 +948,26 @@ document.addEventListener('securitypolicyviolation', function(e) {
         allowValue,
         colorScheme,
         mountMode,
+        appliedCsp,
+        appliedCspMode,
+        cspIntent,
       ) {
+        // Scoped to this proxy instance and incremented for every fresh inner
+        // frame, including automatic reload remounts. The host uses this id to
+        // pair a violation with the policy injected into that exact document.
+        const mountId = `${proxyInstanceId}:${++mountSequence}`;
+        currentMountId = mountId;
+        window.parent.postMessage(
+          {
+            type: "mcpjam:csp-applied",
+            mountId,
+            csp: appliedCsp,
+            mode: appliedCspMode,
+            ...(cspIntent ? { intent: cspIntent } : {}),
+          },
+          hostOrigin || "*",
+        );
+
         const next = createInnerFrame(sandboxValue, allowValue);
         // Appending creates the frame's initial about:blank document
         // synchronously, same-origin with this proxy.
@@ -968,7 +1010,16 @@ document.addEventListener('securitypolicyviolation', function(e) {
         }
         inner = next;
         next.style.colorScheme = applyColorScheme(colorScheme);
-        lastMount = { html, sandboxValue, allowValue, colorScheme, mountMode };
+        lastMount = {
+          html,
+          sandboxValue,
+          allowValue,
+          colorScheme,
+          mountMode,
+          appliedCsp,
+          appliedCspMode,
+          ...(cspIntent ? { cspIntent } : {}),
+        };
         // Tell the host where the view actually landed. `document.URL` is this
         // proxy's URL, which the written document adopts (see above), so this
         // is the origin a developer allowlists with a third party that keys on
@@ -979,6 +1030,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
         window.parent.postMessage(
           {
             type: "mcpjam:view-mode",
+            mountId,
             mode,
             url: mode === "url" ? document.URL : "about:srcdoc",
           },
@@ -999,12 +1051,20 @@ document.addEventListener('securitypolicyviolation', function(e) {
           lastMount.allowValue,
           lastMount.colorScheme,
           lastMount.mountMode,
+          lastMount.appliedCsp,
+          lastMount.appliedCspMode,
+          lastMount.cspIntent,
         );
       }
 
       // The current inner view frame. Replaced on every mount (see mountInner);
       // the message relay below reads this binding live.
       let inner = null;
+      // The proxy owns mount identity because it also owns automatic remounts
+      // that the React host never sees directly.
+      const proxyInstanceId = createProxyInstanceId();
+      let mountSequence = 0;
+      let currentMountId = null;
       // Arguments of the most recent mount, replayed when a widget reloads
       // itself (see the nested sandbox-proxy-ready guard in the relay).
       let lastMount = null;
@@ -1083,7 +1143,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
             const recorderScript = buildRecorderScript(recordMode);
             const connectGuardScript = buildConnectGuardScript(
               cspSubtypePolicy,
-              cspDirectives
+              cspDirectives,
             );
             // Storage is independent of CSP mode: a host that serves a
             // permissive CSP can still deny storage, so this guard rides
@@ -1169,7 +1229,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
               // The single policy string this mount injects. Hoisted out of
               // the two branches so there is exactly one value to inject and
               // exactly one value to report to the host — the Policy Diff's
-              // "Effective" column is only trustworthy if it reads the same
+              // "Applied" column is only trustworthy if it reads the same
               // string `injectCSP` receives, not a re-derivation of it.
               //
               // Declared branch (SEP-1865): `cspDirectives` is the
@@ -1190,21 +1250,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
                 html,
                 appliedCsp,
                 recorderScript,
-                guardScript
-              );
-
-              // Report the policy the host cannot otherwise see. Posted
-              // BEFORE mountInner so the header lands ahead of that mount's
-              // `mcpjam:view-mode`, keeping the host's ordering faithful to
-              // what actually happened. targetOrigin mirrors mountInner: "*"
-              // until host-origin pinning narrows it.
-              window.parent.postMessage(
-                {
-                  type: "mcpjam:csp-applied",
-                  csp: appliedCsp,
-                  mode: permissive ? "permissive" : "widget-declared",
-                },
-                hostOrigin || "*",
+                guardScript,
               );
 
               const mode = mountInner(
@@ -1213,6 +1259,13 @@ document.addEventListener('securitypolicyviolation', function(e) {
                 baseAllow,
                 colorScheme,
                 mountMode,
+                appliedCsp,
+                permissive ? "permissive" : "widget-declared",
+                {
+                  csp,
+                  cspDirectives,
+                  permissive: Boolean(permissive),
+                },
               );
               recorderDebug("view mounted", { mode });
             }
@@ -1274,7 +1327,14 @@ document.addEventListener('securitypolicyviolation', function(e) {
               ) {
                 recorderDebug("forward " + data.type);
               }
-              window.parent.postMessage(data, hostOrigin || "*");
+              // Native and synthetic violation messages originate inside the
+              // current view. Stamp them here so the id cannot be forged by a
+              // widget and always names the frame that emitted the event.
+              const outgoing =
+                data.type === "mcp-apps:csp-violation"
+                  ? { ...data, mountId: currentMountId }
+                  : data;
+              window.parent.postMessage(outgoing, hostOrigin || "*");
             }
           }
         }
@@ -1287,7 +1347,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
           method: "ui/notifications/sandbox-proxy-ready",
           params: {},
         },
-        "*"
+        "*",
       );
     </script>
   </body>

--- a/widget-react/src/index.ts
+++ b/widget-react/src/index.ts
@@ -92,6 +92,8 @@ export type {
   WidgetSandboxApplied,
   WidgetLifecycleEvent,
   WidgetMount,
+  CspMountId,
+  CspApplicationIntent,
   CspViolation,
   UiLogEvent,
   // chrome injection

--- a/widget-react/src/mcp-apps-renderer.tsx
+++ b/widget-react/src/mcp-apps-renderer.tsx
@@ -69,6 +69,8 @@ import {
   type WidgetLifecycleEvent,
   type WidgetHostResolvers,
   type WidgetDebugSink,
+  type CspMountId,
+  type CspApplicationIntent,
 } from "./widget-host";
 
 // The debug sink is OPTIONAL on the contract — a non-inspector host can omit it
@@ -83,6 +85,7 @@ const NOOP_WIDGET_DEBUG_SINK: WidgetDebugSink = {
   setWidgetCsp: () => {},
   setWidgetAppliedCsp: () => {},
   addCspViolation: () => {},
+  reportCspViolation: () => {},
   clearCspViolations: () => {},
   setWidgetModelContext: () => {},
   setWidgetHtml: () => {},
@@ -107,6 +110,34 @@ const PIP_MAX_HEIGHT = "min(40vh, 600px)";
  */
 const CSP_BLOCKED_NOTICE_DELAY_MS = 1500;
 const SAFE_OPEN_IN_APP_PROTOCOLS = new Set(["http:", "https:"]);
+
+function normalizeCspMountId(value: unknown): CspMountId | undefined {
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value > 0 ? value : undefined;
+  }
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 && trimmed.length <= 128 ? trimmed : undefined;
+}
+
+function normalizeCspApplicationIntent(
+  value: unknown
+): CspApplicationIntent | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const candidate = value as Partial<CspApplicationIntent>;
+  if (typeof candidate.permissive !== "boolean") return undefined;
+  return {
+    csp:
+      candidate.csp && typeof candidate.csp === "object"
+        ? candidate.csp
+        : undefined,
+    cspDirectives:
+      candidate.cspDirectives && typeof candidate.cspDirectives === "object"
+        ? candidate.cspDirectives
+        : undefined,
+    permissive: candidate.permissive,
+  };
+}
 
 function toSafeOpenInAppUrl(value: string): string | null {
   try {
@@ -1232,6 +1263,7 @@ export function MCPAppsRendererSurface({
   // Where the proxy mounted the view, reported once per mount. Surfaced as the
   // Sandbox Stack "View origin" chip.
   const [viewMount, setViewMount] = useState<{
+    mountId?: CspMountId;
     mode: "url" | "srcdoc" | "srcdoc-fallback";
     url: string;
   } | null>(null);
@@ -2185,6 +2217,7 @@ export function MCPAppsRendererSurface({
   const setWidgetCspStore = debug.setWidgetCsp;
   const setWidgetAppliedCspStore = debug.setWidgetAppliedCsp;
   const addCspViolation = debug.addCspViolation;
+  const reportCspViolation = debug.reportCspViolation;
   const clearCspViolations = debug.clearCspViolations;
   const setWidgetModelContext = debug.setWidgetModelContext;
   const setWidgetHtmlStore = debug.setWidgetHtml;
@@ -3110,6 +3143,7 @@ export function MCPAppsRendererSurface({
         restrictTo: sandboxCspPolicy?.restrictTo,
         cspMode: sandboxCspPolicy?.mode,
         permissions: effectiveSandbox.permissions,
+        mountId: viewMount?.mountId,
         viewMode: viewMount?.mode,
         viewUrl: viewMount?.url,
         assignedOrigin: viewAssignedOrigin,
@@ -3816,6 +3850,9 @@ export function MCPAppsRendererSurface({
         lineNumber,
         columnNumber,
         effectiveDirective,
+        mountId,
+        originalPolicy,
+        disposition,
         timestamp,
         subtype,
       } = data;
@@ -3829,16 +3866,25 @@ export function MCPAppsRendererSurface({
         message: data,
       });
 
-      addCspViolation(toolCallId, {
+      const violation = {
         directive,
         effectiveDirective,
         blockedUri,
+        mountId: normalizeCspMountId(mountId),
+        originalPolicy:
+          typeof originalPolicy === "string" ? originalPolicy : undefined,
+        disposition:
+          disposition === "enforce" || disposition === "report"
+            ? disposition
+            : undefined,
         sourceFile,
         lineNumber,
         columnNumber,
         timestamp: timestamp || Date.now(),
         subtype,
-      });
+      };
+      addCspViolation(toolCallId, violation);
+      reportCspViolation(toolCallId, serverId, violation);
 
       // Remember the first block so the render path can explain a View
       // that never boots. Cleared on every reload alongside the debug
@@ -3863,7 +3909,14 @@ export function MCPAppsRendererSurface({
         );
       }
     },
-    [addCspViolation, logUiEvent, minimalMode, serverId, toolCallId]
+    [
+      addCspViolation,
+      logUiEvent,
+      minimalMode,
+      reportCspViolation,
+      serverId,
+      toolCallId,
+    ]
   );
 
   const handleSandboxMessage = (event: MessageEvent) => {
@@ -3877,16 +3930,24 @@ export function MCPAppsRendererSurface({
     }
 
     // The CSP string the proxy injected for this mount. Arrives just before
-    // that mount's `mcpjam:view-mode`. This is the only ground truth the host
-    // gets about the policy the browser is enforcing — everything else it
-    // knows is the widget's request, not the outcome.
+    // that mount's `mcpjam:view-mode`. This records what MCPJam applied;
+    // each violation's `originalPolicy` separately records the policy that
+    // caused that specific violation.
     if (data.type === "mcpjam:csp-applied") {
-      if (typeof data.csp === "string" && data.csp.length > 0) {
+      const mountId = normalizeCspMountId(data.mountId);
+      if (
+        mountId !== undefined &&
+        typeof data.csp === "string" &&
+        data.csp.length > 0
+      ) {
         setWidgetAppliedCspStore(toolCallIdRef.current, {
+          mountId,
           headerString: data.csp,
           mode: data.mode === "permissive" ? "permissive" : "widget-declared",
+          intent: normalizeCspApplicationIntent(data.intent),
         });
         logWidgetDebug("ui-to-host", "debug/csp-applied", {
+          mountId,
           mode: data.mode,
           headerLength: data.csp.length,
         });
@@ -3901,8 +3962,13 @@ export function MCPAppsRendererSurface({
       const mode = data.mode;
       if (mode === "url" || mode === "srcdoc" || mode === "srcdoc-fallback") {
         const url = typeof data.url === "string" ? data.url : "";
-        setViewMount({ mode, url });
-        logWidgetDebug("ui-to-host", "debug/view-mounted", { mode, url });
+        const mountId = normalizeCspMountId(data.mountId);
+        setViewMount({ mountId, mode, url });
+        logWidgetDebug("ui-to-host", "debug/view-mounted", {
+          mountId,
+          mode,
+          url,
+        });
       }
       return;
     }

--- a/widget-react/src/widget-host.ts
+++ b/widget-react/src/widget-host.ts
@@ -243,10 +243,25 @@ export interface WidgetMount {
   at: number;
 }
 
+/** New mounts use an opaque string; numbers remain valid for saved data. */
+export type CspMountId = string | number;
+
+/** What MCPJam meant to install before the sandbox proxy serialized it. */
+export interface CspApplicationIntent {
+  csp?: McpUiResourceCsp;
+  cspDirectives?: Record<string, string[]>;
+  permissive: boolean;
+}
+
 export interface CspViolation {
   directive: string;
   effectiveDirective?: string;
   blockedUri: string;
+  /** Id of the exact inner iframe mount that emitted this event. */
+  mountId?: CspMountId;
+  /** The policy that caused this specific violation. */
+  originalPolicy?: string;
+  disposition?: "enforce" | "report";
   sourceFile?: string | null;
   lineNumber?: number | null;
   columnNumber?: number | null;
@@ -299,6 +314,8 @@ export interface WidgetSandboxApplied {
    * forced because the frame's document was unreachable).
    */
   viewMode?: "url" | "srcdoc" | "srcdoc-fallback";
+  /** Id of the currently displayed inner iframe mount. */
+  mountId?: CspMountId;
   /** The view's document URL as reported by the proxy. */
   viewUrl?: string;
   /**
@@ -321,6 +338,17 @@ export interface WidgetSandboxInfo {
     clipboardWrite?: {};
   };
   headerString?: string;
+  /** Latest proxy mount, retained for consumers that show current state. */
+  activeMountId?: CspMountId;
+  /** Applied policies keyed by proxy mount id so remounts cannot mix data. */
+  appliedPoliciesByMount?: Record<
+    string,
+    {
+      headerString: string;
+      mode: "permissive" | "widget-declared";
+      intent?: CspApplicationIntent;
+    }
+  >;
   violations: CspViolation[];
   widgetDeclared?: {
     connect_domains?: string[];
@@ -416,9 +444,19 @@ export interface WidgetDebugSink {
    */
   setWidgetAppliedCsp: (
     toolCallId: string,
-    applied: { headerString: string; mode: "permissive" | "widget-declared" }
+    applied: {
+      mountId: CspMountId;
+      headerString: string;
+      mode: "permissive" | "widget-declared";
+      intent?: CspApplicationIntent;
+    }
   ) => void;
   addCspViolation: (toolCallId: string, violation: CspViolation) => void;
+  reportCspViolation: (
+    toolCallId: string,
+    serverId: string,
+    violation: CspViolation
+  ) => void;
   clearCspViolations: (toolCallId: string) => void;
   setWidgetModelContext: (
     toolCallId: string,


### PR DESCRIPTION
## Summary

Follow-up to #4697 that captures the exact CSP installed for each sandbox mount and pairs browser violations with that mount.

- add monotonic mount IDs to applied-policy, view-mode, and violation messages
- compare parsed Applied and originalPolicy directive maps in Policy Diff
- preserve originalPolicy and disposition on violations
- send sanitized, deduplicated warning events to Sentry
- keep older saved events renderable without comparing them across mounts

No CSP enforcement behavior changes.

## Verification

Relevant CSP workbench, sandbox proxy, renderer, telemetry, and typecheck suites pass. A controlled Chrome check confirmed an allowed frame origin loads without a violation, while the denied control emits a frame-src violation whose originalPolicy matches the installed policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correlates CSP violations with the exact policy applied to the iframe mount that produced them, so the Policy Diff no longer compares evidence against a newer policy after a widget remounts. The per-violation `originalPolicy` comparison is now telemetry-only and hidden from the workbench UI. No CSP enforcement behavior changes.

**Policy correlation**
- Each inner iframe mount gets a monotonic mount ID, prefixed with a random proxy instance ID so a recreated proxy doesn't collide with saved evidence.
- Applied policies, view modes, and violations carry their mount's ID; older saved events stay renderable without cross-mount comparisons.
- A `policy-unavailable` diagnosis flags violations that can't be paired with their mount's applied policy.
- Policy field labels link to browser documentation.

**Telemetry**
- Sends sanitized, deduplicated Sentry warnings when a violation's `originalPolicy` differs from the applied policy for that mount.
- Flags failed policy application with rate-limited warnings.
- Redacts nonce, hash, and URL credentials from policies before reporting.

<sup>Written for commit 39b0e5f1d2844ae458a3392e76981121094d90ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

