### PR TITLE
Keep the plan CTA spinner out of translated text nodes

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -168,6 +168,24 @@ function billingStatusFixture(
   };
 }
 
+/**
+ * Mimics Chrome's built-in page translation, which moves every text node into
+ * a `<font>` wrapper it inserts in the node's place.
+ */
+function translateTextNodes(root: HTMLElement): void {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const textNodes: Text[] = [];
+  while (walker.nextNode()) {
+    textNodes.push(walker.currentNode as Text);
+  }
+
+  for (const textNode of textNodes) {
+    const wrapper = document.createElement("font");
+    textNode.parentNode?.insertBefore(wrapper, textNode);
+    wrapper.appendChild(textNode);
+  }
+}
+
 function createBillingHookState(overrides: Record<string, unknown>) {
   return {
     billingStatus: undefined,
@@ -1581,6 +1599,38 @@ describe("OrganizationsTab billing", () => {
     for (const button of teamButtons) {
       expect(button).toBeDisabled();
     }
+  });
+
+  it("clears the plan CTA spinner after a page translator rewrites its label", () => {
+    mockUseOrganizationBilling.mockReturnValue(
+      createBillingHookState({
+        billingStatus: billingStatusFixture(),
+        isStartingPlanChange: true,
+        pendingPlanChangeTarget: "team",
+      })
+    );
+
+    const { rerender } = render(
+      <OrganizationsTab organizationId="org-1" section="billing" />
+    );
+
+    const pendingButton = within(getPlanColumn("Team")).getByRole("button", {
+      name: /Loading/,
+    });
+    translateTextNodes(pendingButton);
+
+    mockUseOrganizationBilling.mockReturnValue(
+      createBillingHookState({ billingStatus: billingStatusFixture() })
+    );
+
+    // The spinner's label sits next to an icon, so React deletes it as its own
+    // text node. While the translator holds that node inside a `<font>`, the
+    // deletion used to throw NotFoundError from `removeChild`.
+    rerender(<OrganizationsTab organizationId="org-1" section="billing" />);
+
+    expect(
+      within(getPlanColumn("Team")).getByRole("button", { name: "Upgrade" })
+    ).toBeInTheDocument();
   });
 
   it("opens the dedicated cancellation flow when downgrading from a paid plan to Free", async () => {

--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -253,6 +253,32 @@ function PlanPriceDisplay({ label }: { label: string }) {
   );
 }
 
+/**
+ * Chrome's built-in page translation swaps each text node for a `<font>`
+ * wrapper holding the translation. React keeps a reference to the original
+ * node, so removing a bare text child later throws NotFoundError from
+ * `removeChild`. Keeping both branches inside an element means React only ever
+ * removes elements, which the translator leaves where they are.
+ */
+function PlanCtaContent({
+  showSpinner,
+  label,
+}: {
+  showSpinner: boolean;
+  label: string;
+}) {
+  if (showSpinner) {
+    return (
+      <>
+        <Loader2 className="size-4 animate-spin" />
+        <span>Loading...</span>
+      </>
+    );
+  }
+
+  return <span>{label}</span>;
+}
+
 const COMPARE_PLAN_ROW_LABEL_TOOLTIPS: Record<
   string,
   { ariaLabel: string; content: string; contentClassName?: string }
@@ -582,14 +608,7 @@ function FreePlanTeamUpsell({
               tabIndex={0}
               onClick={undefined}
             >
-              {showCtaSpinner ? (
-                <>
-                  <Loader2 className="size-4 animate-spin" />
-                  Loading...
-                </>
-              ) : (
-                cta.label
-              )}
+              <PlanCtaContent showSpinner={showCtaSpinner} label={cta.label} />
             </Button>
           </TooltipTrigger>
           <TooltipContent side="top" className="max-w-[14rem] text-center">
@@ -604,14 +623,7 @@ function FreePlanTeamUpsell({
           disabled={cta.disabled}
           onClick={cta.onClick}
         >
-          {showCtaSpinner ? (
-            <>
-              <Loader2 className="size-4 animate-spin" />
-              Loading...
-            </>
-          ) : (
-            cta.label
-          )}
+          <PlanCtaContent showSpinner={showCtaSpinner} label={cta.label} />
         </Button>
       )}
     </div>
@@ -1171,14 +1183,10 @@ export function OrganizationBillingSection({
                                           tabIndex={0}
                                           onClick={undefined}
                                         >
-                                          {showCtaSpinner ? (
-                                            <>
-                                              <Loader2 className="size-4 animate-spin" />
-                                              Loading...
-                                            </>
-                                          ) : (
-                                            cta.label
-                                          )}
+                                          <PlanCtaContent
+                                            showSpinner={showCtaSpinner}
+                                            label={cta.label}
+                                          />
                                         </Button>
                                       </TooltipTrigger>
                                       <TooltipContent
@@ -1196,14 +1204,10 @@ export function OrganizationBillingSection({
                                       disabled={cta.disabled}
                                       onClick={cta.onClick}
                                     >
-                                      {showCtaSpinner ? (
-                                        <>
-                                          <Loader2 className="size-4 animate-spin" />
-                                          Loading...
-                                        </>
-                                      ) : (
-                                        cta.label
-                                      )}
+                                      <PlanCtaContent
+                                        showSpinner={showCtaSpinner}
+                                        label={cta.label}
+                                      />
                                     </Button>
                                   )}
                                 </div>


### PR DESCRIPTION
## What broke

Clearing the spinner on the org billing page threw `NotFoundError: Failed to execute 'removeChild' on 'Node'` for any user whose browser was translating the page.

Reported by a PostHog alert on [`/organizations/:orgId/billing`](https://us.posthog.com/project/212744/error_tracking/01a07935-d34a-7640-89ee-30c362285336) — Chrome 152 on Android, `$browser_language: zh-CN`, 1 user.

## Why

The spinner branch rendered:

```tsx
{showCtaSpinner ? (<><Loader2 … /> Loading...</>) : cta.label}
```

`Loading...` is a text node with a sibling, so it gets its own HostText fiber. Chrome's built-in translation moves every text node into a `<font>` wrapper it inserts in the node's place. When the plan change resolved and React deleted that fiber, the node React held was no longer a child of the button, so `removeChild` threw. React caught it in `commitDeletionEffectsOnFiber` and reported it — hence `handled: true`.

The label branch was safe by accident: a lone string child is written with `textContent`, which never calls `removeChild`. That's why the crash lands on spinner → label, not label → spinner, and why it fired ~2s after the tap rather than on click.

Both branches now render inside an element. React only ever removes elements, and the translator leaves those in place.

## Evidence the page was being translated

Autocapture from the same session, seconds before the exception, carries Google Translate's wrapper nodes:

```
font:attr__dir="auto"attr__style="vertical-align: inherit"
```

and the annual-savings badge arrived as `title="团队：节省的费用与支付 12 个月的月租金相比。"`, against `title="Team: savings vs paying the monthly rate for 12 months."` in the source (`OrganizationBillingSection.tsx:423`).

## Test

`clears the plan CTA spinner after a page translator rewrites its label` renders the pending CTA, reparents its text nodes into `<font>` wrappers the way Chrome does, then clears the spinner. Without the component change it fails with the same production error:

```
NotFoundError: The node to be removed is not a child of this node.
```

## Verification

Run from the repo root on this branch, merged with `origin/main`:

| Check | Result |
| --- | --- |
| `npm run docs:check-tokens` | exit 0 |
| `npm run typecheck` | exit 0 |
| `npm run typecheck:client -w @mcpjam/inspector` | exit 0 |
| `npm run test -w @mcpjam/inspector` | `4 failed \| 24217 passed \| 51 skipped (24272)` |
| `npm run build:inspector` | exit 0, `✓ built in 40.60s` |

The 4 failures are pre-existing on my machine, not from this diff — the same 4 fail with these two files reverted (DNS resolution, an idle-TTL timing assertion, and two storage-quota/`sessionStorage` cases):

```
server/utils/__tests__/pinned-fetch.test.ts > never reports an unresolvable host as a blocked target
server/services/plugins/__tests__/plugin-vm-shim.test.ts > keeps a session alive that answered after longer than the idle ttl
client/src/lib/__tests__/scenario-chat-transcript.test.ts > clears when the write is rejected by the quota
client/src/components/score/__tests__/score-run-resume.test.ts > stays silent when sessionStorage is unavailable
```

E2E not run — this diff touches neither routing, app boot, nor the OAuth debugger.

## Notes for review

- **This does not close Sentry `INSPECTOR-CLIENT-21H`**, despite the identical title. All 394 of its events are `environment: dev`, and its deepest frame is `removeChildFromContainer` (a root-container deletion) rather than a host-parent `removeChild`. Different failure, same Sentry group — the group collapses them because the whole stack is React internals.
- The same `<>{icon}Text</>` shape exists elsewhere in the client and carries the same risk under translation. Left alone here to keep this scoped to the page the crash was observed on.
- Formatting: this file already fails `prettier --check` on `main` (the deploy job runs `prettier --write`, nothing gates on `--check`). The added lines match the surrounding committed style, and reformatting the file would have buried the change in ~130 unrelated lines.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the org billing page crash when the browser's built-in translation is active, where clearing the plan CTA spinner threw `NotFoundError: removeChild` on `Node`.

- Both the spinner's "Loading..." text and the CTA label now render inside a `<span>`, so React only ever removes elements the translator leaves in place.
- Adds a regression test that mimics Chrome's translation and reproduces the original error without the fix.

<sup>Written for commit 132051c4d123c233fced041ec72f21704853aead. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

