### PR TITLE
feat(playground): let a hosted turn use the open page's WebMCP tools

### DIFF
--- a/mcpjam-inspector/client/src/components/playground/WebmcpPageToolsSection.tsx
+++ b/mcpjam-inspector/client/src/components/playground/WebmcpPageToolsSection.tsx
@@ -17,6 +17,14 @@
  * The toggle is deliberate. A chat that silently gained tools because a browser
  * session was left open in another tab would be a surprise, and these tools run
  * code on somebody else's site.
+ *
+ * Rendered in BOTH modes. It was local-only while `/api/web/chat-v2` ignored
+ * `pageTools` — listing tools that would then be dropped mid-conversation is
+ * worse than not offering them — and the hosted route now validates, advertises
+ * and approval-classifies them exactly as the local one does. Fulfilment was
+ * never the obstacle: the client invokes through the session it already owns,
+ * and that session's transport is hosted or local without this component
+ * knowing which.
  */
 import { Globe } from "lucide-react";
 import {
@@ -27,7 +35,6 @@ import {
 } from "@/lib/app-navigation";
 import { useWebmcpInspectorStore } from "@/stores/webmcp-inspector-store";
 import { useWebmcpInspectorEnabled } from "@/hooks/useWebmcpInspectorEnabled";
-import { HOSTED_MODE } from "@/lib/config";
 
 export function WebmcpPageToolsSection() {
   const flagOn = useWebmcpInspectorEnabled();
@@ -41,16 +48,6 @@ export function WebmcpPageToolsSection() {
   const navigate = useAppNavigate();
 
   if (!flagOn) return null;
-  // HOSTED HAS NO SERVER PATH FOR PAGE TOOLS, yet. The local chat route reads
-  // `pageTools` and classifies their approvals (`routes/mcp/chat-v2.ts`); the
-  // hosted one at `/api/web/chat-v2` never looks at the field, so a turn that
-  // advertised them would silently drop every call. Rendering the section
-  // would offer a capability that does nothing — worse than not offering it,
-  // because the tools would be listed and then ignored mid-conversation.
-  //
-  // The WebMCP tab itself works hosted; this is only the Playground bridge.
-  // Threading page tools through the hosted chat path is its own change.
-  if (HOSTED_MODE) return null;
 
   const live = Boolean(session) && session?.status !== "closed";
 

--- a/mcpjam-inspector/server/__tests__/config.webmcp.test.ts
+++ b/mcpjam-inspector/server/__tests__/config.webmcp.test.ts
@@ -118,3 +118,42 @@ describe("webmcpInspectorHostedEnabled", () => {
     expect(config.webmcpInspectorHostedEnabled()).toBe(true);
   });
 });
+
+describe("webmcpInspectorReachable", () => {
+  afterEach(() => {
+    setEnv(HOSTED_ENV, originalEnv.hosted);
+    setEnv(ENABLED_ENV, originalEnv.enabled);
+    setEnv(HOSTED_GATE_ENV, originalEnv.hostedGate);
+    setEnv(BROWSER_TOOLS_ENV, originalEnv.browserTools);
+  });
+
+  // The composed question — "can a session exist here at all?" — asked by the
+  // inspector router (404 when false) AND by both chat routes, which must not
+  // advertise a page's tools to a model where nothing can fulfil the call.
+
+  it("is true on a local inspector, where the hosted gate does not apply", async () => {
+    const config = await loadConfig({});
+    expect(config.webmcpInspectorReachable()).toBe(true);
+  });
+
+  it("follows the kill switch locally", async () => {
+    const config = await loadConfig({ enabled: "false" });
+    expect(config.webmcpInspectorReachable()).toBe(false);
+  });
+
+  it("needs the hosted gate as well when hosted", async () => {
+    const dark = await loadConfig({ hosted: "true" });
+    expect(dark.webmcpInspectorReachable()).toBe(false);
+    const open = await loadConfig({ hosted: "true", hostedGate: "1" });
+    expect(open.webmcpInspectorReachable()).toBe(true);
+  });
+
+  it("still obeys the kill switch with the hosted gate on", async () => {
+    const config = await loadConfig({
+      hosted: "true",
+      hostedGate: "1",
+      enabled: "false",
+    });
+    expect(config.webmcpInspectorReachable()).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/config.ts
+++ b/mcpjam-inspector/server/config.ts
@@ -105,6 +105,26 @@ export function webmcpInspectorHostedEnabled(
 }
 
 /**
+ * Can a WebMCP Inspector SESSION exist on this deployment at all?
+ *
+ * The kill switch and the hosted-reachability switch, composed — the same
+ * question the inspector router answers with a 404, asked by anything that
+ * must not offer a capability the session behind it cannot provide. The chat
+ * routes ask it before advertising a page's tools to a model: a turn that
+ * offered them where no session can exist would strand on a call nothing can
+ * fulfil.
+ *
+ * Lives HERE rather than in the router so a caller can ask without importing
+ * a Hono app.
+ */
+export function webmcpInspectorReachable(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (!WEBMCP_INSPECTOR_ENABLED) return false;
+  return !HOSTED_MODE || webmcpInspectorHostedEnabled(env);
+}
+
+/**
  * Is the hosted browser (E2B Desktop + browserd) reachable at all?
  *
  * The dark switch the hosted runtime ships behind until the durable backend

--- a/mcpjam-inspector/server/routes/mcp/__tests__/webmcp-inspector.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/webmcp-inspector.hosted.test.ts
@@ -18,6 +18,10 @@ vi.mock("../../../config", () => ({
   },
   hostedBrowserEnabled: () => configState.hostedBrowser,
   webmcpInspectorHostedEnabled: () => configState.webmcpHosted,
+  // Composed exactly as `config.ts` composes it, for HOSTED_MODE true: BOTH
+  // the kill switch and the hosted gate have to be on.
+  webmcpInspectorReachable: () =>
+    configState.enabled && configState.webmcpHosted,
   HOSTED_MODE: true,
 }));
 

--- a/mcpjam-inspector/server/routes/mcp/__tests__/webmcp-inspector.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/webmcp-inspector.test.ts
@@ -16,6 +16,9 @@ vi.mock("../../../config", () => ({
   },
   hostedBrowserEnabled: () => configState.hostedBrowser,
   webmcpInspectorHostedEnabled: () => configState.webmcpHosted,
+  // Composed exactly as `config.ts` composes it, for HOSTED_MODE false: the
+  // hosted gate does not apply locally, so the kill switch is the whole answer.
+  webmcpInspectorReachable: () => configState.enabled,
   HOSTED_MODE: false,
 }));
 

--- a/mcpjam-inspector/server/routes/mcp/webmcp-inspector.ts
+++ b/mcpjam-inspector/server/routes/mcp/webmcp-inspector.ts
@@ -5,9 +5,9 @@ import { z } from "zod";
 import "../../types/hono";
 import {
   HOSTED_MODE,
-  WEBMCP_INSPECTOR_ENABLED,
   hostedBrowserEnabled,
   webmcpInspectorHostedEnabled,
+  webmcpInspectorReachable,
 } from "../../config";
 import {
   hostedSessionId,
@@ -364,17 +364,10 @@ function webMcpErrorResponse(c: Context, error: unknown, fallback: string) {
   );
 }
 
-/**
- * Is this router reachable at all?
- *
- * Two independent switches, both of which answer 404 rather than 403: a
- * capability that is off should not be discoverable, and a 403 tells a prober
- * that the route exists and is merely closed to them.
- */
-function webmcpInspectorReachable(): boolean {
-  if (!WEBMCP_INSPECTOR_ENABLED) return false;
-  return !HOSTED_MODE || webmcpInspectorHostedEnabled();
-}
+// Reachability — the two switches, composed — lives in `config.ts`, because the
+// chat routes ask the same question before advertising a page's tools and must
+// not import a router to do it. Off means 404, never 403: a capability that is
+// off should not be discoverable, and a 403 tells a prober the route is there.
 
 webmcpInspector.use("*", async (c, next) => {
   if (!webmcpInspectorReachable()) {

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -15,6 +15,8 @@ const {
   emitConstructorRpcLogMock,
   validateAppToolEntriesMock,
   AppToolValidationErrorMock,
+  validatePageToolEntriesMock,
+  PageToolValidationErrorMock,
   validateUiToolEntriesMock,
   UiToolValidationErrorMock,
   validateWidgetModelContextEntriesMock,
@@ -37,6 +39,13 @@ const {
     constructor(message: string) {
       super(message);
       this.name = "AppToolValidationError";
+    }
+  },
+  validatePageToolEntriesMock: vi.fn(() => []),
+  PageToolValidationErrorMock: class PageToolValidationError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "PageToolValidationError";
     }
   },
   validateUiToolEntriesMock: vi.fn(() => []),
@@ -103,6 +112,8 @@ vi.mock("../../../utils/chat-v2-orchestration.js", () => ({
   prepareChatV2: prepareChatV2Mock,
   validateAppToolEntries: validateAppToolEntriesMock,
   AppToolValidationError: AppToolValidationErrorMock,
+  validatePageToolEntries: validatePageToolEntriesMock,
+  PageToolValidationError: PageToolValidationErrorMock,
   validateUiToolEntries: validateUiToolEntriesMock,
   UiToolValidationError: UiToolValidationErrorMock,
   validateWidgetModelContextEntries: validateWidgetModelContextEntriesMock,
@@ -332,6 +343,48 @@ describe("web routes — chat-v2 hosted mode", () => {
     // missing_field, which is the desired behavior for scenario/serverShare.
     const persistArgs = persistChatSessionToConvexMock.mock.calls[0][0];
     expect(persistArgs.hostConfig).toBeUndefined();
+  });
+
+  it("validates a pageTools snapshot and forwards it, so a hosted turn can offer a page's own tools", async () => {
+    // The Playground's "Page tools" opt-in was local-only while this route
+    // ignored the field: the model would have been offered tools whose calls
+    // nothing forwarded. `uiTools` below is still ignored — that one is
+    // agent-route-only — and the two live side by side on purpose.
+    const { app, token } = createWebTestApp();
+    const pageTools = [
+      {
+        alias: "page_1a2b3c4d",
+        rawName: "bookSlot",
+        toolKey: "bookSlot",
+        origin: "https://example.test",
+        description: "Book a slot",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ];
+    validatePageToolEntriesMock.mockReturnValueOnce(pageTools as never);
+
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        projectId: "project-1",
+        selectedServerIds: ["server-1"],
+        chatSessionId: "chat-session-1",
+        messages: [{ role: "user", content: "hi" }],
+        model: {
+          id: "openai/gpt-5-mini",
+          provider: "openai",
+          name: "GPT-5 Mini",
+        },
+        pageTools,
+      },
+      token
+    );
+
+    expect(response.status).toBe(200);
+    expect(validatePageToolEntriesMock).toHaveBeenCalledWith(pageTools);
+    const prepareArgs = prepareChatV2Mock.mock.calls.at(-1)![0];
+    expect(prepareArgs.pageTools).toEqual(pageTools);
   });
 
   it("ignores a client uiTools snapshot on direct AND scenario turns (agent-route-only, never rejected)", async () => {

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -18,6 +18,7 @@ import {
   HOSTED_MODE,
   LOCAL_HARNESS_ENABLED,
   WEB_STREAM_TIMEOUT_MS,
+  webmcpInspectorReachable,
 } from "../../config.js";
 import {
   HostedElicitationBridge,
@@ -41,6 +42,9 @@ import {
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import {
   validateAppToolEntries,
+  validatePageToolEntries,
+  PageToolValidationError,
+  type PageToolEntry,
   AppToolValidationError,
   validateWidgetModelContextEntries,
   WidgetModelContextValidationError,
@@ -1295,6 +1299,24 @@ chatV2.post("/", async (c) => {
       throw error;
     }
 
+    // WebMCP page tools: same boundary treatment as the app-tool snapshot, and
+    // gated on whether a session could exist here at all. Hosted, that means
+    // the hosted-reachability switch as well as the kill switch — a turn must
+    // not advertise the tools of a page this deployment cannot drive, because
+    // the model would call one and the client would have no session to fulfil
+    // it with.
+    let validatedPageTools: PageToolEntry[];
+    try {
+      validatedPageTools = webmcpInspectorReachable()
+        ? validatePageToolEntries(body.pageTools)
+        : [];
+    } catch (error) {
+      if (error instanceof PageToolValidationError) {
+        throw new WebRouteError(400, ErrorCode.VALIDATION_ERROR, error.message);
+      }
+      throw error;
+    }
+
     // `body.uiTools` is intentionally ignored here, not rejected: MCPJam UI
     // tools are agent-route-only (server/routes/web/mcpjam-agent.ts), but
     // cached pre-cutover clients may still send the field. MCP server tools
@@ -1829,6 +1851,7 @@ chatV2.post("/", async (c) => {
               }
             : {}),
           appTools: validatedAppTools,
+          pageTools: validatedPageTools,
           widgetModelContext: validatedWidgetModelContext,
           ...(builtInTools ? { builtInTools } : {}),
           ...(browserToolApprovals ? { browserToolApprovals } : {}),

--- a/mcpjam-inspector/server/utils/__tests__/web-chat-turn-page-tools.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/web-chat-turn-page-tools.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Page tools on the HOSTED turn.
+ *
+ * `/api/web/chat-v2` used to ignore `pageTools` entirely, so the Playground's
+ * "Page tools" opt-in was local-only: a hosted turn that advertised them would
+ * have dropped every call. Two things have to be true for it to work, and both
+ * are asserted here because neither is visible from the other side —
+ *
+ *  1. the entries reach `prepareChatV2`, which is what turns them into tools
+ *     the model can see at all;
+ *  2. their aliases reach the engine's `uiToolApprovals`. The hosted engines
+ *     classify approval BY NAME and never read a tool's own `needsApproval`,
+ *     so an unclassified page alias strands the turn: the client defers the
+ *     call and waits for a pill the server never sends.
+ *
+ * Same mocked-handler shape as `web-chat-turn-dispatch.test.ts`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface HandlerOptions {
+  uiToolApprovals?: { requiredNames: Set<string>; freeNames: Set<string> };
+}
+
+const handlers = vi.hoisted(() => ({
+  mcpjamFree: vi.fn(async (_options: HandlerOptions) => new Response("mcpjam")),
+  hostedOrg: vi.fn(async (_options: HandlerOptions) => new Response("org")),
+  localOrg: vi.fn(async (_options: HandlerOptions) => new Response("local")),
+}));
+
+vi.mock("../mcpjam-stream-handler.js", () => ({
+  handleMCPJamFreeChatModel: handlers.mcpjamFree,
+  warnIfChatAbortSignalMissing: vi.fn(),
+}));
+
+vi.mock("../org-model-stream-handler.js", () => ({
+  handleHostedOrgChatModel: handlers.hostedOrg,
+  handleLocalOrgChatModel: handlers.localOrg,
+}));
+
+vi.mock("../org-model-config.js", () => ({
+  deriveOrgProviderKey: vi.fn(() => ({ ok: true, key: "openai" })),
+  isLocalRuntimeEligible: vi.fn(() => false),
+  resolveOrgProviderRuntime: vi.fn(),
+}));
+
+const prepareChatV2 = vi.hoisted(() =>
+  vi.fn(async (_args: { pageTools?: unknown }) => ({
+    allTools: {},
+    enhancedSystemPrompt: "",
+    resolvedTemperature: undefined,
+    scrubMessages: (m: unknown[]) => m,
+    progressivePlan: undefined,
+    discoveryState: undefined,
+  })),
+);
+
+vi.mock("../chat-v2-orchestration.js", () => ({
+  prepareChatV2,
+  buildWidgetModelContextSystemPrompt: vi.fn(() => ""),
+}));
+
+vi.mock("../mcp-tool-result-model-output.js", () => ({
+  convertToMcpjamModelMessages: vi.fn(async () => []),
+}));
+
+vi.mock("../harness/harness-proxy-strategy.js", () => ({
+  resolveWebAuthorizedHarnessStrategy: vi.fn(() => ({
+    plane: "web-authorized",
+    mode: "direct",
+    publicBaseUrl: "https://inspector.example.com",
+  })),
+}));
+
+import { streamWebChatTurn } from "../web-chat-turn";
+
+const PAGE_TOOL = {
+  alias: "page_1a2b3c4d",
+  rawName: "bookSlot",
+  toolKey: "bookSlot",
+  origin: "https://example.test",
+  description: "Book a slot",
+  inputSchema: { type: "object" as const, properties: {} },
+};
+
+function args(pageTools?: unknown[]) {
+  const c = {
+    req: {
+      raw: { headers: new Headers(), signal: undefined },
+      header: () => undefined,
+    },
+  } as never;
+  return {
+    manager: {
+      disconnectAllServers: vi.fn(async () => {}),
+      hasServer: () => false,
+    } as never,
+    prepare: {
+      selectedServerIds: [],
+      modelDefinition: {
+        name: "m",
+        id: "gpt-5-nano",
+        provider: "openai",
+      } as never,
+      uiMessages: [],
+      ...(pageTools ? { pageTools } : {}),
+    },
+    persist: {
+      chatSessionId: undefined,
+      projectId: "p1",
+      sourceType: "direct" as const,
+      origin: "playground" as const,
+      originalMessages: [],
+      selectedServerIds: [],
+    },
+    runtime: {
+      authHeader: "Bearer t",
+      clientIp: null,
+      abortSignal: undefined,
+      c,
+    },
+  };
+}
+
+describe("streamWebChatTurn — WebMCP page tools", () => {
+  beforeEach(() => {
+    handlers.mcpjamFree.mockClear();
+    prepareChatV2.mockClear();
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example.com");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("hands the page tools to prepareChatV2", async () => {
+    await streamWebChatTurn(args([PAGE_TOOL]) as never);
+    expect(prepareChatV2.mock.calls[0]?.[0]?.pageTools).toEqual([PAGE_TOOL]);
+  });
+
+  it("gates every page alias, so the turn cannot strand on a missing pill", async () => {
+    await streamWebChatTurn(args([PAGE_TOOL]) as never);
+    const approvals = handlers.mcpjamFree.mock.calls[0]?.[0]?.uiToolApprovals;
+    expect(approvals?.requiredNames.has("page_1a2b3c4d")).toBe(true);
+    expect(approvals?.freeNames.has("page_1a2b3c4d")).toBe(false);
+  });
+
+  it("leaves a turn with no page tools exactly as it was", async () => {
+    await streamWebChatTurn(args() as never);
+    expect(prepareChatV2.mock.calls[0]?.[0]?.pageTools).toBeUndefined();
+    const approvals = handlers.mcpjamFree.mock.calls[0]?.[0]?.uiToolApprovals;
+    expect(approvals?.requiredNames.size ?? 0).toBe(0);
+  });
+});

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -63,6 +63,7 @@ import {
   buildWidgetModelContextSystemPrompt,
   prepareChatV2,
   type AppToolEntry,
+  type PageToolEntry,
   type UiToolEntry,
   type WidgetModelContextEntry,
 } from "./chat-v2-orchestration.js";
@@ -89,6 +90,7 @@ import { ErrorCode, WebRouteError } from "./../routes/web/errors.js";
 import { readUrlElicitations } from "@/shared/http-tool-calls";
 import { wrapToolsWithScopeStepUp } from "./insufficient-scope-step-up.js";
 import {
+  classifyPageToolApprovals,
   classifyUiToolApprovals,
   mergeUiToolApprovalClassifications,
   type UiToolApprovalClassification,
@@ -361,6 +363,16 @@ export interface WebChatTurnPrepareInputs {
   appTools?: AppToolEntry[];
   /** WebMCP-shaped MCPJam UI tools (client-fulfilled, like `appTools`). */
   uiTools?: UiToolEntry[];
+  /**
+   * The tools of the web page an open WebMCP Inspector session is driving,
+   * client-fulfilled like `appTools` — the client invokes them through the
+   * session it already owns, hosted or local, and posts the result back.
+   *
+   * The CALLER validates and gates them (`webmcpInspectorReachable`), because
+   * a turn must never advertise a page tool on a deployment where no session
+   * can exist: the model would call it and the turn would strand.
+   */
+  pageTools?: PageToolEntry[];
   /** Server-side built-in tools (e.g. web_search) to merge into the tool set. */
   builtInTools?: ToolSet;
   /**
@@ -605,10 +617,19 @@ function uiToolApprovalsFrom(
   uiTools: UiToolEntry[] | undefined,
   requireToolApproval: boolean | undefined,
   browserToolApprovals?: UiToolApprovalClassification,
+  pageTools?: PageToolEntry[],
 ): UiToolApprovalClassification {
+  // Page tools ALWAYS gate, and the hosted engines classify approval by NAME
+  // rather than reading a tool's own `needsApproval` — so a page tool that is
+  // not named here reaches them approval-less, the client defers the call, and
+  // the turn waits forever on a pill the server never sends. Same reasoning,
+  // and the same single `uiToolApprovals` slot, as `browserToolApprovals`.
   return mergeUiToolApprovalClassifications(
-    classifyUiToolApprovals(uiTools, requireToolApproval === true),
-    browserToolApprovals,
+    mergeUiToolApprovalClassifications(
+      classifyUiToolApprovals(uiTools, requireToolApproval === true),
+      browserToolApprovals,
+    ),
+    classifyPageToolApprovals((pageTools ?? []).map((entry) => entry.alias)),
   );
 }
 
@@ -679,6 +700,7 @@ export async function streamWebChatTurn(
         : {}),
       appTools: prepare.appTools,
       uiTools: prepare.uiTools,
+      pageTools: prepare.pageTools,
       builtInTools: prepare.builtInTools,
 
       // Environment-resolved skills outrank the cloud/HOSTED/local chain for the
@@ -1232,6 +1254,7 @@ export async function streamWebChatTurn(
         effectiveUiTools,
         persist.requireToolApproval,
         prepare.browserToolApprovals,
+        prepare.pageTools,
       ),
       modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
       onConversationComplete,
@@ -1321,6 +1344,7 @@ export async function streamWebChatTurn(
       effectiveUiTools,
       persist.requireToolApproval,
       prepare.browserToolApprovals,
+      prepare.pageTools,
     ),
     modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
     // Harness engine only: it builds its own MCP tool set (host-executed


### PR DESCRIPTION
## What this unlocks

The Playground's **"Page tools"** opt-in — offering the model the tools of whatever page the WebMCP Inspector has open — now works on a hosted deployment. Before this, `WebmcpPageToolsSection` returned `null` under `HOSTED_MODE`, and the comment there said exactly why:

> HOSTED HAS NO SERVER PATH FOR PAGE TOOLS, yet. […] a turn that advertised them would silently drop every call.

## Why it was only ever a server gap

Page tools are **client-fulfilled**: the client invokes them through the WebMCP session it already owns, and that session's transport is hosted or local without the chat path knowing which. So fulfilment already worked. What was missing was the two halves `routes/mcp/chat-v2.ts` has and `routes/web/chat-v2.ts` did not:

1. **Validate and forward.** `pageTools` now gets the same boundary treatment as the app-tool snapshot — a malformed entry 400s before `prepareChatV2` sees it — and the validated set reaches the turn.
2. **Classify approval.** The hosted engines classify approval **by name** and never read a tool's own `needsApproval`. An unclassified page alias therefore *strands the turn*: the client defers the call and waits for an approval pill the server never sends. The aliases now join `browserToolApprovals` inside the single `uiToolApprovals` slot, rather than one namespace overwriting the other — the same merge, and the same reason, as the browser tools.

## One predicate, not two copies

`webmcpInspectorReachable()` moves from the inspector router into `config.ts`, so a caller can ask *"can a session exist on this deployment at all?"* without importing a Hono app. Hosted, that is the kill switch **and** the hosted gate. The router's 404 and the chat routes' refusal to advertise now come from one predicate instead of two copies that could drift apart — and the gate matters here: a turn must never offer the tools of a page this deployment cannot drive.

## Tests

- `web-chat-turn-page-tools.test.ts` (new): entries reach `prepareChatV2`; every alias lands in `requiredNames` (never `freeNames`); a turn with no page tools is byte-for-byte unchanged.
- `chat-v2.hosted.test.ts`: the route validates the snapshot and forwards it — sitting deliberately beside the existing "uiTools are ignored here" case, since the two fields now diverge.
- `config.webmcp.test.ts`: the composed predicate — local ignores the hosted gate, hosted needs both, the kill switch still wins.

`server/routes/web`, `server/routes/mcp`, `server/utils`, `server/__tests__`, `client/src/components/playground`: 649 files, 10,876 tests passing (2 failures are stale generated-bundle artifacts of my worktree, not this change). Prettier clean, no new tsc errors.

## Trying it

Open a page in the WebMCP tab, tick **Page tools** in the Playground Tools panel, and ask the model to call one. Every call still gates on approval, unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STvqEtNrAFKVFe1HEqL3KR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hosted chat tool advertisement and approval wiring; page tools still execute user-approved code on third-party pages, now with a single reachability gate that must stay aligned across routes.
> 
> **Overview**
> **Playground "Page tools"** now works on hosted deployments: the UI no longer hides the toggle under `HOSTED_MODE`, because hosted `/api/web/chat-v2` finally treats `pageTools` like the local MCP chat route.
> 
> The hosted route **validates** the client snapshot (bad entries → 400), **forwards** validated tools into `prepareChatV2`, and **strips** them when `webmcpInspectorReachable()` is false so the model is not offered tools no session can fulfil. **`streamWebChatTurn`** passes `pageTools` through and merges **`classifyPageToolApprovals`** into the shared `uiToolApprovals` slot so hosted engines always send approval pills for page aliases (avoiding stuck turns).
> 
> **`webmcpInspectorReachable()`** is centralized in `config.ts` (kill switch + hosted gate) and shared by the WebMCP inspector router and chat routes instead of a duplicated router-local check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b1a04b6c707b875e54b18d19859276e89a33b58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the Playground's "Page tools" opt-in in hosted deployments: hosted turns now validate and forward the open page's WebMCP tools, and page tool aliases are always gated by approval so a turn never waits on an unfulfilled call.

**New Features**
- Hosted chat turns now accept `pageTools`, which were previously ignored.
- Page tool aliases are merged into `uiToolApprovals` to trigger the same approval flow as browser tools.
- The inspector reachability predicate moves to `config.ts`, unifying the router's 404 and chat route gating.

<sup>Written for commit 6b1a04b6c707b875e54b18d19859276e89a33b58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

