### PR TITLE
Keep the WorkOS session alive through a transient refresh failure

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/unified-convex-auth.test.tsx
+++ b/mcpjam-inspector/client/src/lib/__tests__/unified-convex-auth.test.tsx
@@ -257,6 +257,32 @@ describe("useUnifiedConvexAuth", () => {
     it("gives up immediately on a dead WorkOS session", async () => {
       // authkit latches to ERROR after this — retrying only re-throws, and a
       // genuine sign-out is not a fault worth reporting.
+      //
+      // Shaped exactly as authkit throws it: `LoginRequiredError` extends
+      // `Error` without ever assigning `name`, so the instance carries
+      // `name: "Error"` and only the message identifies it.
+      const loginRequired = new Error("No access token available");
+      expect(loginRequired.name).toBe("Error");
+      mockState.workos.user = { id: "user-1" };
+      mockState.workos.getAccessToken.mockRejectedValue(loginRequired);
+
+      const result = await mountGuest();
+
+      let token: string | null = "unset";
+      await act(async () => {
+        token = await result.current.getAccessToken();
+      });
+
+      expect(token).toBeNull();
+      expect(mockState.workos.getAccessToken).toHaveBeenCalledTimes(1);
+      expect(mockState.reportCaught).not.toHaveBeenCalled();
+      // Retrying cannot help here, so the banner must offer sign-in instead.
+      expect(useSessionRefreshStore.getState().kind).toBe("signed_out");
+    });
+
+    it("gives up immediately when authkit labels the error by name", async () => {
+      // Belt and braces: if a later authkit sets `name`, that must keep
+      // classifying as a dead session even if the message is reworded.
       const loginRequired = new Error("login required");
       loginRequired.name = "LoginRequiredError";
       mockState.workos.user = { id: "user-1" };
@@ -272,7 +298,6 @@ describe("useUnifiedConvexAuth", () => {
       expect(token).toBeNull();
       expect(mockState.workos.getAccessToken).toHaveBeenCalledTimes(1);
       expect(mockState.reportCaught).not.toHaveBeenCalled();
-      // Retrying cannot help here, so the banner must offer sign-in instead.
       expect(useSessionRefreshStore.getState().kind).toBe("signed_out");
     });
 

--- a/mcpjam-inspector/client/src/lib/auth/__tests__/login-required-error.test.ts
+++ b/mcpjam-inspector/client/src/lib/auth/__tests__/login-required-error.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { isLoginRequiredError } from "../login-required-error";
+
+describe("isLoginRequiredError", () => {
+  it("recognizes the error authkit actually throws", () => {
+    // authkit's `LoginRequiredError` never assigns `name`, so a real instance
+    // arrives as a plain `Error` carrying only the fixed message.
+    const error = new Error("No access token available");
+    expect(error.name).toBe("Error");
+    expect(isLoginRequiredError(error)).toBe(true);
+  });
+
+  it("recognizes a name-labelled variant", () => {
+    const error = new Error("login required");
+    error.name = "LoginRequiredError";
+    expect(isLoginRequiredError(error)).toBe(true);
+  });
+
+  it("leaves transient failures retryable", () => {
+    expect(isLoginRequiredError(new TypeError("Failed to fetch"))).toBe(false);
+    expect(isLoginRequiredError("No access token available")).toBe(false);
+    expect(isLoginRequiredError(null)).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/auth/__tests__/login-required-error.test.ts
+++ b/mcpjam-inspector/client/src/lib/auth/__tests__/login-required-error.test.ts
@@ -17,6 +17,17 @@ describe("isLoginRequiredError", () => {
     expect(isLoginRequiredError(error)).toBe(true);
   });
 
+  // Deliberately a substring match, not equality. Missing a real
+  // `LoginRequiredError` is the expensive direction: it relabels a dead session
+  // as transient, which is the exact bug this module exists to fix. A wrapper
+  // that prefixes the message would defeat `===` and silently reintroduce it,
+  // so the looser test is the safer one.
+  it("still recognizes the error through a wrapper that prefixes the message", () => {
+    expect(
+      isLoginRequiredError(new Error("Refresh failed: No access token available"))
+    ).toBe(true);
+  });
+
   it("leaves transient failures retryable", () => {
     expect(isLoginRequiredError(new TypeError("Failed to fetch"))).toBe(false);
     expect(isLoginRequiredError("No access token available")).toBe(false);

--- a/mcpjam-inspector/client/src/lib/auth/login-required-error.ts
+++ b/mcpjam-inspector/client/src/lib/auth/login-required-error.ts
@@ -1,0 +1,30 @@
+/**
+ * The message authkit fixes on `LoginRequiredError`
+ * (`readonly message = "No access token available"`), so it is identical for
+ * every throw site.
+ */
+export const LOGIN_REQUIRED_ERROR_MESSAGE = "No access token available";
+
+/**
+ * Is this failure authkit's `LoginRequiredError` — i.e. WorkOS has no session
+ * left, so there is nothing a retry could refresh?
+ *
+ * Both of the obvious identity checks are unusable here:
+ *
+ * - `instanceof` — authkit-react bundles its own copy of the error class, so
+ *   the constructor we could import is not the one the throw site used.
+ * - `error.name` — authkit declares `class LoginRequiredError extends
+ *   AuthKitError` and never assigns `name`, so every instance inherits
+ *   `"Error"` from `Error.prototype`. `constructor.name` is no better: the
+ *   production bundle mangles it.
+ *
+ * The message is the one marker that survives both, so that is what we match.
+ * `name` is still accepted in case a later authkit sets it.
+ */
+export function isLoginRequiredError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.name === "LoginRequiredError" ||
+    error.message.includes(LOGIN_REQUIRED_ERROR_MESSAGE)
+  );
+}

--- a/mcpjam-inspector/client/src/lib/unified-convex-auth.ts
+++ b/mcpjam-inspector/client/src/lib/unified-convex-auth.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useAuth as useWorkOSAuth } from "@workos-inc/authkit-react";
+import { isLoginRequiredError } from "@/lib/auth/login-required-error";
 import { reportCaught } from "@/lib/error-reporting";
 import { useSessionRefreshStore } from "@/stores/session-refresh-store";
 import {
@@ -35,7 +36,8 @@ const GUEST_SESSION_BOOTSTRAP_RETRY_DELAYS_MS = [500, 1500, 3000] as const;
 // Same ladder for token refresh. ~5s worst case, which fits inside the 60s
 // `authRefreshTokenLeewaySeconds` configured in main.tsx — so a retried
 // success still lands while the old token is valid.
-const AUTH_TOKEN_REFRESH_RETRY_DELAYS_MS = GUEST_SESSION_BOOTSTRAP_RETRY_DELAYS_MS;
+const AUTH_TOKEN_REFRESH_RETRY_DELAYS_MS =
+  GUEST_SESSION_BOOTSTRAP_RETRY_DELAYS_MS;
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -155,8 +157,7 @@ export function useUnifiedConvexAuth() {
         attempt <= GUEST_SESSION_BOOTSTRAP_RETRY_DELAYS_MS.length;
         attempt += 1
       ) {
-        let session: Awaited<ReturnType<typeof getOrCreateGuestSession>> =
-          null;
+        let session: Awaited<ReturnType<typeof getOrCreateGuestSession>> = null;
         try {
           session = await getOrCreateGuestSession();
         } catch {
@@ -194,13 +195,13 @@ export function useUnifiedConvexAuth() {
         // rethrown with its state restored to AUTHENTICATED (retryable), while
         // a rejected refresh grant wipes the session, latches state to ERROR,
         // and throws `LoginRequiredError` forever after (retrying can only
-        // re-throw). Matching on `name` rather than `instanceof` because
-        // authkit-react bundles its own copy of the error class.
+        // re-throw). See `isLoginRequiredError` for why that error can only be
+        // recognized by its message — matching on `name` silently classified
+        // every dead session as transient.
         getAccessToken: () =>
           fetchTokenWithRetry(() => workos.getAccessToken(), {
             source: "workos_token_refresh",
-            isTerminalError: (error) =>
-              error instanceof Error && error.name === "LoginRequiredError",
+            isTerminalError: isLoginRequiredError,
           }),
       };
     }
@@ -208,9 +209,9 @@ export function useUnifiedConvexAuth() {
     return {
       isLoading: workos.isLoading || guestLoading,
       user: guestToken ? GUEST_USER_PLACEHOLDER : null,
-      getAccessToken: async (
-        opts?: { forceRefreshToken?: boolean },
-      ): Promise<string | null> => {
+      getAccessToken: async (opts?: {
+        forceRefreshToken?: boolean;
+      }): Promise<string | null> => {
         // Convex asks for a token, gets one, and authenticates the guest —
         // the true "activated as a guest" signal. Marking HERE (rather than
         // in the resolve effect) is immune to the effect-cancel race when a

--- a/mcpjam-inspector/server/routes/__tests__/workos-authkit.test.ts
+++ b/mcpjam-inspector/server/routes/__tests__/workos-authkit.test.ts
@@ -63,7 +63,7 @@ describe("workos authkit local session bridge", () => {
         access_token: "access-token-1",
         refresh_token: "refresh-token-1",
         user: { id: "user_1" },
-      })
+      }),
     );
 
     const res = await app.request(
@@ -77,7 +77,7 @@ describe("workos authkit local session bridge", () => {
           code: "code_123",
           code_verifier: "verifier_123",
         }),
-      }
+      },
     );
 
     expect(res.status).toBe(200);
@@ -94,12 +94,12 @@ describe("workos authkit local session bridge", () => {
     const app = createTestApp();
 
     const res = await app.request(
-      "http://localhost:6274/user_management/authorize?client_id=client_123&code_challenge=abc"
+      "http://localhost:6274/user_management/authorize?client_id=client_123&code_challenge=abc",
     );
 
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe(
-      "https://api.workos.com/user_management/authorize?client_id=client_123&code_challenge=abc"
+      "https://api.workos.com/user_management/authorize?client_id=client_123&code_challenge=abc",
     );
   });
 
@@ -107,15 +107,15 @@ describe("workos authkit local session bridge", () => {
     const app = createTestApp();
 
     const res = await app.request(
-      "http://localhost:6274/user_management/sessions/logout?session_id=session_123"
+      "http://localhost:6274/user_management/sessions/logout?session_id=session_123",
     );
 
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe(
-      "https://api.workos.com/user_management/sessions/logout?session_id=session_123"
+      "https://api.workos.com/user_management/sessions/logout?session_id=session_123",
     );
     expect(res.headers.get("set-cookie")).toContain(
-      "mcpjam_workos_sessions=; Max-Age=0"
+      "mcpjam_workos_sessions=; Max-Age=0",
     );
   });
 
@@ -127,14 +127,14 @@ describe("workos authkit local session bridge", () => {
           access_token: "access-token-1",
           refresh_token: "refresh-token-1",
           user: { id: "user_1" },
-        })
+        }),
       )
       .mockResolvedValueOnce(
         jsonResponse({
           access_token: "access-token-2",
           refresh_token: "refresh-token-2",
           user: { id: "user_1" },
-        })
+        }),
       );
 
     const loginRes = await app.request(
@@ -151,11 +151,11 @@ describe("workos authkit local session bridge", () => {
           code: "code_123",
           code_verifier: "verifier_123",
         }),
-      }
+      },
     );
     const sessionCookie = extractCookie(
       loginRes.headers.get("set-cookie") ?? "",
-      "mcpjam_workos_sessions"
+      "mcpjam_workos_sessions",
     );
 
     const refreshRes = await app.request(
@@ -171,7 +171,7 @@ describe("workos authkit local session bridge", () => {
           client_id: "client_123",
           grant_type: "refresh_token",
         }),
-      }
+      },
     );
 
     expect(refreshRes.status).toBe(200);
