### PR TITLE
fix(evals): export SDK code that compiles against the current SDK

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/sdk-eval-quickstart.tsx
+++ b/mcpjam-inspector/client/src/components/evals/sdk-eval-quickstart.tsx
@@ -58,7 +58,7 @@ export const SDK_EVAL_QUICKSTART_DOTENV = buildSdkEvalQuickstartDotenv();
 export const SDK_EVAL_QUICKSTART_INSTALL = "npm install @mcpjam/sdk";
 
 export const SDK_EVAL_QUICKSTART_RUN = `import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { MCPClientManager, TestAgent, EvalTest } from "@mcpjam/sdk";
+import { MCPClientManager, HostRunner, EvalTest } from "@mcpjam/sdk";
 
 // MCPJam hosted learning server (tools: greet, display-mcp-app — see Learn in the app)
 const SERVER_ID = "learn";
@@ -66,19 +66,19 @@ const MCP_SERVER_URL =
   process.env.MCP_SERVER_URL ?? "https://learn.mcpjam.com/mcp";
 // Use the same env var you exported above (e.g. OPENAI_API_KEY instead of LLM_API_KEY).
 const LLM_API_KEY = process.env.LLM_API_KEY!;
-// provider/model-id — must match an allowed TestAgent provider (see Configure environment in the app or SDK README).
+// provider/model-id — must match an allowed HostRunner provider (see Configure environment in the app or SDK README).
 const MODEL = process.env.EVAL_MODEL!;
 
 describe("MCP eval quickstart", () => {
   let manager: MCPClientManager;
-  let agent: TestAgent;
+  let agent: HostRunner;
 
   beforeAll(async () => {
     manager = new MCPClientManager();
     // Streamable HTTP — swap URL + SERVER_ID for your own MCP server
     await manager.connectToServer(SERVER_ID, { url: MCP_SERVER_URL });
     const tools = await manager.getToolsForAiSdk([SERVER_ID]);
-    agent = new TestAgent({
+    agent = new HostRunner({
       tools,
       model: MODEL,
       apiKey: LLM_API_KEY,
@@ -102,8 +102,8 @@ describe("MCP eval quickstart", () => {
         name: "learning-server-greet-multi-turn",
         expectedToolCalls: [{ toolName: "greet" }],
         test: async (agent) => {
-          const r1 = await agent.prompt("Use the greet tool to say hello to Ada.");
-          const r2 = await agent.prompt("Now greet Grace too.", { context: [r1] });
+          const r1 = await agent.run("Use the greet tool to say hello to Ada.");
+          const r2 = await agent.run("Now greet Grace too.", { context: [r1] });
           return r1.hasToolCall("greet") && r2.hasToolCall("greet");
         },
       });

--- a/mcpjam-inspector/client/src/lib/evals/__tests__/eval-export-compiles.test.ts
+++ b/mcpjam-inspector/client/src/lib/evals/__tests__/eval-export-compiles.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+import { SDK_EVAL_QUICKSTART_RUN } from "@/components/evals/sdk-eval-quickstart";
+import {
+  buildSdkTestFile,
+  buildServerConnections,
+  normalizeEvalCaseForExport,
+} from "@/lib/evals/eval-export";
+
+/**
+ * The export modal hands users a file to run. Every other test in this folder
+ * asserts on the emitted STRING, which cannot tell a live SDK symbol from a
+ * retired one — that blind spot is why the generator kept emitting `TestAgent`
+ * and `.prompt()` for the whole 1.11 → 8.x window after the SDK removed both
+ * without aliases.
+ *
+ * So this test compiles the emitted file against the SDK's real source. It is
+ * slower than a string match by design: a rename that the generator does not
+ * follow has to fail HERE rather than in a user's terminal.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// client/src/lib/evals/__tests__ → …/client → …/mcpjam-inspector → repo root
+const SDK_ENTRY = resolve(HERE, "../../../../../../sdk/src/index.ts");
+
+const httpServer = {
+  name: "mcpjam",
+  config: { url: new URL("https://mcp.mcpjam.com/mcp") },
+} as never;
+
+function exportFor(testCase: Record<string, unknown>): string {
+  return buildSdkTestFile({
+    suite: { name: "compile fixture", description: "compile fixture" },
+    cases: [normalizeEvalCaseForExport(testCase as never)],
+    serverConnections: buildServerConnections(["mcpjam"], {
+      mcpjam: httpServer,
+    }),
+  });
+}
+
+const SINGLE_TURN = exportFor({
+  _id: "c_single",
+  title: "single turn",
+  query: "list my projects",
+  runs: 1,
+  isNegativeTest: false,
+  steps: [
+    { id: "s1", kind: "prompt", prompt: "list my projects" },
+    {
+      id: "s2",
+      kind: "assert",
+      assertion: {
+        type: "toolCalledWith",
+        toolName: "list_projects",
+        args: { args: { limit: 10 } },
+      },
+    },
+  ],
+});
+
+const MULTI_TURN = exportFor({
+  _id: "c_multi",
+  title: "multi turn",
+  query: "list my projects",
+  runs: 2,
+  isNegativeTest: false,
+  steps: [
+    { id: "s1", kind: "prompt", prompt: "list my projects" },
+    {
+      id: "s2",
+      kind: "assert",
+      assertion: {
+        type: "toolCalledWith",
+        toolName: "list_projects",
+        args: { args: { limit: 10 } },
+      },
+    },
+    { id: "s3", kind: "prompt", prompt: "now open the first one" },
+    {
+      id: "s4",
+      kind: "assert",
+      assertion: {
+        type: "toolCalledWith",
+        toolName: "get_project",
+        args: { args: {} },
+      },
+    },
+  ],
+});
+
+const NEGATIVE = exportFor({
+  _id: "c_negative",
+  title: "negative",
+  query: "just chat",
+  runs: 1,
+  isNegativeTest: true,
+  steps: [{ id: "s1", kind: "prompt", prompt: "just chat" }],
+});
+
+/**
+ * Compile `files` against the SDK source and return readable diagnostics.
+ *
+ * The sources are VIRTUAL but addressed inside this directory, so `vitest` and
+ * the workspace `node_modules` resolve exactly as they would for a real file
+ * here; only `@mcpjam/sdk` is mapped explicitly, because the package advertises
+ * `./dist` and a clean checkout has not built it.
+ */
+function typecheck(files: Record<string, string>): string[] {
+  const virtualFiles = new Map<string, string>();
+  for (const [name, contents] of Object.entries(files)) {
+    virtualFiles.set(join(HERE, name), contents);
+  }
+  // The SDK's `skill-reference.ts` raw-imports markdown, which only the SDK's
+  // own bundler config declares. Shim it so those imports resolve here.
+  virtualFiles.set(
+    join(HERE, "__md-shim.d.ts"),
+    'declare module "*.md" { const content: string; export default content; }\n'
+  );
+
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+    resolveJsonModule: true,
+    baseUrl: HERE,
+    paths: { "@mcpjam/sdk": [SDK_ENTRY] },
+  };
+
+  const host = ts.createCompilerHost(options, true);
+  const realGetSourceFile = host.getSourceFile.bind(host);
+  const realFileExists = host.fileExists.bind(host);
+  const realReadFile = host.readFile.bind(host);
+
+  host.getSourceFile = (fileName, languageVersion, ...rest) => {
+    const virtual = virtualFiles.get(fileName);
+    return virtual === undefined
+      ? realGetSourceFile(fileName, languageVersion, ...rest)
+      : ts.createSourceFile(fileName, virtual, languageVersion, true);
+  };
+  host.fileExists = (fileName) =>
+    virtualFiles.has(fileName) || realFileExists(fileName);
+  host.readFile = (fileName) => virtualFiles.get(fileName) ?? realReadFile(fileName);
+
+  const program = ts.createProgram([...virtualFiles.keys()], options, host);
+  const owned = new Set(virtualFiles.keys());
+
+  return ts
+    .getPreEmitDiagnostics(program)
+    .filter((diagnostic) => diagnostic.file && owned.has(diagnostic.file.fileName))
+    .map((diagnostic) => {
+      const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, " ");
+      const { line } = diagnostic.file!.getLineAndCharacterOfPosition(
+        diagnostic.start ?? 0
+      );
+      const name = diagnostic.file!.fileName.split("/").pop();
+      return `${name}:${line + 1} TS${diagnostic.code}: ${message}`;
+    });
+}
+
+describe("exported SDK test files compile against the real SDK", () => {
+  it(
+    "emits only live SDK symbols for single-turn, multi-turn and negative cases",
+    () => {
+      expect(
+        typecheck({
+          "single.test.ts": SINGLE_TURN,
+          "multi.test.ts": MULTI_TURN,
+          "negative.test.ts": NEGATIVE,
+        })
+      ).toEqual([]);
+    },
+    120_000
+  );
+
+  it(
+    "keeps the in-app quickstart snippet compiling",
+    () => {
+      expect(typecheck({ "quickstart.test.ts": SDK_EVAL_QUICKSTART_RUN })).toEqual(
+        []
+      );
+    },
+    120_000
+  );
+
+  it("pins the executor surface the generator depends on", () => {
+    // A rename on either of these is what broke the export before; name them
+    // explicitly so the failure message points at the rename, not at a wall of
+    // compiler output.
+    for (const emitted of [SINGLE_TURN, MULTI_TURN, NEGATIVE]) {
+      expect(emitted).toContain("HostRunner");
+      expect(emitted).toContain("agent.run(");
+      expect(emitted).not.toContain("TestAgent");
+      expect(emitted).not.toContain("agent.prompt(");
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/lib/evals/__tests__/eval-export-compiles.test.ts
+++ b/mcpjam-inspector/client/src/lib/evals/__tests__/eval-export-compiles.test.ts
@@ -240,7 +240,13 @@ describe("exported SDK test files compile against the real SDK", () => {
     // fine and still run. Every line mentioning the payload must be a comment.
     expect(typecheck({ "injection.test.ts": INJECTION })).toEqual([]);
 
-    const offending = INJECTION.split("\n").filter(
+    // Split on the SAME terminator set the generator splits on. Splitting on
+    // "\n" alone would miss this fixture's own vector: a U+2028 inside a tool
+    // name is a line terminator to TypeScript but not to String.split("\n"),
+    // so a regression that stopped splitting on it would leave
+    // `// ...evil\u2028throw ...` looking like one comment line here AND
+    // compiling cleanly — both checks green with the injection live.
+    const offending = INJECTION.split(/[\r\n\u2028\u2029]/).filter(
       (line) => line.includes(INJECTION_MARKER) && !line.trim().startsWith("//")
     );
     expect(offending).toEqual([]);

