### PR TITLE
fix(auth): report exhausted guest bootstrap

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/unified-convex-auth.test.tsx
+++ b/mcpjam-inspector/client/src/lib/__tests__/unified-convex-auth.test.tsx
@@ -79,6 +79,48 @@ describe("useUnifiedConvexAuth", () => {
       __guest: true,
       id: "__guest__",
     });
+    expect(mockState.reportCaught).not.toHaveBeenCalled();
+  });
+
+  it("reports once after guest session bootstrap exhausts every attempt", async () => {
+    mockState.getOrCreateGuestSession.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useUnifiedConvexAuth());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500 + 1500 + 3000);
+    });
+
+    expect(mockState.getOrCreateGuestSession).toHaveBeenCalledTimes(4);
+    expect(mockState.reportCaught).toHaveBeenCalledTimes(1);
+    const [error, options] = mockState.reportCaught.mock.calls[0]!;
+    expect(error).toEqual(
+      new Error("Guest session bootstrap exhausted without a token"),
+    );
+    expect(options).toEqual({
+      source: "guest_session_bootstrap",
+      level: "error",
+      extra: { attempts: 4 },
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+
+  it("does not report guest session bootstrap after unmount", async () => {
+    mockState.getOrCreateGuestSession.mockResolvedValue(null);
+
+    const { unmount } = renderHook(() => useUnifiedConvexAuth());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    unmount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500 + 1500 + 3000);
+    });
+
+    expect(mockState.getOrCreateGuestSession).toHaveBeenCalledTimes(1);
+    expect(mockState.reportCaught).not.toHaveBeenCalled();
   });
 
   it("marks the guest activated only when Convex pulls the guest token, not on resolve", async () => {
@@ -125,6 +167,9 @@ describe("useUnifiedConvexAuth", () => {
       await act(async () => {
         await vi.advanceTimersByTimeAsync(500 + 1500 + 3000);
       });
+      // Bootstrap exhaustion is covered above. Refresh tests count only reports
+      // emitted by the token fetch they invoke after mounting.
+      mockState.reportCaught.mockClear();
       return result;
     }
 

--- a/mcpjam-inspector/client/src/lib/unified-convex-auth.ts
+++ b/mcpjam-inspector/client/src/lib/unified-convex-auth.ts
@@ -165,11 +165,24 @@ export function useUnifiedConvexAuth() {
         }
 
         if (cancelled) return;
-        if (
-          session ||
-          attempt === GUEST_SESSION_BOOTSTRAP_RETRY_DELAYS_MS.length
-        ) {
+        if (session) {
           setGuestToken(session?.token ?? null);
+          setGuestLoading(false);
+          return;
+        }
+
+        if (attempt === GUEST_SESSION_BOOTSTRAP_RETRY_DELAYS_MS.length) {
+          reportCaught(
+            new Error("Guest session bootstrap exhausted without a token"),
+            {
+              source: "guest_session_bootstrap",
+              level: "error",
+              extra: {
+                attempts: GUEST_SESSION_BOOTSTRAP_RETRY_DELAYS_MS.length + 1,
+              },
+            },
+          );
+          setGuestToken(null);
           setGuestLoading(false);
           return;
         }


### PR DESCRIPTION
## Summary
- report guest-session bootstrap exhaustion through the shared Sentry and PostHog error path
- emit one stable error after all four attempts with source and attempt metadata
- keep successful retries and unmounted effects silent

## Tests
- npm exec -w @mcpjam/inspector -- vitest run client/src/lib/__tests__/unified-convex-auth.test.tsx
- npm run typecheck:client -w @mcpjam/inspector

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports exhausted guest session bootstrap attempts through the shared Sentry and PostHog error path. Previously the hook failed silently after all retries; now it emits one stable error with source and attempt metadata, while successful retries and unmounted effects stay silent.

<sup>Written for commit 8236e86f3a8a0f85edd30b64c1c93e3a5fa08fcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