@@ -194,7 +194,7 @@ describe("workos authkit local session bridge", () => {
         access_token: "access-token-1",
         refresh_token: "refresh-token-5173",
         user: { id: "user_1" },
-      })
+      }),
     );
 
     const loginRes = await app.request(
@@ -211,11 +211,11 @@ describe("workos authkit local session bridge", () => {
           code: "code_123",
           code_verifier: "verifier_123",
         }),
-      }
+      },
     );
     const sessionCookie = extractCookie(
       loginRes.headers.get("set-cookie") ?? "",
-      "mcpjam_workos_sessions"
+      "mcpjam_workos_sessions",
     );
 
     const refreshRes = await app.request(
@@ -231,7 +231,7 @@ describe("workos authkit local session bridge", () => {
           client_id: "client_123",
           grant_type: "refresh_token",
         }),
-      }
+      },
     );
 
     expect(refreshRes.status).toBe(400);
@@ -240,7 +240,7 @@ describe("workos authkit local session bridge", () => {
     });
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(refreshRes.headers.get("set-cookie")).not.toContain(
-      "workos-has-session=; Max-Age=0"
+      "workos-has-session=; Max-Age=0",
     );
   });
 
@@ -256,7 +256,7 @@ describe("workos authkit local session bridge", () => {
           client_id: "client_123",
           grant_type: "refresh_token",
         }),
