### PR TITLE
Require installation identity in GitHub repository pickers

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
@@ -361,9 +361,6 @@ describe("SuiteGithubChecksSection repository identity", () => {
       expect(screen.getByRole("button", { name: /Connect/ })).toBeDisabled(),
     );
     expect(mockConnectVerifiedRepo).not.toHaveBeenCalled();
-    expect(
-      screen.queryByRole("option", { name: "mcpjam/pinned" }),
-    ).not.toBeInTheDocument();
   });
 });
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
@@ -32,22 +32,20 @@ const {
   // `repositoryId` is REQUIRED by the contract and is what the picker is keyed
   // on: two connected accounts can each have a `widgets`, so a name is not a
   // selector. `installationRef` says which installation the entry came from.
-  mockListInstallationRepos: vi.fn(
-    async (): Promise<unknown[]> => [
-      {
-        repositoryId: 101,
-        fullName: "mcpjam/inspector",
-        installationRef: "bind-1",
-        accountLogin: "mcpjam",
-      },
-      {
-        repositoryId: 102,
-        fullName: "mcpjam/backend",
-        installationRef: "bind-1",
-        accountLogin: "mcpjam",
-      },
-    ]
-  ),
+  mockListInstallationRepos: vi.fn(async (): Promise<unknown[]> => [
+    {
+      repositoryId: 101,
+      fullName: "mcpjam/inspector",
+      installationRef: "bind-1",
+      accountLogin: "mcpjam",
+    },
+    {
+      repositoryId: 102,
+      fullName: "mcpjam/backend",
+      installationRef: "bind-1",
+      accountLogin: "mcpjam",
+    },
+  ]),
   mockNavigate: vi.fn(),
   mockToast: { error: vi.fn(), success: vi.fn() },
 }));
@@ -88,7 +86,7 @@ function renderSection(
   opts: {
     availability?: { state: "enabled" | "disabled" } | undefined;
     repos?: any[] | undefined;
-  } = {}
+  } = {},
 ) {
   // Read the key's PRESENCE, not its value: a destructuring default fires on an
   // explicit `undefined` too, which would silently turn the "still loading"
@@ -104,7 +102,7 @@ function renderSection(
       suiteId="suite-1"
       projectId="proj-1"
       organizationId="org-1"
-    />
+    />,
   );
 }
 
