### PR TITLE
fix(webmcp): give the hosted browser an X server to draw on

### DIFF
--- a/mcpjam-inspector/server/services/browserd/__tests__/boot-browserd.test.ts
+++ b/mcpjam-inspector/server/services/browserd/__tests__/boot-browserd.test.ts
@@ -5,13 +5,18 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
 const READY = (over: Record<string, unknown> = {}) =>
   `${JSON.stringify({ event: "listening", host: "0.0.0.0", port: 8791, bootId: "boot-1", ...over })}\n`;
 
-function fakeSandbox() {
+function fakeSandbox(over: { displayUp?: boolean } = {}) {
   const state = {
     command: "",
     envs: {} as Record<string, string>,
     onStdout: (_c: string) => {},
     kills: 0,
+    /** Every foreground command the boot ran, in order. */
+    ran: [] as string[],
+    /** Every background command, in order — Xvfb and xfce4 land here. */
+    background: [] as string[],
   };
+  let displayUp = over.displayUp ?? true;
   let resolveWait!: () => void;
   let rejectWait!: (e: unknown) => void;
   const waitPromise = new Promise<void>((res, rej) => {
@@ -20,6 +25,15 @@ function fakeSandbox() {
   });
   const sandbox: BrowserdSandbox = {
     async runBackground(command, options) {
+      state.background.push(command);
+      if (command.startsWith("Xvfb")) {
+        // A started Xvfb is what makes the next probe answer "up".
+        displayUp = true;
+        return { kill: async () => true, wait: () => new Promise(() => {}) };
+      }
+      if (command === "startxfce4") {
+        return { kill: async () => true, wait: () => new Promise(() => {}) };
+      }
       state.command = command;
       state.envs = options.envs;
       state.onStdout = options.onStdout;
@@ -30,6 +44,10 @@ function fakeSandbox() {
         },
         wait: () => waitPromise,
       };
+    },
+    async run(command) {
+      state.ran.push(command);
+      return { exitCode: displayUp ? 0 : 1 };
     },
     getHost: (port) => `box-${port}.e2b.dev`,
   };
@@ -117,6 +135,39 @@ describe("bootBrowserd", () => {
     const fake = fakeSandbox();
     const p = bootBrowserd(fake.sandbox, { ...OPTS, readyTimeoutMs: 20 });
     await expect(p).rejects.toThrow(/within 20ms/);
+  });
+
+  it("gives the daemon a DISPLAY — Chromium is headed and E2B shells inherit no image ENV", async () => {
+    const fake = fakeSandbox();
+    const p = bootBrowserd(fake.sandbox, OPTS);
+    await tick();
+    fake.emit(READY());
+    await p;
+    expect(fake.state.envs.DISPLAY).toBe(":0");
+  });
+
+  it("starts Xvfb (and xfce) when the box has no X server, then boots the daemon", async () => {
+    // The hosted path only ever `connect`s to a backend-provisioned desktop,
+    // and nothing in that flow runs `@e2b/desktop`'s `_start()`.
+    const fake = fakeSandbox({ displayUp: false });
+    const p = bootBrowserd(fake.sandbox, OPTS);
+    await tick();
+    fake.emit(READY());
+    const handle = await p;
+    expect(handle.bootId).toBe("boot-1");
+    expect(fake.state.background[0]).toMatch(/^Xvfb :0 /);
+    expect(fake.state.background).toContain("startxfce4");
+    expect(fake.state.command).toContain("mcpjam-browserd.mjs");
+  });
+
+  it("does not start Xvfb when the display is already up", async () => {
+    const fake = fakeSandbox();
+    const p = bootBrowserd(fake.sandbox, OPTS);
+    await tick();
+    fake.emit(READY());
+    await p;
+    expect(fake.state.background.some((c) => c.startsWith("Xvfb"))).toBe(false);
+    expect(fake.state.ran[0]).toContain("xdpyinfo -display :0");
   });
 
   it("stop() reaps the daemon", async () => {

--- a/mcpjam-inspector/server/services/browserd/__tests__/browser-session.test.ts
+++ b/mcpjam-inspector/server/services/browserd/__tests__/browser-session.test.ts
@@ -154,6 +154,8 @@ function makeFakes(over?: {
         kill: async () => {},
         wait: async () => {},
       }),
+      // The display probe `bootBrowserd` runs first; 0 means "already up".
+      run: async () => ({ exitCode: 0 }),
       getHost: () => "new.example",
     },
     killBrowserd: vi.fn(async () => {}),

--- a/mcpjam-inspector/server/services/browserd/boot-browserd.ts
+++ b/mcpjam-inspector/server/services/browserd/boot-browserd.ts
@@ -32,6 +32,17 @@ export interface BrowserdSandbox {
       onStdout: (chunk: string) => void;
     },
   ): Promise<{ kill: () => Promise<unknown>; wait: () => Promise<unknown> }>;
+  /**
+   * Run a short foreground command and report its exit code.
+   *
+   * Resolves for a FAILING command too, rather than throwing: the display
+   * check below asks `xdpyinfo` a question whose answer is its exit status,
+   * and the E2B SDK turns a non-zero exit into a rejection.
+   */
+  run(
+    command: string,
+    options?: { envs?: Record<string, string> },
+  ): Promise<{ exitCode: number }>;
   /** The public HTTPS host for a sandbox port. */
   getHost(port: number): string;
 }
@@ -51,6 +62,8 @@ export interface BootBrowserdOptions {
    * the persistent profile a playground login depends on.
    */
   contextMode?: "persistent" | "ephemeral";
+  /** The X display browserd's Chromium draws on. Defaults to `:0`. */
+  display?: string;
 }
 
 export interface BrowserdHandle {
@@ -66,6 +79,88 @@ export interface BrowserdHandle {
 }
 
 const DEFAULT_READY_TIMEOUT_MS = 30_000;
+
+/**
+ * The X display a desktop box draws on — `:0`, the same one `@e2b/desktop`
+ * defaults to, so a box we bootstrap and a box that SDK created look alike.
+ */
+export const BROWSERD_DISPLAY = ":0";
+
+/** `@e2b/desktop`'s own default geometry, for the same parity reason. */
+const DISPLAY_GEOMETRY = "1024x768x24";
+const DISPLAY_READY_ATTEMPTS = 20;
+const DISPLAY_POLL_MS = 500;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+async function displayIsUp(
+  sandbox: BrowserdSandbox,
+  display: string,
+): Promise<boolean> {
+  try {
+    const { exitCode } = await sandbox.run(
+      `xdpyinfo -display ${display} >/dev/null 2>&1`,
+    );
+    return exitCode === 0;
+  } catch {
+    // A command that cannot even run is not a display.
+    return false;
+  }
+}
+
+/**
+ * Make sure something is drawing on `display` before the daemon launches a
+ * HEADED Chromium at it.
+ *
+ * The desktop image bakes Xfce, Xvfb and noVNC, but nothing in it STARTS them:
+ * that is `@e2b/desktop`'s `Sandbox.create`, via its internal `_start()`. The
+ * hosted path never calls that — the computer is provisioned by the backend and
+ * this process only ever `connect`s, which the desktop SDK does not override.
+ * So a freshly provisioned desktop box has no X server, Playwright refuses to
+ * launch headed ("Looks like you launched a headed browser without having a
+ * XServer running"), and browserd dies before its ready line — surfacing as
+ * `browserd exited before it reported listening (exit status 1)`.
+ *
+ * Idempotent by construction: a display that is already up (a warm box, a
+ * relaunch, a box the desktop SDK did create) short-circuits on the first
+ * probe, so this costs one command on the common path.
+ *
+ * Xfce is best-effort. The browser only needs an X server; the window manager
+ * is what makes the noVNC stream look like a desktop rather than a bare root
+ * window, and failing the whole boot over cosmetics would be wrong.
+ */
+export async function ensureDisplay(
+  sandbox: BrowserdSandbox,
+  display: string = BROWSERD_DISPLAY,
+): Promise<void> {
+  if (await displayIsUp(sandbox, display)) return;
+
+  await sandbox.runBackground(
+    `Xvfb ${display} -ac -screen 0 ${DISPLAY_GEOMETRY} -retro -dpi 96 -nolisten tcp -nolisten unix`,
+    { envs: {}, onStdout: () => {} },
+  );
+
+  for (let attempt = 0; attempt < DISPLAY_READY_ATTEMPTS; attempt++) {
+    if (await displayIsUp(sandbox, display)) {
+      await sandbox
+        .runBackground("startxfce4", {
+          envs: { DISPLAY: display },
+          onStdout: () => {},
+        })
+        .catch(() => {
+          // Cosmetic; see above.
+        });
+      return;
+    }
+    await sleep(DISPLAY_POLL_MS);
+  }
+  throw new Error(
+    `no X display on ${display}: Xvfb did not come up within ${
+      (DISPLAY_READY_ATTEMPTS * DISPLAY_POLL_MS) / 1000
+    }s`,
+  );
+}
 
 interface BrowserdReadyLine {
   port: number;
@@ -98,6 +193,10 @@ function buildEnv(
     MCPJAM_BROWSERD_TOKEN: bearer,
     MCPJAM_BROWSERD_PORT: String(options.port),
     MCPJAM_BROWSERD_USER_DATA_DIR: options.userDataDir,
+    // Chromium is launched HEADED here and finds its X server through this
+    // variable alone: E2B command shells do not inherit the image's Dockerfile
+    // `ENV`, so an image-level `DISPLAY` would not reach the daemon.
+    DISPLAY: options.display ?? BROWSERD_DISPLAY,
   };
   if (options.windowSize) env.MCPJAM_BROWSERD_WINDOW_SIZE = options.windowSize;
   if (options.headless) env.MCPJAM_BROWSERD_HEADLESS = "true";
@@ -157,21 +256,26 @@ export function bootBrowserd(
       });
     };
 
-    void sandbox
-      .runBackground(`node ${JSON.stringify(options.scriptPath)}`, {
-        envs: env,
-        onStdout: (chunk) => {
-          if (settled) return;
-          carry += chunk;
-          let index: number;
-          while ((index = carry.indexOf("\n")) >= 0) {
-            const line = carry.slice(0, index);
-            carry = carry.slice(index + 1);
-            const ready = parseReadyLine(line);
-            if (ready) finish(ready);
-          }
-        },
-      })
+    // Chained rather than awaited before this promise is built: the boot's
+    // ready-line choreography (and its timeout) must own every failure path,
+    // including "the box never got an X server".
+    void ensureDisplay(sandbox, options.display)
+      .then(() =>
+        sandbox.runBackground(`node ${JSON.stringify(options.scriptPath)}`, {
+          envs: env,
+          onStdout: (chunk) => {
+            if (settled) return;
+            carry += chunk;
+            let index: number;
+            while ((index = carry.indexOf("\n")) >= 0) {
+              const line = carry.slice(0, index);
+              carry = carry.slice(index + 1);
+              const ready = parseReadyLine(line);
+              if (ready) finish(ready);
+            }
+          },
+        }),
+      )
       .then((command) => {
         started = command;
         // The deadline may have fired before the handle existed; reap here.

--- a/mcpjam-inspector/server/services/browserd/live-session-deps.ts
+++ b/mcpjam-inspector/server/services/browserd/live-session-deps.ts
@@ -109,6 +109,21 @@ export function adaptSandbox(sandbox: ConnectedSandboxLike): BrowserdSandbox {
       });
       return { kill: () => handle.kill(), wait: () => handle.wait() };
     },
+    async run(command, options) {
+      try {
+        const result = await sandbox.commands.run(command, {
+          envs: options?.envs,
+          timeoutMs: 30_000,
+        });
+        return { exitCode: Number(result?.exitCode ?? 0) };
+      } catch (error) {
+        // The E2B SDK rejects on a non-zero exit. The caller asked for the
+        // exit CODE — a failing probe is an answer, not an error — so recover
+        // it when the SDK carried one, and read anything else as a failure.
+        const code = (error as { exitCode?: unknown })?.exitCode;
+        return { exitCode: typeof code === "number" ? code : 1 };
+      }
+    },
     getHost: (port) => sandbox.getHost(port),
   };
 }


