### PR TITLE
Eval suites: name the client at create time, and persist a server override by name

### DIFF
--- a/.changeset/eval-suite-client-and-server-attribution.md
+++ b/.changeset/eval-suite-client-and-server-attribution.md
@@ -1,0 +1,11 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": patch
+"@mcpjam/cli": patch
+---
+
+An API-authored eval suite can name its client, and a server override persists as a name
+
+**A suite created outside the app reported no client and an opaque server id.** The create route had no host input at all, so every CLI-, MCP-, and SDK-authored suite stored an empty client list — leaving the suites list showing a dash, and `run_eval_suite`'s host selector, which only runs hosts ATTACHED to a suite, with nothing to select. `POST /eval-suites` now accepts the same `hosts` array PATCH does, resolving the names before anything is authored and attaching them after, so a bad client name is a clean refusal with no half-created suite. `create_eval_suite` takes `hosts` — the same field name `update_eval_suite` already uses — and `mcpjam cloud eval create` takes `--host`.
+
+The second half is the server column. A suite's environment stores names only when the caller sends `serverNames` beside `serverIds`; the run path sent ids alone, so a suite authored by a run kept displaying a Convex id where a server name belongs. `run_eval_suite` and `run_eval_case` now send the display names paired with the ids, and `computeRunTargets` carries the pair through — dropping the names when they do not line up with the ids, because mislabelling a server is worse than showing its id.

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -212,6 +212,7 @@ type CreateOptions = PlatformOptions & {
   model?: string;
   provider?: string;
   server?: string[];
+  host?: string[];
 };
 
 /**
@@ -780,6 +781,7 @@ function loadSuiteDefinition(options: CreateOptions): CreateEvalSuiteInput {
     ...(options.model !== undefined ? { model: options.model } : {}),
     ...(options.provider !== undefined ? { provider: options.provider } : {}),
     ...(options.server !== undefined ? { servers: options.server } : {}),
+    ...(options.host !== undefined ? { hosts: options.host } : {}),
   };
 
   const parsed = createEvalSuiteOperation.inputSchema.safeParse(merged);
@@ -3053,6 +3055,10 @@ export function registerEvalCommands(program: Command): void {
     .option(
       "--server <id-or-name...>",
       "Project HTTP server names or IDs (overrides the file)"
+    )
+    .option(
+      "--host <id-or-name...>",
+      "Clients (hosts) to attach the suite to, by name or ID (overrides the file). Without one the suite lists no client and `eval run --host` has nothing to select"
     )
     .action(async (options: CreateOptions, command) => {
       const globalOptions = getGlobalOptions(command);

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -1159,6 +1159,7 @@ Create a runnable eval suite from authored test cases (does not run it).
 | `--model <model>` | No | Suite-level default model (overrides the file) |
 | `--provider <provider>` | No | Suite-level default provider (overrides the file) |
 | `--server <id-or-name...>` | No | Project HTTP server names or IDs (overrides the file) |
+| `--host <id-or-name...>` | No | Clients (hosts) to attach the suite to (overrides the file). Without one the suite lists no client, and `eval run --host` has nothing to select |
 
 ### `cloud eval list`
 

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -13125,6 +13125,31 @@
               "type": "string"
             }
           },
+          "hosts": {
+            "type": "array",
+            "description": "Clients (hosts) to attach the suite to, in attach order. A suite with no attached client reports none wherever it is listed, and a run has no host to select. Same shape as the PATCH `hosts` field.",
+            "items": {
+              "type": "object",
+              "required": [
+                "host"
+              ],
+              "properties": {
+                "host": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Host name or id."
+                },
+                "servers": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "description": "Server names (as bound in the suite's environment) or project-server ids."
+                }
+              }
+            }
+          },
           "model": {
             "type": "string",
             "minLength": 1,
@@ -13219,6 +13244,22 @@
           "servers": {
             "type": "array",
             "description": "The servers attached to the suite. `name` is present when supplied.",
+            "items": {
+              "type": "object",
+              "required": ["id"],
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "hosts": {
+            "type": "array",
+            "description": "The clients (hosts) attached to the suite at create time. Empty when none were named.",
             "items": {
               "type": "object",
               "required": ["id"],

--- a/mcpjam-inspector/server/routes/v1/__tests__/write-routes.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/write-routes.test.ts
@@ -1631,6 +1631,93 @@ describe("v1 write routes", () => {
       expect(authoredArgs.tests[0].provider).toBe("anthropic");
       expect(disconnectAllServers).toHaveBeenCalledTimes(1);
     });
+
+    it("attaches the named clients after authoring the suite", async () => {
+      // A suite authored over the API had no way to name its client, so every
+      // CLI/MCP/SDK-created suite read back with an empty Client — and the
+      // run route's host selector, which only accepts an ATTACHED host, had
+      // nothing to select.
+      const disconnectAllServers = vi.fn().mockResolvedValue(undefined);
+      createAuthorizedManagerMock.mockResolvedValue({
+        manager: { listServers: () => ["s1"], disconnectAllServers },
+      });
+      authorEvalSuiteMock.mockResolvedValue({
+        suiteId: "suite_new",
+        suiteName: "Fresh suite",
+        caseUpsert: { committed: [{ name: "echo works" }], failed: [] },
+      });
+      mockConvexQueries({
+        "hosts:listHosts": () => [{ hostId: "host_claude", name: "Claude" }],
+        "testSuites:getTestSuite": () => ({
+          _id: "suite_new",
+          projectId: "p1",
+          name: "Fresh suite",
+          environment: {
+            servers: ["Echo"],
+            serverBindings: [{ serverName: "Echo", projectServerId: "s1" }],
+          },
+        }),
+      });
+
+      const res = await request(
+        makeApp(),
+        "POST",
+        "/api/v1/projects/p1/eval-suites",
+        {
+          name: "Fresh suite",
+          serverIds: ["s1"],
+          serverNames: ["Echo"],
+          model: "anthropic/claude-haiku-4.5",
+          tests: [VALID_CASE],
+          hosts: [{ host: "Claude", servers: ["Echo"] }],
+        }
+      );
+
+      expect(res.status).toBe(201);
+      expect((await res.json()) as { hosts?: unknown }).toMatchObject({
+        hosts: [{ id: "host_claude" }],
+      });
+      expect(convexMutationMock).toHaveBeenCalledWith(
+        "testSuites:updateTestSuite",
+        {
+          suiteId: "suite_new",
+          hostAttachments: [
+            { namedHostId: "host_claude", selectedServerIds: ["s1"] },
+          ],
+        }
+      );
+    });
+
+    it("rejects an unknown client BEFORE authoring anything", async () => {
+      // Resolving after the write would leave a half-created suite behind for
+      // a request that was never satisfiable.
+      const disconnectAllServers = vi.fn().mockResolvedValue(undefined);
+      createAuthorizedManagerMock.mockResolvedValue({
+        manager: { listServers: () => ["s1"], disconnectAllServers },
+      });
+      mockConvexQueries({
+        "hosts:listHosts": () => [{ hostId: "host_claude", name: "Claude" }],
+      });
+
+      const res = await request(
+        makeApp(),
+        "POST",
+        "/api/v1/projects/p1/eval-suites",
+        {
+          name: "Fresh suite",
+          serverIds: ["s1"],
+          serverNames: ["Echo"],
+          model: "anthropic/claude-haiku-4.5",
+          tests: [VALID_CASE],
+          hosts: [{ host: "Nope" }],
+        }
+      );
+
+      expect(res.status).toBe(404);
+      expect(authorEvalSuiteMock).not.toHaveBeenCalled();
+      expect(convexMutationMock).not.toHaveBeenCalled();
+      expect(disconnectAllServers).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("eval-run concurrency gate", () => {

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -494,6 +494,19 @@ const createEvalSuiteSchema = z.strictObject({
   description: z.string().optional(),
   serverIds: z.array(z.string()).min(1),
   serverNames: z.array(z.string()).optional(),
+  // Client (host) attachments, same shape PATCH accepts. Without this the
+  // API-authored suite had no way to say which client it runs as, so every
+  // CLI/MCP/SDK-created suite read back with an empty Client — and
+  // `run_eval_suite`'s host selector, which only accepts an ATTACHED host,
+  // had nothing to select.
+  hosts: z
+    .array(
+      z.object({
+        host: z.string().min(1),
+        servers: z.array(z.string().min(1)).optional(),
+      }),
+    )
+    .optional(),
   model: z.string().min(1),
   provider: z.string().optional(),
   passCriteria: z.object({ minimumPassRate: z.number() }).optional(),
@@ -4068,6 +4081,21 @@ evals.post("/projects/:projectId/eval-suites", async (c) => {
   try {
     const resolvedServerIds = resolveServerIdsOrThrow(serverIds, manager);
     const { convexClient } = createConvexClients(convexAuthToken);
+
+    // Resolve the named clients BEFORE anything is authored, so an unknown or
+    // ambiguous client name is a clean 404/400 with no half-created suite left
+    // behind. The per-host `servers` picks are deliberately dropped for this
+    // pass: they resolve against the suite's environment bindings, which do
+    // not exist until the suite is written. The real resolution runs below.
+    if (body.hosts?.length) {
+      await resolveHostAttachments(
+        convexClient,
+        projectId,
+        { environment: {} },
+        body.hosts.map(({ host }) => ({ host })),
+      );
+    }
+
     const { suiteId, caseUpsert } = await authorEvalSuite({
       convexClient,
       tests: normalizedTests,
@@ -4085,6 +4113,36 @@ evals.post("/projects/:projectId/eval-suites", async (c) => {
       // re-authors the same suite instead of a second one.
       ...(idempotencyKey ? { idempotencyKey } : {}),
     });
+
+    // Attach the clients AFTER authoring: a per-host `servers` pick resolves
+    // against the suite's environment bindings, which the write above is what
+    // creates. Re-read for the same reason the PATCH route does.
+    let attachedHostIds: string[] = [];
+    if (body.hosts?.length) {
+      const suite = await readSuiteInProject(
+        convexAuthToken,
+        projectId,
+        suiteId,
+      );
+      const hostAttachments = await resolveHostAttachments(
+        convexClient,
+        projectId,
+        suite,
+        body.hosts,
+      );
+      try {
+        await convexClient.mutation("testSuites:updateTestSuite" as any, {
+          suiteId,
+          hostAttachments,
+        });
+      } catch (error) {
+        throw translateConvexWriteError(error);
+      }
+      attachedHostIds = hostAttachments.map((attachment) =>
+        String(attachment.namedHostId),
+      );
+    }
+
     return v1Resource(
       c,
       {
@@ -4094,6 +4152,7 @@ evals.post("/projects/:projectId/eval-suites", async (c) => {
           id,
           ...(serverNames?.[index] ? { name: serverNames[index] } : {}),
         })),
+        hosts: attachedHostIds.map((id) => ({ id })),
         caseUpsert,
       },
       201,

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -4120,7 +4120,10 @@ export const runEvalSuiteOperation: PlatformOperation<
             ? { allAttached: input.allAttached }
             : {}),
           ...(overrideServers
-            ? { serverIds: overrideServers.map((server) => server.id) }
+            ? {
+                serverIds: overrideServers.map((server) => server.id),
+                serverNames: overrideServers.map((server) => server.name),
+              }
             : {}),
         });
 
@@ -4254,6 +4257,11 @@ export const runEvalSuiteOperation: PlatformOperation<
             body: {
               suiteId: suite.id,
               ...(plan.serverIds ? { serverIds: plan.serverIds } : {}),
+              // Paired with `serverIds` by index. A launch that re-authors the
+              // suite's saved selection persists these NAMES; without them the
+              // platform stores the raw ids and the suite reads back with an
+              // opaque id where the server name belongs.
+              ...(plan.serverNames ? { serverNames: plan.serverNames } : {}),
               ...(plan.target?.kind === "environment"
                 ? { environmentId: plan.target.id }
                 : {}),
@@ -4593,7 +4601,12 @@ export const runEvalCaseOperation: PlatformOperation<
             suiteId: suite.id,
             caseIds: [testCase.id],
             ...(overrideServers
-              ? { serverIds: overrideServers.map((server) => server.id) }
+              ? {
+                  serverIds: overrideServers.map((server) => server.id),
+                  // Index-paired names, so an override persists as names
+                  // rather than ids. See the same pairing in run_eval_suite.
+                  serverNames: overrideServers.map((server) => server.name),
+                }
               : {}),
             // MUTUALLY EXCLUSIVE, and enforced above by
             // `assertRunTargetSelectorsCoherent`: `compose` with `environment`
@@ -4796,6 +4809,13 @@ const createEvalSuiteInput = z.strictObject({
     .describe(
       "Project server names or IDs the suite runs against. Must be HTTP servers; stdio servers can never run hosted."
     ),
+  hosts: z
+    .array(z.string().trim().min(1))
+    .min(1)
+    .optional()
+    .describe(
+      "Client (host) names or IDs to attach the suite to, in attach order. Same vocabulary update_eval_suite uses. A suite with no attached host runs under its own execution config and reports no client anywhere it is listed. Attaching also makes the host selectable on run_eval_suite, which only runs hosts ATTACHED to the suite."
+    ),
   model: z
     .string()
     .trim()
@@ -4827,6 +4847,8 @@ export type CreateEvalSuiteResult = {
   suite: { id: string; name: string | null };
   /** The HTTP servers the suite was configured against. */
   servers: Array<{ id: string; name?: string }>;