@@ -112,7 +110,7 @@ function renderSection(
 async function chooseOption(
   user: ReturnType<typeof userEvent.setup>,
   triggerLabel: string,
-  optionName: string
+  optionName: string,
 ) {
   await user.click(screen.getByLabelText(triggerLabel));
   await user.click(await screen.findByRole("option", { name: optionName }));
@@ -134,19 +132,19 @@ describe("SuiteGithubChecksSection", () => {
   it("lists only the repositories running THIS suite", async () => {
     renderSection({ repos: [CONNECTED_HERE, CONNECTED_ELSEWHERE] });
     expect(
-      await screen.findByTestId("suite-github-repo-mcpjam/mcp-check-fixture")
+      await screen.findByTestId("suite-github-repo-mcpjam/mcp-check-fixture"),
     ).toBeInTheDocument();
     // Connected to a different suite — showing it here would imply this suite
     // runs on it.
     expect(
-      screen.queryByTestId("suite-github-repo-mcpjam/inspector")
+      screen.queryByTestId("suite-github-repo-mcpjam/inspector"),
     ).not.toBeInTheDocument();
   });
 
   it("says so when no repository runs this suite", () => {
     renderSection({ repos: [CONNECTED_ELSEWHERE] });
     expect(
-      screen.getByText("No repositories run this suite yet.")
+      screen.getByText("No repositories run this suite yet."),
     ).toBeInTheDocument();
   });
 
@@ -164,8 +162,8 @@ describe("SuiteGithubChecksSection", () => {
     expect(trigger).toBeInTheDocument();
     await waitFor(() =>
       expect(
-        screen.queryByText("No repositories available to connect.")
-      ).not.toBeInTheDocument()
+        screen.queryByText("No repositories available to connect."),
+      ).not.toBeInTheDocument(),
     );
   });
 
@@ -201,7 +199,7 @@ describe("SuiteGithubChecksSection", () => {
     await user.click(screen.getByRole("button", { name: /Connect/ }));
 
     await waitFor(() =>
-      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1)
+      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1),
     );
     expect(mockConnectVerifiedRepo).toHaveBeenCalledWith({
       repoFullName: "mcpjam/inspector",
@@ -253,7 +251,7 @@ describe("SuiteGithubChecksSection", () => {
       () =>
         new Promise((resolve) => {
           resolveConnect = resolve as (result: unknown) => void;
-        })
+        }),
     );
     const user = userEvent.setup();
     const { unmount } = renderSection({ repos: [] });
@@ -263,7 +261,7 @@ describe("SuiteGithubChecksSection", () => {
     await chooseOption(user, "Outage policy", "Fail open");
     await user.click(screen.getByRole("button", { name: /Connect/ }));
     await waitFor(() =>
-      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1)
+      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1),
     );
 
     unmount();
@@ -280,13 +278,13 @@ describe("SuiteGithubChecksSection", () => {
 
     expect(
       screen.getByText(
-        /During an MCPJam outage or pause, the check reports neutral\./
-      )
+        /During an MCPJam outage or pause, the check reports neutral\./,
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        /Whether a failed or neutral check blocks merging depends on this repository's branch-protection settings\./
-      )
+        /Whether a failed or neutral check blocks merging depends on this repository's branch-protection settings\./,
+      ),
     ).toBeInTheDocument();
     const page = document.body.textContent ?? "";
     for (const forbidden of [/merges proceed/i, /merges are blocked/i]) {
@@ -339,41 +337,33 @@ describe("SuiteGithubChecksSection repository identity", () => {
     await user.click(screen.getByRole("button", { name: /Connect/ }));
 
     await waitFor(() =>
-      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1)
+      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1),
     );
     expect(mockConnectVerifiedRepo).toHaveBeenCalledWith(
       expect.objectContaining({
         repoFullName: "widgets",
         installationRef: "bind-globex",
         repositoryId: 202,
-      })
+      }),
     );
   });
 
-  it("omits installationRef when the listing carried none", async () => {
-    // The compatibility window: an organization with no binding is still listed
-    // through the backend's pinned installation, and omitting the reference is
-    // what keeps that connect path reachable.
+  it("rejects a stale listing entry without installation identity", async () => {
     mockListInstallationRepos.mockResolvedValue([
       { repositoryId: 301, fullName: "mcpjam/pinned" },
     ]);
-    const user = userEvent.setup();
     renderSection({ repos: [] });
     await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
-
-    await chooseOption(user, "Repository", "mcpjam/pinned");
-    await chooseOption(user, "Outage policy", "Fail open");
-    await user.click(screen.getByRole("button", { name: /Connect/ }));
-
+    expect(
+      await screen.findByText(/No repositories available to connect\./)
+    ).toBeInTheDocument();
     await waitFor(() =>
-      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1)
+      expect(screen.getByRole("button", { name: /Connect/ })).toBeDisabled(),
     );
-    const sent = mockConnectVerifiedRepo.mock.calls[0]?.[0] as Record<
-      string,
-      unknown
-    >;
-    expect(sent).not.toHaveProperty("installationRef");
-    expect(sent.repositoryId).toBe(301);
+    expect(mockConnectVerifiedRepo).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("option", { name: "mcpjam/pinned" }),
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -395,20 +385,24 @@ describe("SuiteGithubChecksSection binding changes", () => {
         suiteId="suite-1"
         projectId="proj-1"
         organizationId="org-1"
-      />
+      />,
     );
   }
 
   it("re-lists when an account is connected elsewhere", async () => {
     mockListInstallationRepos.mockReset();
-    mockListInstallationRepos
-      .mockResolvedValueOnce([])
-      .mockResolvedValue([{ repositoryId: 401, fullName: "acme/widgets" }]);
+    mockListInstallationRepos.mockResolvedValueOnce([]).mockResolvedValue([
+      {
+        repositoryId: 401,
+        fullName: "acme/widgets",
+        installationRef: "bind-acme",
+      },
+    ]);
 
     const user = userEvent.setup();
     const { rerender } = renderWithBindings([]);
     await waitFor(() =>
-      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1)
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1),
     );
 
     mockBindings.value = [
@@ -426,22 +420,26 @@ describe("SuiteGithubChecksSection binding changes", () => {
         suiteId="suite-1"
         projectId="proj-1"
         organizationId="org-1"
-      />
+      />,
     );
 
     await waitFor(() =>
-      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2)
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2),
     );
     await user.click(screen.getByLabelText("Repository"));
     expect(
-      await screen.findByRole("option", { name: "acme/widgets" })
+      await screen.findByRole("option", { name: "acme/widgets" }),
     ).toBeInTheDocument();
   });
 
   it("does not re-list when the query re-delivers the same bindings", async () => {
     mockListInstallationRepos.mockReset();
     mockListInstallationRepos.mockResolvedValue([
-      { repositoryId: 402, fullName: "acme/widgets" },
+      {
+        repositoryId: 402,
+        fullName: "acme/widgets",
+        installationRef: "bind-acme",
+      },
     ]);
     const rows = () => [
       {
@@ -456,7 +454,7 @@ describe("SuiteGithubChecksSection binding changes", () => {
 
     const { rerender } = renderWithBindings(rows());
     await waitFor(() =>
-      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1)
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1),
     );
 
     // A fresh array with identical content, which is what every delivery of a
@@ -467,7 +465,7 @@ describe("SuiteGithubChecksSection binding changes", () => {
         suiteId="suite-1"
         projectId="proj-1"
         organizationId="org-1"
-      />
+      />,
     );
     await act(async () => {});
 

--- a/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
@@ -12,6 +12,7 @@ import {
 import { useAppNavigate } from "@/lib/app-navigation";
 import { githubChecksWriteErrorMessage } from "@/lib/github-checks-errors";
 import {
+  isSelectableGithubRepo,
   findRepoByPickerValue,
   installationBindingsKey,
   pickerLabelFor,
@@ -103,7 +104,7 @@ export function SuiteGithubChecksSection({
   // to offer, whatever it read when the page opened.
   const bindingsKey = useMemo(
     () => installationBindingsKey(bindings),
-    [bindings]
+    [bindings],
   );
 
   // The bindings key the listing on screen (or in flight) was fetched under.
@@ -125,7 +126,7 @@ export function SuiteGithubChecksSection({
       hasListedRef.current = false;
       listedBindingsKeyRef.current = null;
     },
-    []
+    [],
   );
 
   useEffect(() => {
@@ -173,7 +174,7 @@ export function SuiteGithubChecksSection({
     void listInstallationRepos()
       .then((repositories) => {
         if (listingGenerationRef.current !== generation) return;
-        setInstallationRepos(repositories);
+        setInstallationRepos(repositories.filter(isSelectableGithubRepo));
       })
       .catch(() => {
         // Silent here, unlike the settings page. This section is incidental to
@@ -189,19 +190,19 @@ export function SuiteGithubChecksSection({
 
   const allRepos = repos ?? [];
   const connectedToThisSuite = allRepos.filter(
-    (row) => row.suiteId === suiteId
+    (row) => row.suiteId === suiteId,
   );
   // Every repo already connected to ANY suite is excluded: a repo runs exactly
   // one suite, so offering one that is spoken for would produce a rejected
   // write, or silently retarget it away from the suite it is on today.
   const alreadyConnected = new Set(
-    allRepos.map((row) => row.repoFullName.toLowerCase())
+    allRepos.map((row) => row.repoFullName.toLowerCase()),
   );
   const connectableRepos =
     repos === undefined
       ? []
       : (installationRepos ?? []).filter(
-          (repo) => !alreadyConnected.has(repo.fullName.toLowerCase())
+          (repo) => !alreadyConnected.has(repo.fullName.toLowerCase()),
         );
 
   // Selection, labelling and the connect payload are shared with the settings
@@ -222,7 +223,7 @@ export function SuiteGithubChecksSection({
           projectId,
           suiteId,
           outagePolicy: pickerPolicy,
-        })
+        }),
       );
       if (!mountedRef.current) return;
       setPickerRepo("");

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/lib/github-checks-errors";
 import { redirectToGithub } from "@/lib/github-external-redirect";
 import {
+  isSelectableGithubRepo,
   findRepoByPickerValue,
   installationBindingsKey,
   pickerLabelFor,
@@ -256,13 +257,13 @@ export function GithubChecksRoute({
   // to the server snapshot until the list refreshes, so two fast clicks would
   // both read the same stale `row.enabled` and send the same value twice.
   const [pendingToggles, setPendingToggles] = useState<ReadonlySet<string>>(
-    () => new Set()
+    () => new Set(),
   );
   // Policy writes are tracked SEPARATELY from `pendingToggles`: they are
   // different writes on the same row, and one set would have a policy change
   // disable the enable switch (and vice versa) for no reason the user can see.
   const [pendingPolicies, setPendingPolicies] = useState<ReadonlySet<string>>(
-    () => new Set()
+    () => new Set(),
   );
   const [pendingConformance, setPendingConformance] = useState<
     ReadonlySet<string>
@@ -271,7 +272,7 @@ export function GithubChecksRoute({
   // different writes land on one row, and a shared set would grey out a control
   // the admin has no reason to think is busy.
   const [pendingFeedback, setPendingFeedback] = useState<ReadonlySet<string>>(
-    () => new Set()
+    () => new Set(),
   );
   // The picker's value is the repository's NUMERIC ID as a string, not its
   // name. Two accounts can both have a `widgets`, and the id is what the connect
@@ -320,7 +321,7 @@ export function GithubChecksRoute({
    */
   const bindingsKey = useMemo(
     () => installationBindingsKey(bindings),
-    [bindings]
+    [bindings],
   );
 
   // Switching organizations must not carry a selection across: the connect
@@ -377,7 +378,7 @@ export function GithubChecksRoute({
       listingGenerationRef.current += 1;
       listedForRef.current = null;
     },
-    []
+    [],
   );
 
   useEffect(() => {
@@ -433,7 +434,7 @@ export function GithubChecksRoute({
     void listInstallationRepos()
       .then((repositories) => {
         if (listingGenerationRef.current !== generation) return;
-        setInstallationRepos(repositories);
+        setInstallationRepos(repositories.filter(isSelectableGithubRepo));
       })
       .catch((error) => {
         if (listingGenerationRef.current !== generation) return;
@@ -540,7 +541,7 @@ export function GithubChecksRoute({
           projectId: suite.projectId,
           suiteId: suite._id,
           outagePolicy: pickerPolicy,
-        })
+        }),
       );
       // A completion for the PREVIOUS org lands on a page that is now showing a
       // different one. Clearing selections there would wipe a fresh choice, and
@@ -582,7 +583,7 @@ export function GithubChecksRoute({
 
   const handleSuiteChange = async (
     row: GithubCheckRepoConfigRow,
-    suiteId: string
+    suiteId: string,
   ) => {
     const suite = suiteById(suiteId);
     if (!suite?.projectId) return;
@@ -599,7 +600,7 @@ export function GithubChecksRoute({
 
   const handlePolicyChange = async (
     row: GithubCheckRepoConfigRow,
-    outagePolicy: GithubCheckOutagePolicy
+    outagePolicy: GithubCheckOutagePolicy,
   ) => {
     // Same reason as the enable toggle: the select stays bound to the server
     // snapshot until the list refreshes, so a second change made before the
@@ -641,7 +642,7 @@ export function GithubChecksRoute({
   };
 
   const handleFeedbackCommentsToggle = async (
-    row: GithubCheckRepoConfigRow
+    row: GithubCheckRepoConfigRow,
   ) => {
     if (pendingFeedback.has(row._id)) return;
     // ABSENT IS `on`. Only a stored `off` turns the comment off, so the flip of
@@ -709,7 +710,7 @@ export function GithubChecksRoute({
   }
 
   const alreadyConnected = new Set(
-    rows.map((row) => normalizeRepoName(row.repoFullName))
+    rows.map((row) => normalizeRepoName(row.repoFullName)),
   );
   // Offer nothing until the connected list has actually loaded. `rows` is `[]`
   // while `repos` is undefined, so filtering then would advertise repositories
@@ -718,7 +719,7 @@ export function GithubChecksRoute({
     repos === undefined
       ? []
       : (installationRepos ?? []).filter(
-          (repo) => !alreadyConnected.has(normalizeRepoName(repo.fullName))
+          (repo) => !alreadyConnected.has(normalizeRepoName(repo.fullName)),
         );
 
   // Selection and labelling live in `@/lib/github-repo-picker`, shared with the
@@ -881,7 +882,7 @@ export function GithubChecksRoute({
                     </span>
                     <RepoVisibilityBadge
                       isPrivate={visibilityByRepo.get(
-                        normalizeRepoName(row.repoFullName)
+                        normalizeRepoName(row.repoFullName),
                       )}
                     />
                     <RepoConnectionState status={row.connectionStatus} />
@@ -943,7 +944,7 @@ export function GithubChecksRoute({
                   onValueChange={(value) =>
                     void handlePolicyChange(
                       row,
-                      value as GithubCheckOutagePolicy
+                      value as GithubCheckOutagePolicy,
                     )
                   }
                 >

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -52,16 +52,14 @@ const {
   mockConnectVerifiedRepo: vi.fn(async (_args?: Record<string, unknown>) => ({
     configId: "cfg-new",
   })),
-  mockListInstallationRepos: vi.fn(
-    async (): Promise<unknown[]> => [
-      {
-        repositoryId: 2,
-        fullName: "mcpjam/other-repo",
-        installationRef: "bind-1",
-        accountLogin: "mcpjam",
-      },
-    ]
-  ),
+  mockListInstallationRepos: vi.fn(async (): Promise<unknown[]> => [
+    {
+      repositoryId: 2,
+      fullName: "mcpjam/other-repo",
+      installationRef: "bind-1",
+      accountLogin: "mcpjam",
+    },
+  ]),
   mockBindings: { value: undefined as unknown[] | undefined },
   mockStartInstallation: vi.fn(async () => ({
     installUrl: "https://github.com/apps/mcpjam/installations/new?state=abc",
@@ -157,7 +155,7 @@ function repo(
     private?: boolean;
     installationRef?: string | null;
     accountLogin?: string;
-  } = {}
+  } = {},
 ) {
   const key = fullName.trim().toLowerCase();
   if (!repositoryIds.has(key)) repositoryIds.set(key, (nextRepositoryId += 1));
@@ -181,7 +179,7 @@ function binding(
     installationRef?: string;
     status?: "active" | "suspended" | "removed" | "unbound";
     accountType?: "Organization" | "User";
-  } = {}
+  } = {},
 ) {
   return {
     installationRef: overrides.installationRef ?? `bind-${accountLogin}`,
@@ -236,7 +234,7 @@ function renderRoute(activeOrganizationId: string | null = "org-1") {
 async function chooseOption(
   user: ReturnType<typeof userEvent.setup>,
   triggerLabel: string,
-  optionName: string | RegExp
+  optionName: string | RegExp,
 ) {
   await user.click(screen.getByLabelText(triggerLabel));
   await user.click(await screen.findByRole("option", { name: optionName }));
@@ -245,7 +243,7 @@ async function chooseOption(
 /** Repository + suite + policy, in the order the page presents them. */
 async function fillConnectForm(
   user: ReturnType<typeof userEvent.setup>,
-  policyLabel: "Fail open" | "Fail closed" = "Fail closed"
+  policyLabel: "Fail open" | "Fail closed" = "Fail closed",
 ) {
   await chooseOption(user, "Repository", "mcpjam/other-repo");
   await chooseOption(user, "Suite", "Fixture suite");
@@ -300,7 +298,7 @@ describe("GithubChecksRoute availability gate", () => {
     mockRepos.value = [];
     renderRoute();
     expect(
-      screen.getByText(/No repositories connected yet/)
+      screen.getByText(/No repositories connected yet/),
     ).toBeInTheDocument();
     expect(screen.getByText("mcpjam.yaml")).toBeInTheDocument();
   });
@@ -311,7 +309,7 @@ describe("GithubChecksRoute availability gate", () => {
     renderRoute();
 
     fireEvent.click(
-      screen.getByLabelText("Enable checks for mcpjam/mcp-check-fixture")
+      screen.getByLabelText("Enable checks for mcpjam/mcp-check-fixture"),
     );
 
     expect(mockSetRepoEnabled).toHaveBeenCalledWith({
@@ -327,8 +325,8 @@ describe("GithubChecksRoute availability gate", () => {
 
     fireEvent.click(
       screen.getByLabelText(
-        "Enable conformance check for mcpjam/mcp-check-fixture"
-      )
+        "Enable conformance check for mcpjam/mcp-check-fixture",
+      ),
     );
 
     expect(mockSetRepoConformance).toHaveBeenCalledWith({
@@ -343,7 +341,7 @@ describe("GithubChecksRoute availability gate", () => {
     renderRoute();
 
     fireEvent.click(
-      screen.getByLabelText("Disconnect mcpjam/mcp-check-fixture")
+      screen.getByLabelText("Disconnect mcpjam/mcp-check-fixture"),
     );
 
     expect(mockDisconnectRepo).toHaveBeenCalledWith({ configId: "cfg-1" });
@@ -388,12 +386,12 @@ describe("GithubChecksRoute availability gate", () => {
       () =>
         new Promise((resolve) => {
           release = () => resolve({ changed: true });
-        })
+        }),
     );
     renderRoute();
 
     const toggle = screen.getByLabelText(
-      "Enable checks for mcpjam/mcp-check-fixture"
+      "Enable checks for mcpjam/mcp-check-fixture",
     );
     fireEvent.click(toggle);
     fireEvent.click(toggle);
@@ -412,10 +410,10 @@ describe("GithubChecksRoute availability gate", () => {
 
     // "Install the App" would be a lie when the real problem is an outage.
     expect(
-      await screen.findByText(/Could not load repositories from GitHub/)
+      await screen.findByText(/Could not load repositories from GitHub/),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(/No repositories available/)
+      screen.queryByText(/No repositories available/),
     ).not.toBeInTheDocument();
   });
 
@@ -427,7 +425,7 @@ describe("GithubChecksRoute availability gate", () => {
     // would flash an install-the-App CTA at someone who has repos.
     expect(screen.getByText("Loading…")).toBeInTheDocument();
     expect(
-      screen.queryByText(/No repositories connected yet/)
+      screen.queryByText(/No repositories connected yet/),
     ).not.toBeInTheDocument();
   });
 });
@@ -438,9 +436,8 @@ describe("GithubChecksRoute availability gate", () => {
  * backend treats as fail-open without anyone having chosen that. So the policy
  * is required, unselected until picked, and described before it is picked.
  *
- * The connect itself goes to the server-VERIFIED action, which proves the
- * pinned installation can reach the repository before writing anything. The
- * unverified mutation is still deployed; nothing here may call it.
+ * The connect goes to the server-VERIFIED action, which proves the selected
+ * organization-owned installation can reach the repository before writing.
  */
 describe("GithubChecksRoute connect flow", () => {
   beforeEach(() => {
@@ -495,10 +492,10 @@ describe("GithubChecksRoute connect flow", () => {
     await user.click(screen.getByLabelText("Repository"));
 
     expect(
-      await screen.findByRole("option", { name: "mcpjam/other-repo" })
+      await screen.findByRole("option", { name: "mcpjam/other-repo" }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("option", { name: /MCP-Check-Fixture/i })
+      screen.queryByRole("option", { name: /MCP-Check-Fixture/i }),
     ).not.toBeInTheDocument();
   });
 
@@ -522,7 +519,7 @@ describe("GithubChecksRoute connect flow", () => {
     await user.click(connectButton());
 
     await waitFor(() =>
-      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1)
+      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1),
     );
     expect(mockConnectVerifiedRepo).toHaveBeenCalledWith({
       repoFullName: "mcpjam/other-repo",
@@ -553,13 +550,13 @@ describe("GithubChecksRoute connect flow", () => {
     await waitFor(() => expect(toast.success).toHaveBeenCalled());
 
     expect(screen.getByLabelText("Repository")).toHaveTextContent(
-      "Select a repository"
+      "Select a repository",
     );
     expect(screen.getByLabelText("Suite")).toHaveTextContent("Select a suite");
     // Especially the policy: leaving it set would carry one repository's
     // decision silently onto the next one connected.
     expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
-      "Select an outage policy"
+      "Select an outage policy",
     );
   });
 
@@ -569,19 +566,19 @@ describe("GithubChecksRoute connect flow", () => {
     await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
     await fillConnectForm(user, "Fail closed");
     expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
-      "Fail closed"
+      "Fail closed",
     );
 
     rerender(routeTree("org-2"));
 
     await waitFor(() =>
-      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2)
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2),
     );
     expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
-      "Select an outage policy"
+      "Select an outage policy",
     );
     expect(screen.getByLabelText("Repository")).toHaveTextContent(
-      "Select a repository"
+      "Select a repository",
     );
   });
 
@@ -590,7 +587,7 @@ describe("GithubChecksRoute connect flow", () => {
     // App can see is not something a caller gets to enumerate. The page repeats
     // it verbatim rather than parsing GitHub detail out of it.
     mockConnectVerifiedRepo.mockRejectedValueOnce(
-      new Error("Repository is not accessible to the MCPJam GitHub App.")
+      new Error("Repository is not accessible to the MCPJam GitHub App."),
     );
     const user = userEvent.setup();
     renderRoute();
@@ -601,16 +598,16 @@ describe("GithubChecksRoute connect flow", () => {
 
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(
-        "Repository is not accessible to the MCPJam GitHub App."
-      )
+        "Repository is not accessible to the MCPJam GitHub App.",
+      ),
     );
     // Nothing was connected, so nothing is cleared: the administrator can fix
     // the App installation and press Connect again.
     expect(screen.getByLabelText("Repository")).toHaveTextContent(
-      "mcpjam/other-repo"
+      "mcpjam/other-repo",
     );
     expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
-      "Fail closed"
+      "Fail closed",
     );
   });
 
@@ -619,18 +616,18 @@ describe("GithubChecksRoute connect flow", () => {
 
     expect(
       screen.getByText(
-        /During an MCPJam outage or pause, the check reports neutral\./
-      )
+        /During an MCPJam outage or pause, the check reports neutral\./,
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        /During an MCPJam outage or pause, the check reports failed\./
-      )
+        /During an MCPJam outage or pause, the check reports failed\./,
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        /Whether a failed or neutral check blocks merging depends on this repository's branch-protection settings\./
-      )
+        /Whether a failed or neutral check blocks merging depends on this repository's branch-protection settings\./,
+      ),
     ).toBeInTheDocument();
 
     // MCPJam sets a conclusion. Whether a conclusion stops a merge is branch
@@ -746,7 +743,7 @@ describe("GithubChecksRoute row outage policy", () => {
       () =>
         new Promise((resolve) => {
           release = () => resolve({ changed: true });
-        })
+        }),
     );
     const user = userEvent.setup();
     renderRoute();
@@ -766,7 +763,7 @@ describe("GithubChecksRoute row outage policy", () => {
 
     release?.();
     await waitFor(() =>
-      expect(screen.getByLabelText(POLICY_LABEL)).toBeEnabled()
+      expect(screen.getByLabelText(POLICY_LABEL)).toBeEnabled(),
     );
   });
 
@@ -781,7 +778,7 @@ describe("GithubChecksRoute row outage policy", () => {
     // Two different writes on one row. Sharing a pending set would freeze a
     // control the user has no reason to think is busy.
     expect(
-      screen.getByLabelText("Enable checks for mcpjam/mcp-check-fixture")
+      screen.getByLabelText("Enable checks for mcpjam/mcp-check-fixture"),
     ).toBeEnabled();
   });
 });
@@ -851,8 +848,8 @@ describe("GithubChecksRoute pull-request comments", () => {
 
     expect(
       screen.getByText(
-        /MCPJam posts one comment per pull request and updates it in place\. Turning this off stops the comments and changes nothing else\./
-      )
+        /MCPJam posts one comment per pull request and updates it in place\. Turning this off stops the comments and changes nothing else\./,
+      ),
     ).toBeInTheDocument();
   });
 
@@ -868,8 +865,8 @@ describe("GithubChecksRoute pull-request comments", () => {
 
     await waitFor(() =>
       expect(toast.success).toHaveBeenCalledWith(
-        "MCPJam will stop commenting on pull requests in this repository. This setting does not change whether the check itself runs."
-      )
+        "MCPJam will stop commenting on pull requests in this repository. This setting does not change whether the check itself runs.",
+      ),
     );
   });
 
@@ -893,7 +890,7 @@ describe("GithubChecksRoute pull-request comments", () => {
   it("shows the backend's own refusal when the write is rejected", async () => {
     mockRepos.value = [ROW];
     mockSetRepoFeedbackComments.mockRejectedValueOnce(
-      new Error("You are not an administrator of this organization.")
+      new Error("You are not an administrator of this organization."),
     );
     renderRoute();
 
@@ -901,8 +898,8 @@ describe("GithubChecksRoute pull-request comments", () => {
 
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(
-        "You are not an administrator of this organization."
-      )
+        "You are not an administrator of this organization.",
+      ),
     );
   });
 
@@ -918,8 +915,8 @@ describe("GithubChecksRoute pull-request comments", () => {
 
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(
-        "We could not change pull-request comments for that repository. Nothing changed — try again."
-      )
+        "We could not change pull-request comments for that repository. Nothing changed — try again.",
+      ),
     );
   });
 
@@ -940,7 +937,7 @@ describe("GithubChecksRoute pull-request comments", () => {
       () =>
         new Promise((resolve) => {
           release = () => resolve({ changed: true });
-        })
+        }),
     );
     renderRoute();
 
@@ -953,14 +950,14 @@ describe("GithubChecksRoute pull-request comments", () => {
     // The enable toggle is a DIFFERENT write on the same row and must not be
     // frozen by this one.
     expect(
-      screen.getByLabelText("Enable checks for mcpjam/mcp-check-fixture")
+      screen.getByLabelText("Enable checks for mcpjam/mcp-check-fixture"),
     ).toBeEnabled();
 
     await act(async () => {
       release?.();
     });
     await waitFor(() =>
-      expect(screen.getByLabelText(COMMENTS_LABEL)).toBeEnabled()
+      expect(screen.getByLabelText(COMMENTS_LABEL)).toBeEnabled(),
     );
   });
 
@@ -974,8 +971,8 @@ describe("GithubChecksRoute pull-request comments", () => {
 
     expect(
       screen.getByText(
-        /MCPJam will also post a comment on each pull request in this repository, updated in place as new commits land\. You can turn that off per repository after connecting\./
-      )
+        /MCPJam will also post a comment on each pull request in this repository, updated in place as new commits land\. You can turn that off per repository after connecting\./,
+      ),
     ).toBeInTheDocument();
   });
 });
@@ -1044,7 +1041,7 @@ describe("GithubChecksRoute repository visibility", () => {
     renderRoute();
 
     expect(
-      await screen.findByText(/Could not load repositories from GitHub/)
+      await screen.findByText(/Could not load repositories from GitHub/),
     ).toBeInTheDocument();
     // An outage is not evidence that anything is public.
     expect(screen.queryByText("Public")).not.toBeInTheDocument();
@@ -1092,7 +1089,7 @@ describe("GithubChecksRoute organization switching", () => {
         () =>
           new Promise((resolve) => {
             resolveStale = resolve as (repos: unknown[]) => void;
-          })
+          }),
       )
       .mockResolvedValue([
         repo("mcpjam/mcp-check-fixture", { private: false }),
@@ -1101,7 +1098,7 @@ describe("GithubChecksRoute organization switching", () => {
     const { rerender } = render(routeTree("org-1"));
     rerender(routeTree("org-2"));
     await waitFor(() =>
-      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2)
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2),
     );
     expect(await screen.findByText("Public")).toBeInTheDocument();
 
@@ -1124,7 +1121,7 @@ describe("GithubChecksRoute organization switching", () => {
       () =>
         new Promise((resolve) => {
           resolveStaleConnect = resolve as (result: unknown) => void;
-        })
+        }),
     );
 
     const user = userEvent.setup();
@@ -1133,12 +1130,12 @@ describe("GithubChecksRoute organization switching", () => {
     await fillConnectForm(user, "Fail closed");
     await user.click(connectButton());
     await waitFor(() =>
-      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1)
+      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1),
     );
 
     rerender(routeTree("org-2"));
     await waitFor(() =>
-      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2)
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2),
     );
     await fillConnectForm(user, "Fail open");
 
@@ -1150,10 +1147,10 @@ describe("GithubChecksRoute organization switching", () => {
     expect(toast.success).not.toHaveBeenCalled();
     // …and the selections just made for THIS organization survive.
     expect(screen.getByLabelText("Repository")).toHaveTextContent(
-      "mcpjam/other-repo"
+      "mcpjam/other-repo",
     );
     expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
-      "Fail open"
+      "Fail open",
     );
   });
 });
@@ -1199,8 +1196,8 @@ describe("GithubChecksRoute binding changes", () => {
     // Where the user starts: nothing connected, so nothing to offer.
     expect(
       await screen.findByText(
-        /No repositories available\. Connect a GitHub account above first\./
-      )
+        /No repositories available\. Connect a GitHub account above first\./,
+      ),
     ).toBeInTheDocument();
     expect(mockListInstallationRepos).toHaveBeenCalledTimes(1);
 
@@ -1211,16 +1208,16 @@ describe("GithubChecksRoute binding changes", () => {
     rerender(routeTree("org-1"));
 
     await waitFor(() =>
-      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2)
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2),
     );
     await waitFor(() =>
       expect(
-        screen.queryByText(/No repositories available/)
-      ).not.toBeInTheDocument()
+        screen.queryByText(/No repositories available/),
+      ).not.toBeInTheDocument(),
     );
     await user.click(screen.getByLabelText("Repository"));
     expect(
-      await screen.findByRole("option", { name: "acme/widgets" })
+      await screen.findByRole("option", { name: "acme/widgets" }),
     ).toBeInTheDocument();
   });
 
@@ -1230,7 +1227,7 @@ describe("GithubChecksRoute binding changes", () => {
 
     const { rerender } = render(routeTree("org-1"));
     await waitFor(() =>
-      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1)
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1),
     );
 
     // Suspended, removed and unbound each stop an installation answering for
@@ -1239,7 +1236,7 @@ describe("GithubChecksRoute binding changes", () => {
     rerender(routeTree("org-1"));
 
     await waitFor(() =>
-      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2)
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2),
     );
   });
 
@@ -1249,7 +1246,7 @@ describe("GithubChecksRoute binding changes", () => {
 
     const { rerender } = render(routeTree("org-1"));
     await waitFor(() =>
-      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1)
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1),
     );
 
     // A new array, equal content, and the rows in the other order — all three
@@ -1272,7 +1269,7 @@ describe("GithubChecksRoute binding changes", () => {
 
     const { rerender } = render(routeTree("org-1"));
     await waitFor(() =>
-      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1)
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1),
     );
 
     mockBindings.value = [binding("acme")];
@@ -1282,7 +1279,7 @@ describe("GithubChecksRoute binding changes", () => {
     expect(mockListInstallationRepos).toHaveBeenCalledTimes(1);
     // …and the listing that was in flight is still the one on screen.
     expect(
-      await screen.findByRole("combobox", { name: "Repository" })
+      await screen.findByRole("combobox", { name: "Repository" }),
     ).toBeInTheDocument();
   });
 
@@ -1300,14 +1297,14 @@ describe("GithubChecksRoute binding changes", () => {
         () =>
           new Promise((resolve) => {
             resolveStale = resolve as (repos: unknown[]) => void;
-          })
+          }),
       )
       .mockResolvedValue([repo("beta/gadgets", { accountLogin: "beta" })]);
 
     const user = userEvent.setup();
     const { rerender } = render(routeTree("org-1"));
     await waitFor(() =>
-      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1)
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(1),
     );
     await chooseOption(user, "Repository", "acme/widgets");
     await chooseOption(user, "Outage policy", "Fail closed");
@@ -1318,22 +1315,22 @@ describe("GithubChecksRoute binding changes", () => {
     mockBindings.value = [binding("acme"), binding("beta")];
     rerender(routeTree("org-1"));
     await waitFor(() =>
-      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2)
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2),
     );
     expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
-      "Fail closed"
+      "Fail closed",
     );
 
     // Now the org changes while that refetch is still in flight.
     rerender(routeTree("org-2"));
     await waitFor(() =>
-      expect(mockListInstallationRepos).toHaveBeenCalledTimes(3)
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(3),
     );
     expect(screen.getByLabelText("Repository")).toHaveTextContent(
-      "Select a repository"
+      "Select a repository",
     );
     expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
-      "Select an outage policy"
+      "Select an outage policy",
     );
 
     // org-1's answer, arriving late. It must not repopulate org-2's picker.
@@ -1342,10 +1339,10 @@ describe("GithubChecksRoute binding changes", () => {
     });
     await user.click(screen.getByLabelText("Repository"));
     expect(
-      await screen.findByRole("option", { name: "beta/gadgets" })
+      await screen.findByRole("option", { name: "beta/gadgets" }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("option", { name: "acme/widgets" })
+      screen.queryByRole("option", { name: "acme/widgets" }),
     ).not.toBeInTheDocument();
   });
 });
@@ -1393,16 +1390,18 @@ describe("GithubChecksRoute installations", () => {
   it("offers both an install and a claim, and explains why claiming needs GitHub", async () => {
     renderRoute();
     expect(
-      await screen.findByRole("button", { name: /Install on a GitHub account/ })
+      await screen.findByRole("button", {
+        name: /Install on a GitHub account/,
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /Claim an existing installation/ })
+      screen.getByRole("button", { name: /Claim an existing installation/ }),
     ).toBeInTheDocument();
     // The whole reason the claim path needs an OAuth leg, in one sentence: the
     // App JWT can read every installation it has, so installing is not proof
     // that an installation is yours to connect here.
     expect(
-      screen.getByText(/is not on its own proof that it is yours to connect/i)
+      screen.getByText(/is not on its own proof that it is yours to connect/i),
     ).toBeInTheDocument();
   });
 
@@ -1410,14 +1409,16 @@ describe("GithubChecksRoute installations", () => {
     const user = userEvent.setup();
     renderRoute();
     await user.click(
-      await screen.findByRole("button", { name: /Install on a GitHub account/ })
+      await screen.findByRole("button", {
+        name: /Install on a GitHub account/,
+      }),
     );
 
     await waitFor(() => expect(mockStartInstallation).toHaveBeenCalledTimes(1));
     // The URL carries a one-time state the BACKEND minted and hashed. The page
     // only follows it.
     expect(mockRedirectToGithub).toHaveBeenCalledWith(
-      "https://github.com/apps/mcpjam/installations/new?state=abc"
+      "https://github.com/apps/mcpjam/installations/new?state=abc",
     );
   });
 
@@ -1427,12 +1428,12 @@ describe("GithubChecksRoute installations", () => {
     await user.click(
       await screen.findByRole("button", {
         name: /Claim an existing installation/,
-      })
+      }),
     );
 
     await waitFor(() => expect(mockStartDirectClaim).toHaveBeenCalledTimes(1));
     expect(mockRedirectToGithub).toHaveBeenCalledWith(
-      "https://github.com/login/oauth/authorize?client_id=x"
+      "https://github.com/login/oauth/authorize?client_id=x",
     );
   });
 
@@ -1445,12 +1446,14 @@ describe("GithubChecksRoute installations", () => {
     renderRoute();
 
     await user.click(
-      await screen.findByRole("button", { name: /Install on a GitHub account/ })
+      await screen.findByRole("button", {
+        name: /Install on a GitHub account/,
+      }),
     );
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
 
     const shown = String(
-      (toast.error as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      (toast.error as ReturnType<typeof vi.fn>).mock.calls[0][0],
     );
     expect(shown).toMatch(/already connected to a workspace/i);
     // Non-disclosure survives the trip through the UI.
@@ -1499,7 +1502,7 @@ describe("GithubChecksRoute installations", () => {
     mockBindings.value = [binding("acme", { status: "unbound" })];
     renderRoute();
     expect(
-      await screen.findByText(/Disconnected from this workspace/i)
+      await screen.findByText(/Disconnected from this workspace/i),
     ).toBeInTheDocument();
   });
 
@@ -1509,15 +1512,15 @@ describe("GithubChecksRoute installations", () => {
     renderRoute();
 
     await user.click(
-      await screen.findByRole("button", { name: "Disconnect acme" })
+      await screen.findByRole("button", { name: "Disconnect acme" }),
     );
     expect(
-      await screen.findByText(/Checks on its repositories stop immediately/i)
+      await screen.findByText(/Checks on its repositories stop immediately/i),
     ).toBeInTheDocument();
     // The limit matters as much as the consequence: reconnecting is not a
     // rebuild, and copy that implied otherwise would stop admins acting.
     expect(
-      screen.getByText(/suite and policy settings are kept/i)
+      screen.getByText(/suite and policy settings are kept/i),
     ).toBeInTheDocument();
     // Nothing has happened yet.
     expect(mockUnbindInstallation).not.toHaveBeenCalled();
@@ -1529,14 +1532,14 @@ describe("GithubChecksRoute installations", () => {
     renderRoute();
 
     await user.click(
-      await screen.findByRole("button", { name: "Disconnect acme" })
+      await screen.findByRole("button", { name: "Disconnect acme" }),
     );
     await user.click(await screen.findByRole("button", { name: "Disconnect" }));
 
     await waitFor(() =>
       expect(mockUnbindInstallation).toHaveBeenCalledWith({
         installationRef: "bind-xyz",
-      })
+      }),
     );
   });
 
@@ -1546,10 +1549,10 @@ describe("GithubChecksRoute installations", () => {
     renderRoute();
 
     await user.click(
-      await screen.findByRole("button", { name: "Disconnect acme" })
+      await screen.findByRole("button", { name: "Disconnect acme" }),
     );
     await user.click(
-      await screen.findByRole("button", { name: "Keep it connected" })
+      await screen.findByRole("button", { name: "Keep it connected" }),
     );
 
     expect(mockUnbindInstallation).not.toHaveBeenCalled();
@@ -1598,8 +1601,8 @@ describe("GithubChecksRoute connection status", () => {
     // stopped check is "my code did something" and none of these is that.
     expect(
       screen.getByText(
-        /not a problem with your pull requests|nothing is wrong/i
-      )
+        /not a problem with your pull requests|nothing is wrong/i,
+      ),
     ).toBeInTheDocument();
   });
 
@@ -1631,10 +1634,10 @@ describe("GithubChecksRoute connection status", () => {
 
     await user.click(screen.getByLabelText("Repository"));
     expect(
-      await screen.findByRole("option", { name: "acme/widgets · acme" })
+      await screen.findByRole("option", { name: "acme/widgets · acme" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("option", { name: "globex/widgets · globex" })
+      screen.getByRole("option", { name: "globex/widgets · globex" }),
     ).toBeInTheDocument();
   });
 
@@ -1651,37 +1654,24 @@ describe("GithubChecksRoute connection status", () => {
     await user.click(screen.getByLabelText("Repository"));
     // One repeated label on every row is a column of noise.
     expect(
-      await screen.findByRole("option", { name: "acme/widgets" })
+      await screen.findByRole("option", { name: "acme/widgets" }),
     ).toBeInTheDocument();
   });
 
-  it("sends no installationRef when the listing carried none", async () => {
-    // The compatibility window: the backend is still falling back to its pinned
-    // installation for an org with no binding, and omitting the reference is
-    // what keeps that connect path reachable.
-    mockRepos.value = [];
-    mockConnectVerifiedRepo.mockReset();
-    mockConnectVerifiedRepo.mockResolvedValue({ configId: "cfg-pinned" });
+  it("rejects a stale listing entry without installation identity", async () => {
     mockListInstallationRepos.mockResolvedValue([
-      repo("mcpjam/pinned-repo", { installationRef: null, accountLogin: "" }),
+      { repositoryId: 301, fullName: "mcpjam/pinned-repo" },
     ]);
-    const user = userEvent.setup();
+    mockRepos.value = [];
     renderRoute();
     await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
-
-    await chooseOption(user, "Repository", "mcpjam/pinned-repo");
-    await chooseOption(user, "Suite", "Fixture suite");
-    await chooseOption(user, "Outage policy", "Fail closed");
-    await user.click(connectButton());
-
-    await waitFor(() =>
-      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1)
-    );
-    const sent = mockConnectVerifiedRepo.mock.calls[0]?.[0] as Record<
-      string,
-      unknown
-    >;
-    expect(sent).not.toHaveProperty("installationRef");
-    expect(sent.repositoryId).toBe(repositoryIds.get("mcpjam/pinned-repo"));
+    expect(
+      await screen.findByText(/No repositories available\./)
+    ).toBeInTheDocument();
+    await waitFor(() => expect(connectButton()).toBeDisabled());
+    expect(mockConnectVerifiedRepo).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("option", { name: "mcpjam/pinned-repo" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -1670,8 +1670,5 @@ describe("GithubChecksRoute connection status", () => {
     ).toBeInTheDocument();
     await waitFor(() => expect(connectButton()).toBeDisabled());
     expect(mockConnectVerifiedRepo).not.toHaveBeenCalled();
-    expect(
-      screen.queryByRole("option", { name: "mcpjam/pinned-repo" }),
-    ).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
@@ -47,8 +47,7 @@ import { useIsMemberActor } from "@/hooks/use-is-member-actor";
  * would bounce a legitimately-flagged user who cold-loads the URL directly.
  */
 export type GithubChecksAvailability =
-  | { state: "enabled" | "disabled" }
-  | undefined;
+  { state: "enabled" | "disabled" } | undefined;
 
 /**
  * What the check concludes when MCPJam cannot run the suite — an outage, or a
@@ -105,10 +104,7 @@ export type GithubCheckConnectionStatus =
 
 export type GithubInstallationAccountType = "Organization" | "User";
 export type GithubInstallationBindingStatus =
-  | "active"
-  | "suspended"
-  | "removed"
-  | "unbound";
+  "active" | "suspended" | "removed" | "unbound";
 
 /**
  * One GitHub App installation this organization holds.
@@ -196,12 +192,9 @@ export type InstallationRepo = {
   /**
    * WHICH binding this repository was listed through, opaque.
    *
-   * ABSENT only while the backend is still falling back to its pinned
-   * installation for an organization with no binding yet. Absent means "send no
-   * reference", which is what keeps the compatibility connect reachable during
-   * that window.
+   * Required: repository access always comes from an active org-owned binding.
    */
-  installationRef?: string;
+  installationRef: string;
   /**
    * The GitHub account, for disambiguating two same-named repositories from
    * different accounts in one picker. Display only.
@@ -236,7 +229,7 @@ const BINDINGS_QUERY = "github/appInstallLink:listBindingsForOrganization";
 // that ought to be checking it.
 
 export function useGithubChecksAvailability(
-  organizationId: string | null | undefined
+  organizationId: string | null | undefined,
 ): GithubChecksAvailability {
   // `useIsMemberActor`, not `useAuth().user`: the WorkOS user object flips
   // truthy while the Convex socket is still carrying the guest bearer that
@@ -249,12 +242,12 @@ export function useGithubChecksAvailability(
 
   return useQuery(
     AVAILABILITY_QUERY as any,
-    canQuery ? ({ organizationId } as any) : "skip"
+    canQuery ? ({ organizationId } as any) : "skip",
   ) as GithubChecksAvailability;
 }
 
 export function useGithubChecksSettings(
-  organizationId: string | null | undefined
+  organizationId: string | null | undefined,
 ) {
   const isMember = useIsMemberActor();
   const isUserReady = useDbUserReady();
@@ -272,12 +265,12 @@ export function useGithubChecksSettings(
   // `isAuthenticated` where the availability gate carried `isAuthenticated &&
   // user` — a weaker term that only `isEnabled` was holding shut.
   const canQuery = Boolean(
-    isMember && isUserReady && organizationId && isEnabled
+    isMember && isUserReady && organizationId && isEnabled,
   );
 
   const repos = useQuery(
     LIST_QUERY as any,
-    canQuery ? ({ organizationId } as any) : "skip"
+    canQuery ? ({ organizationId } as any) : "skip",
   ) as GithubCheckRepoConfigRow[] | undefined;
 
   // `getTestSuitesOverview` accepts an org scope. Note it filters on
@@ -285,7 +278,7 @@ export function useGithubChecksSettings(
   // before that field existed will not appear here.
   const suiteOverview = useQuery(
     SUITES_QUERY as any,
-    canQuery ? ({ organizationId } as any) : "skip"
+    canQuery ? ({ organizationId } as any) : "skip",
   ) as Array<{ suite?: SuiteOption }> | undefined;
 
   const suites: SuiteOption[] | undefined = suiteOverview
@@ -293,34 +286,32 @@ export function useGithubChecksSettings(
     .filter((suite): suite is SuiteOption => Boolean(suite?._id));
 
   // The SERVER-VERIFIED connect, and the only connect path this app uses. It is
-  // an action rather than a mutation because proving the pinned installation can
-  // actually reach the repository takes a GitHub round trip, which a mutation
-  // cannot make — and it is the action that stamps the row's installation id.
-  // The unverified `checkRepoConfigs:connectRepo` mutation survives only for the
-  // two-deploy compatibility window and must not be called from here.
+  // an action because proving the selected organization-owned installation can
+  // reach the repository takes a GitHub round trip, which a mutation cannot
+  // make. The action stamps the row's installation and repository identities.
   const connectVerifiedRepoAction = useAction(
-    "github/checkRepoConfigsNode:connectVerifiedRepo" as any
+    "github/checkRepoConfigsNode:connectVerifiedRepo" as any,
   );
   const setRepoEnabledMutation = useMutation(
-    "github/checkRepoConfigs:setRepoEnabled" as any
+    "github/checkRepoConfigs:setRepoEnabled" as any,
   );
   const setRepoSuiteMutation = useMutation(
-    "github/checkRepoConfigs:setRepoSuite" as any
+    "github/checkRepoConfigs:setRepoSuite" as any,
   );
   const setRepoOutagePolicyMutation = useMutation(
-    "github/checkRepoConfigs:setRepoOutagePolicy" as any
+    "github/checkRepoConfigs:setRepoOutagePolicy" as any,
   );
   const setRepoConformanceMutation = useMutation(
-    "github/checkRepoConfigs:setRepoConformance" as any
+    "github/checkRepoConfigs:setRepoConformance" as any,
   );
   const setRepoFeedbackCommentsMutation = useMutation(
-    "github/checkRepoConfigs:setRepoFeedbackComments" as any
+    "github/checkRepoConfigs:setRepoFeedbackComments" as any,
   );
   const disconnectRepoMutation = useMutation(
-    "github/checkRepoConfigs:disconnectRepo" as any
+    "github/checkRepoConfigs:disconnectRepo" as any,
   );
   const listInstallationReposAction = useAction(
-    "github/checkRepoConfigsNode:listInstallationRepos" as any
+    "github/checkRepoConfigsNode:listInstallationRepos" as any,
   );
 
   // ── The org ↔ installation binding surface ───────────────────────────────
@@ -331,20 +322,20 @@ export function useGithubChecksSettings(
   // the click, in production — not at build time. Treat these call shapes as
   // part of the backend's signature and change them together.
   const startInstallationAction = useAction(
-    "github/appInstallLinkNode:startInstallation" as any
+    "github/appInstallLinkNode:startInstallation" as any,
   );
   const startDirectClaimAction = useAction(
-    "github/appInstallLinkNode:startDirectClaim" as any
+    "github/appInstallLinkNode:startDirectClaim" as any,
   );
   const unbindInstallationMutation = useMutation(
-    "github/appInstallLink:unbindInstallation" as any
+    "github/appInstallLink:unbindInstallation" as any,
   );
 
   // Bindings are read for MEMBERS, like the repository list — the write path is
   // where admin is required — so this rides the same `canQuery` gate.
   const bindings = useQuery(
     BINDINGS_QUERY as any,
-    canQuery ? ({ organizationId } as any) : "skip"
+    canQuery ? ({ organizationId } as any) : "skip",
   ) as GithubInstallationBinding[] | undefined;
 
   /**
@@ -360,7 +351,7 @@ export function useGithubChecksSettings(
       startInstallationAction({ organizationId } as any) as Promise<{
         installUrl: string;
       }>,
-    [startInstallationAction, organizationId]
+    [startInstallationAction, organizationId],
   );
 
   /**
@@ -373,7 +364,7 @@ export function useGithubChecksSettings(
       startDirectClaimAction({ organizationId } as any) as Promise<{
         authorizeUrl: string;
       }>,
-    [startDirectClaimAction, organizationId]
+    [startDirectClaimAction, organizationId],
   );
 
   const unbindInstallation = useCallback(
@@ -384,7 +375,7 @@ export function useGithubChecksSettings(
       } as any) as Promise<{
         changed: boolean;
       }>,
-    [unbindInstallationMutation, organizationId]
+    [unbindInstallationMutation, organizationId],
   );
 
   /**
@@ -396,10 +387,7 @@ export function useGithubChecksSettings(
    * `installationRef` and `repositoryId` come STRAIGHT OFF the picked
    * `InstallationRepo` and are never assembled by hand — they say which
    * installation the repository was listed through and which repository it
-   * actually is, and the server re-verifies both. They are optional here for
-   * exactly one reason: an organization with no binding yet is still listed
-   * through the backend's pinned installation, and those entries carry no ref,
-   * so the connect has to be reachable without one until the pin retires.
+   * actually is, and the server re-verifies both. Both are required.
    */
   const connectVerifiedRepo = useCallback(
     (args: {
@@ -407,25 +395,25 @@ export function useGithubChecksSettings(
       projectId: string;
       suiteId: string;
       outagePolicy: GithubCheckOutagePolicy;
-      installationRef?: string;
-      repositoryId?: number;
+      installationRef: string;
+      repositoryId: number;
     }) =>
       connectVerifiedRepoAction({ organizationId, ...args } as any) as Promise<{
         configId: string;
       }>,
-    [connectVerifiedRepoAction, organizationId]
+    [connectVerifiedRepoAction, organizationId],
   );
 
   const setRepoEnabled = useCallback(
     (args: { configId: string; enabled: boolean }) =>
       setRepoEnabledMutation({ organizationId, ...args } as any),
-    [setRepoEnabledMutation, organizationId]
+    [setRepoEnabledMutation, organizationId],
   );
 
   const setRepoSuite = useCallback(
     (args: { configId: string; projectId: string; suiteId: string }) =>
       setRepoSuiteMutation({ organizationId, ...args } as any),
-    [setRepoSuiteMutation, organizationId]
+    [setRepoSuiteMutation, organizationId],
   );
 
   const setRepoOutagePolicy = useCallback(
@@ -436,7 +424,7 @@ export function useGithubChecksSettings(
       } as any) as Promise<{
         changed: boolean;
       }>,
-    [setRepoOutagePolicyMutation, organizationId]
+    [setRepoOutagePolicyMutation, organizationId],
   );
 
   const setRepoConformance = useCallback(
@@ -451,7 +439,7 @@ export function useGithubChecksSettings(
       } as any) as Promise<{
         changed: boolean;
       }>,
-    [setRepoConformanceMutation, organizationId]
+    [setRepoConformanceMutation, organizationId],
   );
 
   /**
@@ -472,13 +460,13 @@ export function useGithubChecksSettings(
       } as any) as Promise<{
         changed: boolean;
       }>,
-    [setRepoFeedbackCommentsMutation, organizationId]
+    [setRepoFeedbackCommentsMutation, organizationId],
   );
 
   const disconnectRepo = useCallback(
     (args: { configId: string }) =>
       disconnectRepoMutation({ organizationId, ...args } as any),
-    [disconnectRepoMutation, organizationId]
+    [disconnectRepoMutation, organizationId],
   );
 
   const listInstallationRepos = useCallback(
@@ -486,7 +474,7 @@ export function useGithubChecksSettings(
       listInstallationReposAction({ organizationId } as any) as Promise<
         InstallationRepo[]
       >,
-    [listInstallationReposAction, organizationId]
+    [listInstallationReposAction, organizationId],
   );
 
   return {
@@ -524,13 +512,13 @@ export function useGithubChecksSettings(
  */
 export function useGithubInstallCallbacks() {
   const completeInstallSetupAction = useAction(
-    "github/appInstallLinkNode:completeInstallSetup" as any
+    "github/appInstallLinkNode:completeInstallSetup" as any,
   );
   const completeUserAuthorizationAction = useAction(
-    "github/appInstallLinkNode:completeUserAuthorization" as any
+    "github/appInstallLinkNode:completeUserAuthorization" as any,
   );
   const claimProvenInstallationAction = useAction(
-    "github/appInstallLinkNode:claimProvenInstallation" as any
+    "github/appInstallLinkNode:claimProvenInstallation" as any,
   );
 
   /** GitHub's setup redirect. Returns where to send the browser next. */
@@ -539,25 +527,25 @@ export function useGithubInstallCallbacks() {
       completeInstallSetupAction(args as any) as Promise<{
         authorizeUrl: string;
       }>,
-    [completeInstallSetupAction]
+    [completeInstallSetupAction],
   );
 
   /** GitHub's OAuth redirect. Either the bind is done, or a pick is needed. */
   const completeUserAuthorization = useCallback(
     (args: { code: string; state: string }) =>
       completeUserAuthorizationAction(
-        args as any
+        args as any,
       ) as Promise<GithubInstallCallbackResult>,
-    [completeUserAuthorizationAction]
+    [completeUserAuthorizationAction],
   );
 
   /** Adopt one installation out of a direct claim's proven list. */
   const claimProvenInstallation = useCallback(
     (args: { linkSessionId: string; installationId: number }) =>
       claimProvenInstallationAction(
-        args as any
+        args as any,
       ) as Promise<GithubInstallCallbackResult>,
-    [claimProvenInstallationAction]
+    [claimProvenInstallationAction],
   );
 
   return {

--- a/mcpjam-inspector/client/src/lib/__tests__/github-repo-picker.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/github-repo-picker.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import type { InstallationRepo } from "@/hooks/useGithubChecksSettings";
+import {
+  findRepoByPickerValue,
+  isSelectableGithubRepo,
+  verifiedConnectArgs,
+} from "@/lib/github-repo-picker";
+
+const validRepo: InstallationRepo = {
+  repositoryId: 123,
+  installationRef: "binding_123",
+  accountLogin: "acme",
+  fullName: "acme/widgets",
+};
+
+describe("GitHub repository picker identity", () => {
+  it("accepts a complete installation and repository identity", () => {
+    expect(isSelectableGithubRepo(validRepo)).toBe(true);
+    expect(findRepoByPickerValue([validRepo], "123")).toBe(validRepo);
+    expect(
+      verifiedConnectArgs(validRepo, {
+        projectId: "project_123",
+        suiteId: "suite_123",
+        outagePolicy: "fail_closed",
+      }),
+    ).toMatchObject({
+      installationRef: "binding_123",
+      repositoryId: 123,
+    });
+  });
+
+  it.each([
+    { ...validRepo, installationRef: "" },
+    { ...validRepo, installationRef: "   " },
+    { ...validRepo, installationRef: undefined },
+    { ...validRepo, repositoryId: 0 },
+    { ...validRepo, repositoryId: Number.NaN },
+  ])("rejects incomplete or invalid picker entries", (repo) => {
+    const staleRepo = repo as InstallationRepo;
+    expect(isSelectableGithubRepo(staleRepo)).toBe(false);
+    expect(findRepoByPickerValue([staleRepo], String(repo.repositoryId))).toBe(
+      undefined,
+    );
+    expect(() =>
+      verifiedConnectArgs(staleRepo, {
+        projectId: "project_123",
+        suiteId: "suite_123",
+        outagePolicy: "fail_open",
+      }),
+    ).toThrow("Connect a GitHub account");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/github-repo-picker.ts
+++ b/mcpjam-inspector/client/src/lib/github-repo-picker.ts
@@ -45,7 +45,7 @@ import type {
  * that cannot tell them apart would read the first answer as a change.
  */
 export function installationBindingsKey(
-  bindings: readonly GithubInstallationBinding[] | undefined
+  bindings: readonly GithubInstallationBinding[] | undefined,
 ): string | null {
   if (bindings === undefined) return null;
   return bindings
@@ -64,9 +64,22 @@ export function installationBindingsKey(
  */
 export function findRepoByPickerValue(
   repos: readonly InstallationRepo[],
-  value: string
+  value: string,
 ): InstallationRepo | undefined {
-  return repos.find((repo) => String(repo.repositoryId) === value);
+  return repos.find(
+    (repo) =>
+      isSelectableGithubRepo(repo) && String(repo.repositoryId) === value,
+  );
+}
+
+/** Reject stale responses from a backend that omitted installation identity. */
+export function isSelectableGithubRepo(repo: InstallationRepo): boolean {
+  return (
+    typeof repo.installationRef === "string" &&
+    repo.installationRef.trim().length > 0 &&
+    Number.isSafeInteger(repo.repositoryId) &&
+    repo.repositoryId > 0
+  );
 }
 
 /** The value a picker option carries for one entry. */
@@ -83,12 +96,12 @@ export function pickerValueFor(repo: InstallationRepo): string {
  * which is which.
  */
 export function shouldShowAccountLabels(
-  repos: readonly InstallationRepo[]
+  repos: readonly InstallationRepo[],
 ): boolean {
   const logins = new Set(
     repos
       .map((repo) => repo.accountLogin)
-      .filter((login): login is string => Boolean(login))
+      .filter((login): login is string => Boolean(login)),
   );
   return logins.size > 1;
 }
@@ -96,7 +109,7 @@ export function shouldShowAccountLabels(
 /** What one option reads as. */
 export function pickerLabelFor(
   repo: InstallationRepo,
-  showAccountLabels: boolean
+  showAccountLabels: boolean,
 ): string {
   return showAccountLabels && repo.accountLogin
     ? `${repo.fullName} · ${repo.accountLogin}`
@@ -109,10 +122,7 @@ export function pickerLabelFor(
  * `installationRef` and `repositoryId` come STRAIGHT OFF the listing entry and
  * are never reassembled: the reference says which installation the repository
  * was enumerated through, the id says which repository it is, and the server
- * re-verifies both. The reference is omitted — not sent as `undefined` — when
- * the entry carries none, which is how an organization still being listed
- * through the backend's pinned installation keeps the compatibility connect
- * reachable.
+ * re-verifies both. Missing identity is rejected, including stale responses.
  */
 export function verifiedConnectArgs(
   repo: InstallationRepo,
@@ -120,21 +130,24 @@ export function verifiedConnectArgs(
     projectId: string;
     suiteId: string;
     outagePolicy: GithubCheckOutagePolicy;
-  }
+  },
 ): {
   repoFullName: string;
   projectId: string;
   suiteId: string;
   outagePolicy: GithubCheckOutagePolicy;
-  installationRef?: string;
+  installationRef: string;
   repositoryId: number;
 } {
+  if (!isSelectableGithubRepo(repo)) {
+    throw new Error("Connect a GitHub account and reload the repository list.");
+  }
   return {
     repoFullName: repo.fullName,
     projectId: target.projectId,
     suiteId: target.suiteId,
     outagePolicy: target.outagePolicy,
-    ...(repo.installationRef ? { installationRef: repo.installationRef } : {}),
+    installationRef: repo.installationRef,
     repositoryId: repo.repositoryId,
   };
 }


### PR DESCRIPTION
Repository picker entries without an installation reference could still reach the legacy backend fallback path.

This makes installation and repository identities required in the shared client contract, filters incomplete picker entries in Settings and suite connections, and reuses the existing connect-account empty state.

Validation: 95 focused tests pass and the client typecheck passes.

Rollout: merge and deploy https://github.com/MCPJam/mcpjam-backend/pull/1273 first, then this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires installation and repository identity for GitHub repository picker entries, closing the legacy pinned-installation fallback path. Picker entries that lack a valid `installationRef` or `repositoryId` are no longer selectable in Settings or suite connections, and they now surface the existing connect-account empty state with the connect button disabled.

**Rollout**
- Merge and deploy https://github.com/MCPJam/mcpjam-backend/pull/1273 before this PR.

<sup>Written for commit 3a0d0116e855fc85b1d524d36c02d17e2b520932. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