### PR DESCRIPTION
## What broke

A hosted WebMCP session on staging failed with:

```
browserd exited before it reported listening (exit status 1)
```

Two independent causes, both of which make the hosted browser unusable on **any** deployment (this is not a staging-config problem):

**1. Nothing starts the display.** The desktop image bakes Xfce, Xvfb and noVNC, but *starting* them is `@e2b/desktop`'s `Sandbox.create` → its internal `_start()` (`Xvfb :0 …` then `startxfce4`). The hosted path never calls that: the computer is provisioned by the backend, and `live-session-deps.ts` only ever `Sandbox.connect`s — which the desktop SDK does **not** override. So a freshly provisioned desktop box has no X server, and Playwright refuses the headed launch:

```
Looks like you launched a headed browser without having a XServer running.
```

**2. The daemon had no `DISPLAY`.** `buildEnv` never set it, and E2B command shells do not inherit the image's Dockerfile `ENV` — verified in a live sandbox, where `PLAYWRIGHT_BROWSERS_PATH` (also set via `ENV`) reads empty. So an image-level `DISPLAY` would not have reached browserd either.

## The fix

`bootBrowserd` is the single chokepoint that starts the daemon inside a sandbox — the session path and the W1 debug probe both go through it — so both fixes live there:

- `ensureDisplay()` probes `xdpyinfo` and starts `Xvfb` (+ `startxfce4`, best-effort) only when the box has no X server. A warm box, a relaunch, or a box the desktop SDK *did* create short-circuits on the first probe, so this costs one command on the common path.
- `buildEnv` passes `DISPLAY` (`:0` by default, matching `@e2b/desktop`), overridable via a new `display` option.
- `BrowserdSandbox` gains a foreground `run()` that reports an exit code instead of throwing — `xdpyinfo`'s exit status *is* the answer, and the E2B SDK rejects on non-zero.