+  /** The clients (hosts) attached to the suite; empty when none were named. */
+  hosts: Array<{ id: string; name?: string }>;
   caseUpsert: PlatformEvalSuiteCreated["caseUpsert"];
 };
 
@@ -4837,7 +4859,7 @@ export const createEvalSuiteOperation: PlatformOperation<
   name: "create_eval_suite",
   title: "Create MCPJam eval suite",
   description:
-    "Create a runnable eval suite from authored test cases. Specify a name, a default model, the project HTTP servers it runs against, and one or more cases. Each case is an ordered `steps` array (prompt / toolCall / interact / assert) plus optional expected-output / negative-test. Returns the new suite id; run it with run_eval_suite. Does NOT run the suite — authoring is free. Servers must be HTTP; stdio servers can never run hosted.",
+    "Create a runnable eval suite from authored test cases. Specify a name, a default model, the project HTTP servers it runs against, optionally the clients (hosts) to attach it to, and one or more cases. Each case is an ordered `steps` array (prompt / toolCall / interact / assert) plus optional expected-output / negative-test. Returns the new suite id; run it with run_eval_suite. Does NOT run the suite — authoring is free. Servers must be HTTP; stdio servers can never run hosted.",
   readOnly: false,
   permalink: derivePermalinks((result) => [
     {
@@ -4866,6 +4888,9 @@ export const createEvalSuiteOperation: PlatformOperation<
           ...(input.description ? { description: input.description } : {}),
           serverIds: servers.map((server) => server.id),
           serverNames: servers.map((server) => server.name),
+          ...(input.hosts?.length
+            ? { hosts: input.hosts.map((host) => ({ host })) }
+            : {}),
           model: input.model,
           ...(input.provider ? { provider: input.provider } : {}),
           // Ergonomic case shape; the backend normalizes per-case defaults
@@ -4882,6 +4907,7 @@ export const createEvalSuiteOperation: PlatformOperation<
         id: server.id,
         name: server.name,
       })),
