### PR TITLE
One way to connect a GitHub account

### DIFF
--- a/docs/github-checks.mdx
+++ b/docs/github-checks.mdx
@@ -14,25 +14,25 @@ what it measured.
 
 <Note>
 GitHub Checks is configured in the hosted app, at **Settings → Integrations →
-GitHub**. Every write on this page — installing, claiming, connecting,
-disconnecting, and changing per-repository settings — requires an organization
-owner or admin. Members can open the page to see the current setup, but all
-controls are disabled and a note explains why.
+GitHub**. Every write on this page — connecting, installing, disconnecting, and
+changing per-repository settings — requires an organization owner or admin.
+Members can open the page to see the current setup, but all controls are
+disabled and a note explains why.
 
-Two buttons live there, and which one you need depends on whether the MCPJam
-app is already installed on the GitHub account:
+**Connect a GitHub account** starts it. You sign in to GitHub so we can confirm
+which accounts you administer, then pick one from the list that comes back —
+an organization, or your own account. Installing the app is not on its own
+proof that an installation is yours to connect, which is why the sign-in step
+is there and not skippable.
 
-- **Install on a GitHub account** — for a fresh install. GitHub sends you back
-  and the account is connected automatically.
-- **Claim an existing installation** — if somebody already installed the app.
-  GitHub skips the return trip for an account it has already installed on, so
-  the first button quietly leaves you on GitHub's settings page.
+Accounts that already have the app appear in that list ready to connect.
+For one that does not, use **Install on another account** from the same list.
 
 A GitHub account connects to **one MCPJam organization at a time**, for the
 whole account rather than per repository. Two organizations cannot split the
 repositories of one GitHub account between them. If the account is already
 connected elsewhere, connecting it again is refused — free it up in the
-organization holding it, or install the app on a different account.
+organization holding it, or use a different account.
 
 Which organization is holding it is **rolling out**: until it reaches your
 deployment the refusal names nothing, so ask an owner of the GitHub account,

--- a/docs/github-checks.mdx
+++ b/docs/github-checks.mdx
@@ -26,7 +26,14 @@ proof that an installation is yours to connect, which is why the sign-in step
 is there and not skippable.
 
 Accounts that already have the app appear in that list ready to connect.
