### PR TITLE
fix(elicitation): make dismissing the elicitation dialog cancel it

### DIFF
--- a/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
+++ b/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
@@ -281,7 +281,21 @@ export function ElicitationDialog({
   };
 
   return (
-    <Dialog open={!!elicitationRequest} onOpenChange={() => {}}>
+    <Dialog
+      open={!!elicitationRequest}
+      onOpenChange={(next) => {
+        // The X, Escape and a click outside all arrive here, and an empty
+        // handler made all three inert: the only way out was a footer button,
+        // so any failure that left the request unanswered stranded the dialog
+        // open. Dismissing without choosing is `cancel`, not `decline`, the
+        // same distinction UrlElicitationConsent draws. Ignored while a
+        // response is in flight, which is what `disabled={loading}` already
+        // does for the footer buttons, so a dismissal cannot race a second
+        // response onto the same request.
+        if (next || loading) return;
+        void handleResponse("cancel");
+      }}
+    >
       <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-sm font-medium">

--- a/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
+++ b/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
@@ -288,11 +288,15 @@ export function ElicitationDialog({
         // handler made all three inert: the only way out was a footer button,
         // so any failure that left the request unanswered stranded the dialog
         // open. Dismissing without choosing is `cancel`, not `decline`, the
-        // same distinction UrlElicitationConsent draws. Ignored while a
-        // response is in flight, which is what `disabled={loading}` already
-        // does for the footer buttons, so a dismissal cannot race a second
-        // response onto the same request.
-        if (next || loading) return;
+        // same distinction UrlElicitationConsent draws.
+        //
+        // Deliberately NOT gated on `loading`. The footer buttons are disabled
+        // while a response is in flight, but `authFetch` sends no abort signal
+        // and no timeout, so a respond call that hangs leaves `loading` true
+        // for good. Gating dismissal on it would lock the dialog shut in
+        // precisely the case this is meant to fix. A duplicate `cancel` for a
+        // request already being answered is the cheaper of the two failures.
+        if (next) return;
         void handleResponse("cancel");
       }}
     >

--- a/mcpjam-inspector/client/src/components/__tests__/ElicitationDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ElicitationDialog.test.tsx
@@ -362,6 +362,74 @@ describe("ElicitationDialog", () => {
     });
   });
 