+      hosts: created.hosts ?? [],
       caseUpsert: created.caseUpsert,
     };
   },

--- a/sdk/src/platform/suite-run-plans.ts
+++ b/sdk/src/platform/suite-run-plans.ts
@@ -43,8 +43,19 @@ export type RunTargetPlan =
   /**
    * One run. `target` absent means the suite's own saved selection (the legacy
    * path, and the only shape that carries an explicit `serverIds` override).
+   *
+   * `serverNames` is the display-name array PAIRED with `serverIds` by index.
+   * It rides along so the launch can persist the suite's server selection by
+   * NAME: without it the platform falls back to storing the raw ids, and every
+   * surface that reads the suite back shows an opaque id where a server name
+   * belongs.
    */
-  | { kind: "single"; target?: RunTarget; serverIds?: string[] }
+  | {
+      kind: "single";
+      target?: RunTarget;
+      serverIds?: string[];
+      serverNames?: string[];
+    }
   /** One run per target, launched as a group. */
   | { kind: "group"; targets: RunTarget[] }
   /**
@@ -70,6 +81,13 @@ export interface ComputeRunTargetsInput {
   allAttached?: boolean;
   /** An explicit server override, which is a single legacy-path run. */
   serverIds?: string[];
+  /**
+   * Display names for `serverIds`, paired by index. Carried through so the
+   * override persists as names rather than ids; ignored unless it lines up
+   * with `serverIds` exactly, because a mismatched pair would mislabel
+   * servers, which is worse than showing the id.
+   */
+  serverNames?: string[];
 }
 
 /** Dedupe by resolved id, keeping first-seen order. */
