### PR TITLE
Collapse the sidebar when Ask MCPJam opens

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -5082,8 +5082,8 @@ export default function App() {
   const appContent = (
     <SidebarProvider defaultOpen={true}>
       {/* Wide working surfaces (Playground, Evaluate, OAuth Debugger, Swarms)
-          collapse the sidebar to its icon rail; navigating back out of them
-          expands it again. */}
+          and the Ask MCPJam panel collapse the sidebar to its icon rail;
+          leaving those expands it again. */}
       <SidebarAutoCollapse activeTab={activeTab} />
       <AppChromeSidebar
         hidden={playgroundOnboarding}

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -719,7 +719,9 @@ export function MCPSidebar({
               </div>
             ) : (
               <SidebarTrigger
-                className="size-7 shrink-0"
+                // Match the 32px nav icons. size-7 (28px) sat 2px off the
+                // column once this rail became the default on wide surfaces.
+                className="size-8 shrink-0"
                 aria-label="Expand sidebar"
               />
             )}
@@ -797,7 +799,7 @@ export function MCPSidebar({
                   />
                   {/* Add subtle divider between sections (except after the last section) */}
                   {sectionIndex < visibleNavigationSections.length - 1 && (
-                    <div className="mx-4 my-1 border-t border-border/50" />
+                    <div className="mx-4 my-1 border-t border-border/50 group-data-[collapsible=icon]:mx-2" />
                   )}
                 </React.Fragment>
               );
@@ -815,7 +817,7 @@ export function MCPSidebar({
                       aria-label={item.title}
                       onClick={() => handleNavClick(item.url)}
                       className={cn(
-                        "flex size-7 items-center justify-center rounded-md text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+                        "flex size-8 items-center justify-center rounded-md text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
                         isNavItemActive(item) &&
                           "bg-sidebar-accent text-sidebar-accent-foreground",
                       )}

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/nav-main.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/nav-main.test.tsx
@@ -197,6 +197,45 @@ describe("NavMain", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("hides the New badge on the icon rail — a 32px button cannot hold it", () => {
+    mockSidebarOpen = false;
+
+    render(
+      <NavMain
+        items={[
+          {
+            title: "XAA Debugger",
+            url: "#xaa-flow",
+            icon: FakeIcon,
+            badge: "New",
+          },
+        ]}
+      />
+    );
+
+    expect(screen.queryByText("New")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "XAA Debugger" })
+    ).toBeInTheDocument();
+  });
+
+  it("shows the New badge next to the label while the sidebar is expanded", () => {
+    render(
+      <NavMain
+        items={[
+          {
+            title: "XAA Debugger",
+            url: "#xaa-flow",
+            icon: FakeIcon,
+            badge: "New",
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("New")).toBeInTheDocument();
+  });
+
   it("suppresses the built-in collapsed tooltip when learn more is handling it", () => {
     mockSidebarOpen = false;
 

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-auto-collapse.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-auto-collapse.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 
 import {
   SidebarProvider,
@@ -7,6 +7,7 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 import { SidebarAutoCollapse } from "@/components/sidebar/sidebar-auto-collapse";
+import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
 
 function OpenProbe() {
   const { open } = useSidebar();
@@ -38,7 +39,17 @@ function renderAt(activeTab: string | undefined) {
 
 const state = () => screen.getByTestId("open").textContent;
 
+function setAgentPanelOpen(next: boolean) {
+  act(() => {
+    useAgentPanelStore.setState({ isOpen: next });
+  });
+}
+
 describe("SidebarAutoCollapse", () => {
+  beforeEach(() => {
+    useAgentPanelStore.setState({ isOpen: false });
+  });
+
   it.each([
     "playground",
     "evals",
@@ -89,6 +100,66 @@ describe("SidebarAutoCollapse", () => {
     expect(state()).toBe("closed");
 
     navigate("tools");
+
+    expect(state()).toBe("closed");
+  });
+
+  it("collapses the sidebar when Ask MCPJam opens on a normal tab", () => {
+    renderAt("home");
+    expect(state()).toBe("open");
+
+    setAgentPanelOpen(true);
+
+    expect(state()).toBe("closed");
+  });
+
+  it("expands again when Ask MCPJam closes on a normal tab", () => {
+    renderAt("home");
+    setAgentPanelOpen(true);
+    expect(state()).toBe("closed");
+
+    setAgentPanelOpen(false);
+
+    expect(state()).toBe("open");
+  });
+
+  it("collapses even if the user had expanded the rail on a wide tab", () => {
+    renderAt("playground");
+    expect(state()).toBe("closed");
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle sidebar/i }));
+    expect(state()).toBe("open");
+
+    setAgentPanelOpen(true);
+
+    expect(state()).toBe("closed");
+  });
+
+  it("stays collapsed after Ask MCPJam closes on a wide tab", () => {
+    renderAt("playground");
+    setAgentPanelOpen(true);
+    expect(state()).toBe("closed");
+
+    setAgentPanelOpen(false);
+
+    expect(state()).toBe("closed");
+  });
+
+  it("does not re-expand a sidebar the user had already collapsed", () => {
+    renderAt("home");
+    fireEvent.click(screen.getByRole("button", { name: /toggle sidebar/i }));
+    expect(state()).toBe("closed");
+
+    setAgentPanelOpen(true);
+    setAgentPanelOpen(false);
+
+    expect(state()).toBe("closed");
+  });
+
+  it("collapses when the app loads with Ask MCPJam already open", () => {
+    useAgentPanelStore.setState({ isOpen: true });
+
+    renderAt("home");
 
     expect(state()).toBe("closed");
   });

--- a/mcpjam-inspector/client/src/components/sidebar/nav-main.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/nav-main.tsx
@@ -121,11 +121,13 @@ export function NavMain({ items, label, onItemClick, learnMore }: NavMainProps) 
         getButtonClassName(item),
         // Tighten the icon→label gap on badged rows so a long label + badge
         // (e.g. "XAA Debugger" + "New") fits on one line at the 12rem width.
-        item.badge && "gap-1.5"
+        // The rail is 32px — a badge has nowhere to go, so this only applies
+        // while the sidebar is expanded.
+        item.badge && sidebarOpen && "gap-1.5"
       )}
     >
       {item.icon && <item.icon className="h-4 w-4" />}
-      {item.badge ? (
+      {item.badge && sidebarOpen ? (
         // A <div> (not a <span>) sidesteps the sidebar's
         // [&>span:last-child]:truncate rule (which otherwise clips the badge).
         // Tight tracking + compact gaps/badge keep the full title AND the badge

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-auto-collapse.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-auto-collapse.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { useSidebar } from "@/components/ui/sidebar";
+import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
 
 /**
  * Tabs whose working surface is wide enough that the 16rem sidebar costs more
@@ -27,7 +28,8 @@ export function isWideSurfaceTab(activeTab: string | undefined): boolean {
 }
 
 /**
- * Drives the sidebar's open state from the active tab.
+ * Drives the sidebar's open state from the active tab and the Ask MCPJam
+ * panel.
  *
  * Only the *crossing* between a wide-surface tab and a normal one applies a
  * state, so a manual toggle sticks: collapse the sidebar on Home and it stays
@@ -36,6 +38,12 @@ export function isWideSurfaceTab(activeTab: string | undefined): boolean {
  * back out of the wide surfaces — including via the icon rail, which stays
  * clickable while collapsed — restores it.
  *
+ * Opening Ask MCPJam is its own crossing: the panel takes the right side, so
+ * the rail collapses even if the current tab would have left it expanded.
+ * Closing the panel restores the tab policy, but only if this effect was the
+ * one that collapsed it — a sidebar the user had already minimized stays
+ * minimized.
+ *
  * Renders nothing; it exists to hold the effect at the SidebarProvider scope.
  */
 export function SidebarAutoCollapse({
@@ -43,11 +51,14 @@ export function SidebarAutoCollapse({
 }: {
   activeTab: string | undefined;
 }) {
-  const { setOpen, isMobile } = useSidebar();
+  const { open, setOpen, isMobile } = useSidebar();
+  const agentPanelOpen = useAgentPanelStore((s) => s.isOpen);
   const isWide = isWideSurfaceTab(activeTab);
   // null until the first desktop pass, so the initial tab gets its state
   // applied even when the app deep-links straight into a wide surface.
   const lastAppliedWideRef = React.useRef<boolean | null>(null);
+  const lastPanelOpenRef = React.useRef<boolean | null>(null);
+  const collapsedByPanelRef = React.useRef(false);
 
   // Layout, not passive: a passive effect runs after paint, so deep-linking
   // into a wide surface painted the rail at its full 16rem and then animated
@@ -55,16 +66,44 @@ export function SidebarAutoCollapse({
   // paint means the first frame is already collapsed.
   React.useLayoutEffect(() => {
     // Mobile has no inline sidebar to reclaim width from — it is a sheet that
-    // is already closed by default.
+    // is already closed by default. The agent panel is a full-width sheet
+    // there too, so neither crossing is worth applying.
     if (isMobile) {
       return;
     }
+
+    if (agentPanelOpen && lastPanelOpenRef.current !== true) {
+      lastPanelOpenRef.current = true;
+      collapsedByPanelRef.current = open;
+      lastAppliedWideRef.current = true;
+      setOpen(false);
+      return;
+    }
+
+    if (!agentPanelOpen && lastPanelOpenRef.current === true) {
+      lastPanelOpenRef.current = false;
+      if (collapsedByPanelRef.current) {
+        collapsedByPanelRef.current = false;
+        lastAppliedWideRef.current = isWide;
+        setOpen(!isWide);
+      }
+      return;
+    }
+
+    lastPanelOpenRef.current = agentPanelOpen;
+
+    // The panel owns the rail while it is open. Tab crossings wait until
+    // it closes so they cannot expand the sidebar out from under the chat.
+    if (agentPanelOpen) {
+      return;
+    }
+
     if (lastAppliedWideRef.current === isWide) {
       return;
     }
     lastAppliedWideRef.current = isWide;
     setOpen(!isWide);
-  }, [isWide, isMobile, setOpen]);
+  }, [agentPanelOpen, isWide, isMobile, open, setOpen]);
 
   return null;
 }


### PR DESCRIPTION
## Summary
- Opening Ask MCPJam (click or ⌘\) collapses the app sidebar to the icon rail, the same way Playground and Evaluate already do. Closing the panel restores the tab policy unless the user had already collapsed it.
- The rail itself is tightened for collapse-as-default: 32px expand/footer icons aligned with nav, no New badge on a 32px button, and section hairlines that read at 3rem.

## Test plan
- [ ] On Home, click Ask MCPJam — sidebar collapses to the icon rail
- [ ] Close the panel — sidebar expands again
- [ ] On Playground (already collapsed), open Ask MCPJam, then close it — rail stays collapsed
- [ ] Manually collapse on Home, open and close Ask MCPJam — stays collapsed
- [ ] Expand the rail on Playground, then open Ask MCPJam — it collapses
- [ ] Collapsed rail: expand trigger and footer icons line up with nav; XAA has no New badge; section hairlines are visible


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opening Ask MCPJam now collapses the sidebar to the icon rail, matching Playground and Evaluate. Closing the panel restores the previous sidebar state unless the user had already collapsed it manually.

**Collapsed rail polish**
- The expand trigger and footer icons are now 32px so they align with the nav icons.
- The `New` badge is hidden while collapsed because a 32px button can't hold it.
- Section hairlines get tighter margins in the collapsed rail so they remain visible at 3rem.

<sup>Written for commit 11831e6cc8d65e2e580a46b138466a4c78cc9e52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

