### PR TITLE
fix(chat): stop the local-harness send hook from dropping messages

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.local-harness.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.local-harness.test.tsx
@@ -226,29 +226,72 @@ async function renderWithHarness(
   return rendered;
 }
 
+const TURN_MESSAGES = [
+  { id: "m1", role: "user", parts: [{ type: "text", text: "draw a dog" }] },
+];
+
+type TransportUnderTest = {
+  api?: string;
+  body?: () => Record<string, unknown>;
+  headers?: Record<string, string>;
+  prepareSendMessagesRequest?: (args: {
+    api: string;
+    id: string;
+    messages: typeof TURN_MESSAGES;
+    body: Record<string, unknown>;
+    headers: HeadersInit | undefined;
+    credentials: undefined;
+    requestMetadata: undefined;
+    trigger: "submit-message";
+    messageId: string;
+  }) => { body: Record<string, unknown>; headers?: HeadersInit };
+};
+
+function latestTransport(): TransportUnderTest {
+  return mockState.transportOptions.at(-1) as unknown as TransportUnderTest;
+}
+
 /**
- * Drive the transport the way the SDK does: resolve `body` and `headers`, then
- * hand both to `prepareSendMessagesRequest` and take what it returns.
+ * Drive the transport the way `HttpChatTransport.sendMessages` does: resolve
+ * `body` and `headers`, hand the hook the SDK's full argument set, and take
+ * what it returns — or, with no hook installed, compose the SDK's own default
+ * (custom fields + `id`/`messages`/`trigger`/`messageId`). The hook's returned
+ * body REPLACES that default, which is why every path asserts `messages`
+ * below: `lib/__tests__/chat-send-request.test.ts` proves the same against the
+ * real transport.
  *
  * Exercised through that seam rather than by reading the two separately,
  * because the property under test is that they come from one snapshot.
  */
 function sendRequest() {
-  const t = mockState.transportOptions.at(-1) as unknown as {
-    body?: () => Record<string, unknown>;
-    headers?: Record<string, string>;
-    prepareSendMessagesRequest?: (args: {
-      body: Record<string, unknown>;
-      headers: HeadersInit | undefined;
-    }) => { body: Record<string, unknown>; headers?: HeadersInit };
-  };
-  const body = t?.body?.() ?? {};
+  const t = latestTransport();
+  const custom = t?.body?.() ?? {};
   const headers = (t?.headers ?? {}) as Record<string, string>;
-  const prepared = t?.prepareSendMessagesRequest?.({ body, headers });
+  const prepared = t?.prepareSendMessagesRequest?.({
+    api: t.api ?? "",
+    id: "chat_1",
+    messages: TURN_MESSAGES,
+    body: custom,
+    headers,
+    credentials: undefined,
+    requestMetadata: undefined,
+    trigger: "submit-message",
+    messageId: "m1",
+  });
+  const body =
+    prepared?.body ??
+    ({
+      ...custom,
+      id: "chat_1",
+      messages: TURN_MESSAGES,
+      trigger: "submit-message",
+      messageId: "m1",
+    } as Record<string, unknown>);
+  expect(body.messages).toEqual(TURN_MESSAGES);
   return {
-    body: (prepared?.body ?? body) as Record<string, unknown>,
+    body,
     headers: (prepared?.headers ?? headers) as Record<string, string>,
-    api: (t as { api?: string })?.api,
+    api: t?.api,
   };
 }
 
