### PR TITLE
Mark taken GitHub accounts in the picker instead of dead-ending

### DIFF
--- a/docs/github-checks.mdx
+++ b/docs/github-checks.mdx
@@ -16,6 +16,19 @@ what it measured.
 GitHub Checks is configured in the hosted app, at **Settings → Integrations →
 GitHub**. Connecting a repository needs an organization admin.
 
+Two buttons live there, and which one you need depends on whether the MCPJam
+app is already installed on the GitHub account:
+
+- **Install on a GitHub account** — for a fresh install. GitHub sends you back
+  and the account is connected automatically.
+- **Claim an existing installation** — if somebody already installed the app.
+  GitHub skips the return trip for an account it has already installed on, so
+  the first button quietly leaves you on GitHub's settings page.
+
+A GitHub account connects to **one MCPJam organization at a time**. If it is
+already connected somewhere else, the account picker marks it and says so —
+disconnect it there first, or install the app on a different account.
+
 The **pull-request comment** described below is rolling out: it is enabled per
 deployment by an operator, and until it is on for yours a connected repository
 gets the check run and no comment. The per-repository toggle is visible before

--- a/docs/github-checks.mdx
+++ b/docs/github-checks.mdx
@@ -25,9 +25,16 @@ app is already installed on the GitHub account:
   GitHub skips the return trip for an account it has already installed on, so
   the first button quietly leaves you on GitHub's settings page.
 
-A GitHub account connects to **one MCPJam organization at a time**. If it is
-already connected somewhere else, the account picker marks it and says so —
-disconnect it there first, or install the app on a different account.
+A GitHub account connects to **one MCPJam organization at a time**, for the
+whole account rather than per repository. If it is already connected somewhere
+else, the account picker marks it and says so. What you can do about it depends
+on where you stand:
+
+- **You are a member of the organization holding it** — the picker names that
+  organization. Disconnect the account there, then connect it here.
+- **You are not** — the picker cannot name it, because that would be a fact
+  about an organization you cannot see. An owner of the GitHub account can
+  disconnect it, or you can install the app on a different account.
 
 The **pull-request comment** described below is rolling out: it is enabled per
 deployment by an operator, and until it is on for yours a connected repository

--- a/docs/github-checks.mdx
+++ b/docs/github-checks.mdx
@@ -26,15 +26,17 @@ app is already installed on the GitHub account:
   the first button quietly leaves you on GitHub's settings page.
 
 A GitHub account connects to **one MCPJam organization at a time**, for the
-whole account rather than per repository. If it is already connected somewhere
-else, the account picker marks it and says so. What you can do about it depends
-on where you stand:
+whole account rather than per repository. Two organizations cannot split the
+repositories of one GitHub account between them. If the account is already
+connected elsewhere, connecting it again is refused — free it up in the
+organization holding it, or install the app on a different account.
 
-- **You are a member of the organization holding it** — the picker names that
-  organization. Disconnect the account there, then connect it here.
-- **You are not** — the picker cannot name it, because that would be a fact
-  about an organization you cannot see. An owner of the GitHub account can
-  disconnect it, or you can install the app on a different account.
+Which organization is holding it is **rolling out**: until it reaches your
+deployment the refusal names nothing, so ask an owner of the GitHub account,
+who can see the installation. After it reaches you the account picker marks
+the account before you click, and names the holding organization when you are
+a member of it — when you are not, it still cannot name it, because that is a
+fact about an organization you cannot see.
 
 The **pull-request comment** described below is rolling out: it is enabled per
 deployment by an operator, and until it is on for yours a connected repository