+  describe("dismissal", () => {
+    // Every one of these routes through `onOpenChange`, which used to be an
+    // empty handler: the dialog could only be left through a footer button, so
+    // an elicitation that stopped being answerable stranded it open.
+    it("cancels when the close button is used", async () => {
+      render(
+        <ElicitationDialog
+          elicitationRequest={request()}
+          onResponse={onResponse}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /close/i }));
+
+      await waitFor(() => expect(onResponse).toHaveBeenCalledWith("cancel"));
+    });
+
+    it("cancels on Escape", async () => {
+      render(
+        <ElicitationDialog
+          elicitationRequest={request()}
+          onResponse={onResponse}
+        />
+      );
+
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      await waitFor(() => expect(onResponse).toHaveBeenCalledWith("cancel"));
+    });
+
+    it("sends cancel without parameters even when a required field is empty", async () => {
+      render(
+        <ElicitationDialog
+          elicitationRequest={request({
+            schema: {
+              required: ["name"],
+              properties: { name: { type: "string" } },
+            },
+          })}
+          onResponse={onResponse}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /close/i }));
+
+      await waitFor(() => expect(onResponse).toHaveBeenCalledWith("cancel"));
+      expect(screen.queryByText("name is required")).toBeNull();
+    });
+
+    it("ignores a dismissal while a response is in flight", async () => {
+      // The footer buttons are already disabled by `loading`. A dismissal that
+      // still fired would put a second response on the same request.
+      render(
+        <ElicitationDialog
+          elicitationRequest={request()}
+          onResponse={onResponse}
+          loading
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /close/i }));
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      await Promise.resolve();
+      expect(onResponse).not.toHaveBeenCalled();
+    });
+  });
+
   describe("requesting-server identity (spec MUST)", () => {
     it("shows the server name with the immutable serverId alongside it", () => {
       // NOTE: the dialog content is portalled, so it lives on `baseElement`,

--- a/mcpjam-inspector/client/src/components/__tests__/ElicitationDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ElicitationDialog.test.tsx
@@ -411,9 +411,12 @@ describe("ElicitationDialog", () => {
       expect(screen.queryByText("name is required")).toBeNull();
     });
 
-    it("ignores a dismissal while a response is in flight", async () => {
-      // The footer buttons are already disabled by `loading`. A dismissal that
-      // still fired would put a second response on the same request.
+    it("still cancels while a response is in flight", async () => {
+      // The footer buttons are disabled by `loading`, so this is the only way
+      // out at that point. It has to keep working: the respond call carries no
+      // timeout, so one that hangs leaves `loading` true for good, and a
+      // dismissal gated on it would strand the dialog exactly as this issue
+      // describes. A duplicate cancel is the cheaper failure.
       render(
         <ElicitationDialog
           elicitationRequest={request()}
@@ -423,10 +426,8 @@ describe("ElicitationDialog", () => {
       );
 
       fireEvent.click(screen.getByRole("button", { name: /close/i }));
-      fireEvent.keyDown(document, { key: "Escape" });
 
-      await Promise.resolve();
-      expect(onResponse).not.toHaveBeenCalled();
+      await waitFor(() => expect(onResponse).toHaveBeenCalledWith("cancel"));
     });
   });
 


### PR DESCRIPTION
## Root cause

`ElicitationDialog` passed an empty close handler:

```tsx
<Dialog open={!!elicitationRequest} onOpenChange={() => {}}>
```

`DialogContent` renders its close button by default (`showCloseButton = true` in `design-system/src/components/dialog.tsx`), and Radix routes that button, the Escape key and a click outside through `onOpenChange`. All three therefore did nothing, so the only way out of the dialog was a footer button. When something stopped those buttons from completing the elicitation, for example the timeout in #1603 making the request no longer active, the dialog stayed open with no way to close it.

The issue reports the X specifically. It is all three.

## Change

A close request is now answered the same way the Cancel button answers it.

It is deliberately not gated on `loading`. I had that gate in the first push and it was wrong: `authFetch` sends no abort signal and no timeout, so a respond call that hangs never clears `loading`, and gating dismissal on it locked the dialog shut in exactly the case this change is meant to fix. Cubic caught it. The footer buttons stay disabled while a response is in flight; a duplicate `cancel` for a request already being answered is the cheaper of the two failures.

This is what the sibling dialog already does. `UrlElicitationConsent.tsx:115` maps dismissal to `cancel` with a comment ending "either way the dialog must always be closable", so this brings `ElicitationDialog` in line rather than inventing a rule. Cancel rather than decline also keeps the spec distinction between making no choice and explicitly refusing.

Hiding the close button was the other option the issue floated. It would leave the dialog with no escape in exactly the stuck case being reported, so I did not take it.

## Verification

`npx vitest run --project client src/components/__tests__/ElicitationDialog.test.tsx` in `mcpjam-inspector`: 28 passed, the 24 that existed plus 4 new ones in a `dismissal` block.

Restoring the upstream component and keeping the new tests reddens all four:

| test | fix reverted |
| --- | --- |
| cancels when the close button is used | fails |
| cancels on Escape | fails |
| sends cancel without parameters even when a required field is empty | fails |
| still cancels while a response is in flight | fails |

All 24 pre-existing tests pass in both directions.

Across the rest of the `client` project there is no clean baseline to claim, so to be precise: `OrganizationsTab.billing.test.tsx` fails 5 tests, and it fails the same 5 with my change stashed, so they are pre-existing and unrelated. `ScenarioChatPage.test.tsx` and `sidebar/nav-main.test.tsx` failed in one run and passed in the next on the same tree, so they look flaky on this machine. Every elicitation test file passes.

I did not reformat either file. Both are already outside Prettier's output on `main`, so running it would have buried three lines of change in a whole-file rewrite.

## Scope

The issue also asks what should happen when the response itself fails, so the dialog can report the error rather than sit there. That needs a decision about what to show and I have asked on the issue rather than guessing, so it is not in this change.

Be aware of what that leaves: both surfaces only clear the request on success, so a respond call that fails leaves the dialog up and pressing the X again just sends another failing cancel. This change fixes the dead control and the stuck-loading hang, not the failure path.

Fixes #1604

---

AI help was taken for this change.