-For one that does not, use **Install on another account** from the same list.
+
+**Install on another account**, in that same list, is **not generally available
+yet.** During the beta the MCPJam app can only be installed on the MCPJam
+organization, so there is no other account for it to reach — following it sends
+you to the existing installation rather than offering a choice. Even once that
+opens up, GitHub sends an administrator who already has the app somewhere to
+that installation instead of asking which account to use. So for now, connect
+an account that already appears in the list.
 
 A GitHub account connects to **one MCPJam organization at a time**, for the
 whole account rather than per repository. Two organizations cannot split the

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -228,7 +228,6 @@ export function GithubChecksRoute({
     setRepoFeedbackComments,
     disconnectRepo,
     listInstallationRepos,
-    startInstallation,
     startDirectClaim,
     unbindInstallation,
   } = useGithubChecksSettings(activeOrganizationId);
@@ -499,20 +498,26 @@ export function GithubChecksRoute({
     suiteOptions.find((s) => s._id === suiteId);
 
   /**
-   * Send the admin to GitHub to install, or to authorize a claim.
+   * Send the admin to GitHub to sign in, for every case.
    *
-   * Both start server-side — the URL carries a one-time state whose hash the
+   * There used to be a second button here that went straight to GitHub's
+   * install URL. It could not work: GitHub redirects that URL into an existing
+   * installation whenever the signed-in user administers one, so it silently
+   * dead-ended for anyone who already had the app somewhere — and made
+   * installing on a SECOND account impossible. Signing in first and reading the
+   * user's real installation list is the only approach that does not depend on
+   * GitHub's redirect behaviour. Installing is driven from the picker that
+   * comes back.
+   *
+   * Starts server-side — the URL carries a one-time state whose hash the
    * backend stored — so this only follows what it is handed, through a helper
    * that refuses anything not on github.com.
    */
-  const beginBindingFlow = async (kind: "install" | "claim") => {
+  const beginBindingFlow = async () => {
     setBindingBusy(true);
     try {
-      const { url } =
-        kind === "install"
-          ? await startInstallation().then((r) => ({ url: r.installUrl }))
-          : await startDirectClaim().then((r) => ({ url: r.authorizeUrl }));
-      redirectToGithub(url);
+      const { authorizeUrl } = await startDirectClaim();
+      redirectToGithub(authorizeUrl);
     } catch (error) {
       handleWriteError(error);
       // Only cleared on failure: on success the browser is already leaving, and
@@ -797,10 +802,9 @@ export function GithubChecksRoute({
         ) : bindingRows.length === 0 ? (
           <div className="space-y-3 px-4 py-8 text-sm text-muted-foreground">
             <p>
-              No GitHub accounts connected yet. Install the MCPJam app on the
-              account whose repositories you want checked — or, if somebody has
-              already installed it from GitHub, claim that installation for this
-              workspace.
+              No GitHub accounts connected yet. Connect the account whose
+              repositories you want checked — an organization, or your own
+              account.
             </p>
           </div>
         ) : (
@@ -817,24 +821,17 @@ export function GithubChecksRoute({
         <div className="flex flex-wrap items-center gap-3 px-4 py-3">
           <Button
             disabled={bindingBusy || !canManage}
-            onClick={() => void beginBindingFlow("install")}
+            onClick={() => void beginBindingFlow()}
           >
-            <Github className="mr-2 size-4" aria-hidden /> Install on a GitHub
+            <Github className="mr-2 size-4" aria-hidden /> Connect a GitHub
             account
-          </Button>
-          <Button
-            variant="outline"
-            disabled={bindingBusy || !canManage}
-            onClick={() => void beginBindingFlow("claim")}
-          >
-            Claim an existing installation
           </Button>
         </div>
         <p className="px-4 pb-3 text-xs text-muted-foreground">
-          Claiming is for an installation somebody already added from GitHub's
-          side. You will be asked to sign in to GitHub so we can confirm you
-          administer that account — installing the app is not on its own proof
-          that it is yours to connect here.
+          You will be asked to sign in to GitHub so we can confirm which
+          accounts you administer, then pick one — installing the app is not on
+          its own proof that it is yours to connect here. Accounts without the
+          app yet can be installed from that same list.
         </p>
       </SettingsSection>
 

--- a/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
@@ -57,6 +57,7 @@ type Phase =
       kind: "pick";
       linkSessionId: string;
       installations: ClaimableInstallation[];
+      installUrl?: string;
     };
 
 const SETTINGS_PATH = "/settings/integrations/github";
@@ -184,10 +185,34 @@ export function GithubInstallCallbackRoute() {
             appNavigate(SETTINGS_PATH);
             return;
           }
+          // NOTHING TO PICK FROM, and that is an answer rather than a
+          // failure: this GitHub user administers no account with the app on
+          // it. Installing is the only move left, so make it, instead of
+          // rendering a screen whose whole content is "go and install".
+          //
+          // This is what keeps a first-time user at the same number of clicks
+          // they had when a settings-page button sent them straight to GitHub.
+          if (result.installations.length === 0 && result.installUrl) {
+            try {
+              redirectToGithub(result.installUrl);
+              return;
+            } catch {
+              // Same rule as the setup leg above: a refused redirect is not a
+              // backend refusal and its developer text must never reach the
+              // screen.
+              console.error("[github-checks] refused an unsafe install URL");
+              setPhase({
+                kind: "failed",
+                message: GITHUB_BINDING_FAILED_MESSAGE,
+              });
+              return;
+            }
+          }
           setPhase({
             kind: "pick",
             linkSessionId: result.linkSessionId,
             installations: result.installations,
+            installUrl: result.installUrl,
           });
         })
         .catch(fail);
@@ -208,6 +233,35 @@ export function GithubInstallCallbackRoute() {
     state,
     workosUser,
   ]);
+
+  // Lifted out of the JSX because narrowing `phase.installUrl` inside a click
+  // handler does not survive the closure; a const does.
+  const installUrl = phase.kind === "pick" ? phase.installUrl : undefined;
+
+  /**
+   * Go to GitHub to install on an account that is not in the list.
+   *
+   * The URL is the backend's — it carries a one-time state for a second,
+   * `pending_install` session — so this only follows what it was handed,
+   * through the guard that refuses anything not on github.com. A refusal is a
+   * bug on our side, not a backend refusal, and its developer text must never
+   * reach the screen.
+   *
+   * KNOWN LIMITATION, and the reason this is worth reading: GitHub redirects
+   * its install URL into an EXISTING installation whenever the signed-in user
+   * administers one. So this button is not yet guaranteed to reach an account
+   * chooser for a user who already has the app somewhere. No supported GitHub
+   * URL fixes that; see `installUrlFor` in the backend for the matrix that has
+   * to be run before this path can be trusted, and what to do if none passes.
+   */
+  const handleInstallElsewhere = (installUrl: string) => {
+    try {
+      redirectToGithub(installUrl);
+    } catch {
+      console.error("[github-checks] refused an unsafe install URL");
+      setPhase({ kind: "failed", message: GITHUB_BINDING_FAILED_MESSAGE });
+    }
+  };
 
   const handleClaim = async (
     linkSessionId: string,
@@ -264,12 +318,19 @@ export function GithubInstallCallbackRoute() {
         <SettingsSection title="Choose an account">
           {phase.installations.length === 0 ? (
             <div className="space-y-3 px-4 py-4 text-sm text-muted-foreground">
-              {/* An EMPTY proven list is a real answer, not a failure: this
-                  GitHub user has the app installed nowhere. Saying so is more
-                  useful than the generic refusal. */}
+              {/* Reached ONLY against a backend too old to send `installUrl` —
+                  a newer one turns an empty list straight into a redirect, up
+                  in the OAuth leg. It is a guard for a late or rolled-back
+                  deploy, not a supported state.
+
+                  It still has to leave the person somewhere they can act,
+                  though: the settings page no longer carries an install button
+                  of its own, so telling them to "install it first" with no way
+                  to do so would strand them. Name the page to go to. */}
               <p>
                 You are signed in to GitHub, but the MCPJam app is not installed
-                on any account you administer. Install it first, then come back.
+                on any account you administer. Install it from the app&rsquo;s
+                page on GitHub, then connect it here.
               </p>
               <Button
                 variant="outline"
@@ -288,7 +349,8 @@ export function GithubInstallCallbackRoute() {
               <p className="px-4 pt-3 text-sm text-muted-foreground">
                 These are the accounts you administer that already have the
                 MCPJam app installed. Connecting one lets this organization run
-                checks on its repositories.
+                checks on its repositories. To use an account that is not
+                listed, install the app on it.
               </p>
               {phase.installations.map((installation) => {
                 // Ties the disabled button to the reason it is disabled. The
@@ -376,6 +438,21 @@ export function GithubInstallCallbackRoute() {
                 </div>
                 );
               })}
+              {/* The only route to an account that is NOT in the list — which
+                  the product had no way to reach at all before this. Rendered
+                  only when the backend sent a URL; an older one simply shows
+                  the list it can act on. */}
+              {installUrl ? (
+                <div className="px-4 pb-3 pt-1">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleInstallElsewhere(installUrl)}
+                  >
+                    Install on another account
+                  </Button>
+                </div>
+              ) : null}
             </>
           )}
         </SettingsSection>

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -271,7 +271,9 @@ async function fillConnectForm(
   await chooseOption(user, "Outage policy", policyLabel);
 }
 
-const connectButton = () => screen.getByRole("button", { name: /Connect/ });
+// EXACT. The accounts section has a "Connect a GitHub account" button, and a
+// loose /Connect/ matches both — this one is the repository form's.
+const connectButton = () => screen.getByRole("button", { name: /^Connect$/ });
 
 describe("GithubChecksRoute availability gate", () => {
   beforeEach(() => {
@@ -1416,67 +1418,63 @@ describe("GithubChecksRoute installations", () => {
     mockRedirectToGithub.mockReset();
   });
 
-  it("offers both an install and a claim, and explains why claiming needs GitHub", async () => {
+  it("offers ONE way in, and explains why it goes through GitHub", async () => {
     renderRoute();
     expect(
       await screen.findByRole("button", {
-        name: /Install on a GitHub account/,
+        name: /Connect a GitHub account/,
       }),
     ).toBeInTheDocument();
+    // The second button is GONE. It sent the browser to GitHub's install URL,
+    // which GitHub redirects into an existing installation whenever the user
+    // administers one — so it dead-ended for exactly the people it was for,
+    // and could never reach a second account.
     expect(
-      screen.getByRole("button", { name: /Claim an existing installation/ }),
-    ).toBeInTheDocument();
-    // The whole reason the claim path needs an OAuth leg, in one sentence: the
-    // App JWT can read every installation it has, so installing is not proof
-    // that an installation is yours to connect here.
+      screen.queryByRole("button", { name: /Claim an existing installation/ }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /Install on a GitHub account/ }),
+    ).toBeNull();
+    // The whole reason this path has an OAuth leg, in one sentence: the App JWT
+    // can read every installation it has, so installing is not proof that an
+    // installation is yours to connect here. Losing the second button must not
+    // lose that.
     expect(
       screen.getByText(/is not on its own proof that it is yours to connect/i),
     ).toBeInTheDocument();
   });
 
-  it("sends the admin to the server-built install URL", async () => {
+  it("sends the admin to GitHub to sign in, not to the install URL", async () => {
     const user = userEvent.setup();
     renderRoute();
     await user.click(
       await screen.findByRole("button", {
-        name: /Install on a GitHub account/,
-      }),
-    );
-
-    await waitFor(() => expect(mockStartInstallation).toHaveBeenCalledTimes(1));
-    // The URL carries a one-time state the BACKEND minted and hashed. The page
-    // only follows it.
-    expect(mockRedirectToGithub).toHaveBeenCalledWith(
-      "https://github.com/apps/mcpjam/installations/new?state=abc",
-    );
-  });
-
-  it("sends the admin to the OAuth URL for a claim", async () => {
-    const user = userEvent.setup();
-    renderRoute();
-    await user.click(
-      await screen.findByRole("button", {
-        name: /Claim an existing installation/,
+        name: /Connect a GitHub account/,
       }),
     );
 
     await waitFor(() => expect(mockStartDirectClaim).toHaveBeenCalledTimes(1));
+    // The URL carries a one-time state the BACKEND minted and hashed. The page
+    // only follows it.
     expect(mockRedirectToGithub).toHaveBeenCalledWith(
       "https://github.com/login/oauth/authorize?client_id=x",
     );
+    // Installing is now driven from the picker, using a URL that arrives with
+    // it — this page never asks for one.
+    expect(mockStartInstallation).not.toHaveBeenCalled();
   });
 
   it("shows the backend's conflict wording verbatim, naming no other workspace", async () => {
     const conflict = Object.assign(new Error("Server Error"), {
       data: "That GitHub installation is already connected to a workspace. This is not a problem with your repositories — ask whoever set it up to disconnect it first, or install the app on a different account.",
     });
-    mockStartInstallation.mockRejectedValue(conflict);
+    mockStartDirectClaim.mockRejectedValue(conflict);
     const user = userEvent.setup();
     renderRoute();
 
     await user.click(
       await screen.findByRole("button", {
-        name: /Install on a GitHub account/,
+        name: /Connect a GitHub account/,
       }),
     );
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
@@ -1740,10 +1738,7 @@ describe("GithubChecksRoute permissions", () => {
     renderRoute();
 
     expect(
-      await screen.findByRole("button", { name: /Install on a GitHub account/ })
-    ).toBeDisabled();
-    expect(
-      screen.getByRole("button", { name: /Claim an existing installation/ })
+      await screen.findByRole("button", { name: /Connect a GitHub account/ })
     ).toBeDisabled();
     expect(
       screen.getByRole("button", { name: /Disconnect mcpjam$/ })
@@ -1779,7 +1774,7 @@ describe("GithubChecksRoute permissions", () => {
     renderRoute();
 
     expect(
-      await screen.findByRole("button", { name: /Install on a GitHub account/ })
+      await screen.findByRole("button", { name: /Connect a GitHub account/ })
     ).toBeEnabled();
     expect(
       screen.getByRole("switch", {
@@ -1801,7 +1796,7 @@ describe("GithubChecksRoute permissions", () => {
 
     // Closed: the role is not known yet, so the page may not act on it.
     expect(
-      await screen.findByRole("button", { name: /Install on a GitHub account/ })
+      await screen.findByRole("button", { name: /Connect a GitHub account/ })
     ).toBeDisabled();
     // Silent: we do not yet know the notice applies, so it must not flash.
     expect(

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
@@ -414,8 +414,32 @@ describe("the OAuth leg", () => {
     );
   });
 
-  it("says so plainly when the user has the app installed nowhere", async () => {
-    // An EMPTY proven list is a real answer, not a failure.
+  it("goes straight to GitHub when there is nothing to pick from", async () => {
+    // An EMPTY proven list is a real answer, not a failure — this GitHub user
+    // administers no account with the app. Installing is the only move, so
+    // make it, rather than rendering a screen whose whole content is "go and
+    // install". This is what keeps a first-time user at one click.
+    mockCompleteUserAuthorization.mockResolvedValue({
+      status: "pick_required",
+      linkSessionId: "sess-1",
+      installations: [],
+      installUrl: "https://github.com/apps/mcpjam/installations/new?state=xyz",
+    });
+    renderCallback("?code=c&state=s");
+
+    await waitFor(() =>
+      expect(mockRedirectToGithub).toHaveBeenCalledWith(
+        "https://github.com/apps/mcpjam/installations/new?state=xyz"
+      )
+    );
+    expect(
+      screen.queryByText(/not installed on any account you administer/i)
+    ).toBeNull();
+  });
+
+  it("still leaves somewhere to go when the backend sends no install URL", async () => {
+    // The old-backend fallback. The settings page no longer has an install
+    // button of its own, so this branch must not strand anyone while it shows.
     mockCompleteUserAuthorization.mockResolvedValue({
       status: "pick_required",
       linkSessionId: "sess-1",
@@ -426,6 +450,73 @@ describe("the OAuth leg", () => {
     expect(
       await screen.findByText(/not installed on any account you administer/i)
     ).toBeInTheDocument();
+    expect(mockRedirectToGithub).not.toHaveBeenCalled();
+  });
+
+  it("refuses an install URL that is not GitHub, showing no developer text", async () => {
+    mockCompleteUserAuthorization.mockResolvedValue({
+      status: "pick_required",
+      linkSessionId: "sess-1",
+      installations: [],
+      installUrl: "https://github.com.evil.test/apps/mcpjam/installations/new",
+    });
+    mockRedirectToGithub.mockImplementation(() => {
+      throw new Error("Refused to redirect outside GitHub");
+    });
+    renderCallback("?code=c&state=s");
+
+    // The guard's message is developer text and must never reach the screen.
+    const shown = await screen.findByText(/could not finish connecting/i);
+    expect(shown).toBeInTheDocument();
+    expect(shown.textContent).not.toMatch(/Refused to redirect/i);
+  });
+
+  it("offers a way to install on an account that is not listed", async () => {
+    // The capability the product did not have at all: reaching an account the
+    // app is not on yet.
+    mockCompleteUserAuthorization.mockResolvedValue({
+      status: "pick_required",
+      linkSessionId: "sess-1",
+      installations: [
+        {
+          installationId: 11,
+          accountLogin: "acme",
+          accountType: "Organization",
+        },
+      ],
+      installUrl: "https://github.com/apps/mcpjam/installations/new?state=xyz",
+    });
+    const user = userEvent.setup();
+    renderCallback("?code=c&state=s");
+    await screen.findByText("acme");
+
+    await user.click(
+      screen.getByRole("button", { name: /Install on another account/ })
+    );
+
+    expect(mockRedirectToGithub).toHaveBeenCalledWith(
+      "https://github.com/apps/mcpjam/installations/new?state=xyz"
+    );
+  });
+
+  it("offers no install action when the backend sent no URL", async () => {
+    mockCompleteUserAuthorization.mockResolvedValue({
+      status: "pick_required",
+      linkSessionId: "sess-1",
+      installations: [
+        {
+          installationId: 11,
+          accountLogin: "acme",
+          accountType: "Organization",
+        },
+      ],
+    });
+    renderCallback("?code=c&state=s");
+    await screen.findByText("acme");
+
+    expect(
+      screen.queryByRole("button", { name: /Install on another account/ })
+    ).toBeNull();
   });
 
   it("marks an already-connected account instead of offering the click", async () => {

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
@@ -117,6 +117,12 @@ function renderCallback(query: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // `clearAllMocks` clears CALLS, not implementations. Two tests here make the
+  // redirect throw to prove the guard's developer text never reaches the
+  // screen, and without this that throwing implementation leaks into every
+  // test after them — where a redirect assertion still passes, because the
+  // call was made, while the page is actually showing a failure.
+  mockRedirectToGithub.mockReset();
   mockAuth.mockReturnValue({ isLoading: false, isAuthenticated: true });
   mockUserReady.mockReturnValue(true);
   mockWorkosAuth.mockReturnValue({
@@ -497,6 +503,9 @@ describe("the OAuth leg", () => {
     expect(mockRedirectToGithub).toHaveBeenCalledWith(
       "https://github.com/apps/mcpjam/installations/new?state=xyz"
     );
+    // The redirect SUCCEEDED. Asserting the call alone would pass even if the
+    // guard had thrown and the page had fallen back to a refusal.
+    expect(screen.queryByText(/could not finish connecting/i)).toBeNull();
   });
 
   it("offers no install action when the backend sent no URL", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/useGithubChecksSettings.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useGithubChecksSettings.test.tsx
@@ -329,8 +329,8 @@ describe("useGithubChecksSettings writes", () => {
         >
           unbind
         </button>
-        <button type="button" onClick={() => void settings.startInstallation()}>
-          install
+        <button type="button" onClick={() => void settings.startDirectClaim()}>
+          start-connect
         </button>
         <div data-testid="exposed">
           {Object.keys(settings).sort().join(",")}
@@ -365,11 +365,15 @@ describe("useGithubChecksSettings writes", () => {
       [
         "action:github/checkRepoConfigsNode:connectVerifiedRepo",
         "action:github/checkRepoConfigsNode:listInstallationRepos",
-        // The org ↔ installation binding surface. Note what is NOT here: the
-        // two GitHub CALLBACK actions live in `useGithubInstallCallbacks`,
-        // because the callback page has no organization to hand them — it
-        // arrives back from GitHub with query parameters and nothing else.
-        "action:github/appInstallLinkNode:startInstallation",
+        // The org ↔ installation binding surface. ONE way in: `startDirectClaim`
+        // signs the user in to GitHub and the callback's picker answers "which
+        // account". `startInstallation` is deliberately absent — this surface
+        // no longer sends anyone to GitHub's install URL, because GitHub
+        // redirects it into an existing installation and it dead-ends. The
+        // install URL now arrives WITH the pick, from the callback actions,
+        // which live in `useGithubInstallCallbacks` — the callback page has no
+        // organization to hand them, arriving back from GitHub with query
+        // parameters and nothing else.
         "action:github/appInstallLinkNode:startDirectClaim",
         "mutation:github/appInstallLink:unbindInstallation",
         "mutation:github/checkRepoConfigs:disconnectRepo",
@@ -435,17 +439,17 @@ describe("useGithubChecksSettings writes", () => {
     ]);
   });
 
-  it("starts an installation with nothing but the org", () => {
+  it("starts the connect flow with nothing but the org", () => {
     render(<SettingsProbe />);
 
-    screen.getByText("install").click();
+    screen.getByText("start-connect").click();
 
     // The one-time state is minted and hashed SERVER-side; there is nothing for
     // the client to contribute and nothing for it to get wrong.
     expect(mocks.requests).toEqual([
       {
         kind: "action",
-        name: "github/appInstallLinkNode:startInstallation",
+        name: "github/appInstallLinkNode:startDirectClaim",
         args: { organizationId: "org-1" },
       },
     ]);

--- a/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
@@ -153,6 +153,18 @@ export type GithubInstallCallbackResult =
       status: "pick_required";
       linkSessionId: string;
       installations: ClaimableInstallation[];
+      /**
+       * Where to send the browser to install on an account that is not in
+       * `installations` — including when that list is EMPTY, which is a
+       * complete answer (this GitHub user administers no account with the app)
+       * and the case where installing is the only move left.
+       *
+       * Optional because a deployment running the older backend does not send
+       * it. Every use of it must degrade to something the user can still act
+       * on, since the settings page no longer carries an install button of its
+       * own.
+       */
+      installUrl?: string;
     };
 
 export type GithubCheckRepoConfigRow = {
@@ -331,9 +343,6 @@ export function useGithubChecksSettings(
   // that drifts or a required argument that is forgotten fails at RUNTIME, on
   // the click, in production — not at build time. Treat these call shapes as
   // part of the backend's signature and change them together.
-  const startInstallationAction = useAction(
-    "github/appInstallLinkNode:startInstallation" as any,
-  );
   const startDirectClaimAction = useAction(
     "github/appInstallLinkNode:startDirectClaim" as any,
   );
@@ -349,25 +358,21 @@ export function useGithubChecksSettings(
   ) as GithubInstallationBinding[] | undefined;
 
   /**
-   * Begin installing the App for this organization. Returns GitHub's install
-   * URL; the caller navigates to it.
+   * Begin connecting a GitHub account — THE only way in, for every case.
+   *
+   * Goes to the OAuth leg first and lets the callback's pick answer "which of
+   * your accounts", because GitHub's install URL cannot be relied on to ask
+   * that: it redirects into an existing installation whenever the signed-in
+   * user administers one. Asking GitHub who the user is, then reading their
+   * installation list, is the only approach that does not depend on GitHub's
+   * redirect behaviour.
+   *
+   * Installing, when the answer is "none of these", is driven from the pick
+   * using the `installUrl` the backend sends with it — not from here.
    *
    * The URL carries a one-time state whose HASH is what the backend stored, so
    * it is not a credential the browser has to protect beyond the session's
    * ten-minute life.
-   */
-  const startInstallation = useCallback(
-    () =>
-      startInstallationAction({ organizationId } as any) as Promise<{
-        installUrl: string;
-      }>,
-    [startInstallationAction, organizationId],
-  );
-
-  /**
-   * Begin CLAIMING an installation somebody created from GitHub's side, where
-   * there was never a setup redirect for us to catch. Goes straight to the
-   * OAuth leg; the pick comes back from the callback.
    */
   const startDirectClaim = useCallback(
     () =>
@@ -501,7 +506,6 @@ export function useGithubChecksSettings(
     setRepoFeedbackComments,
     disconnectRepo,
     listInstallationRepos,
-    startInstallation,
     startDirectClaim,
     unbindInstallation,
   };


### PR DESCRIPTION
- There were two buttons and nothing told you which one you needed. "Install on a GitHub account" was broken: GitHub redirects that URL to an installation you already have, so it dumped you on a GitHub settings page and the flow just stopped.
- Now there's one "Connect a GitHub account" button. You sign in to GitHub, then pick from a list of every account you administer. That path reads your real installation list instead of relying on GitHub's redirects, so it can't dead-end.
- The list gains "Install on another account".
- If you have it installed nowhere, we skip the list and send you straight to GitHub — same one click as before.
- Needs MCPJam/mcpjam-backend#1279 deployed first. It removes the old install button, so don't merge this until that's live.

### Known: "Install on another account" does nothing useful yet

The MCPJam GitHub App is currently **private** — App settings → Advanced still offers "Make this GitHub App public / Allow this GitHub App to be installed on other accounts". A private app can only be installed on its owner's account, so there is no second account for that button to reach, and clicking it lands on MCPJam's existing installation page.

That is the same dead end as the button this PR removes. **It is not the same bug, and it is not a regression** — it is the app's visibility setting, and it resolves itself the day the app is made public. Shipping the button now means the flow is complete on day one rather than needing another change.

Worth knowing more broadly: while the app stays private, no account outside the MCPJam org can install it, so GitHub Checks cannot onboard an external customer regardless of this UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)