### PR TITLE
Fix cached project sign-in recovery race

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -207,7 +207,6 @@ import {
 import {
   captureAppSignInReturnPath,
   consumeAppSignInReturnPath,
-  readAppSignInReturnPath,
 } from "./lib/app-signin-return-path";
 import {
   trackSignInReturnRestored,
@@ -2516,14 +2515,8 @@ export default function App() {
   const [callbackCompleted, setCallbackCompleted] = useState(false);
   const [callbackRecoveryExpired, setCallbackRecoveryExpired] = useState(false);
   const [pendingProjectReturnRecovery, setPendingProjectReturnRecovery] =
-    useState<ProjectSignInReturnRecoveryIntent | null>(() => {
-      if (window.location.pathname === routePaths.callback) return null;
-      const restoredPath = readAppSignInReturnPath();
-      const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-      return restoredPath === currentPath
-        ? createProjectSignInReturnRecoveryIntent(restoredPath)
-        : null;
-    });
+    useState<ProjectSignInReturnRecoveryIntent | null>(null);
+  const callbackReturnConsumedRef = useRef(false);
   const billingDeepLinkNavRef = useRef(false);
   /** True after we read valid plan/interval from the URL and stripped query params; avoids clearing session on the next /billing tick. */
   const billingCheckoutQueryConsumedRef = useRef(false);
@@ -2538,25 +2531,6 @@ export default function App() {
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
   const compatibilityEnabled = useFeatureFlagEnabled("mcpjam-compatibility");
   const xaaEnabled = useFeatureFlagEnabled("xaa");
-
-  // AuthKit can restore a permalink from `main.tsx` before the callback route
-  // ever renders. Consume the generic return path on that restored page so it
-  // can still arm stale-project recovery. Layout timing prevents the generic
-  // unavailable boundary from painting first.
-  useLayoutEffect(() => {
-    if (window.location.pathname === routePaths.callback) return;
-    const restoredPath = consumeAppSignInReturnPath();
-    if (!restoredPath) return;
-    const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-    if (restoredPath !== currentPath) {
-      trackSignInReturnRestored("superseded");
-      return;
-    }
-    trackSignInReturnRestored("restored");
-    setPendingProjectReturnRecovery(
-      createProjectSignInReturnRecoveryIntent(restoredPath),
-    );
-  }, []);
 
   // Per-tab "hide from this header" list for the OAuth / XAA debugger chip strip.
   // View-only (localStorage) — the x on a chip dismisses it from this header
@@ -2928,6 +2902,8 @@ export default function App() {
 
   useEffect(() => {
     if (!isOAuthCallback) {
+      callbackReturnConsumedRef.current = false;
+      setPendingProjectReturnRecovery(null);
       setCallbackCompleted(false);
       setCallbackRecoveryExpired(false);
       return;
@@ -2950,8 +2926,15 @@ export default function App() {
       return;
     }
 
-    // Let AuthKit + Convex auth settle before leaving /callback.
-    if (!isAuthLoading && isAuthenticated) {
+    // Select the return exactly once after AuthKit + Convex auth settle. A
+    // project-scoped return stays on `/callback` until the database user and
+    // first authoritative membership response are ready below.
+    if (
+      !isAuthLoading &&
+      isAuthenticated &&
+      !callbackReturnConsumedRef.current
+    ) {
+      callbackReturnConsumedRef.current = true;
       const scenarioReturnPath = readScenarioSignInReturnPath();
       const persistedCheckoutIntent = readPersistedCheckoutIntent();
       const billingReturnPath = persistedCheckoutIntent
@@ -2984,9 +2967,12 @@ export default function App() {
             ? "restored"
             : "superseded",
       );
-      setPendingProjectReturnRecovery(
-        createProjectSignInReturnRecoveryIntent(restoredPath),
-      );
+      const projectReturnIntent =
+        createProjectSignInReturnRecoveryIntent(restoredPath);
+      if (projectReturnIntent) {
+        setPendingProjectReturnRecovery(projectReturnIntent);
+        return;
+      }
       // `navigateApp`, not `history.replaceState`: a raw history write leaves
       // the ROUTER matched on `/callback` while the address bar says
       // `/p/<id>/evals/...`, so the project boundary never mounts and the URL
@@ -2995,14 +2981,7 @@ export default function App() {
       navigateApp(restoredPath, { replace: true });
       setCallbackCompleted(true);
       setCallbackRecoveryExpired(false);
-      return;
     }
-
-    const timeout = setTimeout(() => {
-      setCallbackRecoveryExpired(true);
-    }, 15000);
-
-    return () => clearTimeout(timeout);
   }, [
     isOAuthCallback,
     isAuthLoading,
@@ -3011,8 +2990,20 @@ export default function App() {
     workOsUser,
   ]);
 
+  // One deadline covers both session bootstrap and the authoritative project
+  // response. Dependency changes must not restart it while either is pending.
+  useEffect(() => {
+    if (!isOAuthCallback || callbackCompleted) return;
+    const timeout = window.setTimeout(() => {
+      setCallbackRecoveryExpired(true);
+    }, 15000);
+    return () => window.clearTimeout(timeout);
+  }, [isOAuthCallback, callbackCompleted]);
+
   const handleRetryCallbackSignIn = useCallback(() => {
     clearHostedCallbackRetryState();
+    callbackReturnConsumedRef.current = false;
+    setPendingProjectReturnRecovery(null);
     window.history.replaceState({}, "", "/");
     setCallbackCompleted(true);
     setCallbackRecoveryExpired(false);
@@ -4528,17 +4519,6 @@ export default function App() {
         : undefined,
     [allMembershipProjects],
   );
-  const currentLocation = useCurrentLocationParts();
-  const currentProjectPath = `${currentLocation.pathname}${currentLocation.search}${currentLocation.hash}`;
-  const confirmedStaleReturnProjectId =
-    pendingProjectReturnRecovery &&
-    isProjectIdShape(pendingProjectReturnRecovery.requestedProjectId) &&
-    allMembershipProjectIds !== undefined &&
-    !allMembershipProjectIds.has(
-      pendingProjectReturnRecovery.requestedProjectId,
-    )
-      ? pendingProjectReturnRecovery.requestedProjectId
-      : null;
   // Silent: the URL already told the user which project they are in, so a
   // toast on every cold open of a shared link would be narrating the address
   // bar back at them.
@@ -4556,48 +4536,46 @@ export default function App() {
     activeOrganizationId,
     setActiveOrganizationId,
     switchProject: switchProjectForRoute,
-    suppressInaccessibleTelemetryFor: confirmedStaleReturnProjectId,
   });
 
-  const fallbackProjectForStaleReturn =
-    activeProject && allMembershipProjectIds?.has(activeProjectId)
-      ? { id: activeProjectId, name: activeProject.name }
-      : null;
+  const authoritativeMembershipProjectIds =
+    isUserReady && !isLoadingRemoteProjects
+      ? allMembershipProjectIds
+      : undefined;
+  const fallbackProjectIdForStaleReturn =
+    activeProject && authoritativeMembershipProjectIds?.has(activeProjectId)
+      ? activeProjectId
+      : (allMembershipProjects?.[0]?._id ?? null);
   const projectReturnRecoveryDecision = resolveProjectSignInReturnRecovery({
     intent: pendingProjectReturnRecovery,
-    routeState: projectRouteState,
-    currentPath: currentProjectPath,
-    membershipProjectIds: allMembershipProjectIds,
-    fallbackProject: fallbackProjectForStaleReturn,
+    membershipProjectIds: authoritativeMembershipProjectIds,
+    fallbackProjectId: fallbackProjectIdForStaleReturn,
   });
-  const projectRouteStateForBoundary =
-    projectReturnRecoveryDecision.kind === "switch" ||
-    projectReturnRecoveryDecision.kind === "home"
-      ? {
-          status: "resolving" as const,
-          requestedProjectId:
-            pendingProjectReturnRecovery?.requestedProjectId ?? "",
-        }
-      : projectRouteState;
 
-  // Layout timing keeps the generic unavailable screen from painting for a
-  // stale sign-in return. The intent is cleared before navigation so a bad
-  // fallback can show the normal error but can never loop.
+  // Resolve while `/callback` still owns the screen. Clear the one-shot intent
+  // before the only navigation so a bad destination can never loop.
   useLayoutEffect(() => {
-    if (projectReturnRecoveryDecision.kind === "none") return;
+    if (
+      projectReturnRecoveryDecision.kind === "none" ||
+      projectReturnRecoveryDecision.kind === "wait"
+    ) {
+      return;
+    }
     setPendingProjectReturnRecovery(null);
+    setCallbackCompleted(true);
+    setCallbackRecoveryExpired(false);
 
-    if (projectReturnRecoveryDecision.kind === "clear") return;
     if (projectReturnRecoveryDecision.kind === "home") {
       trackStaleProjectReturnRecovered("no-fallback");
       navigateApp(routePaths.root, { replace: true, unscoped: true });
       return;
     }
 
-    trackStaleProjectReturnRecovered("switched");
+    if (projectReturnRecoveryDecision.kind === "switch") {
+      trackStaleProjectReturnRecovered("switched");
+    }
     navigateApp(projectReturnRecoveryDecision.path, { replace: true });
-    toast.error(projectReturnRecoveryDecision.message);
-  }, [pendingProjectReturnRecovery, projectReturnRecoveryDecision]);
+  }, [projectReturnRecoveryDecision]);
 
   /**
    * Picking another project in the switcher NAVIGATES. It does not switch
@@ -5020,7 +4998,7 @@ export default function App() {
     // What the URL's project segment resolved to. `ProjectRouteBoundary`
     // renders on it, and the legacy normalizer reads the rest of this bag to
     // decide which project an old link should adopt.
-    projectRouteState: projectRouteStateForBoundary,
+    projectRouteState,
     activeMcpProfile,
     activeOrganizationId,
     activeOrganizationName,

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -207,6 +207,7 @@ import {
 import {
   captureAppSignInReturnPath,
   consumeAppSignInReturnPath,
+  writeAppSignInReturnPath,
 } from "./lib/app-signin-return-path";
 import {
   trackSignInReturnRestored,
@@ -3001,6 +3002,9 @@ export default function App() {
   }, [isOAuthCallback, callbackCompleted]);
 
   const handleRetryCallbackSignIn = useCallback(() => {
+    if (pendingProjectReturnRecovery) {
+      writeAppSignInReturnPath(pendingProjectReturnRecovery.path);
+    }
     clearHostedCallbackRetryState();
     callbackReturnConsumedRef.current = false;
     setPendingProjectReturnRecovery(null);
@@ -3010,7 +3014,7 @@ export default function App() {
     queueMicrotask(() => {
       signIn();
     });
-  }, [signIn]);
+  }, [pendingProjectReturnRecovery, signIn]);
 
   const handleReloadFromCallback = useCallback(() => {
     clearHostedCallbackRetryState();

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -29,7 +29,10 @@ import {
   writeScenarioSignInReturnPath,
   writeScenarioSession,
 } from "../lib/scenario-session";
-import { writeAppSignInReturnPath } from "../lib/app-signin-return-path";
+import {
+  readAppSignInReturnPath,
+  writeAppSignInReturnPath,
+} from "../lib/app-signin-return-path";
 
 /** Convex-shaped project ids for the cross-organization switch cases. */
 const ORG_A_PROJECT_ID = "k57aaaaaaaaaaaaaaaaaaaaaaaa1";
@@ -599,6 +602,9 @@ describe("App hosted OAuth callback handling", () => {
   });
 
   afterEach(() => {
+    if (vi.isMockFunction(window.history.replaceState)) {
+      vi.mocked(window.history.replaceState).mockRestore();
+    }
     vi.unstubAllGlobals();
   });
 
@@ -2160,24 +2166,55 @@ describe("App hosted OAuth callback handling", () => {
     );
   });
 
-  it("keeps the callback timeout while project memberships are pending", async () => {
+  it("preserves the scoped return through a membership timeout and retry", async () => {
     vi.useFakeTimers();
     try {
       clearScenarioSession();
       const staleProjectId = "k5700000000000000000000000a";
-      writeAppSignInReturnPath(`/p/${staleProjectId}/servers`);
+      const currentProjectId = "k5700000000000000000000000b";
+      const stalePath = `/p/${staleProjectId}/servers?view=grid#tools`;
+      let projectsLoaded = false;
+      writeAppSignInReturnPath(stalePath);
       window.history.replaceState({}, "", "/callback?code=oauth-code");
       mockUseAppState.mockImplementation(() => ({
         ...createAppStateMock(),
-        isLoadingRemoteProjects: true,
-        activeProjectId: staleProjectId,
-        projects: {},
+        isLoadingRemoteProjects: !projectsLoaded,
+        activeProjectId: projectsLoaded ? currentProjectId : staleProjectId,
+        projects: projectsLoaded
+          ? {
+              [currentProjectId]: {
+                id: currentProjectId,
+                name: "Current Project",
+                sharedProjectId: currentProjectId,
+                organizationId: "org-1",
+                servers: {},
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              },
+            }
+          : {},
       }));
-      mockUseQuery.mockImplementation((name: string) =>
-        name === "users:getCurrentUser" ? existingConvexUser : undefined,
-      );
+      mockUseQuery.mockImplementation((name: string) => {
+        if (name === "users:getCurrentUser") return existingConvexUser;
+        if (name === "projects:getMyProjects") {
+          return projectsLoaded
+            ? [
+                {
+                  _id: currentProjectId,
+                  name: "Current Project",
+                  organizationId: "org-1",
+                  ownerId: "user-1",
+                  servers: {},
+                  createdAt: 1,
+                  updatedAt: 1,
+                },
+              ]
+            : undefined;
+        }
+        return undefined;
+      });
 
-      render(<App />);
+      const view = render(<App />);
       await act(async () => {
         await vi.advanceTimersByTimeAsync(15_000);
       });
@@ -2192,6 +2229,30 @@ describe("App hosted OAuth callback handling", () => {
         "project_route_inaccessible",
         expect.anything(),
       );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Try sign in again" }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockWorkOsAuthState.signIn).toHaveBeenCalledTimes(1);
+      expect(readAppSignInReturnPath()).toBe(stalePath);
+      expect(window.location.pathname).toBe("/");
+
+      view.unmount();
+      projectsLoaded = true;
+      vi.useRealTimers();
+      window.history.replaceState({}, "", "/callback?code=retry-code");
+      render(<App />);
+
+      await waitFor(() => {
+        expect(
+          `${window.location.pathname}${window.location.search}${window.location.hash}`,
+        ).toBe(`/p/${currentProjectId}/servers?view=grid#tools`);
+      });
+      expect(readAppSignInReturnPath()).toBeNull();
     } finally {
       vi.useRealTimers();
     }

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -1964,6 +1964,90 @@ describe("App hosted OAuth callback handling", () => {
     );
   });
 
+  it("keeps recovery armed while a cached active project waits for membership", async () => {
+    clearScenarioSession();
+    const staleProjectId = "k5700000000000000000000000a";
+    const currentProjectId = "k5700000000000000000000000b";
+    const stalePath = `/p/${staleProjectId}/playground?model=test#chat`;
+    writeAppSignInReturnPath(stalePath);
+    window.history.replaceState({}, "", stalePath);
+
+    let projectsLoaded = false;
+    mockUseAppState.mockImplementation(() => ({
+      ...createAppStateMock(),
+      isLoadingRemoteProjects: !projectsLoaded,
+      activeProjectId: projectsLoaded ? currentProjectId : staleProjectId,
+      projects: projectsLoaded
+        ? {
+            [currentProjectId]: {
+              id: currentProjectId,
+              name: "Default Project",
+              sharedProjectId: currentProjectId,
+              organizationId: "org-1",
+              servers: {},
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          }
+        : {
+            [staleProjectId]: {
+              id: staleProjectId,
+              name: "Cached Project",
+              sharedProjectId: staleProjectId,
+              organizationId: "org-1",
+              servers: {},
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          },
+    }));
+    mockUseQuery.mockImplementation((name: string) => {
+      if (name === "users:getCurrentUser") return existingConvexUser;
+      if (name === "projects:getMyProjects") {
+        return projectsLoaded
+          ? [
+              {
+                _id: currentProjectId,
+                name: "Default Project",
+                organizationId: "org-1",
+                ownerId: "user-1",
+                servers: {},
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ]
+          : undefined;
+      }
+      return undefined;
+    });
+
+    const view = render(<App />);
+
+    expect(
+      screen.queryByTestId("project-route-inaccessible"),
+    ).not.toBeInTheDocument();
+
+    projectsLoaded = true;
+    view.rerender(<App />);
+
+    await waitFor(() => {
+      expect(
+        `${window.location.pathname}${window.location.search}${window.location.hash}`,
+      ).toBe(`/p/${currentProjectId}/playground?model=test#chat`);
+    });
+    expect(
+      screen.queryByTestId("project-route-inaccessible"),
+    ).not.toBeInTheDocument();
+    expect(mockTrack).toHaveBeenCalledWith(
+      "project_route_stale_return_recovered",
+      { location: "signin-return", outcome: "switched" },
+    );
+    expect(mockTrack).not.toHaveBeenCalledWith(
+      "project_route_inaccessible",
+      expect.anything(),
+    );
+  });
+
   it("returns a no-project account home without claiming it switched projects", async () => {
     clearScenarioSession();
     const staleProjectId = "k5700000000000000000000000a";

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -54,6 +54,7 @@ const {
   mockPlaygroundTabProps,
   mockConvexAuthState,
   mockCompleteHostedOAuthCallback,
+  mockDbUserState,
   mockHandleOAuthCallback,
   mockHeader,
   mockHostedShellGateState,
@@ -124,6 +125,10 @@ const {
       isLoading: false,
     },
     mockCompleteHostedOAuthCallback: vi.fn(),
+    mockDbUserState: {
+      isEnsuringUser: false,
+      isUserReady: true,
+    },
     mockHandleOAuthCallback: vi.fn(),
     mockHostedShellGateState: {
       value: "ready" as
@@ -272,11 +277,8 @@ vi.mock("../hooks/useElectronOAuth", () => ({
 }));
 
 vi.mock("../contexts/db-user-ready-context", () => ({
-  useDbUserBootstrapStatus: vi.fn(() => ({
-    isEnsuringUser: false,
-    isUserReady: true,
-  })),
-  useDbUserReady: vi.fn(() => true),
+  useDbUserBootstrapStatus: vi.fn(() => mockDbUserState),
+  useDbUserReady: vi.fn(() => mockDbUserState.isUserReady),
 }));
 
 vi.mock("../hooks/usePostHogIdentify", () => ({
@@ -516,6 +518,8 @@ describe("App hosted OAuth callback handling", () => {
     mockHostedShellGateState.value = "ready";
     mockConvexAuthState.isAuthenticated = true;
     mockConvexAuthState.isLoading = false;
+    mockDbUserState.isEnsuringUser = false;
+    mockDbUserState.isUserReady = true;
     mockWorkOsAuthState.getAccessToken = vi.fn();
     mockWorkOsAuthState.signIn = vi.fn();
     mockWorkOsAuthState.user = null;
@@ -540,6 +544,7 @@ describe("App hosted OAuth callback handling", () => {
     mockPosthogCapture.mockReset();
     mockTrack.mockReset();
     vi.mocked(sonnerToast.error).mockReset();
+    vi.mocked(sonnerToast.success).mockReset();
     mockPlaygroundTabMounts.mockReset();
     mockPlaygroundTabProps.mockReset();
     mockCompleteHostedOAuthCallback.mockImplementation(
@@ -1875,6 +1880,7 @@ describe("App hosted OAuth callback handling", () => {
       return undefined;
     });
 
+    const replaceStateSpy = vi.spyOn(window.history, "replaceState");
     render(<App />);
 
     await waitFor(() => {
@@ -1886,10 +1892,14 @@ describe("App hosted OAuth callback handling", () => {
     expect(
       screen.queryByTestId("project-route-inaccessible"),
     ).not.toBeInTheDocument();
-    expect(sonnerToast.error).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(sonnerToast.error).mock.calls[0]?.[0]).toMatchObject({
-      props: { text: "Project not found. Switched to Default Project." },
-    });
+    expect(sonnerToast.error).not.toHaveBeenCalled();
+    expect(sonnerToast.success).not.toHaveBeenCalled();
+    expect(
+      replaceStateSpy.mock.calls.filter(
+        ([, , target]) =>
+          target === `/p/${currentProjectId}/evals?view=runs#case-3`,
+      ),
+    ).toHaveLength(1);
     expect(mockTrack).toHaveBeenCalledWith(
       "project_route_stale_return_recovered",
       { location: "signin-return", outcome: "switched" },
@@ -1900,7 +1910,123 @@ describe("App hosted OAuth callback handling", () => {
     );
   });
 
-  it("recovers when AuthKit restores the project URL before App sees the callback", async () => {
+  it("opens a valid scoped sign-in return unchanged", async () => {
+    clearScenarioSession();
+    const projectId = "k5700000000000000000000000b";
+    const savedPath = `/p/${projectId}/servers?view=grid#tools`;
+    writeAppSignInReturnPath(savedPath);
+    window.history.replaceState({}, "", "/callback?code=oauth-code");
+    mockUseAppState.mockImplementation(() => ({
+      ...createAppStateMock(),
+      activeProjectId: projectId,
+      projects: {
+        [projectId]: {
+          id: projectId,
+          name: "Current Project",
+          sharedProjectId: projectId,
+          organizationId: "org-1",
+          servers: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      },
+    }));
+    mockUseQuery.mockImplementation((name: string) => {
+      if (name === "users:getCurrentUser") return existingConvexUser;
+      if (name === "projects:getMyProjects") {
+        return [
+          {
+            _id: projectId,
+            name: "Current Project",
+            organizationId: "org-1",
+            ownerId: "user-1",
+            servers: {},
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ];
+      }
+      return undefined;
+    });
+
+    const replaceStateSpy = vi.spyOn(window.history, "replaceState");
+    render(<App />);
+
+    await waitFor(() => {
+      expect(
+        `${window.location.pathname}${window.location.search}${window.location.hash}`,
+      ).toBe(savedPath);
+    });
+    expect(
+      replaceStateSpy.mock.calls.filter(([, , target]) => target === savedPath),
+    ).toHaveLength(1);
+    expect(sonnerToast.error).not.toHaveBeenCalled();
+    expect(sonnerToast.success).not.toHaveBeenCalled();
+    expect(mockTrack).not.toHaveBeenCalledWith(
+      "project_route_stale_return_recovered",
+      expect.anything(),
+    );
+    expect(mockTrack).not.toHaveBeenCalledWith(
+      "project_route_inaccessible",
+      expect.anything(),
+    );
+  });
+
+  it("keeps a scoped callback loading until the database user is ready", async () => {
+    clearScenarioSession();
+    const staleProjectId = "k5700000000000000000000000a";
+    const currentProjectId = "k5700000000000000000000000b";
+    writeAppSignInReturnPath(`/p/${staleProjectId}/servers`);
+    window.history.replaceState({}, "", "/callback?code=oauth-code");
+    mockDbUserState.isEnsuringUser = true;
+    mockDbUserState.isUserReady = false;
+    mockUseAppState.mockImplementation(() => ({
+      ...createAppStateMock(),
+      activeProjectId: currentProjectId,
+      projects: {
+        [currentProjectId]: {
+          id: currentProjectId,
+          name: "Current Project",
+          sharedProjectId: currentProjectId,
+          organizationId: "org-1",
+          servers: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      },
+    }));
+    mockUseQuery.mockImplementation((name: string) => {
+      if (name === "users:getCurrentUser") return existingConvexUser;
+      if (name === "projects:getMyProjects") {
+        return [
+          {
+            _id: currentProjectId,
+            name: "Current Project",
+            organizationId: "org-1",
+            ownerId: "user-1",
+            servers: {},
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ];
+      }
+      return undefined;
+    });
+
+    const view = render(<App />);
+    expect(window.location.pathname).toBe("/callback");
+    expect(screen.getByTestId("hosted-oauth-loading")).toBeInTheDocument();
+
+    mockDbUserState.isEnsuringUser = false;
+    mockDbUserState.isUserReady = true;
+    view.rerender(<App />);
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe(`/p/${currentProjectId}/servers`);
+    });
+  });
+
+  it("does not automatically recover a stale URL outside the callback", async () => {
     clearScenarioSession();
     const staleProjectId = "k5700000000000000000000000a";
     const currentProjectId = "k5700000000000000000000000b";
@@ -1942,24 +2068,11 @@ describe("App hosted OAuth callback handling", () => {
 
     render(<App />);
 
-    await waitFor(() => {
-      expect(
-        `${window.location.pathname}${window.location.search}${window.location.hash}`,
-      ).toBe(`/p/${currentProjectId}/servers?view=grid#tools`);
-    });
     expect(
-      screen.queryByTestId("project-route-inaccessible"),
-    ).not.toBeInTheDocument();
-    expect(mockTrack).toHaveBeenCalledWith("app_signin_return_restored", {
-      location: "signin-return",
-      outcome: "restored",
-    });
-    expect(mockTrack).toHaveBeenCalledWith(
-      "project_route_stale_return_recovered",
-      { location: "signin-return", outcome: "switched" },
-    );
+      `${window.location.pathname}${window.location.search}${window.location.hash}`,
+    ).toBe(stalePath);
     expect(mockTrack).not.toHaveBeenCalledWith(
-      "project_route_inaccessible",
+      "project_route_stale_return_recovered",
       expect.anything(),
     );
   });
@@ -1970,7 +2083,7 @@ describe("App hosted OAuth callback handling", () => {
     const currentProjectId = "k5700000000000000000000000b";
     const stalePath = `/p/${staleProjectId}/playground?model=test#chat`;
     writeAppSignInReturnPath(stalePath);
-    window.history.replaceState({}, "", stalePath);
+    window.history.replaceState({}, "", "/callback?code=oauth-code");
 
     let projectsLoaded = false;
     mockUseAppState.mockImplementation(() => ({
@@ -2023,9 +2136,8 @@ describe("App hosted OAuth callback handling", () => {
 
     const view = render(<App />);
 
-    expect(
-      screen.queryByTestId("project-route-inaccessible"),
-    ).not.toBeInTheDocument();
+    expect(window.location.pathname).toBe("/callback");
+    expect(screen.getByTestId("hosted-oauth-loading")).toBeInTheDocument();
 
     projectsLoaded = true;
     view.rerender(<App />);
@@ -2046,6 +2158,43 @@ describe("App hosted OAuth callback handling", () => {
       "project_route_inaccessible",
       expect.anything(),
     );
+  });
+
+  it("keeps the callback timeout while project memberships are pending", async () => {
+    vi.useFakeTimers();
+    try {
+      clearScenarioSession();
+      const staleProjectId = "k5700000000000000000000000a";
+      writeAppSignInReturnPath(`/p/${staleProjectId}/servers`);
+      window.history.replaceState({}, "", "/callback?code=oauth-code");
+      mockUseAppState.mockImplementation(() => ({
+        ...createAppStateMock(),
+        isLoadingRemoteProjects: true,
+        activeProjectId: staleProjectId,
+        projects: {},
+      }));
+      mockUseQuery.mockImplementation((name: string) =>
+        name === "users:getCurrentUser" ? existingConvexUser : undefined,
+      );
+
+      render(<App />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15_000);
+      });
+
+      expect(screen.getByTestId("callback-auth-timeout")).toBeInTheDocument();
+      expect(window.location.pathname).toBe("/callback");
+      expect(mockTrack).not.toHaveBeenCalledWith(
+        "project_route_stale_return_recovered",
+        expect.anything(),
+      );
+      expect(mockTrack).not.toHaveBeenCalledWith(
+        "project_route_inaccessible",
+        expect.anything(),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns a no-project account home without claiming it switched projects", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-route-coordinator.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-route-coordinator.test.tsx
@@ -171,24 +171,9 @@ describe("useProjectRouteCoordinator", () => {
       reason: "not-a-member",
     });
     expect(switchProject).not.toHaveBeenCalled();
-  });
-
-  it("does not report an inaccessible event for a confirmed stale sign-in return", () => {
-    renderHook(
-      () =>
-        useProjectRouteCoordinator(
-          inputFor({
-            projects: { [A]: {} },
-            allProjects: [{ _id: A, organizationId: "org_a" }],
-            suppressInaccessibleTelemetryFor: B,
-          }),
-        ),
-      { wrapper: wrapperFor(`/p/${B}/servers`) },
-    );
-
-    expect(vi.mocked(track)).not.toHaveBeenCalledWith(
+    expect(vi.mocked(track)).toHaveBeenCalledWith(
       "project_route_inaccessible",
-      expect.anything(),
+      expect.objectContaining({ reason: "not-a-member" }),
     );
   });
 
@@ -325,13 +310,7 @@ describe("useProjectRouteCoordinator", () => {
     // without waiting out the 15s resolve budget first.
     const switchProject = vi.fn().mockRejectedValue(new Error("persistent"));
     const { result } = renderHook(
-      () =>
-        useProjectRouteCoordinator(
-          inputFor({
-            switchProject,
-            suppressInaccessibleTelemetryFor: B,
-          }),
-        ),
+      () => useProjectRouteCoordinator(inputFor({ switchProject })),
       { wrapper: wrapperFor(`/p/${B}/servers`) },
     );
     await waitFor(

--- a/mcpjam-inspector/client/src/hooks/use-project-route-coordinator.ts
+++ b/mcpjam-inspector/client/src/hooks/use-project-route-coordinator.ts
@@ -34,8 +34,6 @@ export interface ProjectRouteCoordinatorInput {
   activeOrganizationId: string | undefined;
   setActiveOrganizationId: (organizationId: string | undefined) => void;
   switchProject: (projectId: string) => Promise<void>;
-  /** A confirmed stale sign-in return is recovered by App before it paints. */
-  suppressInaccessibleTelemetryFor?: string | null;
 }
 
 /**
@@ -70,7 +68,6 @@ export function useProjectRouteCoordinator(
     activeOrganizationId,
     setActiveOrganizationId,
     switchProject,
-    suppressInaccessibleTelemetryFor,
   } = input;
 
   const pathname = useCurrentPathname();
@@ -244,12 +241,6 @@ export function useProjectRouteCoordinator(
     }
     if (state.status === "inaccessible") {
       if (
-        state.reason === "not-a-member" &&
-        suppressInaccessibleTelemetryFor === state.requestedProjectId
-      ) {
-        return;
-      }
-      if (
         reportedRef.current?.projectId === state.requestedProjectId &&
         reportedRef.current.outcome === "inaccessible"
       ) {
@@ -261,7 +252,7 @@ export function useProjectRouteCoordinator(
       };
       trackProjectRouteInaccessible(state.reason);
     }
-  }, [state, suppressInaccessibleTelemetryFor]);
+  }, [state]);
 
   return state;
 }

--- a/mcpjam-inspector/client/src/lib/__tests__/app-signin-return-path.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/app-signin-return-path.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   APP_SIGN_IN_RETURN_PATH_TTL_MS,
   captureAppSignInReturnPath,
@@ -40,6 +40,28 @@ describe("generic app sign-in return path", () => {
     clearAppSignInReturnPath();
     expect(queueProjectSignInReturnPath("/servers")).toBe(false);
     expect(readAppSignInReturnPath()).toBeNull();
+  });
+
+  it("does not report a queued return when session storage is unavailable", () => {
+    vi.stubGlobal("sessionStorage", undefined);
+    try {
+      expect(queueProjectSignInReturnPath(`/p/${A}/servers`)).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("does not report a queued return when storage rejects the write", () => {
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("storage unavailable");
+      });
+    try {
+      expect(queueProjectSignInReturnPath(`/p/${A}/servers`)).toBe(false);
+    } finally {
+      setItem.mockRestore();
+    }
   });
 
   it("is consumed exactly once", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/app-signin-return-path.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/app-signin-return-path.test.ts
@@ -4,6 +4,7 @@ import {
   captureAppSignInReturnPath,
   clearAppSignInReturnPath,
   consumeAppSignInReturnPath,
+  queueProjectSignInReturnPath,
   readAppSignInReturnPath,
   writeAppSignInReturnPath,
 } from "../app-signin-return-path";
@@ -21,7 +22,7 @@ describe("generic app sign-in return path", () => {
     // not to the app's front door with a project resolved from storage.
     writeAppSignInReturnPath(`/p/${A}/evals/suite/s1?view=runs#case-3`, NOW);
     expect(readAppSignInReturnPath(NOW)).toBe(
-      `/p/${A}/evals/suite/s1?view=runs#case-3`
+      `/p/${A}/evals/suite/s1?view=runs#case-3`,
     );
   });
 
@@ -29,6 +30,16 @@ describe("generic app sign-in return path", () => {
     window.history.replaceState({}, "", `/p/${A}/servers?a=1#b`);
     captureAppSignInReturnPath();
     expect(readAppSignInReturnPath()).toBe(`/p/${A}/servers?a=1#b`);
+  });
+
+  it("queues scoped AuthKit returns but leaves unscoped returns immediate", () => {
+    const path = `/p/${A}/evals?view=runs#case-3`;
+    expect(queueProjectSignInReturnPath(path)).toBe(true);
+    expect(readAppSignInReturnPath()).toBe(path);
+
+    clearAppSignInReturnPath();
+    expect(queueProjectSignInReturnPath("/servers")).toBe(false);
+    expect(readAppSignInReturnPath()).toBeNull();
   });
 
   it("is consumed exactly once", () => {
@@ -40,11 +51,11 @@ describe("generic app sign-in return path", () => {
 
   it("expires", () => {
     writeAppSignInReturnPath("/servers", NOW);
-    expect(readAppSignInReturnPath(NOW + APP_SIGN_IN_RETURN_PATH_TTL_MS - 1)).toBe(
-      "/servers"
-    );
     expect(
-      readAppSignInReturnPath(NOW + APP_SIGN_IN_RETURN_PATH_TTL_MS + 1)
+      readAppSignInReturnPath(NOW + APP_SIGN_IN_RETURN_PATH_TTL_MS - 1),
+    ).toBe("/servers");
+    expect(
+      readAppSignInReturnPath(NOW + APP_SIGN_IN_RETURN_PATH_TTL_MS + 1),
     ).toBeNull();
   });
 
@@ -66,7 +77,7 @@ describe("generic app sign-in return path", () => {
     writeAppSignInReturnPath("/servers", NOW);
     sessionStorage.setItem(
       "mcpjam_app_signin_return_path_v1",
-      JSON.stringify({ path: "https://evil.example", storedAt: NOW })
+      JSON.stringify({ path: "https://evil.example", storedAt: NOW }),
     );
     expect(readAppSignInReturnPath(NOW)).toBeNull();
   });
@@ -74,7 +85,13 @@ describe("generic app sign-in return path", () => {
   it("does not store the sign-in entry points themselves", () => {
     // Restoring one of these would loop the user back into the flow they
     // just completed.
-    for (const path of ["/callback", "/login", "/oauth/callback/debug", "/", "/?x=1"]) {
+    for (const path of [
+      "/callback",
+      "/login",
+      "/oauth/callback/debug",
+      "/",
+      "/?x=1",
+    ]) {
       writeAppSignInReturnPath(path, NOW);
       expect(readAppSignInReturnPath(NOW), path).toBeNull();
     }

--- a/mcpjam-inspector/client/src/lib/__tests__/project-route-recovery.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-route-recovery.test.ts
@@ -8,167 +8,88 @@ const STALE = "k5700000000000000000000000a";
 const CURRENT = "k5700000000000000000000000b";
 
 describe("project sign-in return recovery", () => {
-  it("preserves the current page, query and hash when switching projects", () => {
+  it("waits until membership data is authoritative", () => {
     const intent = createProjectSignInReturnRecoveryIntent(
-      `/p/${STALE}/evals/suite/s1?view=runs#case-3`,
+      `/p/${STALE}/servers`,
     );
-    const currentPath = `/p/${STALE}/servers?tab=tools#details`;
 
     expect(
       resolveProjectSignInReturnRecovery({
         intent,
-        routeState: {
-          status: "inaccessible",
-          requestedProjectId: STALE,
-          reason: "not-a-member",
-        },
-        currentPath,
+        membershipProjectIds: undefined,
+        fallbackProjectId: CURRENT,
+      }),
+    ).toEqual({ kind: "wait" });
+  });
+
+  it("opens a valid saved project without changing its URL", () => {
+    const path = `/p/${CURRENT}/evals/suite/s1?view=runs#case-3`;
+
+    expect(
+      resolveProjectSignInReturnRecovery({
+        intent: createProjectSignInReturnRecoveryIntent(path),
         membershipProjectIds: new Set([CURRENT]),
-        fallbackProject: { id: CURRENT, name: "Default Project" },
+        fallbackProjectId: CURRENT,
+      }),
+    ).toEqual({ kind: "open", path });
+  });
+
+  it("preserves the saved page, query and hash when switching projects", () => {
+    const path = `/p/${STALE}/evals/suite/s1?view=runs#case-3`;
+
+    expect(
+      resolveProjectSignInReturnRecovery({
+        intent: createProjectSignInReturnRecoveryIntent(path),
+        membershipProjectIds: new Set([CURRENT]),
+        fallbackProjectId: CURRENT,
       }),
     ).toEqual({
       kind: "switch",
-      path: `/p/${CURRENT}/servers?tab=tools#details`,
-      message: "Project not found. Switched to Default Project.",
+      path: `/p/${CURRENT}/evals/suite/s1?view=runs#case-3`,
     });
   });
 
-  it("does nothing for a direct inaccessible URL", () => {
+  it("opens malformed scoped returns so normal route handling reports them", () => {
+    const path = "/p/not-a-project/servers";
+
     expect(
       resolveProjectSignInReturnRecovery({
-        intent: null,
-        routeState: {
-          status: "inaccessible",
-          requestedProjectId: STALE,
-          reason: "not-a-member",
-        },
-        currentPath: `/p/${STALE}/servers`,
+        intent: createProjectSignInReturnRecoveryIntent(path),
         membershipProjectIds: new Set([CURRENT]),
-        fallbackProject: { id: CURRENT, name: "Default Project" },
+        fallbackProjectId: CURRENT,
       }),
-    ).toEqual({ kind: "none" });
+    ).toEqual({ kind: "open", path });
   });
 
-  it("does not hide malformed URLs or switch timeouts", () => {
-    const malformed = createProjectSignInReturnRecoveryIntent(
-      "/p/not-a-project/servers",
-    );
+  it("uses home when the account has no valid fallback project", () => {
     expect(
       resolveProjectSignInReturnRecovery({
-        intent: malformed,
-        routeState: {
-          status: "inaccessible",
-          requestedProjectId: "not-a-project",
-          reason: "malformed",
-        },
-        currentPath: "/p/not-a-project/servers",
-        membershipProjectIds: new Set([CURRENT]),
-        fallbackProject: { id: CURRENT, name: "Default Project" },
-      }),
-    ).toEqual({ kind: "clear" });
-
-    const intent = createProjectSignInReturnRecoveryIntent(
-      `/p/${STALE}/servers`,
-    );
-    expect(
-      resolveProjectSignInReturnRecovery({
-        intent,
-        routeState: {
-          status: "inaccessible",
-          requestedProjectId: STALE,
-          reason: "timed-out",
-        },
-        currentPath: `/p/${STALE}/servers`,
-        membershipProjectIds: new Set([CURRENT]),
-        fallbackProject: { id: CURRENT, name: "Default Project" },
-      }),
-    ).toEqual({ kind: "clear" });
-  });
-
-  it("keeps the recovery intent until membership data has loaded", () => {
-    const intent = createProjectSignInReturnRecoveryIntent(
-      `/p/${STALE}/servers`,
-    );
-    const input = {
-      intent,
-      routeState: {
-        status: "inaccessible" as const,
-        requestedProjectId: STALE,
-        reason: "not-a-member" as const,
-      },
-      currentPath: `/p/${STALE}/servers`,
-      fallbackProject: { id: CURRENT, name: "Default Project" },
-    };
-
-    expect(
-      resolveProjectSignInReturnRecovery({
-        ...input,
-        membershipProjectIds: undefined,
-      }),
-    ).toEqual({ kind: "none" });
-    expect(
-      resolveProjectSignInReturnRecovery({
-        ...input,
-        membershipProjectIds: new Set([CURRENT]),
-      }).kind,
-    ).toBe("switch");
-
-    expect(
-      resolveProjectSignInReturnRecovery({
-        ...input,
-        routeState: { status: "ready", projectId: STALE },
-        membershipProjectIds: undefined,
-      }),
-    ).toEqual({ kind: "none" });
-    expect(
-      resolveProjectSignInReturnRecovery({
-        ...input,
-        routeState: { status: "ready", projectId: STALE },
-        membershipProjectIds: new Set([CURRENT]),
-      }).kind,
-    ).toBe("switch");
-  });
-
-  it("uses home when the account has no fallback project", () => {
-    const intent = createProjectSignInReturnRecoveryIntent(
-      `/p/${STALE}/playground`,
-    );
-    expect(
-      resolveProjectSignInReturnRecovery({
-        intent,
-        routeState: {
-          status: "inaccessible",
-          requestedProjectId: STALE,
-          reason: "not-a-member",
-        },
-        currentPath: `/p/${STALE}/playground`,
+        intent: createProjectSignInReturnRecoveryIntent(
+          `/p/${STALE}/playground`,
+        ),
         membershipProjectIds: new Set(),
-        fallbackProject: null,
+        fallbackProjectId: null,
+      }),
+    ).toEqual({ kind: "home" });
+
+    expect(
+      resolveProjectSignInReturnRecovery({
+        intent: createProjectSignInReturnRecoveryIntent(
+          `/p/${STALE}/playground`,
+        ),
+        membershipProjectIds: new Set([CURRENT]),
+        fallbackProjectId: STALE,
       }),
     ).toEqual({ kind: "home" });
   });
 
-  it("clears its one-shot intent after success or unrelated navigation", () => {
-    const intent = createProjectSignInReturnRecoveryIntent(
-      `/p/${STALE}/servers`,
-    );
+  it("does nothing when the selected sign-in return is unscoped", () => {
     expect(
       resolveProjectSignInReturnRecovery({
-        intent,
-        routeState: { status: "ready", projectId: STALE },
-        currentPath: `/p/${STALE}/servers`,
-        membershipProjectIds: new Set([STALE]),
-        fallbackProject: { id: STALE, name: "Original" },
-      }),
-    ).toEqual({ kind: "clear" });
-    expect(
-      resolveProjectSignInReturnRecovery({
-        intent,
-        routeState: { status: "ready", projectId: CURRENT },
-        currentPath: `/p/${CURRENT}/servers`,
+        intent: createProjectSignInReturnRecoveryIntent("/servers"),
         membershipProjectIds: new Set([CURRENT]),
-        fallbackProject: { id: CURRENT, name: "Current" },
+        fallbackProjectId: CURRENT,
       }),
-    ).toEqual({ kind: "clear" });
+    ).toEqual({ kind: "none" });
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/project-route-recovery.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-route-recovery.test.ts
@@ -112,6 +112,21 @@ describe("project sign-in return recovery", () => {
         membershipProjectIds: new Set([CURRENT]),
       }).kind,
     ).toBe("switch");
+
+    expect(
+      resolveProjectSignInReturnRecovery({
+        ...input,
+        routeState: { status: "ready", projectId: STALE },
+        membershipProjectIds: undefined,
+      }),
+    ).toEqual({ kind: "none" });
+    expect(
+      resolveProjectSignInReturnRecovery({
+        ...input,
+        routeState: { status: "ready", projectId: STALE },
+        membershipProjectIds: new Set([CURRENT]),
+      }).kind,
+    ).toBe("switch");
   });
 
   it("uses home when the account has no fallback project", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/project-route-state.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-route-state.test.ts
@@ -23,16 +23,67 @@ describe("resolveProjectRouteState", () => {
     ).toEqual({ status: "unscoped" });
   });
 
-  it("is ready when the URL and the active project already agree", () => {
-    // Checked before any loading gate, so a refresh on the project you are
-    // already in renders without a spinner.
+  it("waits for membership even when a cached active project matches", () => {
     expect(
       resolveProjectRouteState({
         ...base,
         activeProjectId: A,
         isLoadingRemoteProjects: true,
       }).state,
+    ).toEqual({ status: "resolving", requestedProjectId: A });
+
+    expect(
+      resolveProjectRouteState({
+        ...base,
+        activeProjectId: A,
+        allProjects: undefined,
+      }).state,
+    ).toEqual({ status: "resolving", requestedProjectId: A });
+  });
+
+  it("is ready when loaded membership confirms the active project", () => {
+    expect(
+      resolveProjectRouteState({
+        ...base,
+        activeProjectId: A,
+        allProjects: [{ _id: A, organizationId: "org_a" }],
+      }).state,
     ).toEqual({ status: "ready", projectId: A });
+  });
+
+  it("keeps an unauthenticated local active project ready after auth settles", () => {
+    expect(
+      resolveProjectRouteState({
+        ...base,
+        isAuthenticated: false,
+        activeProjectId: A,
+        allProjects: undefined,
+      }).state,
+    ).toEqual({ status: "ready", projectId: A });
+
+    expect(
+      resolveProjectRouteState({
+        ...base,
+        isAuthLoading: true,
+        isAuthenticated: false,
+        activeProjectId: A,
+        allProjects: undefined,
+      }).state,
+    ).toEqual({ status: "resolving", requestedProjectId: A });
+  });
+
+  it("rejects a cached active project missing from loaded membership", () => {
+    expect(
+      resolveProjectRouteState({
+        ...base,
+        activeProjectId: A,
+        allProjects: [{ _id: B, organizationId: "org_a" }],
+      }).state,
+    ).toEqual({
+      status: "inaccessible",
+      requestedProjectId: A,
+      reason: "not-a-member",
+    });
   });
 
   it("answers a malformed id immediately, without waiting for auth", () => {
@@ -69,6 +120,7 @@ describe("resolveProjectRouteState", () => {
     const { state, effect } = resolveProjectRouteState({
       ...base,
       activeOrgProjectIds: new Set([A]),
+      allProjects: [{ _id: A, organizationId: "org_a" }],
     });
     expect(state).toEqual({ status: "resolving", requestedProjectId: A });
     expect(effect).toEqual({ kind: "switch-project", projectId: A });
@@ -166,6 +218,20 @@ describe("resolveProjectRouteState", () => {
       requestedProjectId: A,
       reason: "timed-out",
     });
+
+    expect(
+      resolveProjectRouteState({
+        ...base,
+        activeProjectId: A,
+        isLoadingRemoteProjects: true,
+        allProjects: undefined,
+        hasExceededResolveBudget: true,
+      }).state,
+    ).toEqual({
+      status: "inaccessible",
+      requestedProjectId: A,
+      reason: "timed-out",
+    });
   });
 
   it("still reports ready after the budget is spent if the app caught up", () => {
@@ -174,6 +240,7 @@ describe("resolveProjectRouteState", () => {
       resolveProjectRouteState({
         ...base,
         activeProjectId: A,
+        allProjects: [{ _id: A, organizationId: "org_a" }],
         hasExceededResolveBudget: true,
       }).state,
     ).toEqual({ status: "ready", projectId: A });

--- a/mcpjam-inspector/client/src/lib/app-signin-return-path.ts
+++ b/mcpjam-inspector/client/src/lib/app-signin-return-path.ts
@@ -65,26 +65,27 @@ function isStorableReturnPath(path: string): boolean {
 export function writeAppSignInReturnPath(
   path: string | null | undefined,
   now: number = Date.now(),
-): void {
-  if (typeof sessionStorage === "undefined") return;
+): boolean {
+  if (typeof sessionStorage === "undefined") return false;
   const trimmed = path?.trim() ?? "";
-  if (!isStorableReturnPath(trimmed)) return;
+  if (!isStorableReturnPath(trimmed)) return false;
   try {
     const payload: StoredReturnPath = { path: trimmed, storedAt: now };
     sessionStorage.setItem(
       APP_SIGN_IN_RETURN_PATH_STORAGE_KEY,
       JSON.stringify(payload),
     );
+    return true;
   } catch {
     // Ignore storage failures — the user lands on the default route.
+    return false;
   }
 }
 
 /** Keep a scoped AuthKit return on `/callback` for membership validation. */
 export function queueProjectSignInReturnPath(path: string): boolean {
   if (readProjectPathSegment(path) === null) return false;
-  writeAppSignInReturnPath(path);
-  return true;
+  return writeAppSignInReturnPath(path);
 }
 
 /** Capture the whole current URL (path + search + hash) before signing in. */

--- a/mcpjam-inspector/client/src/lib/app-signin-return-path.ts
+++ b/mcpjam-inspector/client/src/lib/app-signin-return-path.ts
@@ -21,7 +21,7 @@
  *     hijack an unrelated sign-in later.
  */
 import { normalizeReturnTargetPath, routePaths } from "./app-navigation";
-import { isAppRelativeTarget } from "./project-route";
+import { isAppRelativeTarget, readProjectPathSegment } from "./project-route";
 
 const APP_SIGN_IN_RETURN_PATH_STORAGE_KEY = "mcpjam_app_signin_return_path_v1";
 
@@ -64,7 +64,7 @@ function isStorableReturnPath(path: string): boolean {
  */
 export function writeAppSignInReturnPath(
   path: string | null | undefined,
-  now: number = Date.now()
+  now: number = Date.now(),
 ): void {
   if (typeof sessionStorage === "undefined") return;
   const trimmed = path?.trim() ?? "";
@@ -73,11 +73,18 @@ export function writeAppSignInReturnPath(
     const payload: StoredReturnPath = { path: trimmed, storedAt: now };
     sessionStorage.setItem(
       APP_SIGN_IN_RETURN_PATH_STORAGE_KEY,
-      JSON.stringify(payload)
+      JSON.stringify(payload),
     );
   } catch {
     // Ignore storage failures — the user lands on the default route.
   }
+}
+
+/** Keep a scoped AuthKit return on `/callback` for membership validation. */
+export function queueProjectSignInReturnPath(path: string): boolean {
+  if (readProjectPathSegment(path) === null) return false;
+  writeAppSignInReturnPath(path);
+  return true;
 }
 
 /** Capture the whole current URL (path + search + hash) before signing in. */
@@ -88,7 +95,7 @@ export function captureAppSignInReturnPath(): void {
 }
 
 export function readAppSignInReturnPath(
-  now: number = Date.now()
+  now: number = Date.now(),
 ): string | null {
   if (typeof sessionStorage === "undefined") return null;
   try {
@@ -125,7 +132,7 @@ export function clearAppSignInReturnPath(): void {
 
 /** Read and clear in one step. A return path is used at most once. */
 export function consumeAppSignInReturnPath(
-  now: number = Date.now()
+  now: number = Date.now(),
 ): string | null {
   const path = readAppSignInReturnPath(now);
   clearAppSignInReturnPath();

--- a/mcpjam-inspector/client/src/lib/project-route-recovery.ts
+++ b/mcpjam-inspector/client/src/lib/project-route-recovery.ts
@@ -1,4 +1,3 @@
-import type { ProjectRouteState } from "./project-route-state";
 import {
   isProjectIdShape,
   readProjectPathSegment,
@@ -6,66 +5,54 @@ import {
 } from "./project-route";
 
 export interface ProjectSignInReturnRecoveryIntent {
+  path: string;
   requestedProjectId: string;
 }
 
 export type ProjectSignInReturnRecoveryDecision =
   | { kind: "none" }
-  | { kind: "clear" }
+  | { kind: "wait" }
+  | { kind: "open"; path: string }
   | { kind: "home" }
-  | { kind: "switch"; path: string; message: string };
+  | { kind: "switch"; path: string };
 
-/** Arm recovery only for a path selected by the completed sign-in flow. */
+/** Arm recovery only for a project-scoped path selected by sign-in. */
 export function createProjectSignInReturnRecoveryIntent(
   path: string,
 ): ProjectSignInReturnRecoveryIntent | null {
   const requestedProjectId = readProjectPathSegment(path);
-  return requestedProjectId ? { requestedProjectId } : null;
+  return requestedProjectId ? { path, requestedProjectId } : null;
 }
 
 /**
- * Decide whether a sign-in return is stale using the authoritative membership
- * response. Timeouts, malformed ids, direct links and ordinary navigation do
- * not recover to another project.
+ * Resolve a project-scoped sign-in return before it is allowed to navigate.
+ * Only the first authoritative membership response may declare the saved
+ * project stale; malformed paths still open normally so the route boundary
+ * can report them instead of silently changing their meaning.
  */
 export function resolveProjectSignInReturnRecovery(args: {
   intent: ProjectSignInReturnRecoveryIntent | null;
-  routeState: ProjectRouteState;
-  currentPath: string;
   membershipProjectIds: ReadonlySet<string> | undefined;
-  fallbackProject: { id: string; name: string } | null;
+  fallbackProjectId: string | null;
 }): ProjectSignInReturnRecoveryDecision {
-  const {
-    intent,
-    routeState,
-    currentPath,
-    membershipProjectIds,
-    fallbackProject,
-  } = args;
+  const { intent, membershipProjectIds, fallbackProjectId } = args;
   if (!intent) return { kind: "none" };
-  if (routeState.status === "unscoped") return { kind: "clear" };
-
-  const routeProjectId =
-    routeState.status === "ready"
-      ? routeState.projectId
-      : routeState.requestedProjectId;
-  if (routeProjectId !== intent.requestedProjectId) return { kind: "clear" };
-  if (routeState.status === "resolving") return { kind: "none" };
-
-  if (!isProjectIdShape(intent.requestedProjectId)) return { kind: "clear" };
-  if (membershipProjectIds === undefined) return { kind: "none" };
-  if (
-    (routeState.status === "inaccessible" &&
-      routeState.reason !== "not-a-member") ||
-    membershipProjectIds.has(intent.requestedProjectId)
-  ) {
-    return { kind: "clear" };
+  if (!isProjectIdShape(intent.requestedProjectId)) {
+    return { kind: "open", path: intent.path };
   }
-  if (!fallbackProject) return { kind: "home" };
-
-  return {
-    kind: "switch",
-    path: replaceProjectInPath(currentPath, fallbackProject.id),
-    message: `Project not found. Switched to ${fallbackProject.name}.`,
-  };
+  if (membershipProjectIds === undefined) return { kind: "wait" };
+  if (membershipProjectIds.has(intent.requestedProjectId)) {
+    return { kind: "open", path: intent.path };
+  }
+  if (
+    fallbackProjectId &&
+    isProjectIdShape(fallbackProjectId) &&
+    membershipProjectIds.has(fallbackProjectId)
+  ) {
+    return {
+      kind: "switch",
+      path: replaceProjectInPath(intent.path, fallbackProjectId),
+    };
+  }
+  return { kind: "home" };
 }

--- a/mcpjam-inspector/client/src/lib/project-route-recovery.ts
+++ b/mcpjam-inspector/client/src/lib/project-route-recovery.ts
@@ -51,12 +51,12 @@ export function resolveProjectSignInReturnRecovery(args: {
       : routeState.requestedProjectId;
   if (routeProjectId !== intent.requestedProjectId) return { kind: "clear" };
   if (routeState.status === "resolving") return { kind: "none" };
-  if (routeState.status === "ready") return { kind: "clear" };
 
   if (!isProjectIdShape(intent.requestedProjectId)) return { kind: "clear" };
   if (membershipProjectIds === undefined) return { kind: "none" };
   if (
-    routeState.reason !== "not-a-member" ||
+    (routeState.status === "inaccessible" &&
+      routeState.reason !== "not-a-member") ||
     membershipProjectIds.has(intent.requestedProjectId)
   ) {
     return { kind: "clear" };

--- a/mcpjam-inspector/client/src/lib/project-route-state.ts
+++ b/mcpjam-inspector/client/src/lib/project-route-state.ts
@@ -103,9 +103,37 @@ export function resolveProjectRouteState(
   // `/p/none/servers` and `/p/<typo>/servers` are answered immediately.
   if (!isProjectIdShape(requestedProjectId)) return inaccessible("malformed");
 
-  // The URL already matches the app's state. Checked before any loading gate
-  // so a refresh on the project you are already in renders without a spinner.
-  if (activeProjectId === requestedProjectId) {
+  // 1. Auth first. While it is changing, the persisted active project may
+  //    belong to the previous actor and cannot prove this route is ready.
+  if (isAuthLoading) {
+    return hasExceededResolveBudget ? inaccessible("timed-out") : resolving;
+  }
+
+  // Local/self-hosted projects have no remote membership response. Preserve
+  // their active-project fast path after auth has settled.
+  if (!isAuthenticated) {
+    if (activeProjectId === requestedProjectId) {
+      return {
+        state: { status: "ready", projectId: requestedProjectId },
+        effect: { kind: "none" },
+      };
+    }
+    return hasExceededResolveBudget ? inaccessible("timed-out") : resolving;
+  }
+
+  if (isLoadingRemoteProjects || allProjects === undefined) {
+    return hasExceededResolveBudget ? inaccessible("timed-out") : resolving;
+  }
+
+  // The unfiltered response is the authority for this actor. Do not let a
+  // cached active id make a stale sign-in return look ready for one render:
+  // recovery would consume its one-shot intent before membership catches up.
+  const match = allProjects.find(
+    (project) => project._id === requestedProjectId,
+  );
+
+  // The URL and active state agree, and the loaded membership confirms it.
+  if (match && activeProjectId === requestedProjectId) {
     return {
       state: { status: "ready", projectId: requestedProjectId },
       effect: { kind: "none" },
@@ -113,12 +141,7 @@ export function resolveProjectRouteState(
   }
 
   if (hasExceededResolveBudget) return inaccessible("timed-out");
-
-  // 1. Auth first: membership is the only thing that can answer this URL, and
-  //    it does not exist yet.
-  if (isAuthLoading) return resolving;
-  if (!isAuthenticated) return resolving;
-  if (isLoadingRemoteProjects) return resolving;
+  if (!match) return inaccessible("not-a-member");
 
   // 2. Visible under the active organization — switch straight to it.
   if (activeOrgProjectIds.has(requestedProjectId)) {
@@ -128,15 +151,7 @@ export function resolveProjectRouteState(
     };
   }
 
-  // 3. Not in this organization's list. The unfiltered membership decides
-  //    whether that means "another organization" or "not yours".
-  if (allProjects === undefined) return resolving;
-
-  const match = allProjects.find(
-    (project) => project._id === requestedProjectId,
-  );
-  if (!match) return inaccessible("not-a-member");
-
+  // 3. The unfiltered membership says this belongs to another organization.
   if (!match.organizationId) {
     // An organization-less project can never enter an organization-filtered
     // set, so waiting for one would hang forever. With no organization filter

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -32,6 +32,7 @@ import {
   isDebugOAuthCallbackPath,
   normalizeInitialLegacyHashBookmark,
 } from "./lib/app-navigation";
+import { queueProjectSignInReturnPath } from "./lib/app-signin-return-path";
 import { TESTER_LINK_RUNTIME_PATH_PATTERN } from "./lib/tester-link-path";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
 import { ServerConnectionHandoff } from "./components/server-connections/ServerConnectionHandoff";
@@ -383,13 +384,15 @@ if (isInIframe) {
             carried?.[PERMALINK_SIGN_IN_STATE_KEY],
             window.location.origin,
           );
-        // `replace`, not `assign`: `/callback` is not somewhere the back
-        // button should return to.
         if (returnTo) {
-          // Keep the generic return path through this redirect. `App.tsx`
-          // consumes it on the restored page, where it also arms stale-project
-          // recovery. Clearing it here loses that signal because this replace
-          // navigates away before the callback route's App effect can run.
+          // A scoped return cannot navigate until App has the database user
+          // and authoritative memberships. Keep it in same-origin storage and
+          // leave the browser on `/callback`; App consumes and validates it,
+          // then performs the one final replacement navigation.
+          if (queueProjectSignInReturnPath(returnTo)) return;
+          // `replace`, not `assign`: `/callback` is not somewhere the back
+          // button should return to. Unscoped handoffs need no membership
+          // validation and retain their existing immediate behavior.
           window.location.replace(returnTo);
         }
       }}

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -303,7 +303,7 @@ function terminalForOutcome(
  * disagree on `mcpjam_rate_limit`. A parity test pins the overlap so a code
  * added there is not silently missed here. Exported for that test. */
 export const ACCOUNT_LIMIT_CODE =
-  /\b(?:user_rate_limit|org_rate_limit|mcpjam_rate_limit|billing_limit_reached|wallet_locked|billing_feature_not_included)\b/i;
+  /\b(?:user_rate_limit|org_rate_limit|mcpjam_rate_limit|billing_limit_reached|spend_budget_reached|wallet_locked|billing_feature_not_included)\b/i;
 
 /**
  * Distinguish an ORG spend-cap breach from a PROVIDER rate-limit — across the


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a race where returning from sign-in to a cached project URL could leave users stuck on an inaccessible project page. Scoped sign-in returns now stay on `/callback` until remote membership is loaded and the saved project is validated; stale URLs outside the callback are no longer auto-recovered.

- Scoped returns are queued in storage and held on `/callback` until the database user and first membership response are ready; retrying sign-in re-queues the saved return.
- A valid saved project opens unchanged; a stale one switches to a fallback preserving the saved page, query, and hash, or goes home when no fallback exists; malformed scoped returns open normally so the route boundary reports them.
- Authenticated route state waits for loaded membership even when the cached active project matches the URL; a cached project missing from membership reports `not-a-member`.
- Unauthenticated and local projects keep the immediate ready path once auth settles; the stale-project switch no longer shows a toast.
- One 15s deadline covers session bootstrap and the project response so an unreachable route cannot hang.
- The session-simulation account-limit regex now also matches `spend_budget_reached`.

<sup>Written for commit 0b0cccf7bf491865eb86d10c18751ae00a25f3b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