--- a/mcpjam-inspector/client/src/lib/evals/__tests__/eval-export-compiles.test.ts
+++ b/mcpjam-inspector/client/src/lib/evals/__tests__/eval-export-compiles.test.ts
@@ -118,6 +118,36 @@ const EMPTY_TURNS = buildSdkTestFile({
  * close a generated comment and turn the rest into code.
  */
 const INJECTION_MARKER = "INJECTED_BY_FIXTURE";
+const INJECTION_SUITE = buildSdkTestFile({
+  suite: {
+    name: `suite\u2028      throw new Error("${INJECTION_MARKER}");`,
+    description: `desc\u2029      throw new Error("${INJECTION_MARKER}");`,
+  },
+  cases: [
+    {
+      id: "c_srv",
+      title: `title\u2028      throw new Error("${INJECTION_MARKER}");`,
+      query: "hi",
+      runs: 1,
+      isNegativeTest: false,
+      expectedToolCalls: [],
+      promptTurns: [{ id: "t1", prompt: "hi", expectedToolCalls: [] }],
+    },
+  ],
+  // A server NAME is user-chosen free text and reaches both a `//` comment and
+  // a generated string literal.
+  serverConnections: [
+    {
+      serverId: `srv\u2028      throw new Error("${INJECTION_MARKER}");`,
+      kind: "stdio",
+      command: "npx",
+      args: ["x"],
+      envKeys: [],
+      placeholder: false,
+    },
+  ],
+});
+
 const INJECTION = exportFor({
   _id: "c_inject",
   title: "injection",
@@ -236,17 +266,33 @@ describe("exported SDK test files compile against the real SDK", () => {
   );
 
   it("cannot be made to emit code through a comment", () => {
-    // Compiling is necessary but not sufficient: injected source could compile
-    // fine and still run. Every line mentioning the payload must be a comment.
+    // Compiling is necessary but nowhere near sufficient — injected source can
+    // be perfectly valid TypeScript — so it is the first of three checks, not
+    // the proof.
     expect(typecheck({ "injection.test.ts": INJECTION })).toEqual([]);
+    expect(typecheck({ "injection-suite.test.ts": INJECTION_SUITE })).toEqual(
+      []
+    );
 
-    // Split on the SAME terminator set the generator splits on. Splitting on
-    // "\n" alone would miss this fixture's own vector: a U+2028 inside a tool
-    // name is a line terminator to TypeScript but not to String.split("\n"),
-    // so a regression that stopped splitting on it would leave
-    // `// ...evil\u2028throw ...` looking like one comment line here AND
-    // compiling cleanly — both checks green with the injection live.
-    const offending = INJECTION.split(/[\r\n\u2028\u2029]/).filter(
+    // This is the load-bearing one, and the only check that does not depend on
+    // what the payload happens to say: the generator's ONLY line separator is
+    // "\n", so a raw CR, U+2028 or U+2029 anywhere in the output came from
+    // injected data. With none present, nothing can leave a comment or a string
+    // literal no matter what the payload contains.
+    //
+    // Note U+2028 is exactly the case a "\n"-only check misses: it ends a line
+    // for TypeScript but not for String.split("\n"), so a regression would
+    // leave `// ...evil\u2028throw ...` looking like a single comment line AND
+    // compiling cleanly.
+    for (const emitted of [INJECTION, INJECTION_SUITE]) {
+      expect(emitted).not.toMatch(/[\r\u2028\u2029]/);
+    }
+
+    // Scoped to the fixture whose payload reaches comments ONLY. A suite name,
+    // case title or server id is DATA and belongs in a generated string literal,
+    // so the marker on a non-comment line there is correct output — the check
+    // above is what proves it cannot break out of that literal.
+    const offending = INJECTION.split("\n").filter(
       (line) => line.includes(INJECTION_MARKER) && !line.trim().startsWith("//")
     );
     expect(offending).toEqual([]);

--- a/mcpjam-inspector/client/src/lib/evals/__tests__/eval-export-compiles.test.ts
+++ b/mcpjam-inspector/client/src/lib/evals/__tests__/eval-export-compiles.test.ts
@@ -91,6 +91,52 @@ const MULTI_TURN = exportFor({
   ],
 });
 
+/**
+ * A case with NO turns. `buildSdkTestFile` is exported, and its multi-turn
+ * branch is the `else` of `promptTurns.length === 1` — so it renders
+ * `ExportedTurn[]` here too, and the declaration guard has to agree.
+ */
+const EMPTY_TURNS = buildSdkTestFile({
+  suite: { name: "empty", description: "" },
+  cases: [
+    {
+      id: "c_empty",
+      title: "no turns",
+      query: "",
+      runs: 1,
+      isNegativeTest: false,
+      expectedToolCalls: [],
+      promptTurns: [],
+    },
+  ],
+  serverConnections: buildServerConnections(["mcpjam"], { mcpjam: httpServer }),
+});
+
+/**
+ * Free text and tool names come from outside this codebase — an MCP server
+ * names its own tools — so a line terminator in either must not be able to
+ * close a generated comment and turn the rest into code.
+ */
+const INJECTION_MARKER = "INJECTED_BY_FIXTURE";
+const INJECTION = exportFor({
+  _id: "c_inject",
+  title: "injection",
+  query: "hi",
+  runs: 1,
+  isNegativeTest: false,
+  scenario: `line one\n      throw new Error("${INJECTION_MARKER}");`,
+  steps: [
+    { id: "s1", kind: "prompt", prompt: "hi" },
+    {
+      id: "s2",
+      kind: "toolCall",
+      serverName: "mcpjam",
+      toolName: `evil\u2028      throw new Error("${INJECTION_MARKER}");`,
+      arguments: {},
+    },
+  ],
+});
+
 const NEGATIVE = exportFor({
   _id: "c_negative",
   title: "negative",
@@ -172,6 +218,7 @@ describe("exported SDK test files compile against the real SDK", () => {
           "single.test.ts": SINGLE_TURN,
           "multi.test.ts": MULTI_TURN,
           "negative.test.ts": NEGATIVE,
+          "empty.test.ts": EMPTY_TURNS,
         })
       ).toEqual([]);
     },
@@ -187,6 +234,17 @@ describe("exported SDK test files compile against the real SDK", () => {
     },
     120_000
   );
+
+  it("cannot be made to emit code through a comment", () => {
+    // Compiling is necessary but not sufficient: injected source could compile
+    // fine and still run. Every line mentioning the payload must be a comment.
+    expect(typecheck({ "injection.test.ts": INJECTION })).toEqual([]);
+
+    const offending = INJECTION.split("\n").filter(
+      (line) => line.includes(INJECTION_MARKER) && !line.trim().startsWith("//")
+    );
+    expect(offending).toEqual([]);
+  });
 
   it("pins the executor surface the generator depends on", () => {
     // A rename on either of these is what broke the export before; name them

--- a/mcpjam-inspector/client/src/lib/evals/__tests__/eval-export.test.ts
+++ b/mcpjam-inspector/client/src/lib/evals/__tests__/eval-export.test.ts
@@ -153,7 +153,7 @@ describe("eval-export", () => {
   it("pins exported env snippets to the project the export came from", () => {
     const envSnippet = buildSdkEnvSnippet([], {}, "jd7fromexport");
     expect(envSnippet.snippet).toContain(
-      "export MCPJAM_PROJECT_ID=jd7fromexport",
+      "export MCPJAM_PROJECT_ID='jd7fromexport'",
     );
   });
 

--- a/mcpjam-inspector/client/src/lib/evals/__tests__/eval-export.test.ts
+++ b/mcpjam-inspector/client/src/lib/evals/__tests__/eval-export.test.ts
@@ -119,7 +119,7 @@ describe("eval-export", () => {
       "export MCP_SERVER_URL_CALENDAR=<replace-with-server-url>"
     );
     expect(envSnippet.snippet).toContain(
-      "export MCP_SERVER_URL_WEATHER=https://weather.example.com/mcp"
+      "export MCP_SERVER_URL_WEATHER='https://weather.example.com/mcp'"
     );
     // Reporting runs on MCPJam API keys (sk_); the retired mcpjam_ project
     // keys must never resurface in generated snippets.
@@ -127,6 +127,27 @@ describe("eval-export", () => {
     expect(envSnippet.snippet).not.toContain("mcpjam_");
     // No projectId given → no pin; uploads fall back to the Default project.
     expect(envSnippet.snippet).not.toContain("MCPJAM_PROJECT_ID");
+  });
+
+  it("shell-quotes server URLs so a pasted snippet cannot run them", () => {
+    // This snippet exists to be copied into a terminal, so a saved URL is
+    // input to a shell, not just a string. Stripping line terminators is not
+    // enough on its own: `$(...)`, backticks and `;` all run unquoted.
+    const url = "https://x/$(id)/`whoami`/;touch /tmp/pwned/'q'";
+    const hostile = { name: "weather", config: { url } } as unknown as ServerWithName;
+
+    const { snippet } = buildSdkEnvSnippet(["weather"], { weather: hostile });
+    const line = snippet
+      .split("\n")
+      .find((l) => l.startsWith("export MCP_SERVER_URL_WEATHER="))!;
+
+    // The whole value is single-quoted runs and escaped quotes, nothing else —
+    // which is precisely what leaves no room for the shell to expand anything.
+    expect(line).toMatch(
+      /^export MCP_SERVER_URL_WEATHER=(?:'[^']*'|\\')+$/
+    );
+    // And the URL is preserved rather than sanitized away.
+    expect(line).toContain("$(id)");
   });
 
   it("pins exported env snippets to the project the export came from", () => {

--- a/mcpjam-inspector/client/src/lib/evals/eval-export.ts
+++ b/mcpjam-inspector/client/src/lib/evals/eval-export.ts
@@ -223,7 +223,9 @@ export function buildSdkEnvSnippet(
     "export MCPJAM_API_KEY=<your sk_… key>",
     // Pin uploads to the project this export came from; without it they
     // land in the org's Default project.
-    ...(projectId ? [`export MCPJAM_PROJECT_ID=${projectId}`] : []),
+    ...(projectId
+      ? [`export MCPJAM_PROJECT_ID=${shellSingleQuote(projectId)}`]
+      : []),
   ];
 
   if (httpConnections.length > 0) {
@@ -322,7 +324,7 @@ export function buildSdkTestFile({
     "const SERVER_IDS = SERVER_CONFIGS.map((server) => server.id);",
     "const LLM_API_KEY = process.env.LLM_API_KEY!;",
     "const MODEL = process.env.EVAL_MODEL!;",
-    `const SUITE_NAME = ${JSON.stringify(suite.name || "MCPJam export")};`,
+    `const SUITE_NAME = ${jsonLiteral(suite.name || "MCPJam export")};`,
   ];
 
   if (suite.description?.trim()) {
@@ -495,7 +497,7 @@ function buildCaseTestBlock(
 
   const lines: string[] = [
     "  it(",
-    `    ${JSON.stringify(caseTitle)},`,
+    `    ${jsonLiteral(caseTitle)},`,
     "    async () => {",
   ];
 
@@ -510,14 +512,14 @@ function buildCaseTestBlock(
   // rename of `name` cannot fork the case.
   lines.push(
     "      const evalTest = new EvalTest({",
-    `        id: ${JSON.stringify(exportedCaseId(testCase))},`,
-    `        name: ${JSON.stringify(caseTitle)},`
+    `        id: ${jsonLiteral(exportedCaseId(testCase))},`,
+    `        name: ${jsonLiteral(caseTitle)},`
   );
 
   if (allExpectedToolCalls.length > 0) {
     lines.push(
       `        expectedToolCalls: ${indentBlock(
-        JSON.stringify(allExpectedToolCalls, null, 2),
+        jsonLiteral(allExpectedToolCalls, 2),
         8
       ).trimStart()},`
     );
@@ -527,7 +529,7 @@ function buildCaseTestBlock(
   if (promptTurns.length === 1 && firstTurn) {
     lines.push(
       "        test: async (agent) => {",
-      `          const result = await agent.run(${JSON.stringify(
+      `          const result = await agent.run(${jsonLiteral(
         firstTurn.prompt
       )});`
     );
@@ -543,12 +545,11 @@ function buildCaseTestBlock(
       "        test: async (agent) => {",
       "          const turns: ExportedTurn[] =",
       `${indentBlock(
-        JSON.stringify(
+        jsonLiteral(
           promptTurns.map((turn) => ({
             prompt: turn.prompt,
             expectedToolCalls: turn.expectedToolCalls ?? [],
           })),
-          null,
           2
         ),
         12
@@ -623,12 +624,12 @@ function buildSingleTurnReturnExpression(
     const hasArgs = Object.keys(tc.arguments ?? {}).length > 0;
     if (hasArgs) {
       checks.push(
-        `matchToolCallWithPartialArgs(${JSON.stringify(
+        `matchToolCallWithPartialArgs(${jsonLiteral(
           tc.toolName
-        )}, ${JSON.stringify(tc.arguments)}, result.getToolCalls())`
+        )}, ${jsonLiteral(tc.arguments)}, result.getToolCalls())`
       );
     } else {
-      checks.push(`result.hasToolCall(${JSON.stringify(tc.toolName)})`);
+      checks.push(`result.hasToolCall(${jsonLiteral(tc.toolName)})`);
     }
   }
 
@@ -742,7 +743,7 @@ function pushCaseComments(lines: string[], testCase: EvalExportCaseInput) {
     commentLines.push(
       "Advanced config captured in MCPJam (apply manually if you need stricter runtime parity):"
     );
-    commentLines.push(...JSON.stringify(advancedConfig, null, 2).split("\n"));
+    commentLines.push(...jsonLiteral(advancedConfig, 2).split("\n"));
   }
 
   if (commentLines.length === 0) {
@@ -769,16 +770,16 @@ function renderServerConnectionEntries(
     if (connection.kind === "http") {
       if (connection.placeholder) {
         lines.push(
-          `// Replace the placeholder URL for ${JSON.stringify(
+          `// Replace the placeholder URL for ${collapseToSingleLine(
             connection.serverId
           )} with the real server URL if needed.`
         );
       }
       lines.push(
         "{",
-        `  id: ${JSON.stringify(connection.serverId)},`,
+        `  id: ${jsonLiteral(connection.serverId)},`,
         '  kind: "http",',
-        `  url: process.env.${connection.envVarName} ?? ${JSON.stringify(
+        `  url: process.env.${connection.envVarName} ?? ${jsonLiteral(
           connection.url
         )},`,
         "},"
@@ -787,7 +788,7 @@ function renderServerConnectionEntries(
     }
 
     lines.push(
-      `// ${JSON.stringify(
+      `// ${collapseToSingleLine(
         connection.serverId
       )} runs over stdio: ${collapseToSingleLine(
         formatCommandDisplay(connection.command, connection.args)
@@ -802,15 +803,31 @@ function renderServerConnectionEntries(
     }
     lines.push(
       "{",
-      `  id: ${JSON.stringify(connection.serverId)},`,
+      `  id: ${jsonLiteral(connection.serverId)},`,
       '  kind: "stdio",',
-      `  command: ${JSON.stringify(connection.command)},`,
-      `  args: ${JSON.stringify(connection.args)},`,
+      `  command: ${jsonLiteral(connection.command)},`,
+      `  args: ${jsonLiteral(connection.args)},`,
       "},"
     );
   }
 
   return lines.join("\n");
+}
+
+/**
+ * `JSON.stringify` for a value that becomes part of the GENERATED SOURCE.
+ *
+ * `JSON.stringify` escapes CR and LF but leaves U+2028 / U+2029 as raw
+ * characters, because the JSON spec permits them in a string. JavaScript does
+ * not: they terminate a line. Inside a `//` comment that ends the comment, and
+ * in a string literal it is only legal from ES2019 on — the exported file is
+ * compiled under the AUTHOR's tsconfig, not ours, so an older target breaks on
+ * it. Escaping them here keeps both cases sound whatever the value contains.
+ */
+function jsonLiteral(value: unknown, indent?: number): string {
+  return JSON.stringify(value, null, indent)
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/evals/eval-export.ts
+++ b/mcpjam-inspector/client/src/lib/evals/eval-export.ts
@@ -702,8 +702,12 @@ function describeUntranslatedTurnState(testCase: EvalExportCaseInput): string[] 
       );
     }
     if (turn.pinnedToolCall) {
+      // Deliberately not "asserts nothing": a NEGATIVE case's callback is a
+      // single `results.every(... toolsCalled().length === 0)`, which covers
+      // this turn like any other. What is true in both branches is that the
+      // pinned call never runs and the turn prompts with an empty string.
       notes.push(
-        `  ${label}: pinned (model-free) call "${turn.pinnedToolCall.toolName}" is NOT replayed; this turn asserts nothing.`
+        `  ${label}: pinned (model-free) call "${turn.pinnedToolCall.toolName}" is NOT replayed; the turn sends an empty prompt and only the case's own assertions apply.`
       );
     }
   });

--- a/mcpjam-inspector/client/src/lib/evals/eval-export.ts
+++ b/mcpjam-inspector/client/src/lib/evals/eval-export.ts
@@ -232,7 +232,9 @@ export function buildSdkEnvSnippet(
       lines.push(
         connection.placeholder
           ? `export ${connection.envVarName}=<replace-with-server-url>`
-          : `export ${connection.envVarName}=${connection.url}`
+          : `export ${connection.envVarName}=${collapseToSingleLine(
+              connection.url
+            )}`
       );
     }
   }
@@ -244,16 +246,19 @@ export function buildSdkEnvSnippet(
     );
     for (const connection of stdioConnections) {
       lines.push(
-        `# ${connection.serverId}: ${formatCommandDisplay(
-          connection.command,
-          connection.args
+        `# ${collapseToSingleLine(
+          connection.serverId
+        )}: ${collapseToSingleLine(
+          formatCommandDisplay(connection.command, connection.args)
         )}`
       );
       if (connection.envKeys.length > 0) {
         lines.push(
-          `# ${
+          `# ${collapseToSingleLine(
             connection.serverId
-          } also expects local env vars: ${connection.envKeys.join(", ")}`
+          )} also expects local env vars: ${collapseToSingleLine(
+            connection.envKeys.join(", ")
+          )}`
         );
       }
     }
@@ -277,7 +282,11 @@ export function buildSdkTestFile({
   usedPlaceholderFallback = false,
 }: SdkTestFileInput): string {
   const needsPartialArgMatching = anyTestCaseUsesPartialArgMatching(cases);
-  const needsTurnType = cases.some((c) => c.promptTurns.length > 1);
+  // Must match the multi-turn branch in `buildCaseTestBlock` EXACTLY: that
+  // branch is the `else` of `promptTurns.length === 1`, so it also renders
+  // `ExportedTurn[]` for a case with NO turns. Guarding on `> 1` emitted the
+  // reference without its declaration (TS2304) for the empty case.
+  const needsTurnType = cases.some((c) => c.promptTurns.length !== 1);
   const sdkImports = ["  MCPClientManager,", "  HostRunner,", "  EvalTest,"];
   if (needsPartialArgMatching) {
     sdkImports.push("  matchToolCallWithPartialArgs,");
@@ -317,7 +326,10 @@ export function buildSdkTestFile({
   ];
 
   if (suite.description?.trim()) {
-    lines.push("", `// ${suite.description.trim()}`);
+    lines.push(
+      "",
+      ...toCommentLines(suite.description.trim()).map((line) => `// ${line}`)
+    );
   }
 
   if (usedPlaceholderFallback) {
@@ -627,16 +639,35 @@ function buildSingleTurnReturnExpression(
   return `(\n            ${checks.join(" &&\n            ")}\n          )`;
 }
 
+/**
+ * Whether any case's generated body REFERENCES `matchToolCallWithPartialArgs`.
+ *
+ * This has to mirror the emission sites exactly, not approximate them — an
+ * import guard that is narrower than the code it guards emits a call with no
+ * import (TS2304), which is how a multi-turn case whose turns declare no
+ * arguments used to produce a file that could not compile.
+ *
+ * A negative case never references the matcher (it asserts no tool ran), and
+ * the MULTI-TURN branch always does — its loop keeps the partial-args ternary
+ * whether or not this particular case supplies arguments. Only the single-turn
+ * branch actually varies with the arguments present.
+ */
 function anyTestCaseUsesPartialArgMatching(
   cases: EvalExportCaseInput[]
 ): boolean {
-  return cases.some((c) =>
-    c.promptTurns.some((turn) =>
+  return cases.some((testCase) => {
+    if (testCase.isNegativeTest) {
+      return false;
+    }
+    if (testCase.promptTurns.length !== 1) {
+      return true;
+    }
+    return testCase.promptTurns.some((turn) =>
       (turn.expectedToolCalls ?? []).some(
         (tc) => Object.keys(tc.arguments ?? {}).length > 0
       )
-    )
-  );
+    );
+  });
 }
 
 /**
@@ -714,8 +745,13 @@ function pushCaseComments(lines: string[], testCase: EvalExportCaseInput) {
     return;
   }
 
-  for (const line of commentLines) {
-    lines.push(`      // ${line}`);
+  // Split here rather than at each call site: this is the ONE place a case's
+  // free-text fields reach the file, so a value that carries a line terminator
+  // cannot escape its comment no matter which field it came from.
+  for (const entry of commentLines) {
+    for (const line of toCommentLines(entry)) {
+      lines.push(`      // ${line}`);
+    }
   }
   lines.push("");
 }
@@ -749,15 +785,14 @@ function renderServerConnectionEntries(
     lines.push(
       `// ${JSON.stringify(
         connection.serverId
-      )} runs over stdio: ${formatCommandDisplay(
-        connection.command,
-        connection.args
+      )} runs over stdio: ${collapseToSingleLine(
+        formatCommandDisplay(connection.command, connection.args)
       )}`
     );
     if (connection.envKeys.length > 0) {
       lines.push(
-        `// Add any required local env vars before running: ${connection.envKeys.join(
-          ", "
+        `// Add any required local env vars before running: ${collapseToSingleLine(
+          connection.envKeys.join(", ")
         )}`
       );
     }
@@ -772,6 +807,40 @@ function renderServerConnectionEntries(
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Every line terminator JavaScript recognizes.
+ *
+ * U+2028 / U+2029 belong here beside CR and LF: both end a line in JS source,
+ * and `JSON.stringify` does NOT escape them, so a value that survived
+ * serialization can still terminate a comment.
+ */
+const LINE_TERMINATORS = /[\r\n\u2028\u2029]/;
+
+/**
+ * Split a value into physical lines so the caller can prefix each one as its
+ * own comment.
+ *
+ * A `//` (or shell `#`) comment ends at the first line terminator, so an
+ * interpolated value carrying one does not merely garble the comment — the
+ * remainder becomes executable code in a file the author is about to run. Case
+ * titles, scenarios, and tool names all originate outside this codebase (an
+ * MCP server names its own tools), so none of them may be pasted into a
+ * comment whole. Splitting rather than escaping keeps genuinely multi-line
+ * prose readable, which is the common case.
+ */
+function toCommentLines(value: unknown): string[] {
+  return String(value).split(LINE_TERMINATORS);
+}
+
+/**
+ * Flatten a value onto ONE line, for places that cannot span lines — a shell
+ * `export VAR=value`, where a newline would not comment out but would run as
+ * the next command.
+ */
+function collapseToSingleLine(value: string): string {
+  return value.split(LINE_TERMINATORS).join(" ");
 }
 
 function normalizeOptionalString(

--- a/mcpjam-inspector/client/src/lib/evals/eval-export.ts
+++ b/mcpjam-inspector/client/src/lib/evals/eval-export.ts
@@ -277,7 +277,8 @@ export function buildSdkTestFile({
   usedPlaceholderFallback = false,
 }: SdkTestFileInput): string {
   const needsPartialArgMatching = anyTestCaseUsesPartialArgMatching(cases);
-  const sdkImports = ["  MCPClientManager,", "  TestAgent,", "  EvalTest,"];
+  const needsTurnType = cases.some((c) => c.promptTurns.length > 1);
+  const sdkImports = ["  MCPClientManager,", "  HostRunner,", "  EvalTest,"];
   if (needsPartialArgMatching) {
     sdkImports.push("  matchToolCallWithPartialArgs,");
   }
@@ -292,6 +293,19 @@ export function buildSdkTestFile({
     '  | { id: string; kind: "http"; url: string }',
     '  | { id: string; kind: "stdio"; command: string; args: string[] };',
     "",
+    // Annotated rather than `as const`: a const-asserted literal gives
+    // `expectedToolCalls.length` the LITERAL type of each turn's length, so the
+    // `expected.length === 0` guard below fails to compile (TS2367) on any case
+    // whose turns all declare the same non-zero number of calls.
+    ...(needsTurnType
+      ? [
+          "type ExportedTurn = {",
+          "  prompt: string;",
+          "  expectedToolCalls: { toolName: string; arguments: Record<string, unknown> }[];",
+          "};",
+          "",
+        ]
+      : []),
     "const SERVER_CONFIGS: ServerConnection[] = [",
     indentBlock(renderServerConnectionEntries(serverConnections), 2),
     "];",
@@ -317,7 +331,7 @@ export function buildSdkTestFile({
     "",
     `describe(SUITE_NAME, () => {`,
     "  let manager: MCPClientManager;",
-    "  let agent: TestAgent;",
+    "  let agent: HostRunner;",
     "",
     "  beforeAll(async () => {",
     "    manager = new MCPClientManager();",
@@ -333,7 +347,7 @@ export function buildSdkTestFile({
     "    }",
     "",
     "    const tools = await manager.getToolsForAiSdk(SERVER_IDS);",
-    "    agent = new TestAgent({",
+    "    agent = new HostRunner({",
     "      tools,",
     "      model: MODEL,",
     "      apiKey: LLM_API_KEY,",
@@ -501,7 +515,7 @@ function buildCaseTestBlock(
   if (promptTurns.length === 1 && firstTurn) {
     lines.push(
       "        test: async (agent) => {",
-      `          const result = await agent.prompt(${JSON.stringify(
+      `          const result = await agent.run(${JSON.stringify(
         firstTurn.prompt
       )});`
     );
@@ -515,12 +529,22 @@ function buildCaseTestBlock(
   } else {
     lines.push(
       "        test: async (agent) => {",
-      "          const turns =",
-      `${indentBlock(JSON.stringify(promptTurns, null, 2), 12)} as const;`,
-      "          const results: Awaited<ReturnType<typeof agent.prompt>>[] = [];",
+      "          const turns: ExportedTurn[] =",
+      `${indentBlock(
+        JSON.stringify(
+          promptTurns.map((turn) => ({
+            prompt: turn.prompt,
+            expectedToolCalls: turn.expectedToolCalls ?? [],
+          })),
+          null,
+          2
+        ),
+        12
+      )};`,
+      "          const results: Awaited<ReturnType<typeof agent.run>>[] = [];",
       "",
       "          for (const turn of turns) {",
-      "            const result = await agent.prompt(turn.prompt, {",
+      "            const result = await agent.run(turn.prompt, {",
       "              context: results.length > 0 ? results : undefined,",
       "            });",
       "            results.push(result);",
@@ -615,6 +639,53 @@ function anyTestCaseUsesPartialArgMatching(
   );
 }
 
+/**
+ * Per-turn state the exported file cannot evaluate.
+ *
+ * A turn carries more than `prompt` + `expectedToolCalls`: `checks` are
+ * deterministic predicates (including every ADVISORY `toolCalledWith`, which
+ * `stepsToPromptTurns` deliberately leaves as a predicate), `widgetChecks` are
+ * DOM-level, and `pinnedToolCall` marks a MODEL-FREE turn. The generated
+ * `test()` reads none of them, so they are named here rather than dropped
+ * silently — an author who sees the case pass locally needs to know what that
+ * pass did and did not cover.
+ */
+function describeUntranslatedTurnState(testCase: EvalExportCaseInput): string[] {
+  const notes: string[] = [];
+
+  testCase.promptTurns.forEach((turn, index) => {
+    const label = `turn ${index + 1}`;
+    for (const check of turn.checks ?? []) {
+      const role = (check as { role?: string }).role === "advisory"
+        ? "advisory"
+        : "gating";
+      notes.push(
+        `  ${label}: ${role} check "${String(
+          (check as { type?: string }).type ?? "unknown"
+        )}" is NOT evaluated by this file.`
+      );
+    }
+    for (const widgetCheck of turn.widgetChecks ?? []) {
+      notes.push(
+        `  ${label}: widget checks on "${widgetCheck.toolName}" need a hosted run; NOT evaluated here.`
+      );
+    }
+    if (turn.pinnedToolCall) {
+      notes.push(
+        `  ${label}: pinned (model-free) call "${turn.pinnedToolCall.toolName}" is NOT replayed; this turn asserts nothing.`
+      );
+    }
+  });
+
+  if (notes.length === 0) {
+    return [];
+  }
+  return [
+    "Not carried over from MCPJam — run this case in the hosted suite to cover it:",
+    ...notes,
+  ];
+}
+
 function pushCaseComments(lines: string[], testCase: EvalExportCaseInput) {
   const commentLines: string[] = [];
   if (testCase.scenario) {
@@ -628,6 +699,8 @@ function pushCaseComments(lines: string[], testCase: EvalExportCaseInput) {
       `Model hints from MCPJam: ${testCase.modelHints.join(", ")}`
     );
   }
+
+  commentLines.push(...describeUntranslatedTurnState(testCase));
 
   const advancedConfig = testCase.advancedConfig ?? undefined;
   if (advancedConfig && Object.keys(advancedConfig).length > 0) {

--- a/mcpjam-inspector/client/src/lib/evals/eval-export.ts
+++ b/mcpjam-inspector/client/src/lib/evals/eval-export.ts
@@ -232,7 +232,7 @@ export function buildSdkEnvSnippet(
       lines.push(
         connection.placeholder
           ? `export ${connection.envVarName}=<replace-with-server-url>`
-          : `export ${connection.envVarName}=${collapseToSingleLine(
+          : `export ${connection.envVarName}=${shellSingleQuote(
               connection.url
             )}`
       );
@@ -836,6 +836,19 @@ const LINE_TERMINATORS = /[\r\n\u2028\u2029]/;
  */
 function toCommentLines(value: unknown): string[] {
   return String(value).split(LINE_TERMINATORS);
+}
+
+/**
+ * Quote a value for a POSIX shell so the shell treats it as literal text.
+ *
+ * Collapsing line terminators is not enough on its own: this snippet is meant
+ * to be COPIED INTO A TERMINAL, so an unquoted `$(...)`, backtick, `;` or `&`
+ * in a saved server URL runs as a command the moment it is pasted. Single
+ * quotes suppress every expansion, and the `'\''` dance is the standard way
+ * to carry a literal single quote through them.
+ */
+function shellSingleQuote(value: string): string {
+  return `'${collapseToSingleLine(value).replace(/'/g, "'\\''")}'`;
 }
 
 /**


### PR DESCRIPTION
## Summary

The **Export test case → SDK code** tab handed users a file that could not run. Four compile-breaking defects, verified with `tsc` against `sdk/src` — three of them pre-dating this PR:

```
TS2305  Module '"@mcpjam/sdk"' has no exported member 'TestAgent'.
TS2339  Property 'prompt' does not exist on type 'HostExecutor'.
TS2367  This comparison appears to be unintentional because the types '1' and '0' have no overlap.
TS2304  Cannot find name 'matchToolCallWithPartialArgs'.
```

Plus a code-injection hole (CWE-94) on the same generator, reachable through an already-shipping field.

## Why it went unnoticed

`TestAgent` and `.prompt()` were removed in **SDK 1.11.0** ("Stage 4"), which shipped `TestAgent` → `HostRunner` and `.prompt()` → `.run()` with *no deprecation aliases*. That release's codemod was scoped to `sdk` and `examples`, so the inspector's generator was never migrated. The SDK is now at **8.6.0**.

The emitted symbols only ever appear inside **string literals**, so neither the client typecheck nor the existing string-matching tests could see them — the tests check the generator against itself.

## Changes

**Live SDK surface.** `TestAgent` → `HostRunner`, `agent.prompt(...)` → `agent.run(...)`, in the generator (`eval-export.ts`) and the in-app quickstart snippet (`sdk-eval-quickstart.tsx`).

**Declaration guards that didn't match their emission sites** — two, one root cause: a guard deciding whether to DECLARE a symbol was narrower than the branch that USES it.

- `needsTurnType` guarded on `promptTurns.length > 1`, but the branch rendering `ExportedTurn[]` is the `else` of `=== 1`, which also covers a case with no turns.
- `anyTestCaseUsesPartialArgMatching` gated the matcher import on some turn declaring arguments, but the multi-turn branch references `matchToolCallWithPartialArgs` unconditionally. Any multi-turn non-negative case with no arguments emitted the call without its import. Pre-existing; found by the injection fixture added here.

**`as const` on the turn list** gave `expectedToolCalls.length` a literal type, so `expected.length === 0` failed to compile on any case whose turns all declared the same non-zero call count. It escaped notice because the one multi-turn fixture has an empty first turn, widening the union to include `0`. Now annotated with an emitted `ExportedTurn` type.

**Comment injection (CWE-94).** Case free text and MCP tool names both originate outside this codebase, and a `//` comment ends at the first line terminator — so the remainder ran as TypeScript in a file the author is about to execute. This reproduces on the pre-existing `scenario` path:

```
// Scenario: line1
process.exit(1); // SCENARIO INJECTION
```

Fixed at every site a dynamic value reaches a generated comment, not only the flagged ones. Free text is split into one comment line per physical line (multi-line prose stays readable); values that cannot span lines — the env snippet's `export VAR=value`, where a newline runs as the next shell command — are collapsed. U+2028/U+2029 count as terminators alongside CR/LF, since `JSON.stringify` does not escape them.

**Turn serialization.** The turn list now carries only the fields the generated `test()` reads. It previously embedded per-turn `checks` (including every advisory `toolCalledWith`), `widgetChecks`, and `pinnedToolCall` — none of which the emitted code evaluates, so the file showed authors checks that silently did not run. What is left behind is now named on the case:

```ts
// Not carried over from MCPJam — run this case in the hosted suite to cover it:
//   turn 1: advisory check "toolCalledWith" is NOT evaluated by this file.
//   turn 2: pinned (model-free) call "get_project" is NOT replayed; the turn sends an empty prompt and only the case's own assertions apply.
```

## Test plan

- New `eval-export-compiles.test.ts` compiles the emitted file — single-turn, multi-turn, negative, and empty-turn cases — plus the in-app quickstart snippet, against the SDK **source**. String assertions cannot tell a live SDK symbol from a retired one; this is the check that can.
- An injection fixture asserts more than "it compiles" (injected source could compile and still run): every line mentioning the payload must be a comment.
- `vitest run src/lib/evals/__tests__/` → **8 files, 65 tests passing**, including the 8 pre-existing `eval-export` tests unchanged.
- The 3 failures in `eval-export-modal.test.tsx` in my sandbox are missing `@testing-library/jest-dom` matchers and reproduce identically on a pristine checkout; `downloads the generated SDK test file` passes.

## Not addressed here (follow-ups)

Found during the audit, left out because each is a design call rather than a mechanical fix:

- A turn's `checks` are still not *evaluated*, only reported. `EvalTestConfig.predicates` takes the same `Predicate` type, but its scope is the whole iteration transcript while `turn.checks` are per-turn; the SDK exports `evaluateTurnChecks` / `buildTurnTranscript` for the faithful mapping. Note `requiresRenderObservations` is **not** re-exported from `@mcpjam/sdk/predicates`, so a consumer cannot currently filter the three hosted-only predicate kinds that `EvalTest` throws on.
- A `pinnedToolCall` turn still emits `agent.run("")` — the pinned call never replays. On a positive case the turn contributes no assertion at all; on a negative case the case-wide "no tools were called" assertion still covers it. It is now flagged in a comment, but `it.skip` or a hard failure would be more honest than a turn that prompts with an empty string.
- `advancedConfig.system` / `.temperature` are still emitted as an "apply manually" comment even though `HostRunnerConfig` has first-class `systemPrompt` / `temperature` (and `withOptions` honors both), so an exported run does not reproduce dashboard conditions.
- `EvalTestConfig.scorers` and `matchOptions` are never emitted; `expectedToolCalls` is enforced twice, once via the SDK matcher and once re-implemented inside `test()`.
- Unrelated to this generator: `result.getText()` appears in 9 docs locations, but `PromptResult` has a `readonly text` property and no `getText()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNr7Gm5HjGNAgeJxbAu4Wj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNr7Gm5HjGNAgeJxbAu4Wj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect user-executed generated code and terminal-pasted env snippets; fixes are well-tested but any generator bug could still ship broken or unsafe exports.
> 
> **Overview**
> Fixes **Export test case → SDK code** so downloaded files typecheck and run against today's `@mcpjam/sdk`, and hardens the generator against injection in generated source and shell env snippets.
> 
> **SDK API alignment:** Generated tests and the in-app eval quickstart now use **`HostRunner`** and **`agent.run(...)`** instead of the removed **`TestAgent`** / **`.prompt()`**. Multi-turn exports use an emitted **`ExportedTurn[]`** type instead of **`as const`**, and import/declaration guards (**`needsTurnType`**, **`matchToolCallWithPartialArgs`**) match the branches that actually reference those symbols (including empty-turn and argument-free multi-turn cases).
> 
> **Safety & fidelity:** User-controlled text (scenarios, titles, tool names, URLs) is emitted via **`jsonLiteral`** (U+2028/U+2029), **`toCommentLines`**, and **`collapseToSingleLine`** so line terminators cannot break out of comments; env **`export`** lines **shell-single-quote** URLs and project IDs. Exported turn data is limited to fields the generated **`test()`** evaluates, with comments calling out checks, widgets, and pinned turns that still require a hosted run.
> 
> **Tests:** New **`eval-export-compiles.test.ts`** typechecks emitted files and the quickstart against **`sdk/src`**, plus injection and symbol-pinning assertions; existing **`eval-export.test.ts`** covers shell quoting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05bce2cde4182e61c4dfea5e5eaf52a0482cf91d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Export test case → SDK code" tab so generated files compile against the current `@mcpjam/sdk` and no external value can run as code.

**Bug Fixes**
- Swapped `TestAgent` → `HostRunner` and `.prompt()` → `.run()` in the generator and the in-app quickstart snippet.
- Annotated the emitted turn list with an `ExportedTurn` type instead of `as const`, which fixes the `expected.length === 0` comparison on cases whose turns all declare the same non-zero call count.
- Split free-text fields into one comment line per physical line so a line terminator can't close a comment and run as code; values that can't span lines are collapsed, and U+2028/U+2029 count as terminators alongside CR/LF.
- Single-quotes saved server URLs and the project ID in the env snippet so shell metacharacters like `$(...)`, backticks, and `;` can't run when pasted into a terminal.
- Escapes U+2028/U+2029 in every generated string literal via a new `jsonLiteral` helper, since `JSON.stringify` leaves them raw and they end a line in JavaScript.
- Made the `ExportedTurn` and `matchToolCallWithPartialArgs` declaration guards mirror their emission sites, so the generated file never references a symbol without its declaration.

The turn list now serializes only the fields the generated `test()` actually reads. The previously embedded per-turn `checks`, `widgetChecks`, and `pinnedToolCall` were never evaluated, so they're now named in a comment on the case; a pinned turn never replays its call — positive cases send an empty prompt with no assertions, while negative cases still assert that no tools ran.

Added a regression test that compiles single-turn, multi-turn, negative, empty-turn, and injection exports plus the quickstart snippet against the SDK source — string assertions can't tell a live SDK symbol from a retired one.

<sup>Written for commit 05bce2cde4182e61c4dfea5e5eaf52a0482cf91d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