--- a/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
@@ -290,7 +290,13 @@ export function GithubInstallCallbackRoute() {
                 MCPJam app installed. Connecting one lets this organization run
                 checks on its repositories.
               </p>
-              {phase.installations.map((installation) => (
+              {phase.installations.map((installation) => {
+                // Ties the disabled button to the reason it is disabled. The
+                // note sits AFTER the button in the DOM, so without this a
+                // screen reader reaches "Connect, unavailable" with no cause
+                // — the one thing a blocked row exists to communicate.
+                const conflictNoteId = `github-claim-conflict-${installation.installationId}`;
+                return (
                 <div
                   key={installation.installationId}
                   data-testid={`claimable-${installation.accountLogin}`}
@@ -324,6 +330,9 @@ export function GithubInstallCallbackRoute() {
                       disabled={
                         claiming !== null || Boolean(installation.conflict)
                       }
+                      aria-describedby={
+                        installation.conflict ? conflictNoteId : undefined
+                      }
                       onClick={() =>
                         void handleClaim(phase.linkSessionId, installation)
                       }
@@ -332,7 +341,10 @@ export function GithubInstallCallbackRoute() {
                     </Button>
                   </div>
                   {installation.conflict ? (
-                    <p className="flex items-start gap-2 px-4 pb-3 text-xs leading-relaxed text-muted-foreground">
+                    <p
+                      id={conflictNoteId}
+                      className="flex items-start gap-2 px-4 pb-3 text-xs leading-relaxed text-muted-foreground"
+                    >
                       <Lock
                         className="size-3.5 shrink-0 mt-0.5 text-destructive"
                         aria-hidden
@@ -362,7 +374,8 @@ export function GithubInstallCallbackRoute() {
                     </p>
                   ) : null}
                 </div>
-              ))}
+                );
+              })}
             </>
           )}
         </SettingsSection>

--- a/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
-import { Github } from "lucide-react";
+import { Github, Lock } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { useDbUserReady } from "@/contexts/db-user-ready-context";
 import { useAppNavigate } from "@/lib/app-navigation";
@@ -280,42 +280,87 @@ export function GithubInstallCallbackRoute() {
             </div>
           ) : (
             <>
+              {/* "organization", not "workspace": `workspaces` is a different
+                  table entirely (a set of servers and a client config), and a
+                  GitHub installation binds to an ORGANIZATION. Calling it a
+                  workspace here reads as "one project", which is the wrong
+                  mental model for a limit that is actually per-org. */}
               <p className="px-4 pt-3 text-sm text-muted-foreground">
                 These are the accounts you administer that already have the
-                MCPJam app installed. Connecting one lets this workspace run
+                MCPJam app installed. Connecting one lets this organization run
                 checks on its repositories.
               </p>
               {phase.installations.map((installation) => (
                 <div
                   key={installation.installationId}
-                  className="flex items-center justify-between gap-4 px-4 py-3"
                   data-testid={`claimable-${installation.accountLogin}`}
                 >
-                  <div className="flex items-center gap-3 min-w-0">
-                    <Github
-                      className="size-4 text-muted-foreground shrink-0"
-                      aria-hidden
-                    />
-                    <div className="flex flex-col min-w-0">
-                      <span className="text-sm font-medium truncate">
-                        {installation.accountLogin}
-                      </span>
-                      <span className="text-xs text-muted-foreground">
-                        {installation.accountType === "Organization"
-                          ? "Organization"
-                          : "Personal account"}
-                      </span>
+                  <div className="flex items-center justify-between gap-4 px-4 py-3">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <Github
+                        className="size-4 text-muted-foreground shrink-0"
+                        aria-hidden
+                      />
+                      <div className="flex flex-col min-w-0">
+                        <span
+                          className={`text-sm font-medium truncate ${
+                            installation.conflict ? "text-muted-foreground" : ""
+                          }`}
+                        >
+                          {installation.accountLogin}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {installation.accountType === "Organization"
+                            ? "Organization"
+                            : "Personal account"}
+                        </span>
+                      </div>
                     </div>
+                    <Button
+                      size="sm"
+                      // A conflicting row is disabled rather than hidden: the
+                      // account IS one they administer, and hiding it would
+                      // read as "GitHub lost it" rather than "it is taken".
+                      disabled={
+                        claiming !== null || Boolean(installation.conflict)
+                      }
+                      onClick={() =>
+                        void handleClaim(phase.linkSessionId, installation)
+                      }
+                    >
+                      Connect
+                    </Button>
                   </div>
-                  <Button
-                    size="sm"
-                    disabled={claiming !== null}
-                    onClick={() =>
-                      void handleClaim(phase.linkSessionId, installation)
-                    }
-                  >
-                    Connect
-                  </Button>
+                  {installation.conflict ? (
+                    <p className="flex items-start gap-2 px-4 pb-3 text-xs leading-relaxed text-muted-foreground">
+                      <Lock
+                        className="size-3.5 shrink-0 mt-0.5 text-destructive"
+                        aria-hidden
+                      />
+                      {/* Two sentences, not one, because the second is the
+                          only actionable half and must survive being skimmed.
+                          The name is used when the backend gave one — its
+                          absence means the caller may not see that org, so the
+                          non-member copy names the party they CAN reach. */}
+                      <span>
+                        {installation.conflict.organizationName ? (
+                          <>
+                            Already connected to{" "}
+                            <span className="font-medium text-foreground">
+                              {installation.conflict.organizationName}
+                            </span>
+                            . Disconnect it there to use it here.
+                          </>
+                        ) : (
+                          <>
+                            Already connected to another MCPJam organization. An
+                            owner of the {installation.accountLogin} GitHub
+                            account can disconnect it there.
+                          </>
+                        )}
+                      </span>
+                    </p>
+                  ) : null}
                 </div>
               ))}
             </>

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
@@ -455,6 +455,36 @@ describe("the OAuth leg", () => {
     expect(buttons[1]).toBeEnabled();
   });
 
+  it("points the disabled button at the reason it is disabled", async () => {
+    // The note renders AFTER the button, so without the association a screen
+    // reader reaches "Connect, unavailable" and never learns why — which is
+    // the only thing a blocked row exists to say.
+    mockCompleteUserAuthorization.mockResolvedValue({
+      status: "pick_required",
+      linkSessionId: "sess-1",
+      installations: [
+        {
+          installationId: 11,
+          accountLogin: "acme",
+          accountType: "Organization",
+          conflict: { organizationName: "Dana's Org" },
+        },
+        { installationId: 12, accountLogin: "dana", accountType: "User" },
+      ],
+    });
+    renderCallback("?code=c&state=s");
+    await screen.findByText("acme");
+
+    const [taken, free] = screen.getAllByRole("button", { name: "Connect" });
+    const noteId = taken.getAttribute("aria-describedby");
+    expect(noteId).toBeTruthy();
+    expect(document.getElementById(noteId as string)?.textContent).toMatch(
+      /Dana's Org/
+    );
+    // A connectable row describes nothing — there is no reason to give.
+    expect(free).not.toHaveAttribute("aria-describedby");
+  });
+
   it("never fires a claim the backend would refuse", async () => {
     mockCompleteUserAuthorization.mockResolvedValue({
       status: "pick_required",

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
@@ -428,6 +428,85 @@ describe("the OAuth leg", () => {
     ).toBeInTheDocument();
   });
 
+  it("marks an already-connected account instead of offering the click", async () => {
+    mockCompleteUserAuthorization.mockResolvedValue({
+      status: "pick_required",
+      linkSessionId: "sess-1",
+      installations: [
+        {
+          installationId: 11,
+          accountLogin: "acme",
+          accountType: "Organization",
+          conflict: { organizationName: "Dana's Org" },
+        },
+        { installationId: 12, accountLogin: "dana", accountType: "User" },
+      ],
+    });
+    renderCallback("?code=c&state=s");
+
+    await screen.findByText("acme");
+    // The taken row stays VISIBLE — it is an account they administer, and
+    // hiding it would read as GitHub losing it rather than it being taken.
+    expect(await screen.findByText(/Dana's Org/)).toBeInTheDocument();
+
+    const buttons = screen.getAllByRole("button", { name: "Connect" });
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]).toBeDisabled();
+    expect(buttons[1]).toBeEnabled();
+  });
+
+  it("never fires a claim the backend would refuse", async () => {
+    mockCompleteUserAuthorization.mockResolvedValue({
+      status: "pick_required",
+      linkSessionId: "sess-1",
+      installations: [
+        {
+          installationId: 11,
+          accountLogin: "acme",
+          accountType: "Organization",
+          conflict: { organizationName: "Dana's Org" },
+        },
+      ],
+    });
+    const user = userEvent.setup();
+    renderCallback("?code=c&state=s");
+    await screen.findByText("acme");
+
+    await user.click(screen.getByRole("button", { name: "Connect" }));
+
+    // The point of the whole change: no round trip, and no navigation away to
+    // a dead-end failure screen.
+    expect(mockClaimProvenInstallation).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("names no organization when the backend named none", async () => {
+    // An absent `organizationName` is the ANSWER — the caller is not a member
+    // of the holding org — not a lookup that failed. The row must not imply
+    // one exists to go and look at.
+    mockCompleteUserAuthorization.mockResolvedValue({
+      status: "pick_required",
+      linkSessionId: "sess-1",
+      installations: [
+        {
+          installationId: 11,
+          accountLogin: "acme",
+          accountType: "Organization",
+          conflict: {},
+        },
+      ],
+    });
+    renderCallback("?code=c&state=s");
+
+    const note = await screen.findByText(
+      /already connected to another MCPJam organization/i
+    );
+    expect(note).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Connect" })).toBeDisabled();
+    // It points at the party the person can actually reach.
+    expect(note.textContent).toMatch(/owner of the acme GitHub account/i);
+  });
+
   it("shows a non-disclosing conflict exactly as the backend worded it", async () => {
     mockCompleteUserAuthorization.mockRejectedValue(
       Object.assign(new Error("Server Error"), {

--- a/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
@@ -131,6 +131,16 @@ export type ClaimableInstallation = {
   installationId: number;
   accountLogin: string;
   accountType: GithubInstallationAccountType;
+  /**
+   * Present when this installation is already connected to another MCPJam
+   * organization, so the row can say so instead of offering a click the
+   * backend will refuse. Absent means connectable.
+   *
+   * `organizationName` is present ONLY when the signed-in user is a member of
+   * the organization holding it. Its absence is the backend's answer, not a
+   * missing lookup — do not retry for it, and do not imply one exists to name.
+   */
+  conflict?: { organizationName?: string };
 };
 
 /**


### PR DESCRIPTION
- Connecting a GitHub account another MCPJam org already holds used to throw you off the picker onto a "Could not connect" page, written in the same grey as everything else, where the only real button was the one that leaves.
- Now the taken account just shows up disabled in the list with a lock and the reason next to it, and you can still connect any other account.
- If you're a member of the org holding it, the note names that org. If you're not, it tells you a GitHub owner of that account can free it up.
- Also stops calling an org a "workspace" on this screen — that's a different thing in our schema, and it made a per-org limit read like a per-project one.
- Needs MCPJam/mcpjam-backend#1274 for the org name to appear; without it every row just stays connectable as it does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops dead-ending users who connect a GitHub account another MCPJam org already holds. The taken account now shows up disabled in the picker with a lock and the reason inline; every other account stays connectable, and the blocked row's button states its reason to screen readers.

**Notes**
- Needs `MCPJam/mcpjam-backend#1274` for the holding org's name to appear; until it deploys, taken rows stay connectable as they do today.
- Replaces "workspace" with "organization" on this screen — `workspaces` is a different schema concept, and the old wording made a per-org limit read like a per-project one.
- Docs state the one-account-per-organization rule as current behavior, frame the naming and pre-click marking as rolling out until the backend lands, and cover what a holding-org member can do versus a non-member.

<sup>Written for commit 2b7943bc8c32b44c9631d78e45222eaa3813ca31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

