### PR TITLE
fix(hosted browser): recover a desktop stream this process did not start

### DIFF
--- a/mcpjam-inspector/server/services/browserd/__tests__/live-session-deps.test.ts
+++ b/mcpjam-inspector/server/services/browserd/__tests__/live-session-deps.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   adaptSandbox,
   browserdBundleHash,
+  ensureStreamOn,
   loadBrowserdBundle,
   writeBundleInto,
 } from "../live-session-deps";
@@ -73,5 +74,104 @@ describe("live-session-deps — sandbox adapters", () => {
     expect(sandbox.files.makeDir).toHaveBeenCalledWith("/opt/mcpjam");
     expect(writes).toHaveLength(1);
     expect(new Uint8Array(writes[0][1])).toEqual(content);
+  });
+});
+
+describe("live-session-deps — desktop stream", () => {
+  /**
+   * `@e2b/desktop`'s VNCServer, in the one detail that matters: the password is
+   * MINTED by `start()` and kept in memory. An instance that did not start the
+   * stream has no password to report, which is what `getAuthKey()` throws about.
+   */
+  function fakeStream(over: { alreadyRunning?: boolean } = {}) {
+    const state = { running: over.alreadyRunning ?? false, starts: 0 };
+    let password: string | null = null;
+    return {
+      state,
+      stream: {
+        start: vi.fn(async () => {
+          if (state.running) throw new Error("Stream is already running");
+          state.starts += 1;
+          state.running = true;
+          password = `key-${state.starts}`;
+        }),
+        getAuthKey: () => {
+          if (!password) {
+            throw new Error(
+              "Unable to retrieve stream auth key, check if requireAuth is enabled",
+            );
+          }
+          return password;
+        },
+        getUrl: () => "https://box-6080.e2b.dev/vnc.html",
+      },
+    };
+  }
+
+  function fakeSandbox(
+    stream: unknown,
+    state?: { running: boolean; starts: number },
+  ) {
+    const ran: string[] = [];
+    return {
+      ran,
+      sandbox: {
+        stream,
+        commands: {
+          run: vi.fn(async (command: string) => {
+            ran.push(command);
+            // The reset kills x11vnc, which is what `checkVNCRunning()` sees.
+            if (state && command.includes("pkill x11vnc")) {
+              state.running = false;
+            }
+            return { exitCode: 0 };
+          }),
+        },
+        files: { write: vi.fn(), makeDir: vi.fn() },
+        getHost: (port: number) => `box-${port}.e2b.dev`,
+      } as never,
+    };
+  }
+
+  it("returns the URL and the key it just minted", async () => {
+    const { stream } = fakeStream();
+    const { sandbox, ran } = fakeSandbox(stream);
+    expect(await ensureStreamOn(sandbox)).toEqual({
+      streamUrl: "https://box-6080.e2b.dev/vnc.html",
+      streamPassword: "key-1",
+    });
+    expect(ran).toEqual([]); // nothing to reset on a cold box
+  });
+
+  it("resets and restarts a stream an earlier process left running", async () => {
+    // The failure this fixes: the surviving stream's password lives in a
+    // process that is gone, so `getAuthKey()` throws and the model's
+    // `browser_navigate` fails.
+    const { stream, state } = fakeStream({ alreadyRunning: true });
+    const { sandbox, ran } = fakeSandbox(stream, state);
+    const result = await ensureStreamOn(sandbox);
+    expect(ran[0]).toContain("pkill x11vnc");
+    expect(ran[0]).toContain("novnc_proxy");
+    expect(result.streamPassword).toBe("key-1");
+    expect(state.running).toBe(true);
+  });
+
+  it("surfaces any other start failure instead of resetting the box", async () => {
+    const { stream } = fakeStream();
+    stream.start = vi.fn(async () => {
+      throw new Error("Could not start noVNC server");
+    });
+    const { sandbox, ran } = fakeSandbox(stream);
+    await expect(ensureStreamOn(sandbox)).rejects.toThrow(
+      /Could not start noVNC server/,
+    );
+    expect(ran).toEqual([]);
+  });
+
+  it("refuses a sandbox with no stream API rather than guessing", async () => {
+    const { sandbox } = fakeSandbox(undefined);
+    await expect(ensureStreamOn(sandbox)).rejects.toThrow(
+      /desktop stream API unavailable/,
+    );
   });
 });