-      }
+      },
     );
 
     expect(res.status).toBe(400);
@@ -264,6 +264,134 @@ describe("workos authkit local session bridge", () => {
       error_description: "No local WorkOS session",
     });
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  // A refresh that WorkOS could not answer is not a refresh WorkOS refused.
+  // The jar holds the only copy of the token, so the two have to be told
+  // apart here or a blip becomes a sign-out. See `isTransientWorkosFailure`.
+  describe("when WorkOS cannot answer a refresh", () => {
+    async function signIn(app: ReturnType<typeof createTestApp>) {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        jsonResponse({
+          access_token: "access-token-1",
+          refresh_token: "refresh-token-1",
+          user: { id: "user_1" },
+        }),
+      );
+
+      const res = await app.request(
+        "http://localhost:6274/user_management/authenticate",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Origin: "http://localhost:6274",
+          },
+          body: JSON.stringify({
+            client_id: "client_123",
+            grant_type: "authorization_code",
+            code: "code_123",
+            code_verifier: "verifier_123",
+          }),
+        },
+      );
+
+      return extractCookie(
+        res.headers.get("set-cookie") ?? "",
+        "mcpjam_workos_sessions",
+      );
+    }
+
+    function refresh(
+      app: ReturnType<typeof createTestApp>,
+      sessionCookie: string,
+    ) {
+      return app.request("http://localhost:6274/user_management/authenticate", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:6274",
+          Cookie: `${sessionCookie}; workos-has-session=true`,
+        },
+        body: JSON.stringify({
+          client_id: "client_123",
+          grant_type: "refresh_token",
+        }),
+      });
+    }
+
+    it("keeps the stored token through an outage, so the next attempt recovers", async () => {
+      const app = createTestApp();
+      const sessionCookie = await signIn(app);
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(
+          jsonResponse({ error_description: "Service unavailable" }, 503),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            access_token: "access-token-2",
+            refresh_token: "refresh-token-2",
+            user: { id: "user_1" },
+          }),
+        );
+
+      const failed = await refresh(app, sessionCookie);
+      expect(failed.status).toBe(503);
+      expect(failed.headers.get("set-cookie") ?? "").not.toContain(
+        "mcpjam_workos_sessions=; Max-Age=0",
+      );
+
+      // The point of not clearing: the SAME cookie still carries the token, so
+      // the retry that follows is able to spend it.
+      const recovered = await refresh(app, sessionCookie);
+      expect(recovered.status).toBe(200);
+      expect(
+        JSON.parse(String(vi.mocked(fetch).mock.calls[2]?.[1]?.body)),
+      ).toMatchObject({
+        grant_type: "refresh_token",
+        refresh_token: "refresh-token-1",
+      });
+    });
+
+    it.each([408, 429, 500, 502, 504])(
+      "keeps the stored token on a %i",
+      async (status) => {
+        const app = createTestApp();
+        const sessionCookie = await signIn(app);
+        vi.mocked(fetch).mockResolvedValueOnce(
+          jsonResponse({ error_description: "Try later" }, status),
+        );
+
+        const res = await refresh(app, sessionCookie);
+
+        expect(res.status).toBe(status);
+        expect(res.headers.get("set-cookie") ?? "").not.toContain(
+          "mcpjam_workos_sessions=; Max-Age=0",
+        );
+      },
+    );
+
+    it("still clears the session when WorkOS rejects the token itself", async () => {
+      const app = createTestApp();
+      const sessionCookie = await signIn(app);
+      vi.mocked(fetch).mockResolvedValueOnce(
+        jsonResponse(
+          {
+            error: "invalid_grant",
+            error_description: "Refresh token is invalid",
+          },
+          400,
+        ),
+      );
+
+      const res = await refresh(app, sessionCookie);
+
+      expect(res.status).toBe(400);
+      expect(setCookieFor(res, "mcpjam_workos_sessions")).toContain(
+        "Max-Age=0",
+      );
+    });
   });
 
   // The hosted path. Everything above runs on localhost, where the refresh
