### PR TITLE
Keep Evaluate (New) Add case on /evaluate

### DIFF
--- a/mcpjam-inspector/client/src/components/EvaluateTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvaluateTab.tsx
@@ -276,6 +276,9 @@ function EvaluateTabContent({
     connectedServerNames,
     ensureServersReady,
     latestRunBySuiteId,
+    // Shared handlers default to `/evals`. Without this, Add case / Record /
+    // post-run landing would dump the reader onto the old tab.
+    evalsNavigationContext: "evaluate",
     projectServers,
     isDirectGuest,
     availableModels,

--- a/mcpjam-inspector/client/src/components/__tests__/EvaluateTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvaluateTab.test.tsx
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   handleGenerateTests: vi.fn(),
   handleRerun: vi.fn(),
   handleCancelRun: vi.fn(),
+  useEvalHandlers: vi.fn(),
   confirmDelete: vi.fn(async () => true),
   setSuiteToDelete: vi.fn(),
   getEffectiveSuiteServers: vi.fn((..._args: unknown[]): string[] => []),
@@ -214,33 +215,36 @@ vi.mock("../evals/use-eval-mutations", () => ({
 }));
 
 vi.mock("../evals/use-eval-handlers", () => ({
-  useEvalHandlers: () => ({
-    deletingSuiteId: null,
-    suiteToDelete: null,
-    setSuiteToDelete: mocks.setSuiteToDelete,
-    runToDelete: null,
-    setRunToDelete: vi.fn(),
-    testCaseToDelete: null,
-    setTestCaseToDelete: vi.fn(),
-    deletingRunId: null,
-    deletingTestCaseId: null,
-    rerunningSuiteId: null,
-    cancellingRunId: null,
-    runningTestCaseId: null,
-    isGeneratingTests: false,
-    handleGenerateTests: mocks.handleGenerateTests,
-    handleCreateTestCase: vi.fn(),
-    handleRerun: mocks.handleRerun,
-    handleCancelRun: mocks.handleCancelRun,
-    handleDelete: vi.fn(),
-    handleDeleteRun: vi.fn(),
-    directDeleteRun: vi.fn().mockResolvedValue(undefined),
-    directDeleteTestCase: vi.fn().mockResolvedValue(undefined),
-    handleRunTestCase: vi.fn().mockResolvedValue(undefined),
-    confirmDelete: mocks.confirmDelete,
-    confirmDeleteRun: vi.fn(),
-    confirmDeleteTestCase: vi.fn(),
-  }),
+  useEvalHandlers: (props: unknown) => {
+    mocks.useEvalHandlers(props);
+    return {
+      deletingSuiteId: null,
+      suiteToDelete: null,
+      setSuiteToDelete: mocks.setSuiteToDelete,
+      runToDelete: null,
+      setRunToDelete: vi.fn(),
+      testCaseToDelete: null,
+      setTestCaseToDelete: vi.fn(),
+      deletingRunId: null,
+      deletingTestCaseId: null,
+      rerunningSuiteId: null,
+      cancellingRunId: null,
+      runningTestCaseId: null,
+      isGeneratingTests: false,
+      handleGenerateTests: mocks.handleGenerateTests,
+      handleCreateTestCase: vi.fn(),
+      handleRerun: mocks.handleRerun,
+      handleCancelRun: mocks.handleCancelRun,
+      handleDelete: vi.fn(),
+      handleDeleteRun: vi.fn(),
+      directDeleteRun: vi.fn().mockResolvedValue(undefined),
+      directDeleteTestCase: vi.fn().mockResolvedValue(undefined),
+      handleRunTestCase: vi.fn().mockResolvedValue(undefined),
+      confirmDelete: mocks.confirmDelete,
+      confirmDeleteRun: vi.fn(),
+      confirmDeleteTestCase: vi.fn(),
+    };
+  },
 }));
 
 vi.mock("../evals/use-eval-queries", () => ({
@@ -352,6 +356,14 @@ describe("EvaluateTab", () => {
         expect.objectContaining({ name: "server-a" }),
         expect.objectContaining({ name: "server-b" }),
       ]),
+    });
+  });
+
+  it("keeps handler-driven navigation on /evaluate", () => {
+    render(<EvaluateTab projectId="ws-1" />);
+
+    expect(mocks.useEvalHandlers.mock.calls.at(-1)?.[0]).toMatchObject({
+      evalsNavigationContext: "evaluate",
     });
   });
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
@@ -2169,6 +2169,37 @@ describe("useEvalHandlers", () => {
       });
     });
   });
