### PR TITLE
Pin the synthetic-monitor payload to the shape the backend accepts

### DIFF
--- a/.changeset/production-checks-advisory-wire.md
+++ b/.changeset/production-checks-advisory-wire.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Pin the synthetic-monitor completion payload to the shape the backend accepts. The advisory-failure test asserted a `role` field that `criterionResultValidator` — a closed Convex object — refuses, so a rubric carrying a Warn criterion would have 500'd on every completion and re-entered the lease/retry loop. The test now proves the wire contract instead of a field that could never travel.

--- a/mcpjam-inspector/server/services/__tests__/production-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/production-checks-worker.test.ts
@@ -124,11 +124,21 @@ describe("executeClaimedCheck", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].path).toBe("/internal/v1/production-checks/complete");
     expect(calls[0].body.passed).toBe(true);
+    // The advisory row still travels, and still says it did not pass — what
+    // it must NOT carry is the check policy. `criterionResultValidator` on the
+    // backend is a closed `v.object`, so an extra key fails argument
+    // validation, the completion 500s, the row stays `running`, and recovery
+    // re-claims it into the same 500 forever. The advisory reduction is
+    // carried by `passed` above, which is the field the verdict reads.
     expect(calls[0].body.criterionResults[0]).toMatchObject({
       criterionId: "crit-advisory",
       passed: false,
-      role: "advisory",
     });
+    expect(Object.keys(calls[0].body.criterionResults[0]).sort()).toEqual([
+      "criterionId",
+      "passed",
+      "reason",
+    ]);
   });
 
   it("grades an EMPTY transcript rather than skipping it", async () => {


### PR DESCRIPTION
## Summary

`Inspector Tests 3/6` is red on `main`. The advisory-failure test in `production-checks-worker.test.ts` asserts a `role` field on the posted criterion result, and the enterprise-grading review removed that field on purpose.

**The removal was right.** `criterionResultValidator` (`convex/lib/gradingConfig.ts` in the backend) is a closed `v.object` of `{criterionId, passed, reason, scope?}`, and Convex rejects an unknown key before the handler runs. Posting `role` would have failed argument validation on `/internal/v1/production-checks/complete`, so the check row stays `running`, the lease expires, and recovery re-claims it into the same 500 — for every rubric carrying a Warn criterion. Nothing rendered the field either, because nothing could store it.

So the test is what was wrong. Deleting the one assertion would make it pass while saying nothing about why the key is absent, so it now pins the **whole key set** against the validator's — the property that actually has to hold — and says in a comment what breaks when it does not.

The behaviour the test was written to protect is untouched: the advisory row still travels, still reports `passed: false`, and the check still completes green.

## Verification

`npx vitest run server/services/__tests__` — 710 passed, 47 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and changelog only; no runtime behavior changes to the production-checks worker or completion API.
> 
> **Overview**
> Fixes a failing **Inspector** test by aligning assertions with the `/internal/v1/production-checks/complete` wire contract instead of expecting a `role` field on each criterion result.
> 
> The advisory-failure case still expects a green check (`passed: true`) while the advisory row reports `passed: false`, and now **locks the criterion result to exactly** `criterionId`, `passed`, and `reason`—matching the backend’s closed `criterionResultValidator`. Inline comments document why extra keys would 500 completions and trap checks in the lease/retry loop. A patch **changeset** records the fix for `@mcpjam/inspector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f114a17605015eb00479ceadce0233f91a602a2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing advisory-failure test by pinning the synthetic-monitor completion payload to the exact shape the backend accepts.

- The test asserted a `role` field that `criterionResultValidator` rejects, which would 500 every completion for a rubric with a Warn criterion and re-enter the lease/retry loop.
- It now asserts the full key set against the validator's contract, so the wire shape is what's protected.
- Advisory rows still travel with `passed: false`, and the check still completes green.

<sup>Written for commit f114a17605015eb00479ceadce0233f91a602a2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

