### PR TITLE
fix(evals): skip Convex queries for a direct guest instead of throwing

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-queries.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-queries.test.ts
@@ -162,7 +162,12 @@ describe("useEvalQueries", () => {
     );
   });
 
-  it("preserves direct-guest overview access while the user row is not ready", () => {
+  // Replaces "preserves direct-guest overview access while the user row is not
+  // ready", which asserted the opposite. That test passed a projectId, but
+  // `useIsDirectGuest` returns false as soon as one exists — so the case it
+  // locked in was unreachable. The reachable shape is a guest with no project
+  // and no Convex identity, and there the overview query can only throw.
+  it("skips the overview query for a direct guest", () => {
     mocks.isUserReady = false;
 
     const { result } = renderHook(() =>
@@ -170,16 +175,16 @@ describe("useEvalQueries", () => {
         isAuthenticated: false,
         selectedSuiteId: null,
         deletingSuiteId: null,
-        projectId: "guest-project",
+        projectId: null,
         organizationId: null,
         isDirectGuest: true,
       }),
     );
 
-    expect(result.current.enableOverviewQuery).toBe(true);
+    expect(result.current.enableOverviewQuery).toBe(false);
     expect(mocks.useQuery).toHaveBeenCalledWith(
       "testSuites:getTestSuitesOverview",
-      { projectId: "guest-project" }
+      "skip"
     );
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/use-eval-queries.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-queries.ts
@@ -58,7 +58,17 @@ export function useEvalQueries({
   // Convex's `isAuthenticated` already covers hosted guests — they hold a
   // guest token via the unified auth provider — so a separate WorkOS `user`
   // check would wrongly skip queries for guests with a project.
-  const hasActorAccess = isDirectGuest || (isAuthenticated && isUserReady);
+  //
+  // `isDirectGuest` is deliberately NOT an escape hatch here. It is only true
+  // when the guest token mint has failed every retry (`unified-convex-auth`
+  // sets the token to null and clears loading), which means the session holds
+  // no Convex identity at all. Every one of these queries is a `userQuery`, so
+  // letting them through cannot produce data — it produces a thrown
+  // "Authentication required" from `requireIdentity`, which surfaces as the
+  // "Could not load Testing" fallback and a Sentry event (CONVEX-CQ). Every
+  // other Convex-backed surface skips in this state and renders its
+  // signed-out/empty view; Evals now matches them.
+  const hasActorAccess = isAuthenticated && isUserReady;
   // Authenticated, but the `users` row is still bootstrapping: the queries are
   // skipped and an answer IS coming, so this window must report as loading.
   // Reporting it as settled-and-empty makes `EvalsTab`'s redirect read a


### PR DESCRIPTION
`isDirectGuest` is only true when the guest-token mint has failed every retry — `unified-convex-auth`'s bootstrap loop sets the token to null and clears loading, leaving the session with no Convex identity at all. Using it as an escape hatch in `useEvalQueries` let `getTestSuitesOverview` (a `userQuery`) fire with `{}` and no auth, so `requireIdentity` threw "Authentication required". The user got the "Could not load Testing" fallback and the throw landed in Sentry as CONVEX-CQ, currently 16 of the last 92 events on that issue.

Every other Convex-backed surface already gates on `isAuthenticated && isUserReady` and skips in this state, rendering its signed-out/empty view. Evals now matches them. Nothing is lost: the query cannot succeed without an identity, so skipping only replaces a guaranteed throw with an empty state.

The test this replaces asserted the opposite, but passed a `projectId` — and `useIsDirectGuest` returns false as soon as one exists, so the case it locked in was unreachable. The reachable shape is a guest with no project.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Evals so direct guests (no project, failed guest-token mint) skip Convex queries instead of firing them without an identity, which always threw "Authentication required", showed the "Could not load Testing" fallback, and produced Sentry events (CONVEX-CQ). Evals now matches every other Convex-backed surface, which gates on `isAuthenticated && isUserReady` and renders the signed-out/empty view in this state.

**Bug Fixes**
- Removed `isDirectGuest` as an escape hatch in `useEvalQueries`; all gated queries now require an identity.
- Replaced the test that asserted the opposite, which was unreachable because `useIsDirectGuest` is false when a `projectId` exists.

<sup>Written for commit d47db707b8e64447ddb4c4e888f470ddde494334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