@@ -116,7 +134,15 @@ export function computeRunTargets(
   // the suite's selection for ONE run and is mutually exclusive with both
   // target axes (the callers enforce that before getting here).
   if (input.serverIds && input.serverIds.length > 0) {
-    return { kind: "single", serverIds: input.serverIds };
+    const serverNames =
+      input.serverNames && input.serverNames.length === input.serverIds.length
+        ? input.serverNames
+        : undefined;
+    return {
+      kind: "single",
+      serverIds: input.serverIds,
+      ...(serverNames ? { serverNames } : {}),
+    };
   }
 
   const selectedEnvironments = dedupe(

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -1311,6 +1311,8 @@ export interface PlatformEvalSuiteCreated {
   name: string;
   /** The HTTP servers the suite was configured against. */
   servers?: Array<{ id: string; name?: string }>;
+  /** The clients (hosts) attached at create time; empty when none were named. */
+  hosts?: Array<{ id: string; name?: string }>;
   /** Per-case create outcomes, mirroring eval-run caseUpsert. */
   caseUpsert: {
     committed?: Array<{ id?: string; name?: string }>;

--- a/sdk/tests/platform/operations-run-targets.test.ts
+++ b/sdk/tests/platform/operations-run-targets.test.ts
@@ -394,6 +394,34 @@ describe("computeRunTargets", () => {
       }),
     ).toEqual({ kind: "single", serverIds: ["s1"] });
   });
+
+  it("carries server names through, paired with the ids by index", () => {
+    expect(
+      computeRunTargets({
+        attachedEnvironments: [],
+        attachedHosts: [],
+        serverIds: ["s1", "s2"],
+        serverNames: ["Echo", "Docs"],
+      }),
+    ).toEqual({
+      kind: "single",
+      serverIds: ["s1", "s2"],
+      serverNames: ["Echo", "Docs"],
+    });
+  });
+
+  it("drops names that do not line up with the ids", () => {
+    // A mismatched pair would label servers with each other's names, which is
+    // worse than showing the id — so the names are dropped, not zipped.
+    expect(
+      computeRunTargets({
+        attachedEnvironments: [],
+        attachedHosts: [],
+        serverIds: ["s1", "s2"],
+        serverNames: ["Echo"],
+      }),
+    ).toEqual({ kind: "single", serverIds: ["s1", "s2"] });
+  });
 });
 
 describe("run_eval_suite target selection", () => {

--- a/sdk/tests/platform/operations.test.ts
+++ b/sdk/tests/platform/operations.test.ts
@@ -955,9 +955,14 @@ describe("runEvalSuiteOperation", () => {
     const createCall = fetchMock.mock.calls.find(([target]) =>
       String(target).endsWith("/eval-runs")
     );
+    // `serverNames` rides along PAIRED WITH `serverIds` by index. A launch
+    // that re-authors the suite's saved selection persists these names; when
+    // they were missing the platform stored the raw ids, and every surface
+    // that lists the suite showed an opaque id where the server name belongs.
     expect(JSON.parse(String((createCall?.[1] as RequestInit).body))).toEqual({
       suiteId: "suite-1",
       serverIds: ["server-http", "server-disabled"],
+      serverNames: ["Echo", "Retired"],
     });
   });
 
@@ -1122,6 +1127,24 @@ describe("runEvalCaseOperation", () => {
     });
   });
 