--- a/mcpjam-inspector/server/services/browserd/live-session-deps.ts
+++ b/mcpjam-inspector/server/services/browserd/live-session-deps.ts
@@ -25,6 +25,7 @@
  */
 import { createHash } from "node:crypto";
 import type { Sandbox } from "e2b";
+import { logger } from "../../utils/logger.js";
 import {
   ensureComputerReady,
   getComputerSandboxInfo,
@@ -168,13 +169,42 @@ function streamOf(sandbox: unknown): DesktopStreamLike | null {
 }
 
 /**
+ * Reset a stream this process cannot speak for.
+ *
+ * `x11vnc` holds the password and the noVNC proxy in front of it serves the
+ * page. Both are sandbox processes that outlive whichever inspector replica
+ * started them, and `@e2b/desktop`'s own `stop()` only kills the proxy handle
+ * ITS instance owns — which a fresh `connect` does not have. So the reset is
+ * done here, by name, and covers both.
+ */
+const STREAM_RESET_COMMAND =
+  "pkill x11vnc || true; pkill -f novnc_proxy || true";
+
+/**
  * Ensure the desktop stream is up with auth required and return its URL +
  * minted password. `MCPJAM_BROWSER_STREAM_DISABLED=1` is a staging bring-up
  * hatch: it records a well-formed but deliberately unusable stream so the
  * command path can be validated before the stream seam is.
+ *
+ * THE PASSWORD IS NOT RETRIEVABLE, only mintable. `stream.start()` generates it
+ * and keeps it in memory on that `VNCServer` instance; `getAuthKey()` reads
+ * that field and nothing else. A stream left running by an earlier session —
+ * another replica, or this box's WebMCP Inspector session an hour ago — makes
+ * `start()` throw "Stream is already running", and the fresh instance then has
+ * no password to report:
+ *
+ *     Unable to retrieve stream auth key, check if requireAuth is enabled
+ *
+ * which is what reached the model as a failed `browser_navigate`. Swallowing
+ * "already running" was only ever safe for a stream THIS instance had started.
+ *
+ * So an already-running stream is reset and restarted, minting a key we hold.
+ * That rotates the password, which is what a relaunch does anyway (see the
+ * comment on the relaunch path in `browser-session.ts`) — and it is the only
+ * outcome that leaves the row's durable copy actually matching the box.
  */
-async function ensureStreamOn(
-  sandbox: unknown,
+export async function ensureStreamOn(
+  sandbox: ConnectedSandboxLike,
 ): Promise<{ streamUrl: string; streamPassword: string }> {
   if (process.env.MCPJAM_BROWSER_STREAM_DISABLED === "1") {
     return {
@@ -191,10 +221,19 @@ async function ensureStreamOn(
   try {
     await stream.start({ requireAuth: true });
   } catch (error) {
-    // An already-running stream is fine — its auth key is still readable.
-    // Anything else is a real failure the caller must surface.
     const message = error instanceof Error ? error.message : String(error);
+    // Anything but "already running" is a real failure the caller must surface.
     if (!/already/i.test(message)) throw error;
+    logger.info(
+      "[browserd] desktop stream was already running; restarting it to mint a key this process holds",
+    );
+    await sandbox.commands
+      .run(STREAM_RESET_COMMAND, { timeoutMs: 15_000 })
+      .catch(() => {
+        // Best-effort: if the reset could not run, the restart below fails
+        // with the SDK's own error, which says more than this would.
+      });
+    await stream.start({ requireAuth: true });
   }
   const streamPassword = String(await stream.getAuthKey());
   if (!streamPassword) {


### PR DESCRIPTION
## What the model saw

`browser_navigate` from the Playground, twice, on an otherwise healthy box:

```
Unable to retrieve stream auth key, check if requireAuth is enabled
```

## Why

The noVNC password is **minted, never retrievable**. `@e2b/desktop`'s `stream.start()` generates it and keeps it in memory on that `VNCServer` instance; `getAuthKey()` reads that field and nothing else. `start()` refuses to run twice — it throws `Stream is already running` when `x11vnc` is up.

So when a stream is already running from an **earlier process** — another replica, or (as here) the same computer's WebMCP Inspector session an hour before — the fresh instance gets the throw, `ensureStreamOn` swallowed it as benign, and `getAuthKey()` then had no password to report. Swallowing "already running" was only ever safe for a stream *this* instance had started.

This is the hazard the M0 spike wrote down ("the row MUST cache the stream URL+password — a fresh replica can't mint or retrieve it"). The reuse path honours it: `handleFromRecord` reads `streamUrl`/`streamPassword` off the session row. Only the **relaunch** path re-derives, and that is the one that broke.

## The fix

An already-running stream is reset and restarted, minting a key this process holds.

The reset is by process name, not the SDK's `stop()`: that only kills the noVNC handle *its own instance* owns, which a fresh `connect` does not have, and both `x11vnc` and the proxy have to go for `start()` to run again.

Rotating the password is what a relaunch does anyway — the relaunch path in `browser-session.ts` says so explicitly — and it is the only outcome that leaves the row's durable copy actually matching the box. An unrelated `start()` failure still surfaces untouched rather than triggering a reset.

## Tests

`ensureStreamOn` is exported and covered for the first time: cold start, the surviving-stream recovery (asserting both processes are killed and a fresh key is minted), an unrelated start failure surfacing instead of resetting the box, and a sandbox with no stream API. `server/services/browserd`: 39 files, 686 tests, passing. Prettier clean, no new tsc errors.

Without this, the workaround is deleting the project's computer so the next boot is a cold one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STvqEtNrAFKVFe1HEqL3KR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hosted browser relaunch/stream setup on E2B desktops; incorrect reset logic could disrupt live streams, but scope is narrow and guarded by tests.
> 
> **Overview**
> Fixes **`browser_navigate`** failures when a desktop sandbox still has **noVNC/x11vnc** running from an earlier inspector session or replica. The VNC password is only available on the **`VNCServer`** instance that called **`stream.start()`**; treating “Stream is already running” as harmless left **`getAuthKey()`** with nothing to return.
> 
> **`ensureStreamOn`** now **kills `x11vnc` and `novnc_proxy` by name** (not SDK **`stop()`**, which a fresh connect cannot use), then **restarts** the stream so this process holds a new password—aligned with relaunch behavior and keeping the session row in sync with the box. Other start errors still propagate without a reset. The helper is **exported** and covered by new unit tests (cold start, stale-stream recovery, unrelated failures, missing stream API).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 937c908641d921edad232816969c36ec379a3080. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `browser_navigate` from the Playground failing with "Unable to retrieve stream auth key" when a desktop stream was left running by an earlier process. An already-running stream is now reset by killing `x11vnc` and `novnc_proxy`, then restarted to mint a fresh key this process holds.

- The noVNC password is minted at `start()` time and held in memory; `getAuthKey()` can't retrieve one a previous instance minted.
- The reset targets processes by name because the SDK's `stop()` only kills handles its own instance owns.
- Rotating the password matches what the relaunch path already does, keeping the session row's durable copy consistent with the box.
- `ensureStreamOn` is now exported and tested for cold start, recovery, unrelated start failures, and a sandbox without a stream API.

<sup>Written for commit 937c908641d921edad232816969c36ec379a3080. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

