### PR TITLE
Collapse the sidebar on the wide working surfaces

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -88,6 +88,7 @@ import {
   SidebarProvider,
   useSidebar,
 } from "./components/ui/sidebar";
+import { SidebarAutoCollapse } from "./components/sidebar/sidebar-auto-collapse";
 import { AgentSidePanelMount } from "./components/mcpjam-agent/AgentSidePanelMount";
 import { AppChromePanel } from "@/components/app-chrome-panel";
 import {
@@ -5080,6 +5081,10 @@ export default function App() {
 
   const appContent = (
     <SidebarProvider defaultOpen={true}>
+      {/* Wide working surfaces (Playground, Evaluate, OAuth Debugger, Swarms)
+          collapse the sidebar to its icon rail; navigating back out of them
+          expands it again. */}
+      <SidebarAutoCollapse activeTab={activeTab} />
       <AppChromeSidebar
         hidden={playgroundOnboarding}
         onNavigate={handleNavigate}

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -435,7 +435,8 @@ vi.mock("../components/ui/sidebar", () => ({
   SidebarProvider: ({ children }: { children?: ReactNode }) => (
     <div>{children}</div>
   ),
-  useSidebar: () => ({ isMobile: false }),
+  // `setOpen` is what `SidebarAutoCollapse` drives the open state through.
+  useSidebar: () => ({ isMobile: false, setOpen: () => {} }),
 }));
 vi.mock("../stores/preferences/preferences-provider", () => ({
   PreferencesStoreProvider: ({ children }: { children?: ReactNode }) => (

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-auto-collapse.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-auto-collapse.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import {
+  SidebarProvider,
+  SidebarTrigger,
+  useSidebar,
+} from "@/components/ui/sidebar";
+import { SidebarAutoCollapse } from "@/components/sidebar/sidebar-auto-collapse";
+
+function OpenProbe() {
+  const { open } = useSidebar();
+  return <span data-testid="open">{open ? "open" : "closed"}</span>;
+}
+
+function renderAt(activeTab: string | undefined) {
+  const view = render(
+    <SidebarProvider defaultOpen={true}>
+      <SidebarAutoCollapse activeTab={activeTab} />
+      <OpenProbe />
+      <SidebarTrigger />
+    </SidebarProvider>,
+  );
+
+  return {
+    ...view,
+    navigate(next: string | undefined) {
+      view.rerender(
+        <SidebarProvider defaultOpen={true}>
+          <SidebarAutoCollapse activeTab={next} />
+          <OpenProbe />
+          <SidebarTrigger />
+        </SidebarProvider>,
+      );
+    },
+  };
+}
+
+const state = () => screen.getByTestId("open").textContent;
+
+describe("SidebarAutoCollapse", () => {
+  it.each([
+    "playground",
+    "evals",
+    "evaluate",
+    "oauth-flow",
+    "xaa-flow",
+    "swarms",
+  ])("collapses the sidebar when navigating to %s", (tab) => {
+    const { navigate } = renderAt("home");
+    expect(state()).toBe("open");
+
+    navigate(tab);
+
+    expect(state()).toBe("closed");
+  });
+
+  it("collapses on a wide surface the app deep-links straight into", () => {
+    renderAt("playground");
+
+    expect(state()).toBe("closed");
+  });
+
+  it("expands again when navigating back to a normal tab", () => {
+    const { navigate } = renderAt("playground");
+    expect(state()).toBe("closed");
+
+    navigate("tools");
+
+    expect(state()).toBe("open");
+  });
+
+  it("keeps a manual expand while moving between wide surfaces", () => {
+    const { navigate } = renderAt("playground");
+    expect(state()).toBe("closed");
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle sidebar/i }));
+    expect(state()).toBe("open");
+
+    navigate("evals");
+
+    expect(state()).toBe("open");
+  });
+
+  it("keeps a manual collapse while moving between normal tabs", () => {
+    const { navigate } = renderAt("home");
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle sidebar/i }));
+    expect(state()).toBe("closed");
+
+    navigate("tools");
+
+    expect(state()).toBe("closed");
+  });
+});

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-auto-collapse.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-auto-collapse.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+
+import { useSidebar } from "@/components/ui/sidebar";
+
+/**
+ * Tabs whose working surface is wide enough that the 16rem sidebar costs more
+ * than it gives: transcript + inspector panes (Playground), run tables
+ * (Evaluate), the request/response timeline (OAuth and XAA Debugger), and the
+ * swarm grid. Entering one of these collapses the sidebar to its icon rail;
+ * leaving for any other tab expands it again.
+ *
+ * The two debuggers are listed together deliberately: they render the same
+ * timeline, so splitting them would collapse the rail on one and not the other
+ * for no reason a user could see.
+ */
+const WIDE_SURFACE_TABS = new Set([
+  "playground",
+  "evals",
+  "evaluate",
+  "oauth-flow",
+  "xaa-flow",
+  "swarms",
+]);
+
+export function isWideSurfaceTab(activeTab: string | undefined): boolean {
+  return activeTab !== undefined && WIDE_SURFACE_TABS.has(activeTab);
+}
+
+/**
+ * Drives the sidebar's open state from the active tab.
+ *
+ * Only the *crossing* between a wide-surface tab and a normal one applies a
+ * state, so a manual toggle sticks: collapse the sidebar on Home and it stays
+ * collapsed across every other normal tab; expand it on Playground and it stays
+ * expanded while you move between Playground, Evaluate and Swarms. Navigating
+ * back out of the wide surfaces — including via the icon rail, which stays
+ * clickable while collapsed — restores it.
+ *
+ * Renders nothing; it exists to hold the effect at the SidebarProvider scope.
+ */
+export function SidebarAutoCollapse({
+  activeTab,
+}: {
+  activeTab: string | undefined;
+}) {
+  const { setOpen, isMobile } = useSidebar();
+  const isWide = isWideSurfaceTab(activeTab);
+  // null until the first desktop pass, so the initial tab gets its state
+  // applied even when the app deep-links straight into a wide surface.
+  const lastAppliedWideRef = React.useRef<boolean | null>(null);
+
+  React.useEffect(() => {
+    // Mobile has no inline sidebar to reclaim width from — it is a sheet that
+    // is already closed by default.
+    if (isMobile) {
+      return;
+    }
+    if (lastAppliedWideRef.current === isWide) {
+      return;
+    }
+    lastAppliedWideRef.current = isWide;
+    setOpen(!isWide);
+  }, [isWide, isMobile, setOpen]);
+
+  return null;
+}

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-auto-collapse.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-auto-collapse.tsx
@@ -49,7 +49,11 @@ export function SidebarAutoCollapse({
   // applied even when the app deep-links straight into a wide surface.
   const lastAppliedWideRef = React.useRef<boolean | null>(null);
 
-  React.useEffect(() => {
+  // Layout, not passive: a passive effect runs after paint, so deep-linking
+  // into a wide surface painted the rail at its full 16rem and then animated
+  // it shut through the primitive's 200ms width transition. Running before
+  // paint means the first frame is already collapsed.
+  React.useLayoutEffect(() => {
     // Mobile has no inline sidebar to reclaim width from — it is a sheet that
     // is already closed by default.
     if (isMobile) {

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/__tests__/use-playground-state.app-sidebar.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/__tests__/use-playground-state.app-sidebar.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SidebarProvider, useSidebar } from "@/components/ui/sidebar";
+import { PreferencesStoreProvider } from "@/stores/preferences/preferences-provider";
+
+/**
+ * The Playground must not force the APP sidebar open.
+ *
+ * It used to, on mount and on unmount, as part of restoring chrome after
+ * first-run onboarding. That silently defeated `SidebarAutoCollapse`: the
+ * Playground route mounts a commit later than the policy's effect, so its
+ * layout effect re-expanded the rail the policy had just collapsed — Evaluate
+ * collapsed and Playground did not. Onboarding hides the sidebar via the
+ * `hidden` prop, never by closing it, so nothing here needs to reopen it.
+ */
+
+vi.mock("convex/react", () => ({
+  useMutation: () => vi.fn(),
+  useQuery: () => undefined,
+  useAction: () => vi.fn(),
+  useConvex: () => ({}),
+  useConvexAuth: () => ({ isLoading: false, isAuthenticated: false }),
+}));
+
+import { usePlaygroundState } from "../use-playground-state";
+
+function PlaygroundHost() {
+  usePlaygroundState({});
+  return null;
+}
+
+function OpenProbe() {
+  const { open } = useSidebar();
+  return <span data-testid="open">{open ? "open" : "closed"}</span>;
+}
+
+/**
+ * The provider outlives the route in the real tree, so it stays mounted here
+ * while the Playground consumer comes and goes.
+ */
+function Shell({ playgroundMounted }: { playgroundMounted: boolean }) {
+  return (
+    <PreferencesStoreProvider themeMode="light" themePreset="default">
+      <SidebarProvider defaultOpen={false}>
+        <OpenProbe />
+        {playgroundMounted ? <PlaygroundHost /> : null}
+      </SidebarProvider>
+    </PreferencesStoreProvider>
+  );
+}
+
+const state = () => screen.getByTestId("open").textContent;
+
+describe("usePlaygroundState — app sidebar", () => {
+  it("leaves a collapsed app sidebar collapsed on mount", () => {
+    render(<Shell playgroundMounted={true} />);
+
+    expect(state()).toBe("closed");
+  });
+
+  it("does not reopen the app sidebar when the Playground unmounts", () => {
+    const view = render(<Shell playgroundMounted={true} />);
+    expect(state()).toBe("closed");
+
+    view.rerender(<Shell playgroundMounted={false} />);
+
+    expect(state()).toBe("closed");
+  });
+});

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/use-playground-state.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/use-playground-state.ts
@@ -49,7 +49,6 @@ import type {
   EnsureServersReadyResult,
   ServerWithName,
 } from "@/hooks/use-app-state";
-import { useSidebar } from "@/components/ui/sidebar";
 import {
   createInspectorCommandClientError,
   registerInspectorCommandHandler,
@@ -245,12 +244,9 @@ export function usePlaygroundState(options: UsePlaygroundStateOptions) {
   } = useUIPlaygroundStore();
   const hostStyle = usePreferencesStore((s) => s.hostStyle);
 
-  const { setOpen: setMcpSidebarOpen } = useSidebar();
-
   useLayoutEffect(() => {
     onOnboardingChange?.(false);
-    setMcpSidebarOpen(true);
-  }, [onOnboardingChange, setMcpSidebarOpen]);
+  }, [onOnboardingChange]);
 
   useLayoutEffect(() => {
     // NUX: collapse the tools sidebar for the whole first-run connect + guided
@@ -267,13 +263,17 @@ export function usePlaygroundState(options: UsePlaygroundStateOptions) {
     }
   }, [onboarding.phase, onboarding.isGuidedPostConnect, setSidebarVisible]);
 
+  // Whether the APP sidebar is open is not this surface's call: entering and
+  // leaving Playground is one of the transitions `SidebarAutoCollapse` owns,
+  // and forcing it open here re-expanded the rail a commit after the policy
+  // had collapsed it (this route mounts lazily, after the policy's effect).
+  // Only the playground-local tools sidebar is restored.
   useLayoutEffect(() => {
     return () => {
       onOnboardingChange?.(false);
       setSidebarVisible(true);
-      setMcpSidebarOpen(true);
     };
-  }, [onOnboardingChange, setMcpSidebarOpen, setSidebarVisible]);
+  }, [onOnboardingChange, setSidebarVisible]);
 
   // Event name `app_builder_tab_viewed` is kept for analytics continuity
   // (the only surface that still mounts this hook is the Playground tab).


### PR DESCRIPTION
Playground, Evaluate, the OAuth and XAA Debuggers, and Swarms all want the horizontal room the 16rem sidebar takes.

`SidebarAutoCollapse` drives the sidebar's open state from the active tab: entering one of those collapses it to the icon rail, leaving for any other tab expands it again. No new control — the rail keeps every nav row as a tooltipped icon button, so clicking back out is what expands it, in the primitive's existing 200ms transition.

Only the *crossing* between a wide surface and a normal tab applies a state, so a manual toggle sticks. Expand it on Playground and it stays expanded across Evaluate and Swarms; collapse it on Home and it stays collapsed across the other normal tabs.

## The Playground bug this surfaced

Playground had been forcing the app sidebar open itself, on mount and in its unmount cleanup, as part of restoring chrome after first-run onboarding.

That defeated the policy. The route mounts lazily, a commit after the policy's effect, so its layout effect re-expanded the rail that had just been collapsed — Evaluate collapsed and Playground did not. Going Playground → Evaluate reopened it too, and since both are wide the policy saw no crossing to re-collapse.

Onboarding hides the sidebar via the `hidden` prop rather than closing it, so nothing there needs reopening. The playground-local *tools* sidebar is untouched. This was the only caller of the app sidebar's `setOpen` outside the primitive, which leaves the policy its single owner.

## Testing

- 10 cases on the policy: each wide tab, deep-link into one, return to a normal tab, and both manual-override directions.
- 2 regression cases on the Playground hook, verified to fail against the old code.
- 432 tests across the affected suites pass. Diffed a full client-suite run against a stashed baseline: no new failures.
- `App.hosted-oauth`'s `useSidebar` double returned only `isMobile`, so it threw once something called `setOpen` — fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFEUCevGwWS2QV7C7q7KXE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses the app sidebar to its icon rail when entering Playground, Evaluate, the OAuth/XAA Debuggers, or Swarms, and expands it again when leaving any of those tabs. Manual toggles stick: only the crossing between a wide surface and a normal tab changes the state.

- Applies the collapse before paint, so deep-linking into a wide surface renders the first frame already collapsed instead of animating the rail shut.
- Removes Playground's forced sidebar reopening that previously defeated the collapse policy on lazy-mounted routes.
- Updates the hosted OAuth test mock to provide `setOpen`, which `SidebarAutoCollapse` relies on.

<sup>Written for commit d471c23d09233cac3874ca47a377fcdb4682f0f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