@@ -278,7 +406,7 @@ describe("workos authkit local session bridge", () => {
           access_token: "access-token-1",
           refresh_token: "refresh-token-1",
           user: { id: "user_1" },
-        })
+        }),
       );
 
       const res = await app.request(
@@ -292,7 +420,7 @@ describe("workos authkit local session bridge", () => {
             code: "code_123",
             code_verifier: "verifier_123",
           }),
-        }
+        },
       );
 
       expect(res.status).toBe(200);
@@ -321,7 +449,7 @@ describe("workos authkit local session bridge", () => {
           access_token: "access-token-1",
           refresh_token: "refresh-token-1",
           user: { id: "user_1" },
-        })
+        }),
       );
 
       const res = await app.request(
@@ -335,7 +463,7 @@ describe("workos authkit local session bridge", () => {
             code: "code_123",
             code_verifier: "verifier_123",
           }),
-        }
+        },
       );
 
       const hasSessionCookie = setCookieFor(res, "workos-has-session");

--- a/mcpjam-inspector/server/routes/__tests__/workos-authkit.test.ts
+++ b/mcpjam-inspector/server/routes/__tests__/workos-authkit.test.ts
@@ -369,6 +369,12 @@ describe("workos authkit local session bridge", () => {
         expect(res.headers.get("set-cookie") ?? "").not.toContain(
           "mcpjam_workos_sessions=; Max-Age=0",
         );
+        // The marker AuthKit reads to decide whether a refresh is worth
+        // attempting at all. Expiring it would strand the token this test
+        // just proved we kept.
+        expect(res.headers.get("set-cookie") ?? "").not.toContain(
+          "workos-has-session=; Max-Age=0",
+        );
       },
     );
 
