### PR TITLE
fix(browser panel): a deploy should not kill the browser view

### DIFF
--- a/mcpjam-inspector/client/src/components/computer/BrowserStream.tsx
+++ b/mcpjam-inspector/client/src/components/computer/BrowserStream.tsx
@@ -32,9 +32,69 @@ interface BrowserStreamProps {
 /** Close codes the server sends. 4401 is recoverable — mint a new token. */
 const CLOSE_UNAUTHORIZED = 4401;
 const CLOSE_GONE = 4404;
+/**
+ * The two ways a HEALTHY stream ends without the server deciding anything:
+ * `1001` is a replica draining (every deploy to this environment does it) and
+ * `1006` is the socket dying with no close frame at all. Both are the same
+ * situation from here — the far end went away and will be back — and both were
+ * previously terminal, so a routine deploy left a member staring at "The
+ * connection to the browser dropped." over a browser that was still running.
+ */
+const CLOSE_GOING_AWAY = 1001;
+const CLOSE_ABNORMAL = 1006;
 /** Bounded, so a token rejected for any OTHER reason cannot spin forever. */
 const MAX_RECONNECTS = 5;
 const RECONNECT_DELAY_MS = 500;
+
+export interface StreamCloseOutcome {
+  /** Reconnect (with a fresh token), rather than showing a dead pane. */
+  retry: boolean;
+  /** What to show if this is the end of the line. */
+  detail: string;
+}
+
+/**
+ * What a close code means, as a pure function so the policy is testable
+ * without a socket, a DOM, or noVNC.
+ *
+ * `reason` is the server's own sentence — the stream proxy sends real ones
+ * ("Could not reach the browser stream.", "The browser stream did not
+ * respond.") and dropping them on the floor is how an explained failure
+ * reaches a member as an unexplained one.
+ */
+export function streamCloseOutcome(event: {
+  code: number;
+  reason?: string;
+}): StreamCloseOutcome {
+  const reason = event.reason?.trim();
+  switch (event.code) {
+    case CLOSE_UNAUTHORIZED:
+      // The 60s token expired, which is how a long view normally ends.
+      return { retry: true, detail: "The browser session expired." };
+    case CLOSE_GOING_AWAY:
+    case CLOSE_ABNORMAL:
+      return { retry: true, detail: "The connection to the browser dropped." };
+    case CLOSE_GONE:
+      return {
+        retry: false,
+        detail: "The browser on this computer is no longer running.",
+      };
+    default:
+      return {
+        retry: false,
+        detail: reason || "The connection to the browser dropped.",
+      };
+  }
+}
+
+/**
+ * Back off between reconnects rather than retrying five times in 2.5s: the
+ * common cause is a deploy, and a replica needs longer than that to come back.
+ * 0.5s → 8s across the five attempts, ~15s in total.
+ */
+export function reconnectDelayMs(consecutive: number): number {
+  return RECONNECT_DELAY_MS * 2 ** Math.max(0, consecutive - 1);
+}
 
 export function BrowserStream({
   mintToken,
@@ -104,28 +164,21 @@ export function BrowserStream({
       socket.binaryType = "arraybuffer";
       socket.addEventListener("close", (event) => {
         if (disposed) return;
-        if (
-          event.code === CLOSE_UNAUTHORIZED &&
-          consecutiveRef.current < MAX_RECONNECTS
-        ) {
+        const outcome = streamCloseOutcome(event);
+        if (outcome.retry && consecutiveRef.current < MAX_RECONNECTS) {
           consecutiveRef.current += 1;
-          // The 60s token expired, which is how a long view normally ends.
-          // Reconnecting mints a fresh one; nothing about the session changed.
-          // Capped and delayed, so a token that is being rejected for some
-          // other reason cannot spin.
+          // Reconnecting mints a fresh token; nothing about the session
+          // changed. Capped and backed off, so a socket failing for some other
+          // reason cannot spin.
           setStatus("connecting");
           retry = setTimeout(
             () => setAttempt((n) => n + 1),
-            RECONNECT_DELAY_MS,
+            reconnectDelayMs(consecutiveRef.current),
           );
           return;
         }
         setStatus("lost");
-        setDetail(
-          event.code === CLOSE_GONE
-            ? "The browser on this computer is no longer running."
-            : "The connection to the browser dropped.",
-        );
+        setDetail(outcome.detail);
       });
 
       rfb = new RFB(container, socket);

--- a/mcpjam-inspector/client/src/components/computer/__tests__/BrowserStream.close.test.ts
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/BrowserStream.close.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The close-code policy for the browser video stream.
+ *
+ * Extracted as a pure function precisely so it can be tested without noVNC, a
+ * WebSocket, or a DOM — the policy is the part that was wrong, and it is the
+ * part a member notices: every deploy to an environment drains its replicas,
+ * which closes this socket, which used to end the view for good.
+ */
+import { describe, expect, it } from "vitest";
+import { reconnectDelayMs, streamCloseOutcome } from "../BrowserStream";
+
+describe("streamCloseOutcome", () => {
+  it("retries a drained replica (1001) — a deploy is not a dead browser", () => {
+    expect(streamCloseOutcome({ code: 1001 })).toEqual({
+      retry: true,
+      detail: "The connection to the browser dropped.",
+    });
+  });
+
+  it("retries a socket that died with no close frame (1006)", () => {
+    expect(streamCloseOutcome({ code: 1006 }).retry).toBe(true);
+  });
+
+  it("still retries an expired token (4401)", () => {
+    expect(streamCloseOutcome({ code: 4401 }).retry).toBe(true);
+  });
+
+  it("does not retry a browser that is gone (4404)", () => {
+    expect(streamCloseOutcome({ code: 4404 })).toEqual({
+      retry: false,
+      detail: "The browser on this computer is no longer running.",
+    });
+  });
+
+  it("shows the server's own reason rather than a generic line", () => {
+    // 4503 with a sentence is what the stream proxy sends when the upstream
+    // noVNC cannot be reached; that sentence is the whole diagnosis.
+    expect(
+      streamCloseOutcome({
+        code: 4503,
+        reason: "The browser stream did not respond.",
+      }),
+    ).toEqual({
+      retry: false,
+      detail: "The browser stream did not respond.",
+    });
+  });
+
+  it("falls back to the generic line when the server sent no reason", () => {
+    expect(streamCloseOutcome({ code: 4503, reason: "   " }).detail).toBe(
+      "The connection to the browser dropped.",
+    );
+  });
+});
+
+describe("reconnectDelayMs", () => {
+  it("backs off, because a restarting replica needs longer than 2.5s", () => {
+    expect([1, 2, 3, 4, 5].map(reconnectDelayMs)).toEqual([
+      500, 1000, 2000, 4000, 8000,
+    ]);
+  });
+});


### PR DESCRIPTION
## What happened

Testing the hosted browser on staging, the video pane died with:

> The connection to the browser dropped.

The browser was fine. **An unrelated commit landed on main and staging redeployed**: Railway created the deployment at 23:55:18Z, its container booted at 23:58:08–23:58:10Z, and the old replica was drained — which closes every in-flight WebSocket, the RFB video stream included. The session itself survived (the next `POST /computers/browser/lease` returned 200 on the new replica); only the picture was lost, permanently, until a manual reload.

## Why it was terminal

`BrowserStream` already knows how to recover from a close — it reconnects on `4401`, the 60s token expiry — but every other code ended the view. A drain closes with **`1001`** (going away), and a socket that dies without a close frame surfaces as **`1006`**. Both mean "the far end went away and will be back", which is exactly the recoverable case.

So: any teammate merging anything logs everyone out of the browser view, and it reads as a browser failure rather than a restart.

## Changes

- **Retry `1001` and `1006`** alongside `4401`. `4404` (browser gone) stays terminal.
- **Back off** — `0.5s → 8s` across the five attempts (~15s total) instead of a flat `500ms` × 5 = 2.5s, which cannot outlast a replica restart. The cap is still on *consecutive* failures, so a connection that succeeds in between resets the budget.
- **Stop discarding the server's reason.** The stream proxy closes with real sentences — "Could not reach the browser stream.", "The browser stream did not respond.", "The browser stream failed.", "Malformed stream." (`computer-browser-stream.ts:452-508`) — and the client replaced all of them with one generic line.
- The policy is now a pure `streamCloseOutcome({code, reason})`, testable without noVNC, a socket, or a DOM.

## Tests

New `BrowserStream.close.test.ts` — 7 cases covering each code and the backoff schedule. `client/src/components/computer` + `client/src/components/browser`: 17 files, 188 tests, passing. Prettier clean, no new tsc errors.

## Related

Two sibling swallows, not in this PR: `WebmcpInspectorTab` renders `lease-blocked` through `ErrorBanner` (red "Someone has taken control of this browser") even when *you* are the lease holder and the pane above already says "You have control"; and the WebMCP store reads only `body.error`, so middleware 401s (`{code, message}`) arrive as "The WebMCP Inspector request failed."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STvqEtNrAFKVFe1HEqL3KR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only stream resilience and messaging; reconnect still goes through existing token minting and the same reconnect cap.
> 
> **Overview**
> **Routine deploys no longer permanently kill the hosted browser video pane.** `BrowserStream` used to treat every WebSocket close except token expiry (`4401`) as fatal, so replica drains (`1001`) and abrupt disconnects (`1006`) showed a dead view even when the browser session was still alive.
> 
> Close handling is centralized in **`streamCloseOutcome`**, which retries `1001`/`1006`/`4401`, keeps **`4404`** terminal, and surfaces the proxy’s **`reason`** when the server sends one instead of always showing a generic message. Reconnect spacing uses **`reconnectDelayMs`** exponential backoff (500ms → 8s over five attempts) instead of a flat 500ms loop. **`BrowserStream.close.test.ts`** locks in the policy and backoff schedule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 574e821dfc4cdd351548a5fffe0f7f960b866da4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the browser video pane dying permanently on every deploy. A deploy drains replicas, closing the RFB socket with code 1001 or 1006, which previously ended the view with "The connection to the browser dropped." even though the browser was fine; those codes now reconnect like the 4401 token-expiry path.

**Bug Fixes**
- Retries codes 1001 and 1006 alongside 4401; 4404 (browser gone) stays terminal.
- Backs off retries from 0.5s to 8s over five attempts (~15s) instead of a flat 500ms×5, which could not outlast a replica restart.
- Shows the server's own close reason (e.g., "The browser stream did not respond.") instead of one generic line.
- Extracts the policy into a pure `streamCloseOutcome` function, tested with 7 new cases in `BrowserStream.close.test.ts` without noVNC or a socket.

<sup>Written for commit 574e821dfc4cdd351548a5fffe0f7f960b866da4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