+
+  describe("handleCreateTestCase", () => {
+    it("opens a draft case on /evals by default", () => {
+      const { result } = renderHook(() => useEvalHandlers(defaultProps));
+
+      act(() => {
+        result.current.handleCreateTestCase("suite-1");
+      });
+
+      expect(mockNavigateApp).toHaveBeenCalledWith(
+        "/evals/suite/suite-1/test/draft%3Aprompt/edit",
+      );
+    });
+
+    it("stays on /evaluate when the Evaluate (New) tab owns navigation", () => {
+      const { result } = renderHook(() =>
+        useEvalHandlers({
+          ...defaultProps,
+          evalsNavigationContext: "evaluate",
+        }),
+      );
+
+      act(() => {
+        result.current.handleCreateTestCase("suite-1");
+      });
+
+      expect(mockNavigateApp).toHaveBeenCalledWith(
+        "/evaluate/suite/suite-1/test/draft%3Aprompt/edit",
+      );
+    });
+  });
 });
 
 describe("formatEnsureServersReadyError", () => {

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -6,6 +6,7 @@ import { isMCPJamProvidedModel } from "@/shared/types";
 import {
   buildEvalsRunsPath,
   buildEvalsPath,
+  buildEvaluatePath,
   navigateApp,
 } from "@/lib/app-navigation";
 import type { EvalRoute, SuiteOverviewView } from "@/lib/eval-route-types";
@@ -58,9 +59,15 @@ import {
 } from "./single-test-case-runner";
 import type { EnsureServersReadyResult } from "@/hooks/use-app-state";
 
-function navigateEvalRoute(route: EvalRoute, context: "evals" | "ci-evals") {
+type EvalsNavigationContext = "evals" | "ci-evals" | "evaluate";
+
+function navigateEvalRoute(route: EvalRoute, context: EvalsNavigationContext) {
   navigateApp(
-    context === "ci-evals" ? buildEvalsRunsPath(route) : buildEvalsPath(route)
+    context === "ci-evals"
+      ? buildEvalsRunsPath(route)
+      : context === "evaluate"
+        ? buildEvaluatePath(route)
+        : buildEvalsPath(route)
   );
 }
 import type { RemoteServer } from "@/hooks/useProjects";
@@ -223,10 +230,11 @@ interface UseEvalHandlersProps {
   ) => Promise<EnsureServersReadyResult>;
   latestRunBySuiteId?: Map<string, EvalSuiteRun | null>;
   /**
-   * When `ci-evals`, navigation after test-case mutations stays on Runs
-   * mode (`/evals/runs/...`). Defaults to Suites mode (`/evals/...`).
+   * Prefix for handler-driven navigation (create case, duplicate, post-run
+   * landing). `ci-evals` stays on Runs (`/evals/runs/...`); `evaluate` stays
+   * on Evaluate (New) (`/evaluate/...`). Defaults to Suites (`/evals/...`).
    */
-  evalsNavigationContext?: "evals" | "ci-evals";
+  evalsNavigationContext?: EvalsNavigationContext;
   /** For user-facing server labels (names instead of raw Convex ids). */
   projectServers?: RemoteServer[];
   /** When true, this uses the direct-guest eval playground flow. */


### PR DESCRIPTION
## Summary
- Add case on Evaluate (New) went through the shared eval handlers, which default to `/evals` and dumped the reader onto the old tab.
- The new tab now passes `evalsNavigationContext: "evaluate"` so handler-driven navigation (Add case, Record, duplicate, post-run landing) stays on `/evaluate`.
- Clicking an existing case was already correct via playground navigation; this closes the same leak for the shared-handler path.

## Test plan
- [ ] Open a suite on Evaluate (New) (`/evaluate/suite/...`) that already has cases
- [ ] Click **Add case** — URL should stay under `/evaluate/.../test/draft:prompt/edit`, not `/evals/...`
- [ ] Confirm an existing case row still opens on `/evaluate`
- [ ] Optional: Record / run a suite and confirm landing stays on `/evaluate`
- [ ] Confirm the old `/evals` tab still opens new cases under `/evals`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes handler-driven navigation on the Evaluate (New) tab so actions like Add case, Record, and duplicate stay on `/evaluate` instead of defaulting to `/evals`.

- Adds `evalsNavigationContext: "evaluate"` to the Evaluate tab, which passes the new context to shared eval handlers.
- Updates the shared handlers to accept the `evaluate` context and route to `/evaluate/...` paths.
- Adds tests for both the default `/evals` and new `/evaluate` navigation behavior.

<sup>Written for commit 6d238d482ce274fe3274e386000a1d0b266be7c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