Geometry and display number mirror `@e2b/desktop`'s defaults (`:0`, 1024x768) so a box we bootstrap and a box that SDK created look alike.

## Verification

Against a real desktop sandbox, with the shipped `mcpjam-browserd.mjs` bundle:

- as production runs it today → `[mcpjam-browserd] fatal: browserType.launchPersistentContext: … Looks like you launched a headed browser without having a XServer running` → exit 1, the reported error.
- with `Xvfb :0` + `startxfce4` running and `DISPLAY=:0` in the daemon env → `{"event":"listening","host":"0.0.0.0","port":49111,"bootId":"5c96b175-…"}`.

Unit tests: 3 new cases (DISPLAY is passed; Xvfb starts when the box has none; no Xvfb when the display is already up). `server/services/browserd` — 39 files, 682 tests, all passing.

## Not in this PR

`mcpjam-backend/templates/desktop/e2b.Dockerfile` installs **`playwright-core`** into `/opt/mcpjam/browserd`, but browserd runs as `/opt/mcpjam/mcpjam-browserd.mjs` and does `import("playwright")` — wrong package, wrong directory, so `ERR_MODULE_NOT_FOUND` on a stock build. Filed separately against the backend repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STvqEtNrAFKVFe1HEqL3KR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the sandbox boot path for all hosted browserd launches (Xvfb, polling, env), but behavior is idempotent when a display already exists and failures surface as explicit boot errors.
> 
> **Overview**
> Fixes hosted WebMCP sessions failing with **browserd exited before it reported listening** when headed Chromium starts on E2B desktops that only `connect` (no `@e2b/desktop` `_start()`), so there is often no X server and no `DISPLAY` in the daemon env.
> 
> **`bootBrowserd`** now runs **`ensureDisplay`** first: probe with `xdpyinfo`, start **`Xvfb`** (and best-effort **`startxfce4`**) when the display is down, then launch browserd. **`buildEnv`** sets **`DISPLAY=:0`** (overridable via a new `display` option). The **`BrowserdSandbox`** contract adds foreground **`run()`** that returns exit codes instead of throwing; **`live-session-deps`** maps that to E2B `commands.run` and treats non-zero exits as answers, not failures.
> 
> Unit tests cover `DISPLAY` in env, Xvfb when the box has no display, and skipping Xvfb when already up; session test fakes implement `run` for the probe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17d1f8120a145c3f3a20c6f286fcafdcb278d51d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the hosted WebMCP browser dying on every deployment with `browserd exited before it reported listening (exit status 1)`. Nothing was starting an X server on the backend-provisioned desktop box, and the daemon's env had no `DISPLAY` (E2B shell environments don't inherit image-level `ENV`). Both fixes live in `bootBrowserd`, the single chokepoint that launches the daemon.

**Changes**

- Probes `xdpyinfo` first and starts `Xvfb :0` + `startxfce4` (best-effort) only when the box has no X server.
- Passes `DISPLAY=:0` in the daemon's env by default, overridable via a new `display` option.
- `BrowserdSandbox.run()` reports exit codes instead of throwing, so a failing display probe is treated as an answer rather than an error.

Not in this PR: a separately filed issue where the desktop image installs `playwright-core` into the wrong directory while browserd imports `playwright`.

<sup>Written for commit 17d1f8120a145c3f3a20c6f286fcafdcb278d51d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