@@ -387,19 +393,22 @@ describe("workos authkit local session bridge", () => {
             access_token: "access-token-2",
             refresh_token: "refresh-token-2",
             user: { id: "user_1" },
-          })
+          }),
         );
 
       const failed = await refresh(app, sessionCookie);
       expect(failed.status).toBe(500);
       expect(failed.headers.get("set-cookie") ?? "").not.toContain(
-        "mcpjam_workos_sessions=; Max-Age=0"
+        "mcpjam_workos_sessions=; Max-Age=0",
+      );
+      expect(failed.headers.get("set-cookie") ?? "").not.toContain(
+        "workos-has-session=; Max-Age=0",
       );
 
       const recovered = await refresh(app, sessionCookie);
       expect(recovered.status).toBe(200);
       expect(
-        JSON.parse(String(vi.mocked(fetch).mock.calls[2]?.[1]?.body))
+        JSON.parse(String(vi.mocked(fetch).mock.calls[2]?.[1]?.body)),
       ).toMatchObject({ refresh_token: "refresh-token-1" });
     });
 

--- a/mcpjam-inspector/server/routes/__tests__/workos-authkit.test.ts
+++ b/mcpjam-inspector/server/routes/__tests__/workos-authkit.test.ts
@@ -372,6 +372,37 @@ describe("workos authkit local session bridge", () => {
       },
     );
 