+  it("pairs serverNames with an explicit server override", async () => {
+    const { client, fetchMock } = makeClient({ servers: HTTP_SERVERS });
+
+    await runEvalCaseOperation.execute(
+      { suite: "Smoke", case: "echo works", servers: ["echo"] },
+      { client }
+    );
+
+    const runCall = fetchMock.mock.calls.find(
+      (call) =>
+        String(call[0]).endsWith("/eval-runs") &&
+        (call[1] as RequestInit | undefined)?.method === "POST"
+    );
+    const body = JSON.parse(String((runCall?.[1] as RequestInit).body));
+    expect(body.serverIds).toEqual(["server-http"]);
+    expect(body.serverNames).toEqual(["Echo"]);
+  });
+
   it("requires a suite and a case", () => {
     expect(
       runEvalCaseOperation.inputSchema.safeParse({ suite: "Smoke" }).success
@@ -1191,6 +1214,65 @@ describe("createEvalSuiteOperation", () => {
         expect.objectContaining({ kind: "assert" }),
       ],
     });
+  });
+
+  it("attaches the named clients so the suite is not authored without one", async () => {
+    // An API-authored suite had no way to name its client: it read back with
+    // an empty Client everywhere it was listed, and `run_eval_suite`'s host
+    // selector — which only runs hosts ATTACHED to the suite — had nothing to
+    // select.
+    const { client, fetchMock } = makeClient({ servers: HTTP_SERVERS });
+
+    await createEvalSuiteOperation.execute(
+      {
+        name: "Authored smoke",
+        servers: ["echo"],
+        hosts: ["Claude", "host-chatgpt"],
+        model: "anthropic/claude-haiku-4.5",
+        cases: [
+          {
+            title: "echo works",
+            steps: [{ id: "s1", kind: "prompt", prompt: "say hi" }],
+          },
+        ],
+      },
+      { client }
+    );
+
+    const createCall = fetchMock.mock.calls.find(
+      ([target, init]) =>
+        String(target).endsWith("/eval-suites") &&
+        (init as RequestInit | undefined)?.method === "POST"
+    );
+    const body = JSON.parse(String((createCall?.[1] as RequestInit).body));
+    expect(body.hosts).toEqual([{ host: "Claude" }, { host: "host-chatgpt" }]);
+  });
+
+  it("omits hosts entirely when no client is named", async () => {
+    const { client, fetchMock } = makeClient({ servers: HTTP_SERVERS });
+
+    await createEvalSuiteOperation.execute(
+      {
+        name: "Authored smoke",
+        servers: ["echo"],
+        model: "anthropic/claude-haiku-4.5",
+        cases: [
+          {
+            title: "echo works",
+            steps: [{ id: "s1", kind: "prompt", prompt: "say hi" }],
+          },
+        ],
+      },
+      { client }
+    );
+
+    const createCall = fetchMock.mock.calls.find(
+      ([target, init]) =>
+        String(target).endsWith("/eval-suites") &&
+        (init as RequestInit | undefined)?.method === "POST"
+    );
+    const body = JSON.parse(String((createCall?.[1] as RequestInit).body));
+    expect(body).not.toHaveProperty("hosts");
   });
 
   it("rejects stdio servers before creating the suite", async () => {


### PR DESCRIPTION
## What

An eval suite created outside the app reported no client, and a suite authored by a run showed a raw Convex id where the server name belongs.

Two independent causes, fixed together because they produce the same broken row.

**The create route had no host input at all.** Every CLI-, MCP-, and SDK-authored suite stored an empty client list, so the suites list rendered a dash. It also left `run_eval_suite`'s host selector — which only runs hosts ATTACHED to a suite — with nothing to select, so an API-authored suite could never be run against a named client. `POST /eval-suites` now accepts the same `hosts` array `PATCH` does. Host names resolve **before** anything is authored, so an unknown or ambiguous client is a clean 404/400 with no half-created suite left behind; the attachment itself lands after, where a per-host `servers` pick can resolve against the environment bindings the create just wrote.

**A server override persisted as ids.** A suite's environment stores names only when the caller sends `serverNames` beside `serverIds`, and the run path sent ids alone. `run_eval_suite` and `run_eval_case` now send the display names paired with the ids, and `computeRunTargets` carries the pair through the plan. The names are dropped when they do not line up with the ids exactly, because mislabelling a server is worse than showing its id.

## Surfaces

| Surface | Before | After |
|---|---|---|
| `create_eval_suite` | no client input | `hosts: string[]`, the field name `update_eval_suite` already uses |
| `mcpjam cloud eval create` | `--server` only | `--host <id-or-name...>` |
| `POST /eval-suites` | no `hosts` key | `hosts: [{ host, servers? }]`, mirroring PATCH |
| run launches with `--server` | `serverIds` only | `serverIds` + paired `serverNames` |

## Testing

- `npm run test -w @mcpjam/sdk` — 7327 pass
- `npm run test:fast -w @mcpjam/cli` — 1250 pass
- `vitest run server/routes/v1/__tests__` — 1636 pass
- `npm run typecheck -w @mcpjam/sdk` and `-w @mcpjam/cli` clean

New coverage: the route attaches resolved clients and refuses an unknown one before authoring; the create operation sends `hosts` only when named; both run operations pair names with ids; the plan drops mismatched names.

## Repair for existing suites

A suite already stored with ids can be fixed without a migration, since the update API replaces servers by name and accepts host attachments:

```
mcpjam cloud eval update --suite <id> --server <name> --host <client name>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS79nQvDknTyPooZmqjLZs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches eval suite create/run API paths and persistence semantics; behavior changes for API-authored suites and server overrides, but validation-before-write and strict name/id pairing limit blast radius.
> 
> **Overview**
> **Eval suites created via API/CLI/SDK can now declare attached clients at create time**, fixing empty “Client” columns and making `run_eval_suite` host selection work for those suites. `POST /eval-suites` accepts a **`hosts`** array (same shape as PATCH); **`create_eval_suite`** and **`mcpjam cloud eval create --host`** pass it through. Hosts are **validated before** suite authoring and **attached after** bindings exist, so unknown clients fail without leaving a half-created suite.
> 
> **Runs that override servers now persist display names**, not only Convex ids. **`run_eval_suite`** and **`run_eval_case`** send **`serverNames`** index-paired with **`serverIds`**; **`computeRunTargets`** forwards the pair and **drops names** when lengths do not match, avoiding mislabeled servers in the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a64838a12c8fa79ebdb8f64b482d1652636dc97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes eval suites created outside the app reporting no client, and server overrides persisting as raw IDs instead of display names. The create route had no host input, so CLI-, MCP-, and SDK-authored suites stored an empty client list; the run path sent only server IDs, so a suite authored by a run showed an opaque Convex ID where the server name belongs.

**Bug Fixes**

- `POST /eval-suites` now accepts the same `hosts` array PATCH uses; client names resolve before authoring, so an unknown host is a clean 404/400 with no half-created suite, and attachments land after the suite is written.
- `create_eval_suite` takes `hosts` — the field name `update_eval_suite` already uses — and `mcpjam cloud eval create` takes `--host <id-or-name...>`.
- `run_eval_suite` and `run_eval_case` now send `serverNames` paired with `serverIds`, and `computeRunTargets` carries the pair through; mismatched names are dropped because mislabeling is worse than showing the ID.
- Attaching a host makes it selectable in `run_eval_suite`'s host selector, which only runs attached hosts.
- Suites already stored with IDs can be repaired in place: `mcpjam cloud eval update --suite <id> --server <name> --host <client name>`.

<sup>Written for commit 2a64838a12c8fa79ebdb8f64b482d1652636dc97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

