### PR TITLE
fix(slack): keep cancel announcements truthful and cap button labels by code point

### DIFF
--- a/slack-app/listeners/actions/proposal-button.js
+++ b/slack-app/listeners/actions/proposal-button.js
@@ -27,6 +27,24 @@ import { postRunEvidence } from './run-evidence.js';
 import { announceAndWatchRun, isFailedOutcome } from './run-watcher.js';
 
 /**
+ * Whether an approved action was a CANCELLATION.
+ *
+ * One definition, because the copy and the routing both need the answer and
+ * two of them would drift. It recognises the two spellings the copy below
+ * uses: `kind` when the server sends one, and the operation name as the
+ * fallback for a server that predates `kind`. A build that matched only the
+ * first would leave every cancellation from an older server announced, and
+ * routed, as an approval.
+ *
+ * @param {{ operation: string, kind?: string | null }} outcome
+ * @returns {boolean}
+ */
+export function isCancellation(outcome) {
+  if (outcome.kind === 'cancel') return true;
+  return outcome.kind == null && outcome.operation === 'cancel_eval_run';
+}
+
+/**
  * What to say once the action has actually run.
  *
  * KIND FIRST. The server tells us what the approved action does — start,
@@ -49,13 +67,8 @@ export function announcementFor(outcome, userId) {
     null;
 
   // A cancellation is not an approval, so the URL shortcut must not speak for
-  // one. Both spellings of "this was a cancel" are checked, because the copy
-  // below has two: `kind` when the server sends one, the operation name as the
-  // older-server fallback. Recognising only the first would leave the same
-  // wrong announcement reachable through the second.
-  const cancelled = outcome.kind === 'cancel' || (outcome.kind == null && outcome.operation === 'cancel_eval_run');
-
-  if (url && !cancelled) {
+  // one.
+  if (url && !isCancellation(outcome)) {
     return `:white_check_mark: Approved by <@${userId}> — <${url}|follow it here>.`;
   }
 
@@ -197,12 +210,19 @@ export async function handleProposalButton({ ack, body, client, context, logger,
   // operation-name ternary stays as the mixed-version fallback for a server
   // that predates `kind`.
   const text = announcementFor(outcome, userId);
+
+  // A cancellation started nothing, so it must not be routed into a run
+  // watcher. Both branches below post their OWN "running…" copy and return,
+  // which would throw away the truthful text above and announce a cancel as a
+  // started run — the same lie the wording was just fixed to stop telling.
+  const watchable = !isCancellation(outcome);
+
   try {
     // A run gets a LIVE message: the same "running… → here's how it went"
     // surface the retired Run-it button gave, now reached through the approval
     // path. Recognised by the server-sent resource type rather than by an
     // operation name, so a future op that also produces a run gets it free.
-    if (outcome.resource?.type === 'eval_run' && outcome.resource.id && outcome.resource.url) {
+    if (watchable && outcome.resource?.type === 'eval_run' && outcome.resource.id && outcome.resource.url) {
       const runId = outcome.resource.id;
       await announceAndWatchRun(client, {
         runId,
@@ -238,7 +258,7 @@ export async function handleProposalButton({ ack, body, client, context, logger,
     // eval runs (see surface-core's journey-run-watcher header), so routing it
     // into the eval watcher would report a rate-limited fan-out as a pass.
     // Same recognition rule as above: the server-sent resource TYPE.
-    if (outcome.resource?.type === 'journey_run' && outcome.resource.id && outcome.resource.url) {
+    if (watchable && outcome.resource?.type === 'journey_run' && outcome.resource.id && outcome.resource.url) {
       await announceAndWatchJourneyRun(client, {
         runId: outcome.resource.id,
         url: outcome.resource.url,

--- a/slack-app/listeners/actions/proposal-button.js
+++ b/slack-app/listeners/actions/proposal-button.js
@@ -47,7 +47,17 @@ export function announcementFor(outcome, userId) {
     (outcome.resource && typeof outcome.resource.url === 'string' ? outcome.resource.url : null) ??
     outcome.runUrl ??
     null;
-  if (url) return `:white_check_mark: Approved by <@${userId}> — <${url}|follow it here>.`;
+
+  // A cancellation is not an approval, so the URL shortcut must not speak for
+  // one. Both spellings of "this was a cancel" are checked, because the copy
+  // below has two: `kind` when the server sends one, the operation name as the
+  // older-server fallback. Recognising only the first would leave the same
+  // wrong announcement reachable through the second.
+  const cancelled = outcome.kind === 'cancel' || (outcome.kind == null && outcome.operation === 'cancel_eval_run');
+
+  if (url && !cancelled) {
+    return `:white_check_mark: Approved by <@${userId}> — <${url}|follow it here>.`;
+  }
 
   switch (outcome.kind) {
     case 'cancel':

--- a/slack-app/listeners/views/proposal-builder.js
+++ b/slack-app/listeners/views/proposal-builder.js
@@ -211,11 +211,18 @@ export function buildProposalBlocks(proposals) {
     if (!proposal?.actionId) continue;
     // Server first. It knows what the operation is; this bot only knows what
     // it knew at build time.
-    const label = String(
-      proposal.buttonLabel ||
-        BUTTON_LABELS[/** @type {keyof typeof BUTTON_LABELS} */ (proposal.operation)] ||
-        'Approve',
-    ).slice(0, MAX_BUTTON_LABEL);
+    // `capChars`, not `slice`: the cap counts UTF-16 units, so a server-sent
+    // label with an emoji straddling the limit would be cut mid surrogate pair
+    // and the lone half can make Slack reject the whole message. The confirm
+    // label two lines down already caps this way.
+    const label = capChars(
+      String(
+        proposal.buttonLabel ||
+          BUTTON_LABELS[/** @type {keyof typeof BUTTON_LABELS} */ (proposal.operation)] ||
+          'Approve',
+      ),
+      MAX_BUTTON_LABEL,
+    );
     blocks.push({
       type: 'section',
       text: {

--- a/slack-app/tests/listeners/actions/proposal-button.test.js
+++ b/slack-app/tests/listeners/actions/proposal-button.test.js
@@ -273,6 +273,44 @@ describe('announcementFor', () => {
     assert.strictEqual(text, ':white_check_mark: Approved by <@U1>.');
   });
 
+  it('still says Cancelled when a cancellation carries a resource', () => {
+    // The link shortcut speaks for approvals. A cancel that returns a resource
+    // would otherwise be announced as "Approved — follow it here", which tells
+    // the channel the opposite of what happened.
+    const text = announcementFor(
+      { operation: 'cancel_eval_run', kind: 'cancel', resource: { url: 'https://app/x' } },
+      'U1',
+    );
+    assert.match(text, /Cancelled by <@U1>/);
+    assert.ok(!/Approved/.test(text));
+    assert.ok(!/follow it here/.test(text));
+  });
+
+  it('still says Cancelled when a cancellation carries a runUrl', () => {
+    const text = announcementFor({ operation: 'cancel_eval_run', kind: 'cancel', runUrl: 'https://app/run/1' }, 'U1');
+    assert.match(text, /Cancelled by <@U1>/);
+    assert.ok(!/follow it here/.test(text));
+  });
+
+  it('still says Cancelled for a pre-`kind` server that carries a resource', () => {
+    // The copy below recognises a cancellation two ways, by `kind` and by
+    // operation name. The link shortcut has to recognise both, or the wrong
+    // announcement stays reachable through the older one.
+    const text = announcementFor({ operation: 'cancel_eval_run', resource: { url: 'https://app/x' } }, 'U1');
+    assert.match(text, /Cancelled by <@U1>/);
+    assert.ok(!/follow it here/.test(text));
+  });
+
+  it('keeps the link for a NEWER server whose unknown kind carries a resource', () => {
+    // Only cancellations lose the shortcut. An unrecognised kind is still an
+    // approval, and the server-built link is the most useful thing to say.
+    const text = announcementFor(
+      { operation: 'some_new_op', kind: 'teleport', resource: { url: 'https://app/x' } },
+      'U1',
+    );
+    assert.match(text, /<https:\/\/app\/x\|follow it here>/);
+  });
+
   it('does not let an UNKNOWN kind fall through to the operation-name table', () => {
     // A kind we do not recognise means a NEWER server, and the name table is
     // older than the kind vocabulary — consulting it would announce a

--- a/slack-app/tests/listeners/actions/proposal-button.test.js
+++ b/slack-app/tests/listeners/actions/proposal-button.test.js
@@ -468,6 +468,66 @@ describe('handleProposalButton', () => {
     assert.ok(posted[0].text.includes('https://app/swarms/jr_1'));
   });
 
+  it('announces a CANCELLATION rather than routing it into the run watcher', async () => {
+    // The watcher branch posts its own "running…" copy and returns, so a
+    // cancellation that carries a typed run resource would be announced as a
+    // started run even with the wording fixed. Latent while nothing builds a
+    // resource for cancel, which is why it is pinned here rather than later.
+    stub({
+      executeBody: {
+        status: 'succeeded',
+        operation: 'cancel_eval_run',
+        kind: 'cancel',
+        resource: { type: 'eval_run', id: 'run_1', url: 'https://app/evals/x/runs/run_1' },
+        result: {},
+      },
+    });
+    const { args, posted } = clickArgs();
+    await handleProposalButton(/** @type {any} */ (args));
+
+    assert.strictEqual(posted.length, 1);
+    assert.match(posted[0].text, /Cancelled by <@U_CLICKER>/);
+    assert.ok(!/running…/.test(posted[0].text));
+    assert.ok(!/watch it here/.test(posted[0].text));
+  });
+
+  it('announces a CANCELLATION rather than routing it into the journey watcher', async () => {
+    stub({
+      executeBody: {
+        status: 'succeeded',
+        operation: 'cancel_journey_run',
+        kind: 'cancel',
+        resource: { type: 'journey_run', id: 'jr_1', url: 'https://app/swarms/jr_1?project=p1' },
+        result: {},
+      },
+    });
+    const { args, posted } = clickArgs();
+    await handleProposalButton(/** @type {any} */ (args));
+
+    assert.strictEqual(posted.length, 1);
+    assert.match(posted[0].text, /Cancelled by <@U_CLICKER>/);
+    assert.ok(!/swarm running…/.test(posted[0].text));
+  });
+
+  it('announces a CANCELLATION from a server that predates `kind`', async () => {
+    // The routing has to recognise the same two spellings the copy does, or
+    // the wrong announcement stays reachable through the older one.
+    stub({
+      executeBody: {
+        status: 'succeeded',
+        operation: 'cancel_eval_run',
+        resource: { type: 'eval_run', id: 'run_1', url: 'https://app/evals/x/runs/run_1' },
+        result: {},
+      },
+    });
+    const { args, posted } = clickArgs();
+    await handleProposalButton(/** @type {any} */ (args));
+
+    assert.strictEqual(posted.length, 1);
+    assert.match(posted[0].text, /Cancelled by <@U_CLICKER>/);
+    assert.ok(!/running…/.test(posted[0].text));
+  });
+
   it('posts a plain announcement when the approval produced no run', async () => {
     stub({
       executeBody: { status: 'succeeded', operation: 'cancel_eval_run', kind: 'cancel', result: {} },

--- a/slack-app/tests/listeners/views/proposal-builder.test.js
+++ b/slack-app/tests/listeners/views/proposal-builder.test.js
@@ -1,0 +1,63 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { buildProposalBlocks } from '../../../listeners/views/proposal-builder.js';
+
+/** Slack's own limit on a button label. */
+const MAX_BUTTON_LABEL = 75;
+
+const proposalWith = (buttonLabel) => ({
+  actionId: 'act_1',
+  operation: 'run_eval_suite',
+  description: 'Run eval suite ts_1',
+  buttonLabel,
+});
+
+const labelOf = (blocks) => /** @type {any} */ (blocks[0]).accessory.text.text;
+
+/** A lone half of a surrogate pair, which is what a mid-emoji cut leaves behind. */
+const hasLoneSurrogate = (text) => {
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+    const isHigh = code >= 0xd800 && code <= 0xdbff;
+    const isLow = code >= 0xdc00 && code <= 0xdfff;
+    if (!isHigh && !isLow) continue;
+    if (isLow) return true;
+    const next = text.charCodeAt(index + 1);
+    if (Number.isNaN(next) || next < 0xdc00 || next > 0xdfff) return true;
+    index += 1;
+  }
+  return false;
+};
+
+describe('buildProposalBlocks button labels', () => {
+  it('leaves a label within the limit alone', () => {
+    const blocks = buildProposalBlocks([proposalWith('Run it')]);
+    assert.strictEqual(labelOf(blocks), 'Run it');
+  });
+
+  it('does not split an emoji sitting on the limit', () => {
+    // The rocket is a surrogate PAIR, so it occupies units 74 and 75 of a
+    // UTF-16 cut. Slicing there leaves half a character, and Slack can reject
+    // the whole message over it: the answer, the links and every other button.
+    const label = `${'a'.repeat(74)}🚀${'b'.repeat(20)}`;
+    const rendered = labelOf(buildProposalBlocks([proposalWith(label)]));
+
+    assert.ok(!hasLoneSurrogate(rendered), 'a lone surrogate reached the block');
+    assert.ok(rendered.length <= MAX_BUTTON_LABEL, 'the label outgrew the limit');
+  });
+
+  it('caps a long label by code points rather than UTF-16 units', () => {
+    // 80 rockets is 160 UTF-16 units. Counting units would keep 37 of them and
+    // call that a 75-character label.
+    const rendered = labelOf(buildProposalBlocks([proposalWith('🚀'.repeat(80))]));
+
+    assert.ok(!hasLoneSurrogate(rendered), 'a lone surrogate reached the block');
+    assert.ok(Array.from(rendered).length <= MAX_BUTTON_LABEL, 'too many code points');
+  });
+
+  it('still falls back to the built-in label when the server sends none', () => {
+    const { buttonLabel, ...withoutLabel } = proposalWith('unused');
+    assert.strictEqual(labelOf(buildProposalBlocks([withoutLabel])), 'Run it');
+  });
+});


### PR DESCRIPTION
Two of the three residuals from #3705, plus a third defect the review surfaced. The remaining item is left alone on purpose, see below.

## Announcement ordering

`announcementFor` resolved the resource link and returned before the `kind` switch was reached:

```js
if (url) return `:white_check_mark: Approved by <@${userId}> — <${url}|follow it here>.`;
switch (outcome.kind) {
  case 'cancel': return `:white_check_mark: Cancelled by <@${userId}>.`;
```

So a cancel-kind op that also returned a resource announced an approval, which is the opposite of what happened. The function's own docblock says **KIND FIRST**, so the code and the contract written above it disagreed.

A cancellation now keeps its own copy. It is recognised through **both** spellings the wording below uses: `kind === 'cancel'` when the server sends a kind, and `operation === 'cancel_eval_run'` for a server that predates `kind`. Matching only the first would have left the same wrong announcement reachable through the second, which is the same defect one layer down.

Nothing else loses the link. An unrecognised kind is still an approval, and there is a test pinning that.

## Watcher routing, added after review

CodeRabbit pointed out that fixing the wording alone left the lie reachable, and it was right. `handleProposalButton` computes the announcement and then, for a typed `eval_run` or `journey_run` resource, hands off to a watcher that posts its own hard-coded "Approved … running…" copy and returns. The corrected text was computed and then thrown away, so a cancellation carrying a typed resource still announced a started run.

Both watcher branches are now gated on the same cancellation test, and that test is one exported predicate, `isCancellation`, shared by the copy and the routing. Two spellings of this particular condition are exactly what would drift apart, which is the whole subject of the first section.

## Label cap

`buildProposalBlocks` capped the server-sent label with `.slice(0, MAX_BUTTON_LABEL)`. `String.prototype.slice` counts UTF-16 units, so an emoji straddling 75 was cut mid surrogate pair, and the lone half is what Slack can reject the whole message over. It now uses `capChars` from the same file, which iterates with `Array.from` and therefore counts code points. The confirm label two lines down already caps that way, so this makes the two consistent rather than introducing anything new.

## Verification

`npm run verify` in `slack-app` exits 0: 206 tests pass, `tsc --checkJs` is clean, and Biome reports only the pre-existing `noUnusedFunctionParameters` warning in `journey-run-watcher.js`, which this change does not touch. Baseline before the change was 195 passing, so the 11 added tests are the difference.

Reverting each fix on its own reddens only its own tests:

| reverted | fails | still passes |
| --- | --- | --- |
| the URL shortcut guard | the 3 cancel-with-resource announcement tests | the "unknown kind keeps its link" guard |
| the two `watchable` guards | the 3 cancellation-routing handler tests | both "starts a LIVE run/swarm message" tests |
| `capChars` in `proposal-builder.js` | the 2 emoji-boundary tests | the short-label and fallback-label guards |

The guards matter as much as the failures here. Each of these fixes is easy to overshoot into suppressing a link, a watcher, or an ellipsis that should still be there.

Worth stating plainly: the repository's `Build and Test` and `Tests` workflows show `action_required` on this pull request, so CI has not run any of the above. Those numbers are from running the suite locally.

One note for anyone running it: `tests/user-value-chain-labels.test.js` fails with `ERR_MODULE_NOT_FOUND` until `npm run build -w @mcpjam/sdk` has been run, which CI does through `test:checks`. Nothing to do with this change, but it cost me a few minutes.

## Not included

**The frozen base prompt.** The third item, the stale spend enumeration, is a deliberate cache-invalidating edit to a snapshot-pinned literal. Whether to spend that invalidation now is a maintainer call, so I have left it and said so on the issue.

**`app-home-builder.js:138`.** It does `.slice(0, 75)` on a project name, which is the same UTF-16 defect in a different file. Not in scope for this issue, and I would rather ask than widen the diff. Happy to add it here or open a separate one.

Refs #3705

---

AI help was taken for this change.