@@ -308,6 +351,25 @@ describe("useChatSession — local Claude Code transmission", () => {
     expect(() => sendRequest()).toThrow(
       "Local execution is not authorized for this turn",
     );
+  });
+
+  it("leaves the SDK's own body composition alone unless local was requested", async () => {
+    // The hook exists to rewrite the body on a local turn. Installed on every
+    // turn it once replaced the SDK's default body — `messages` included —
+    // with the custom fields alone, and every chat turn 400'd.
+    await renderWithHarness(undefined, { projectId: "proj-1" });
+    expect(latestTransport().prepareSendMessagesRequest).toBeUndefined();
+    await renderWithHarness(grantedController(), { projectId: "proj-1" });
+    expect(latestTransport().prepareSendMessagesRequest).toBeDefined();
+  });
+
+  it("still sends the turn's messages on a local turn", async () => {
+    await renderWithHarness(grantedController(), { projectId: "proj-1" });
+    const { body } = sendRequest();
+    expect(body.messages).toEqual(TURN_MESSAGES);
+    expect(body.id).toBe("chat_1");
+    expect(body.trigger).toBe("submit-message");
+    expect(body.harnessTarget).toEqual(LOCAL_TARGET);
   });
 
   it("sends nothing when the caller did not request local", async () => {

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -96,7 +96,10 @@ import {
 import { getGuestBearerToken } from "@/lib/guest-session";
 import { HOSTED_MODE } from "@/lib/config";
 import { LOCAL_CONSENT_HEADER } from "@/lib/local-computer-consent";
-import { LOCAL_HARNESS_GRANT_HEADER } from "@/lib/local-harness-consent";
+import {
+  prepareLocalHarnessSendRequest,
+  type ChatSendRequestOptions,
+} from "@/lib/chat-send-request";
 import type { LocalHarnessTargetIds } from "@/lib/local-harness-consent";
 import {
   preserveHydratedMessageIds,
@@ -1641,22 +1644,6 @@ function isAuthDeniedError(error: unknown): boolean {
   return /\b(401|403)\b|unauthorized|forbidden/i.test(withStatus.message);
 }
 
-/**
- * `HeadersInit` as a plain record.
- *
- * The SDK hands `prepareSendMessagesRequest` whatever the transport resolved,
- * which is a `Headers`, an entry array, or a record depending on where it came
- * from. Spreading one of the first two into an object literal silently
- * produces `{}` — and the consent capability would be the header that went
- * missing.
- */
-function normalizeSendHeaders(headers: HeadersInit | undefined): Record<string, string> {
-  if (headers === undefined) return {};
-  if (headers instanceof Headers) return Object.fromEntries(headers.entries());
-  if (Array.isArray(headers)) return Object.fromEntries(headers);
-  return { ...headers };
-}
-
 export function useChatSession(
   options: UseChatSessionOptions,
 ): UseChatSessionReturn {
@@ -3160,27 +3147,28 @@ export function useChatSession(
        * hosted. A user who deliberately scoped work to their machine got a
        * cloud sandbox and no indication of it. Failing loudly is the point.
        */
-      prepareSendMessagesRequest: ({ body, headers }) => {
-        if (!localHarnessRequested) return { body: body ?? {}, headers };
-        const snapshot = localHarnessExecution?.resolveSendTarget() ?? null;
-        if (snapshot === null) {
-          throw new Error("Local execution is not authorized for this turn");
-        }
-        return {
-          body: {
-            ...(body ?? {}),
-            // Opaque ids only. Every one of them is re-derived server-side
-            // before anything spawns.
-            harnessTarget: snapshot.target,
-          },
-          headers: {
-            ...normalizeSendHeaders(headers),
-            // The capability, in a HEADER. Never in the body, which is
-            // persisted into a transcript.
-            [LOCAL_HARNESS_GRANT_HEADER]: snapshot.token,
-          },
-        };
-      },
+      //
+      // Installed ONLY on a local-harness turn. The SDK adds `messages` (and
+      // `id`/`trigger`/`messageId`) to the request itself, but only when no
+      // `prepareSendMessagesRequest` returns a body — any returned body replaces
+      // the SDK's wholesale. A hook that ran on every turn and handed back the
+      // custom fields it was given sent every chat turn out with no `messages`
+      // (400 "messages are required", both routes). Not installing it on the
+      // ordinary path leaves the SDK's own composition in charge there, and
+      // `prepareLocalHarnessSendRequest` re-adds the SDK fields on the path
+      // that does rewrite the body — `lib/chat-send-request.ts` owns that
+      // contract and pins it against the real transport.
+      ...(localHarnessRequested
+        ? {
+            prepareSendMessagesRequest: (
+              options: ChatSendRequestOptions<UIMessage>,
+            ) =>
+              prepareLocalHarnessSendRequest(
+                options,
+                localHarnessExecution?.resolveSendTarget() ?? null,
+              ),
+          }
+        : {}),
     });
   }, [
     selectedModel,

--- a/mcpjam-inspector/client/src/lib/__tests__/chat-send-request.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/chat-send-request.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+// The REAL transport, deliberately un-mocked. The regression this file guards
+// against lived entirely inside the SDK's body composition, which every
+// `use-chat-session.*` suite mocks away.
+import { DefaultChatTransport, type UIMessage } from "ai";
+import { LOCAL_HARNESS_GRANT_HEADER } from "../local-harness-consent";
+import {
+  prepareLocalHarnessSendRequest,
+  withSdkSendFields,
+  type ChatSendRequestOptions,
+} from "../chat-send-request";
+
+const MESSAGES: UIMessage[] = [
+  { id: "m1", role: "user", parts: [{ type: "text", text: "draw a dog" }] },
+];
+
+const TARGET = {
+  kind: "local-native" as const,
+  harnessId: "claude-code",
+  machineId: "mach_1",
+  workspaceGrantId: "ws_1",
+  runtimeId: "rt_1",
+  permissionProfile: "workspace-edits",
+  policyVersion: "local-harness-policy-2026-09-01",
+};
+
+const CUSTOM_BODY = {
+  model: { id: "anthropic/claude-haiku-4.5" },
+  temperature: 0.7,
+  projectId: "proj_1",
+  selectedServerIds: ["srv_1"],
+};
+
+function sendOptions(
+  overrides: Partial<ChatSendRequestOptions> = {},
+): ChatSendRequestOptions {
+  return {
+    api: "/api/web/chat-v2",
+    id: "chat_1",
+    messages: MESSAGES,
+    body: CUSTOM_BODY,
+    headers: undefined,
+    credentials: undefined,
+    requestMetadata: undefined,
+    trigger: "submit-message",
+    messageId: "m1",
+    ...overrides,
+  };
+}
+
+/**
+ * Build a real `DefaultChatTransport`, send one turn through it, and return
+ * the JSON body that reached `fetch`. The stub fetch throws after capturing,
+ * so no stream parsing is involved.
+ */
+async function postedBody(
+  prepare?: ConstructorParameters<
+    typeof DefaultChatTransport<UIMessage>
+  >[0]["prepareSendMessagesRequest"],
+): Promise<Record<string, unknown>> {
+  let captured: Record<string, unknown> | null = null;
+  const transport = new DefaultChatTransport<UIMessage>({
+    api: "/api/web/chat-v2",
+    body: () => CUSTOM_BODY,
+    fetch: (async (_url: unknown, init?: RequestInit) => {
+      captured = JSON.parse(String(init?.body));
+      throw new Error("captured");
+    }) as typeof fetch,
+    ...(prepare ? { prepareSendMessagesRequest: prepare } : {}),
+  });
+  await expect(
+    transport.sendMessages({
+      chatId: "chat_1",
+      messages: MESSAGES,
+      trigger: "submit-message",
+      messageId: "m1",
+      abortSignal: undefined,
+    }),
+  ).rejects.toThrow("captured");
+  if (captured === null) throw new Error("fetch was never called");
+  return captured;
+}
+
+describe("withSdkSendFields", () => {
+  it("adds the SDK's four fields on top of the custom body", () => {
+    expect(withSdkSendFields(sendOptions())).toEqual({
+      ...CUSTOM_BODY,
+      id: "chat_1",
+      messages: MESSAGES,
+      trigger: "submit-message",
+      messageId: "m1",
+    });
+  });
+
+  it("never lets a custom field shadow `messages`", () => {
+    const body = withSdkSendFields(
+      sendOptions({ body: { ...CUSTOM_BODY, messages: [] } }),
+    );
+    expect(body.messages).toBe(MESSAGES);
+  });
+
+  it("tolerates an absent custom body", () => {
+    expect(withSdkSendFields(sendOptions({ body: undefined })).messages).toBe(
+      MESSAGES,
+    );
+  });
+});
+
+describe("prepareLocalHarnessSendRequest", () => {
+  it("keeps the SDK fields, adds the target to the body and the token to a header", () => {
+    const prepared = prepareLocalHarnessSendRequest(
+      sendOptions({ headers: { "x-existing": "1" } }),
+      { target: TARGET, token: "grant-token" },
+    );
+    expect(prepared.body).toEqual({
+      ...CUSTOM_BODY,
+      id: "chat_1",
+      messages: MESSAGES,
+      trigger: "submit-message",
+      messageId: "m1",
+      harnessTarget: TARGET,
+    });
+    expect(prepared.headers).toEqual({
+      "x-existing": "1",
+      [LOCAL_HARNESS_GRANT_HEADER]: "grant-token",
+    });
+    // The capability rides the header only — the body is persisted.
+    expect(JSON.stringify(prepared.body)).not.toContain("grant-token");
+  });
+
+  it("refuses the turn when the local target cannot be resolved", () => {
+    expect(() => prepareLocalHarnessSendRequest(sendOptions(), null)).toThrow(
+      "Local execution is not authorized for this turn",
+    );
+  });
+
+  it("does not lose headers handed over as a Headers instance", () => {
+    const prepared = prepareLocalHarnessSendRequest(
+      sendOptions({ headers: new Headers({ "x-existing": "1" }) }),
+      { target: TARGET, token: "t" },
+    );
+    expect(prepared.headers["x-existing"]).toBe("1");
+  });
+});
+
+describe("against the real DefaultChatTransport", () => {
+  it("SDK contract: with no prepare hook the transport sends custom fields + id/messages/trigger/messageId", async () => {
+    // If an SDK upgrade changes what the default body carries, this is the
+    // test that says so — and `withSdkSendFields` must follow.
+    const body = await postedBody();
+    expect(Object.keys(body).sort()).toEqual(
+      [
+        ...Object.keys(CUSTOM_BODY),
+        "id",
+        "messages",
+        "trigger",
+        "messageId",
+      ].sort(),
+    );
+    expect(body.messages).toEqual(MESSAGES);
+  });
+
+  it("SDK contract: a prepare hook that returns any body REPLACES the default (the regression)", async () => {
+    // Documents the trap, so nobody re-introduces `return { body }`.
+    const body = await postedBody(({ body }) => ({ body: body ?? {} }));
+    expect(body).not.toHaveProperty("messages");
+  });
+
+  it("the local-harness prepare hook posts the same key set as the SDK default, plus harnessTarget", async () => {
+    const sdkDefault = await postedBody();
+    const body = await postedBody((options) =>
+      prepareLocalHarnessSendRequest(options, {
+        target: TARGET,
+        token: "grant-token",
+      }),
+    );
+    expect(Object.keys(body).sort()).toEqual(
+      [...Object.keys(sdkDefault), "harnessTarget"].sort(),
+    );
+    expect(body.messages).toEqual(MESSAGES);
+    expect(body.harnessTarget).toEqual(TARGET);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/chat-send-request.ts
+++ b/mcpjam-inspector/client/src/lib/chat-send-request.ts
@@ -1,0 +1,111 @@
+import type { PrepareSendMessagesRequest, UIMessage } from "ai";
+import {
+  LOCAL_HARNESS_GRANT_HEADER,
+  type LocalHarnessTargetIds,
+} from "./local-harness-consent";
+
+/**
+ * The chat transport's `prepareSendMessagesRequest`, as a pure function.
+ *
+ * WHY THIS EXISTS. `HttpChatTransport.sendMessages` (ai@6) hands the callback
+ * a `body` that is ONLY the transport's custom fields (`model`, `temperature`,
+ * `selectedServerIds`, …). The SDK adds `id`, `messages`, `trigger` and
+ * `messageId` itself — but only on the fallback path it takes when the
+ * callback returns no `body`. Return any `body` at all and it REPLACES the
+ * default wholesale: the request goes out with no `messages`, and both chat
+ * routes answer 400 "messages are required". That is exactly what took every
+ * chat turn down when the callback first landed as `return { body }`.
+ *
+ * The callback's return type requires `body`, so "return nothing" is not an
+ * option once the hook is installed. The contract here is therefore: whatever
+ * else this function does, the four SDK fields are present on what it returns.
+ * `chat-send-request.test.ts` pins that against the REAL transport, not a
+ * mock, and against the key set the SDK itself would have sent.
+ */
+
+/** What `prepareSendMessagesRequest` receives. Named so tests can build one. */
+export type ChatSendRequestOptions<UI_MESSAGE extends UIMessage = UIMessage> =
+  Parameters<PrepareSendMessagesRequest<UI_MESSAGE>>[0];
+
+/** What `prepareSendMessagesRequest` must hand back. */
+export type ChatSendRequest = {
+  body: Record<string, unknown>;
+  headers: Record<string, string>;
+};
+
+/**
+ * The request body exactly as `DefaultChatTransport` would have composed it
+ * with no `prepareSendMessagesRequest` installed: custom fields first, then the
+ * SDK's own four. Field order matters only in that the SDK fields win — a
+ * custom `body` can never shadow `messages`.
+ */
+export function withSdkSendFields<UI_MESSAGE extends UIMessage>(
+  options: Pick<
+    ChatSendRequestOptions<UI_MESSAGE>,
+    "id" | "messages" | "trigger" | "messageId" | "body"
+  >,
+): Record<string, unknown> {
+  return {
+    ...(options.body ?? {}),
+    id: options.id,
+    messages: options.messages,
+    trigger: options.trigger,
+    messageId: options.messageId,
+  };
+}
+
+/**
+ * `HeadersInit` as a plain record.
+ *
+ * The SDK hands the callback whatever the transport resolved, which is a
+ * `Headers`, an entry array, or a record depending on where it came from.
+ * Spreading one of the first two into an object literal silently produces
+ * `{}` — and the consent capability would be the header that went missing.
+ */
+export function normalizeSendHeaders(
+  headers: HeadersInit | undefined,
+): Record<string, string> {
+  if (headers === undefined) return {};
+  if (headers instanceof Headers) return Object.fromEntries(headers.entries());
+  if (Array.isArray(headers)) return Object.fromEntries(headers);
+  return { ...headers };
+}
+
+export type LocalHarnessSendSnapshot = {
+  target: LocalHarnessTargetIds;
+  token: string;
+};
+
+/**
+ * A local-harness turn's request: the SDK body plus the opaque target ids,
+ * with the capability in a HEADER (never the body, which is persisted into a
+ * transcript). Ids and token come from ONE snapshot taken at send time, so a
+ * grant minted after the transport was built cannot produce a body that names
+ * a target with no capability to authorize it.
+ *
+ * `null` means "requested but cannot be satisfied" — an expired grant, a
+ * sign-out — and the turn is REFUSED rather than quietly sent hosted. Before
+ * that refusal existed, the target was simply omitted and the server ran the
+ * turn in a cloud sandbox with no indication to the user who had deliberately
+ * scoped work to their machine.
+ */
+export function prepareLocalHarnessSendRequest<UI_MESSAGE extends UIMessage>(
+  options: ChatSendRequestOptions<UI_MESSAGE>,
+  snapshot: LocalHarnessSendSnapshot | null,
+): ChatSendRequest {
+  if (snapshot === null) {
+    throw new Error("Local execution is not authorized for this turn");
+  }
+  return {
+    body: {
+      ...withSdkSendFields(options),
+      // Opaque ids only. Every one of them is re-derived server-side before
+      // anything spawns.
+      harnessTarget: snapshot.target,
+    },
+    headers: {
+      ...normalizeSendHeaders(options.headers),
+      [LOCAL_HARNESS_GRANT_HEADER]: snapshot.token,
+    },
+  };
+}


### PR DESCRIPTION
## What broke

Every chat turn on staging (any surface, both `/api/web/chat-v2` and `/api/mcp/chat-v2`) fails with **"An error occurred: messages are required"** since #4746 (`7e4fb25e07`).

That PR installed a `prepareSendMessagesRequest` on the chat transport that ran on **every** turn and returned `{ body }`. In `ai@6` the `body` handed to that hook is only the transport's custom fields (`model`, `temperature`, `selectedServerIds`, …). The SDK adds `id`/`messages`/`trigger`/`messageId` itself — but only on the fallback path it takes when the hook returns **no** body. Any returned body replaces the default wholesale, so the POST went out with no `messages`:

```
POSTED BODY: {"model":{"id":"x"},"temperature":0.7,"projectId":"p"}
has messages? false
```

It shipped because every `use-chat-session.*` suite mocks `@ai-sdk/react` and `ai`, so the real body composition was never exercised.

## The fix

- **Hook only on a local-harness turn.** The ordinary path no longer installs `prepareSendMessagesRequest` at all — the SDK's own body composition stays in charge, so there is nothing to get wrong there.
- **`client/src/lib/chat-send-request.ts`** owns the harness rewrite as a pure function. `withSdkSendFields` mirrors the SDK default (custom fields, then the four SDK fields — SDK fields win), and `prepareLocalHarnessSendRequest` builds on it: `harnessTarget` in the body, the grant token in a header, refusal when the target can't be resolved. Same behaviour #4746 wanted, minus the outage.
- **Tests against the real transport** (`chat-send-request.test.ts`, `ai` un-mocked):
  - the SDK default key set — an SDK upgrade that changes it fails here;
  - the replace-on-return trap that caused this, documented as a test so nobody reintroduces `return { body }`;
  - the harness hook posts exactly the default keys + `harnessTarget`, with `messages` intact.
- The local-harness suite's send seam now drives the hook with the SDK's full argument set and asserts `messages` on every path, plus a case that a non-harness transport installs no hook.

## Verification

- `vitest run client/src/hooks/__tests__/use-chat-session*` — 13 files, 178 tests pass
- `vitest run client/src/lib/__tests__/chat-send-request.test.ts` — 9 tests pass
- `npm run typecheck:client` clean

Not touched: the `/api/mcp/models` 410 and `/api/web/computers/browser/session` 409 in the same console — separate, non-fatal, pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ar8cnnFdaJf8SHtNtUUcte

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chat transport wiring for all sessions; the change is narrowly scoped (conditional hook + shared send helper) but incorrect body composition would break every chat turn again.
> 
> **Overview**
> Fixes a production outage where **every** chat POST omitted `messages` and returned 400, because `prepareSendMessagesRequest` ran on all turns and returned only the transport’s custom `body`. In **ai@6**, any returned `body` **replaces** the SDK default (`id`, `messages`, `trigger`, `messageId`) instead of merging with it.
> 
> **`use-chat-session`** now installs `prepareSendMessagesRequest` **only** when a local-harness turn is requested; ordinary turns leave SDK body composition unchanged. Local turns delegate to **`prepareLocalHarnessSendRequest`** in new **`client/src/lib/chat-send-request.ts`**, which merges custom fields with the four SDK fields via **`withSdkSendFields`**, adds `harnessTarget` and the grant header, and still throws when local execution cannot be authorized.
> 
> **Tests:** **`chat-send-request.test.ts`** exercises the real **`DefaultChatTransport`** (unmocked) to document the replace-on-return trap and lock the harness body shape. The local-harness suite’s **`sendRequest`** helper mirrors **`HttpChatTransport.sendMessages`** and adds cases that the hook is absent without local and that **`messages`** stay on local sends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff887ec8bcccc4b5fd9804007eccff6135824141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes every chat turn failing with "messages are required" by stopping the transport's send hook from replacing the SDK's default request body.

- The `prepareSendMessagesRequest` hook is now installed only on local-harness turns; the ordinary path leaves the SDK's body composition alone.
- `prepareLocalHarnessSendRequest` in `client/src/lib/chat-send-request.ts` re-adds the SDK's `id`, `messages`, `trigger`, and `messageId` fields on top of custom fields whenever a body is returned.
- New tests against the real `DefaultChatTransport` pin the SDK's default key set, document the replace-on-return trap, and verify the harness hook posts the default keys plus `harnessTarget`.
- The local-harness test suite now asserts `messages` on every path.

<sup>Written for commit ff887ec8bcccc4b5fd9804007eccff6135824141. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