+    // The comment on `isTransientWorkosFailure` claims a `fetch` rejection is
+    // safe "by construction" — it throws before any cookie is touched. That is
+    // a property of where the throw lands in the handler, which a refactor can
+    // silently move, so it is asserted rather than reasoned about.
+    it("keeps the stored token when the request never reaches WorkOS", async () => {
+      const app = createTestApp();
+      const sessionCookie = await signIn(app);
+
+      vi.mocked(fetch)
+        .mockRejectedValueOnce(new TypeError("fetch failed"))
+        .mockResolvedValueOnce(
+          jsonResponse({
+            access_token: "access-token-2",
+            refresh_token: "refresh-token-2",
+            user: { id: "user_1" },
+          })
+        );
+
+      const failed = await refresh(app, sessionCookie);
+      expect(failed.status).toBe(500);
+      expect(failed.headers.get("set-cookie") ?? "").not.toContain(
+        "mcpjam_workos_sessions=; Max-Age=0"
+      );
+
+      const recovered = await refresh(app, sessionCookie);
+      expect(recovered.status).toBe(200);
+      expect(
+        JSON.parse(String(vi.mocked(fetch).mock.calls[2]?.[1]?.body))
+      ).toMatchObject({ refresh_token: "refresh-token-1" });
+    });
+
     it("still clears the session when WorkOS rejects the token itself", async () => {
       const app = createTestApp();
       const sessionCookie = await signIn(app);

--- a/mcpjam-inspector/server/routes/workos-authkit.ts
+++ b/mcpjam-inspector/server/routes/workos-authkit.ts
@@ -89,7 +89,7 @@ function unsealValue(value: string | undefined): unknown {
 
   try {
     const [iv, tag, ciphertext] = parts.map((part) =>
-      Buffer.from(part, "base64url")
+      Buffer.from(part, "base64url"),
     );
     const decipher = createDecipheriv("aes-256-gcm", getEncryptionKey(), iv);
     decipher.setAuthTag(tag);
@@ -153,20 +153,25 @@ function getClientOrigin(c: Context): string {
 }
 
 function getClientOriginKey(c: Context): string {
-  return createHash("sha256").update(getClientOrigin(c)).digest("hex").slice(0, 16);
+  return createHash("sha256")
+    .update(getClientOrigin(c))
+    .digest("hex")
+    .slice(0, 16);
 }
 
 function getLocalSessionJar(c: Context): StoredWorkosSessionJar {
-  return parseStoredSessionJar(unsealValue(getCookie(c, LOCAL_WORKOS_SESSION_COOKIE)));
+  return parseStoredSessionJar(
+    unsealValue(getCookie(c, LOCAL_WORKOS_SESSION_COOKIE)),
+  );
 }
 
 function pruneLocalSessions(
-  sessions: Record<string, StoredWorkosSession>
+  sessions: Record<string, StoredWorkosSession>,
 ): Record<string, StoredWorkosSession> {
   return Object.fromEntries(
     Object.entries(sessions)
       .sort(([, a], [, b]) => b.updatedAt - a.updatedAt)
-      .slice(0, MAX_LOCAL_SESSIONS)
+      .slice(0, MAX_LOCAL_SESSIONS),
   );
 }
 
@@ -178,12 +183,17 @@ function setSessionCookies(c: Context, session: StoredWorkosSession) {
       ...jar.sessions,
       [key]: session,
     });
-    setCookie(c, LOCAL_WORKOS_SESSION_COOKIE, sealValue({ version: 1, sessions }), {
-      httpOnly: true,
-      sameSite: "Lax",
-      path: "/",
-      maxAge: COOKIE_MAX_AGE,
-    });
+    setCookie(
+      c,
+      LOCAL_WORKOS_SESSION_COOKIE,
+      sealValue({ version: 1, sessions }),
+      {
+        httpOnly: true,
+        sameSite: "Lax",
+        path: "/",
+        maxAge: COOKIE_MAX_AGE,
+      },
+    );
     setCookie(c, LEGACY_LOCAL_WORKOS_SESSION_COOKIE, "", {
       path: "/",
       maxAge: 0,
@@ -232,7 +242,7 @@ function clearSessionCookies(c: Context) {
           sameSite: "Lax",
           path: "/",
           maxAge: COOKIE_MAX_AGE,
-        }
+        },
       );
     } else {
       setCookie(c, LOCAL_WORKOS_SESSION_COOKIE, "", {
@@ -279,6 +289,30 @@ async function postToWorkos(body: Record<string, unknown>) {
   });
 }
 
+/**
+ * Whether a non-OK WorkOS refresh response leaves the stored token dead.
+ *
+ * Clearing is destructive in a way nothing above can undo: this jar holds the
+ * ONLY copy of the refresh token, so wiping it on a 502 converts one bad
+ * second at WorkOS into a forced sign-in. That is the failure class the
+ * client's retry ladder (`fetchTokenWithRetry` in `unified-convex-auth.ts`)
+ * exists to absorb — but no retry can help once the credential itself is gone:
+ * the next attempt finds an empty jar, gets "No local WorkOS session", and
+ * AuthKit treats that as terminal and fires `onRefreshFailure`.
+ *
+ * A rejected grant is the opposite case and must still clear. WorkOS answers
+ * 400 for a refresh token that is expired, revoked, or already rotated, and
+ * keeping one would leave `workos-has-session` set so every subsequent load
+ * re-enters the same refusal.
+ *
+ * A `fetch` rejection (offline, DNS, connection reset) never reaches here: it
+ * throws before any cookie is touched, which lands on the same side of this
+ * line by construction.
+ */
+function isTransientWorkosFailure(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
 function redirectToWorkos(c: Context, path: string) {
   const source = new URL(c.req.url);
   const target = new URL(path, WORKOS_BASE_URL);
@@ -287,7 +321,7 @@ function redirectToWorkos(c: Context, path: string) {
 }
 
 workosAuthkitRoutes.get("/authorize", (c) =>
-  redirectToWorkos(c, "/user_management/authorize")
+  redirectToWorkos(c, "/user_management/authorize"),
 );
 
 workosAuthkitRoutes.get("/sessions/logout", (c) => {
@@ -338,7 +372,11 @@ workosAuthkitRoutes.post("/authenticate", async (c) => {
   const refreshToken = responseJson.refresh_token;
   if (response.ok && typeof refreshToken === "string") {
     setSessionCookies(c, { refreshToken, updatedAt: Date.now() });
-  } else if (!response.ok && body.grant_type === "refresh_token") {
+  } else if (
+    !response.ok &&
+    body.grant_type === "refresh_token" &&
+    !isTransientWorkosFailure(response.status)
+  ) {
     clearSessionCookies(c);
   }
 


### PR DESCRIPTION
## The bug

The local AuthKit proxy cleared the stored refresh token on **any** non-OK response from WorkOS during a refresh — 429 and 5xx included:

```js
} else if (!response.ok && body.grant_type === "refresh_token") {
  clearSessionCookies(c);
}
```

That jar holds the only copy of the token, so one bad second upstream deleted the credential permanently. The next refresh found an empty jar, got `400 "No local WorkOS session"`, and AuthKit treats that as terminal: ERROR state → `onRefreshFailure` → involuntary bounce to sign-in.

That is exactly the failure class the retry ladder from #4403 ("one wifi blip or laptop wake") was written to absorb — except the retry lives in `unified-convex-auth.ts`, above the layer that had already thrown the token away. Nothing it retried with could work.

Surfaced as the `WorkOS session refresh failed` issue in PostHog. Affects every surface that goes through the proxy — hosted, local inspector, packaged desktop — and is undercounted, since `isErrorCaptureSurface()` only reports from hosted and packaged desktop.

## The fix

Two opposite corrections of the same transient-vs-terminal distinction:

**Server** — `isTransientWorkosFailure` gates the clear. 408/429/5xx keep the token so the next attempt can spend it; a rejected grant (WorkOS answers 400 for an expired, revoked or already-rotated token) still clears, because keeping one would leave `workos-has-session` set and re-enter the same refusal on every load. A `fetch` rejection throws before any cookie is touched, so it lands on the safe side by construction.

**Client** — `isLoginRequiredError` recognizes a genuinely dead session. `error.name === "LoginRequiredError"` never matched: authkit declares `class LoginRequiredError extends AuthKitError` and never assigns `name`, so every instance inherits `"Error"`. Dead sessions were therefore classified as transient and retried four times before giving up. Matching on the message is the one marker that survives both the bundled-class problem and production mangling.

## Tests

- `workos-authkit.test.ts` — 11 blocks (15 cases), covering transient statuses keeping the token, a follow-up refresh still spending it, and a rejected grant still clearing.
- `login-required-error.test.ts` — 3 cases.
- `unified-convex-auth.test.tsx` — 12 blocks.

The transient-status cases were verified non-vacuous: with the server fix stashed, the six of them fail and the "still clears on a rejected grant" guard stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops transient WorkOS refresh failures from permanently deleting the local refresh token, and correctly recognizes dead sessions so they aren't retried pointlessly. Previously any non-OK refresh response wiped the token, and authkit's `LoginRequiredError` was never matched by name, so dead sessions were retried four times before giving up.

**Bug Fixes**
- 408, 429, and 5xx refresh responses and network failures keep the stored token so a retry can recover; a rejected grant (400) still clears the session.
- Dead sessions are now detected by message instead of `name`, since authkit's `LoginRequiredError` never sets `name`.
- Tests assert the `workos-has-session` marker also survives transient failures, so AuthKit keeps attempting the next refresh.

<sup>Written for commit 6ffbfde40cea605e40b17fb25938b6331da7f8ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

