### PR TITLE
github checks: only offer the controls to an org admin

### DIFF
--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -24,7 +24,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@mcpjam/design-system/select";
-import { useOrganizationQueries } from "@/hooks/useOrganizations";
+import {
+  canManageGithubChecks,
+  useOrganizationQueries,
+} from "@/hooks/useOrganizations";
 import {
   OutagePolicyExplainer,
   OutagePolicySelectItems,
@@ -239,9 +242,27 @@ export function GithubChecksRoute({
   // window a cold deep link lands in. Only once auth AND the org list have
   // settled is a missing id genuinely missing rather than merely early.
   const { isAuthenticated, isLoading: authLoading } = useConvexAuth();
-  const { isLoading: organizationsLoading } = useOrganizationQueries({
-    isAuthenticated,
-  });
+  const { sortedOrganizations, isLoading: organizationsLoading } =
+    useOrganizationQueries({
+      isAuthenticated,
+    });
+
+  // Every write on this page is org-ADMIN-only server-side; the availability
+  // query behind it needs only MEMBER. So a member reaches the page
+  // legitimately and must NOT be handed live controls — see
+  // `canManageGithubChecks`.
+  //
+  // Unresolved reads as "may not", which greys the page for the moment before
+  // the org list settles. That is the safe direction: the opposite flashes
+  // enabled controls at somebody who is about to be refused.
+  const activeOrganization = useMemo(
+    () =>
+      activeOrganizationId
+        ? sortedOrganizations.find((org) => org._id === activeOrganizationId)
+        : undefined,
+    [sortedOrganizations, activeOrganizationId]
+  );
+  const canManage = canManageGithubChecks(activeOrganization);
 
   // `null` = not loaded yet, `[]` = loaded and genuinely empty. The error is
   // tracked separately so a failed fetch never renders as "you have no
@@ -757,6 +778,16 @@ export function GithubChecksRoute({
         — existing repositories stay eval-only until you turn it on.
       </p>
 
+      {/* Says WHY the page is read-only, next to the controls it explains.
+          Without it a member reads the greyed page as broken, and the only
+          alternative answer they had was to click and get a refusal toast. */}
+      {!canManage && !organizationsLoading ? (
+        <p className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+          You can see this organization's GitHub Checks setup, but only an
+          organization owner or admin can change it.
+        </p>
+      ) : null}
+
       <SettingsSection title="GitHub accounts">
         {bindings === undefined ? (
           <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
@@ -776,7 +807,7 @@ export function GithubChecksRoute({
             <InstallationRow
               key={binding.installationRef}
               binding={binding}
-              disabled={bindingBusy}
+              disabled={bindingBusy || !canManage}
               onUnbind={() => setPendingUnbind(binding)}
             />
           ))
@@ -784,7 +815,7 @@ export function GithubChecksRoute({
 
         <div className="flex flex-wrap items-center gap-3 px-4 py-3">
           <Button
-            disabled={bindingBusy}
+            disabled={bindingBusy || !canManage}
             onClick={() => void beginBindingFlow("install")}
           >
             <Github className="mr-2 size-4" aria-hidden /> Install on a GitHub
@@ -792,7 +823,7 @@ export function GithubChecksRoute({
           </Button>
           <Button
             variant="outline"
-            disabled={bindingBusy}
+            disabled={bindingBusy || !canManage}
             onClick={() => void beginBindingFlow("claim")}
           >
             Claim an existing installation
@@ -939,7 +970,7 @@ export function GithubChecksRoute({
                     the default — a claim the stored row does not make. */}
                 <Select
                   value={row.outagePolicy ?? ""}
-                  disabled={pendingPolicies.has(row._id)}
+                  disabled={pendingPolicies.has(row._id) || !canManage}
                   onValueChange={(value) =>
                     void handlePolicyChange(
                       row,
@@ -960,14 +991,18 @@ export function GithubChecksRoute({
 
                 <Switch
                   checked={row.enabled}
-                  disabled={pendingToggles.has(row._id)}
+                  disabled={pendingToggles.has(row._id) || !canManage}
                   onCheckedChange={() => void handleToggle(row)}
                   aria-label={`Enable checks for ${row.repoFullName}`}
                 />
 
                 <Switch
                   checked={row.conformanceEnabled === true}
-                  disabled={pendingConformance.has(row._id) || !row.enabled}
+                  disabled={
+                    pendingConformance.has(row._id) ||
+                    !row.enabled ||
+                    !canManage
+                  }
                   onCheckedChange={() => void handleConformanceToggle(row)}
                   aria-label={`Enable conformance check for ${row.repoFullName}`}
                 />
@@ -981,7 +1016,7 @@ export function GithubChecksRoute({
                     write, and it stays answerable while checks are paused. */}
                 <Switch
                   checked={row.feedbackComments !== "off"}
-                  disabled={pendingFeedback.has(row._id)}
+                  disabled={pendingFeedback.has(row._id) || !canManage}
                   onCheckedChange={() => void handleFeedbackCommentsToggle(row)}
                   aria-label={`Post feedback comments on pull requests for ${row.repoFullName}`}
                   aria-describedby={`feedback-comments-note-${row._id}`}
@@ -990,6 +1025,7 @@ export function GithubChecksRoute({
                 <Button
                   variant="ghost"
                   size="icon"
+                  disabled={!canManage}
                   aria-label={`Disconnect ${row.repoFullName}`}
                   onClick={() => void handleDisconnect(row)}
                 >
@@ -1053,7 +1089,11 @@ export function GithubChecksRoute({
           <Button
             onClick={() => void handleConnect()}
             disabled={
-              connecting || !pickerRepo || !pickerSuite || !pickerPolicy
+              connecting ||
+              !pickerRepo ||
+              !pickerSuite ||
+              !pickerPolicy ||
+              !canManage
             }
           >
             <Plus className="mr-2 size-4" aria-hidden /> Connect

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -947,6 +947,7 @@ export function GithubChecksRoute({
               <div className="flex items-center gap-3 shrink-0">
                 <Select
                   value={row.suiteId}
+                  disabled={!canManage}
                   onValueChange={(value) => void handleSuiteChange(row, value)}
                 >
                   <SelectTrigger
@@ -1043,7 +1044,11 @@ export function GithubChecksRoute({
               each have a `widgets`, and the id is what the connect is actually
               keyed on — selecting by name would make the account label below
               purely decorative and let one pick resolve to the other repo. */}
-          <Select value={pickerRepo} onValueChange={setPickerRepo}>
+          <Select
+            value={pickerRepo}
+            disabled={!canManage}
+            onValueChange={setPickerRepo}
+          >
             <SelectTrigger className="w-72" aria-label="Repository">
               <SelectValue placeholder="Select a repository" />
             </SelectTrigger>
@@ -1059,7 +1064,11 @@ export function GithubChecksRoute({
             </SelectContent>
           </Select>
 
-          <Select value={pickerSuite} onValueChange={setPickerSuite}>
+          <Select
+            value={pickerSuite}
+            disabled={!canManage}
+            onValueChange={setPickerSuite}
+          >
             <SelectTrigger className="w-56" aria-label="Suite">
               <SelectValue placeholder="Select a suite" />
             </SelectTrigger>
@@ -1074,6 +1083,7 @@ export function GithubChecksRoute({
 
           <Select
             value={pickerPolicy}
+            disabled={!canManage}
             onValueChange={(value) =>
               setPickerPolicy(value as GithubCheckOutagePolicy)
             }

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -29,6 +29,7 @@ const {
   mockRedirectToGithub,
   mockOrgsLoading,
   mockAuthLoading,
+  mockMyRole,
 } = vi.hoisted(() => ({
   mockAvailability: {
     value: undefined as { state: "enabled" | "disabled" } | undefined,
@@ -76,6 +77,9 @@ const {
   mockRedirectToGithub: vi.fn(),
   mockOrgsLoading: { value: false },
   mockAuthLoading: { value: false },
+  // The viewer's org role. Admin by default: every case below that is not
+  // about the permission gate is written from an admin's seat.
+  mockMyRole: { value: "admin" as string | undefined },
 }));
 
 // The availability gate is the unit under test; the data layer is stubbed.
@@ -117,7 +121,14 @@ vi.mock("convex/react", () => ({
 }));
 
 vi.mock("@/hooks/useOrganizations", () => ({
-  useOrganizationQueries: () => ({ isLoading: mockOrgsLoading.value }),
+  useOrganizationQueries: () => ({
+    isLoading: mockOrgsLoading.value,
+    sortedOrganizations: [{ _id: "org-1", myRole: mockMyRole.value }],
+  }),
+  // The real predicate, not a stub: what is under test here is that the page
+  // asks it and honours the answer.
+  canManageGithubChecks: (org?: { myRole?: string } | null) =>
+    org?.myRole === "owner" || org?.myRole === "admin",
 }));
 
 // The nav resolves availability itself now; it is not what this file tests.
@@ -264,6 +275,7 @@ describe("GithubChecksRoute availability gate", () => {
     ];
     mockOrgsLoading.value = false;
     mockAuthLoading.value = false;
+    mockMyRole.value = "admin";
     mockBindings.value = [binding("mcpjam")];
     vi.clearAllMocks();
   });
@@ -453,6 +465,7 @@ describe("GithubChecksRoute connect flow", () => {
     ];
     mockOrgsLoading.value = false;
     mockAuthLoading.value = false;
+    mockMyRole.value = "admin";
     mockBindings.value = [binding("mcpjam")];
     mockListInstallationRepos.mockReset();
     mockListInstallationRepos.mockResolvedValue([
@@ -666,6 +679,7 @@ describe("GithubChecksRoute row outage policy", () => {
     ];
     mockOrgsLoading.value = false;
     mockAuthLoading.value = false;
+    mockMyRole.value = "admin";
     mockBindings.value = [binding("mcpjam")];
     mockListInstallationRepos.mockReset();
     mockListInstallationRepos.mockResolvedValue([]);
@@ -807,6 +821,7 @@ describe("GithubChecksRoute pull-request comments", () => {
     ];
     mockOrgsLoading.value = false;
     mockAuthLoading.value = false;
+    mockMyRole.value = "admin";
     mockBindings.value = [binding("mcpjam")];
     mockListInstallationRepos.mockReset();
     mockListInstallationRepos.mockResolvedValue([]);
@@ -995,6 +1010,7 @@ describe("GithubChecksRoute repository visibility", () => {
     ];
     mockOrgsLoading.value = false;
     mockAuthLoading.value = false;
+    mockMyRole.value = "admin";
     mockBindings.value = [binding("mcpjam")];
     mockRepos.value = [ROW];
     mockListInstallationRepos.mockReset();
@@ -1078,6 +1094,7 @@ describe("GithubChecksRoute organization switching", () => {
     ];
     mockOrgsLoading.value = false;
     mockAuthLoading.value = false;
+    mockMyRole.value = "admin";
     mockBindings.value = [binding("mcpjam")];
     mockListInstallationRepos.mockReset();
     mockConnectVerifiedRepo.mockReset();
@@ -1182,6 +1199,7 @@ describe("GithubChecksRoute binding changes", () => {
     ];
     mockOrgsLoading.value = false;
     mockAuthLoading.value = false;
+    mockMyRole.value = "admin";
     mockBindings.value = [];
     mockListInstallationRepos.mockReset();
     mockConnectVerifiedRepo.mockReset();
@@ -1374,6 +1392,7 @@ describe("GithubChecksRoute installations", () => {
     mockSuites.value = [];
     mockOrgsLoading.value = false;
     mockAuthLoading.value = false;
+    mockMyRole.value = "admin";
     mockBindings.value = [];
     mockListInstallationRepos.mockReset();
     mockListInstallationRepos.mockResolvedValue([]);
@@ -1569,6 +1588,7 @@ describe("GithubChecksRoute connection status", () => {
     ];
     mockOrgsLoading.value = false;
     mockAuthLoading.value = false;
+    mockMyRole.value = "admin";
     mockBindings.value = [binding("mcpjam")];
     mockListInstallationRepos.mockReset();
     mockListInstallationRepos.mockResolvedValue([]);
@@ -1683,5 +1703,101 @@ describe("GithubChecksRoute connection status", () => {
     >;
     expect(sent).not.toHaveProperty("installationRef");
     expect(sent.repositoryId).toBe(repositoryIds.get("mcpjam/pinned-repo"));
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// WHO MAY CHANGE ANY OF THIS
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Every write on this page is org-ADMIN-only server-side, while the
+// availability query it renders behind needs only MEMBER — deliberately, so a
+// member is told the integration exists rather than that the org does not.
+// A member therefore reaches this page legitimately, and used to find every
+// control live: clicking one produced `OrgAccessDeniedError`, which Convex
+// masks to `Server Error` on a production deployment. The member got a crash
+// where a refusal belonged, and the error tracker got paged for it (Sentry
+// CONVEX-24N / CONVEX-24P).
+//
+// The gate is a RENDER concern only. It is not a substitute for the backend
+// check, which stays exactly where it was.
+
+describe("GithubChecksRoute permissions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = [ROW];
+    mockSuites.value = [
+      { _id: "suite-1", name: "Fixture suite", projectId: "proj-1" },
+    ];
+    mockOrgsLoading.value = false;
+    mockAuthLoading.value = false;
+    mockMyRole.value = "admin";
+    mockBindings.value = [binding("mcpjam")];
+    mockListInstallationRepos.mockReset();
+    mockListInstallationRepos.mockResolvedValue([]);
+  });
+
+  it("leaves every write control dead for a member, and says why", async () => {
+    mockMyRole.value = "member";
+    renderRoute();
+
+    expect(
+      await screen.findByRole("button", { name: /Install on a GitHub account/ })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /Claim an existing installation/ })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /Disconnect mcpjam$/ })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("switch", {
+        name: /Enable checks for mcpjam\/mcp-check-fixture/,
+      })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: /Disconnect mcpjam\/mcp-check-fixture/,
+      })
+    ).toBeDisabled();
+
+    // The greyed page has to explain itself, or it reads as broken.
+    expect(
+      screen.getByText(/only an organization owner or admin can change it/i)
+    ).toBeInTheDocument();
+  });
+
+  it.each(["admin", "owner"])("leaves them live for an %s", async (role) => {
+    mockMyRole.value = role;
+    renderRoute();
+
+    expect(
+      await screen.findByRole("button", { name: /Install on a GitHub account/ })
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("switch", {
+        name: /Enable checks for mcpjam\/mcp-check-fixture/,
+      })
+    ).toBeEnabled();
+    expect(
+      screen.queryByText(/only an organization owner or admin can change it/i)
+    ).not.toBeInTheDocument();
+  });
+
+  // Unresolved is not "allowed". The org list settling after the page mounts
+  // would otherwise flash live controls at somebody about to be refused — and
+  // the notice must not flash either, since we do not yet know it applies.
+  it("stays closed, and silent, while the org list is still loading", async () => {
+    mockMyRole.value = "admin";
+    mockOrgsLoading.value = true;
+    renderRoute();
+
+    expect(
+      await screen.findByRole("button", { name: /Install on a GitHub account/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/only an organization owner or admin can change it/i)
+    ).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -123,7 +123,17 @@ vi.mock("convex/react", () => ({
 vi.mock("@/hooks/useOrganizations", () => ({
   useOrganizationQueries: () => ({
     isLoading: mockOrgsLoading.value,
-    sortedOrganizations: [{ _id: "org-1", myRole: mockMyRole.value }],
+    // `[]` while loading, exactly as the real hook does — it returns an empty
+    // array until the query resolves. Handing back a populated list mid-load
+    // would make the unresolved window untestable.
+    // Both ids the switching cases below render with, so an org switch stays a
+    // switch rather than a silent drop out of the list.
+    sortedOrganizations: mockOrgsLoading.value
+      ? []
+      : [
+          { _id: "org-1", myRole: mockMyRole.value },
+          { _id: "org-2", myRole: mockMyRole.value },
+        ],
   }),
   // The real predicate, not a stub: what is under test here is that the page
   // asks it and honours the answer.
@@ -1761,6 +1771,15 @@ describe("GithubChecksRoute permissions", () => {
         name: /Disconnect mcpjam\/mcp-check-fixture/,
       })
     ).toBeDisabled();
+    // The row's suite picker is a write too — `setRepoSuite` — and is the one
+    // control on this page that had no `disabled` of its own to extend.
+    expect(
+      screen.getByRole("combobox", {
+        name: /Suite for mcpjam\/mcp-check-fixture/,
+      })
+    ).toBeDisabled();
+    // Nothing to fill in either, when the Connect it feeds is dead.
+    expect(screen.getByRole("combobox", { name: "Repository" })).toBeDisabled();
 
     // The greyed page has to explain itself, or it reads as broken.
     expect(
@@ -1793,9 +1812,11 @@ describe("GithubChecksRoute permissions", () => {
     mockOrgsLoading.value = true;
     renderRoute();
 
+    // Closed: the role is not known yet, so the page may not act on it.
     expect(
       await screen.findByRole("button", { name: /Install on a GitHub account/ })
-    ).toBeInTheDocument();
+    ).toBeDisabled();
+    // Silent: we do not yet know the notice applies, so it must not flash.
     expect(
       screen.queryByText(/only an organization owner or admin can change it/i)
     ).not.toBeInTheDocument();

--- a/mcpjam-inspector/client/src/hooks/useOrganizations.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizations.ts
@@ -88,6 +88,24 @@ export function canManageOrgModels(
   return org.myRole === "owner" || org.myRole === "admin";
 }
 
+/**
+ * Whether the current user may change the GitHub Checks integration.
+ *
+ * The backend's `authorizeWrite` requires org ADMIN for every write on that
+ * page, while the availability query it renders behind requires only MEMBER —
+ * on purpose, so a member is told the integration exists rather than that the
+ * org does not. Without this the page rendered every control live for someone
+ * the backend was always going to refuse, and the refusal arrived as a toast
+ * after the click. Same owner/admin pair as `canManageOrgModels`, kept separate
+ * because the two surfaces are free to diverge.
+ */
+export function canManageGithubChecks(
+  org: Pick<Organization, "myRole"> | null | undefined,
+): boolean {
+  if (!org) return false;
+  return org.myRole === "owner" || org.myRole === "admin";
+}
+
 export function useOrganizationQueries({
   isAuthenticated,
 }: {


### PR DESCRIPTION
- The GitHub Checks settings page showed every control as live to any org member, but the backend requires org admin for all of them. You'd click, and get an error toast.
- Members can still open the page (that part is deliberate — they should be able to see the setup). Now the buttons, switches and dropdowns are just greyed out, with a line explaining that only an owner or admin can change things.
- While the org list is still loading we treat you as "may not", so nothing flashes enabled at someone who's about to be refused.
- This is UI only. The server-side permission check is untouched and still the real gate.
- Pairs with MCPJam/mcpjam-backend#1275, which makes the refusal itself a clean message instead of a "Server Error" (Sentry CONVEX-24N / CONVEX-24P).
- 76 tests pass, client typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the GitHub Checks settings controls to org owners and admins so members can still view the setup but no longer click into a backend refusal toast.

**Bug Fixes**
- Disables every write control — install, claim, connect, disconnect, suite, policy, and toggles — for non-admins, with an inline note explaining only an owner or admin can change things.
- The connect pickers are gated too so the read-only page doesn't read as a fillable form.
- While the org list is loading, treats the role as non-admin so nothing flashes enabled; the loading test now uses an empty org list and asserts the disabled state.
- UI only; the server-side permission check is untouched and still authoritative.

<sup>Written for commit 2b6cecd44573c604dc1a4be72c705bf473462503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

