### PR TITLE
Actually show the browser section: the bearer, and the default host

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/useBrowserTools.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useBrowserTools.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * `useBrowserTools` — which host the Tools panel's Browser section believes it
+ * is describing, and when it asks the server anything at all.
+ *
+ * The bug this pins: the hook keyed on the EXPLICITLY previewed host, while the
+ * Browser pane in the right rail resolves explicit-pick-else-project-default
+ * like the rest of the app. On a project whose DEFAULT host carries the browser
+ * and nothing was explicitly picked, the pane offered a live browser while the
+ * panel beside it said no server was connected.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const state = vi.hoisted(() => ({
+  explicitHost: null as { config?: { builtInToolIds?: string[] } } | null,
+  projectDefault: null as { builtInToolIds?: string[] } | null,
+  selectedEngine: "cloud" as "cloud" | "local",
+  consentToken: null as string | null,
+  definitions: [{ name: "browser_navigate", description: "Open a URL." }],
+  definitionCalls: [] as string[],
+  pageCalls: [] as string[],
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+  useQuery: () => state.projectDefault ?? undefined,
+  useAction: () => vi.fn(),
+}));
+
+vi.mock("@/hooks/useClients", () => ({
+  useHost: () => ({ host: state.explicitHost, isLoading: false }),
+}));
+
+vi.mock("@/hooks/useComputerEngine", () => ({
+  useComputerEngine: () => ({
+    engine: state.selectedEngine,
+    selectedEngine: state.selectedEngine,
+    consent: { token: state.consentToken, granted: !!state.consentToken },
+  }),
+}));
+
+vi.mock("@/hooks/useProjectComputer", () => ({
+  useMintBrowserToken: () =>
+    vi.fn(async () => ({
+      token: "tok",
+      expiresAt: Date.now() + 60_000,
+    })),
+}));
+
+vi.mock("@/lib/hosted-browser/client", () => ({
+  createBrowserTokenCache: () => ({
+    get: async () => "tok",
+    invalidate: vi.fn(),
+    invalidateIf: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/browser-page-tools/client", () => ({
+  fetchBrowserToolDefinitions: vi.fn(async (engine: string) => {
+    state.definitionCalls.push(engine);
+    return state.definitions;
+  }),
+  fetchHostedPageTools: vi.fn(async () => {
+    state.pageCalls.push("hosted");
+    return {
+      ok: true,
+      url: "https://webmcp.dev/",
+      webmcpSupported: true,
+      tools: [],
+    };
+  }),
+  fetchLocalPageTools: vi.fn(async () => {
+    state.pageCalls.push("local");
+    return {
+      ok: true,
+      url: "http://localhost/",
+      webmcpSupported: false,
+      tools: [],
+    };
+  }),
+}));
+
+import { useBrowserTools } from "../useBrowserTools";
+
+const WITH_BROWSER = { builtInToolIds: ["browser", "bash"] };
+const WITHOUT_BROWSER = { builtInToolIds: ["bash"] };
+
+beforeEach(() => {
+  state.explicitHost = null;
+  state.projectDefault = null;
+  state.selectedEngine = "cloud";
+  state.consentToken = null;
+  state.definitionCalls = [];
+  state.pageCalls = [];
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("useBrowserTools — which host it describes", () => {
+  it("falls back to the PROJECT DEFAULT when no host is explicitly previewed", async () => {
+    // The reported bug, exactly: the Browser pane was live and the Tools panel
+    // was empty, because only the pane looked at the default host.
+    state.projectDefault = WITH_BROWSER;
+    const { result } = renderHook(() =>
+      useBrowserTools({ projectId: "proj_1", hostId: null }),
+    );
+    await waitFor(() => expect(result.current.tools).toHaveLength(1));
+    expect(result.current.attached).toBe(true);
+  });
+
+  it("prefers an explicitly previewed host over the project default", async () => {
+    // Picking a host without the browser must HIDE the section, even on a
+    // project whose default has one — otherwise the panel describes tools this
+    // turn will not be given.
+    state.explicitHost = { config: WITHOUT_BROWSER };
+    state.projectDefault = WITH_BROWSER;
+    const { result } = renderHook(() =>
+      useBrowserTools({ projectId: "proj_1", hostId: "host_1" }),
+    );
+    await waitFor(() => expect(result.current.attached).toBe(false));
+    expect(result.current.tools).toEqual([]);
+    expect(state.definitionCalls).toEqual([]);
+  });
+
+  it("describes the browser when the explicit host carries it", async () => {
+    state.explicitHost = { config: WITH_BROWSER };
+    state.projectDefault = WITHOUT_BROWSER;
+    const { result } = renderHook(() =>
+      useBrowserTools({ projectId: "proj_1", hostId: "host_1" }),
+    );
+    await waitFor(() => expect(result.current.tools).toHaveLength(1));
+  });
+
+  it("asks for nothing when no host has a browser", async () => {
+    // Not merely empty output: a panel that fetched a catalog and read a live
+    // page for every project would be spending requests to render nothing.
+    state.projectDefault = WITHOUT_BROWSER;
+    const { result } = renderHook(() =>
+      useBrowserTools({ projectId: "proj_1", hostId: null }),
+    );
+    await waitFor(() => expect(result.current.attached).toBe(false));
+    expect(state.definitionCalls).toEqual([]);
+    expect(state.pageCalls).toEqual([]);
+  });
+});
+
+describe("useBrowserTools — which browser it reads", () => {
+  it("reads the hosted browser under the cloud engine", async () => {
+    state.projectDefault = WITH_BROWSER;
+    const { result } = renderHook(() =>
+      useBrowserTools({ projectId: "proj_1", hostId: null }),
+    );
+    await waitFor(() => expect(state.pageCalls).toEqual(["hosted"]));
+    expect(result.current.engine).toBe("hosted");
+    // Definitions are NOT asserted by call here: they are cached per engine for
+    // the session, so by this point an earlier test has already warmed
+    // `hosted`. That caching is the behaviour, not an obstacle to it — the
+    // panel is remounted on every rail tab switch, and re-fetching a constant
+    // each time is noise on the wire and a flicker in the list.
+    expect(result.current.tools).toHaveLength(1);
+  });
+
+  it("reads this machine's browser once consent exists", async () => {
+    state.projectDefault = WITH_BROWSER;
+    state.selectedEngine = "local";
+    state.consentToken = "consent-tok";
+    const { result } = renderHook(() =>
+      useBrowserTools({ projectId: "proj_1", hostId: null }),
+    );
+    await waitFor(() => expect(state.pageCalls).toEqual(["local"]));
+    // The definitions differ per engine — they say whose browser this is.
+    expect(state.definitionCalls).toEqual(["local"]);
+    expect(result.current.engine).toBe("local");
+  });
+
+  it("does not read the local browser before consent is granted", async () => {
+    // The Browser pane is where a person authorizes this machine. Until they
+    // do there is nothing to read, and asking would 403 on every render.
+    state.projectDefault = WITH_BROWSER;
+    state.selectedEngine = "local";
+    state.consentToken = null;
+    const { result } = renderHook(() =>
+      useBrowserTools({ projectId: "proj_1", hostId: null }),
+    );
+    await waitFor(() =>
+      expect(result.current.page).toEqual({
+        ok: false,
+        error: "no_browser_session",
+      }),
+    );
+    expect(state.pageCalls).toEqual([]);
+  });
+
+  it("re-reads the page on request, without re-fetching the definitions", async () => {
+    // The page changes every time the agent navigates; the definitions are
+    // static, and re-fetching a constant on each refresh is pure noise.
+    state.projectDefault = WITH_BROWSER;
+    const { result } = renderHook(() =>
+      useBrowserTools({ projectId: "proj_1", hostId: null }),
+    );
+    await waitFor(() => expect(state.pageCalls).toEqual(["hosted"]));
+    const definitionsBefore = state.definitionCalls.length;
+
+    result.current.refreshPage();
+
+    await waitFor(() => expect(state.pageCalls).toEqual(["hosted", "hosted"]));
+    expect(state.definitionCalls).toHaveLength(definitionsBefore);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useBrowserTools.ts
+++ b/mcpjam-inspector/client/src/hooks/useBrowserTools.ts
@@ -16,9 +16,11 @@
  * project and a host config, and reads one answer.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useConvexAuth } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import { useComputerEngine } from "@/hooks/useComputerEngine";
 import { useHost } from "@/hooks/useClients";
+import { resolveEffectiveHost } from "@/lib/effective-client";
+import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
 import { useMintBrowserToken } from "@/hooks/useProjectComputer";
 import {
   createBrowserTokenCache,
@@ -61,19 +63,38 @@ export interface BrowserToolsState {
 export function useBrowserTools(args: {
   projectId: string | null;
   /**
-   * The previewed host. Resolved HERE rather than taken as a list of ids, so a
-   * caller needs one hook rather than a Convex subscription plus a host lookup
-   * plus this — the browser is one capability, and asking about it should be
-   * one question. `useHost` short-circuits on a null id, so this is cheap when
-   * no host is picked.
+   * The EXPLICITLY previewed host, or null when the user has not picked one.
+   *
+   * Resolved here rather than taken as a list of ids, so a caller needs one
+   * hook rather than a Convex subscription plus a host lookup plus this — the
+   * browser is one capability, and asking about it should be one question.
+   * `useHost` short-circuits on a null id, so this is cheap when nothing is
+   * picked.
    */
   hostId: string | null;
 }): BrowserToolsState {
   const { isAuthenticated } = useConvexAuth();
   const { host } = useHost({ isAuthenticated, hostId: args.hostId });
+  // THE PROJECT DEFAULT, and the reason this hook cannot key on the previewed
+  // id alone. "Which host is this surface operating under" is explicit-pick
+  // ELSE project-default everywhere else in the app (`resolveEffectiveHost`),
+  // and the Browser pane in the right rail resolves it that way — so a hook
+  // that stopped at the explicit pick reported "no browser" for a project
+  // whose DEFAULT host has one, which is the common case: the pane offered a
+  // live browser while the Tools panel beside it said no server was connected.
+  const projectDefaultHostConfig = useQuery(
+    "hostConfigsV2:getProjectDefault" as never,
+    isAuthenticated && args.projectId
+      ? ({ projectId: args.projectId } as never)
+      : "skip",
+  ) as HostConfigDtoV2 | null | undefined;
+  const hostConfig = resolveEffectiveHost({
+    explicitHostConfig: host?.config ?? null,
+    projectDefaultHostConfig: projectDefaultHostConfig ?? null,
+  });
   const engineState = useComputerEngine(args.projectId);
   const mintToken = useMintBrowserToken();
-  const attached = (host?.config?.builtInToolIds ?? []).includes(
+  const attached = (hostConfig?.builtInToolIds ?? []).includes(
     BROWSER_BUILT_IN_TOOL_ID,
   );
   // The BODY-side engine choice, exactly as the Browser pane resolves it, so
@@ -100,6 +121,21 @@ export function useBrowserTools(args: {
     const mint: MintBrowserToken = () => mintToken({ projectId });
     return createBrowserTokenCache(mint);
   }, [engine, args.projectId, isAuthenticated, mintToken]);
+  /**
+   * The cache, readable from the page effect WITHOUT being one of its
+   * dependencies.
+   *
+   * `tokens` is derived, so its identity is only as stable as `mintToken`'s —
+   * and an effect that re-runs on a new cache object also re-reads the page,
+   * which sets state, which renders again. One unstable dependency upstream
+   * turns a tool list into an unbounded request loop against a metered box.
+   * The effect keys on the stable facts instead (project, engine, consent,
+   * and an explicit refresh), and reaches the cache through here.
+   */
+  const tokensRef = useRef(tokens);
+  tokensRef.current = tokens;
+  /** Whether a hosted read is possible at all — a boolean, so it can be a dep. */
+  const hostedReadable = tokens !== null;
 
   // Definitions. Cached per engine for the session; a failure leaves the list
   // empty rather than surfacing an error, because a pane that cannot describe
@@ -149,7 +185,8 @@ export function useBrowserTools(args: {
       setPage({ ok: false, error: "no_browser_session" });
       return;
     }
-    if (engine === "hosted" && !tokens) {
+    const cache = tokensRef.current;
+    if (engine === "hosted" && !cache) {
       setPage(null);
       return;
     }
@@ -157,8 +194,8 @@ export function useBrowserTools(args: {
     const serial = (latestRead.current += 1);
     const projectId = args.projectId;
     const read =
-      engine === "hosted" && tokens
-        ? fetchHostedPageTools(tokens, controller.signal)
+      engine === "hosted" && cache
+        ? fetchHostedPageTools(cache, controller.signal)
         : fetchLocalPageTools({ projectId }, consentToken, controller.signal);
     read
       .then((answer) => {
@@ -172,7 +209,17 @@ export function useBrowserTools(args: {
         }
       });
     return () => controller.abort();
-  }, [attached, args.projectId, engine, consentToken, tokens, pageNonce]);
+    // `hostedReadable` rather than `tokens`: the boolean changes only when a
+    // hosted read becomes possible or stops being, while the object it stands
+    // for can churn on every render. See `tokensRef`.
+  }, [
+    attached,
+    args.projectId,
+    engine,
+    consentToken,
+    hostedReadable,
+    pageNonce,
+  ]);
 
   return { attached, engine, tools, page, refreshPage };
 }

--- a/mcpjam-inspector/client/src/lib/__tests__/session-token.built-in-tools.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/session-token.built-in-tools.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The hosted bearer on MCPJam's built-in tool definitions — and off everything
+ * beside them.
+ *
+ * The fourth instance of one failure mode, and the first where it was INVISIBLE.
+ * `/api/v1/*` gets the user's bearer only from a path-by-path allowlist, so a
+ * route the list does not name ships no `Authorization` at all and the API
+ * answers "Bearer token required". The eval-chain reads at least rendered that
+ * 401 as service copy; this one is read by a panel that soft-fails an
+ * unreachable catalog to "no tools", so the Browser section simply never
+ * appeared — a feature that looked unbuilt rather than unauthorized.
+ *
+ * The second half is the half that matters over time: proof the grant stayed at
+ * the built-in-tools catalog rather than becoming `/api/v1/`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/apis/web/context", () => ({
+  getApiAuthorizationHeader: vi.fn(async () => "Bearer hosted-bearer"),
+}));
+
+vi.mock("@/lib/convex-site-url", () => ({
+  getConvexSiteUrl: () => "https://outstanding-fennec-304.convex.site",
+}));
+
+describe("authFetch bearer on the built-in tool definitions", () => {
+  let sessionToken: typeof import("../session-token");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    delete (window as any).__MCP_SESSION_TOKEN__;
+    vi.mocked(global.fetch).mockReset();
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+    sessionToken = await import("../session-token");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function headersOf(call: number): Record<string, string> {
+    const init = vi.mocked(global.fetch).mock.calls[call]?.[1] as RequestInit;
+    return (init?.headers ?? {}) as Record<string, string>;
+  }
+
+  it("attaches the bearer to the browser definitions", async () => {
+    await sessionToken.authFetch("/api/v1/built-in-tools/browser/definitions", {
+      method: "GET",
+    });
+    expect(headersOf(0).Authorization).toBe("Bearer hosted-bearer");
+  });
+
+  it("attaches it with the engine query the Tools panel sends", async () => {
+    // The panel always sends one, so a rule that only matched the bare path
+    // would pass a test and fail every real call.
+    await sessionToken.authFetch(
+      "/api/v1/built-in-tools/browser/definitions?engine=local",
+      { method: "GET" },
+    );
+    expect(headersOf(0).Authorization).toBe("Bearer hosted-bearer");
+  });
+
+  for (const path of [
+    // Paths that merely start the same way — the boundary is `/`.
+    "/api/v1/built-in-toolsets/browser/definitions",
+    "/api/v1/built-in-tools-catalog",
+    // A sibling public-API surface must not inherit the UI's bearer just
+    // because this one needed it.
+    "/api/v1/projects/proj_1/servers",
+    "/api/v1/clients",
+  ]) {
+    it(`does NOT attach the bearer to ${path}`, async () => {
+      await sessionToken.authFetch(path, { method: "GET" });
+      expect(headersOf(0).Authorization).toBeUndefined();
+    });
+  }
+
+  it("does not attach the bearer to a foreign origin on this path", async () => {
+    // The exfiltration guard: a path match is not enough, the origin has to be
+    // ours. Otherwise an absolute URL that merely looks right takes the token.
+    await sessionToken.authFetch(
+      "https://evil.example.com/api/v1/built-in-tools/browser/definitions",
+      { method: "GET" },
+    );
+    expect(headersOf(0).Authorization).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -352,6 +352,15 @@ const HOSTED_AUTH_PATH_PREFIXES = [
   // paths that need the user's bearer attached. Scoped path-by-path — not all
   // of `/api/v1/` — so unrelated public-API routes don't get the UI bearer.
   "/api/v1/harness/",
+  // The Tools panel and the Raw request preview reading MCPJam's own built-in
+  // tool definitions (`/api/v1/built-in-tools/browser/definitions`), so neither
+  // has to keep a hand-written copy of schemas built at turn time. Same shape
+  // and same reason as the harness catalog above: `requireVerifiedAuth`-gated,
+  // so without this entry the fetch ships no `Authorization` at all and 401s —
+  // and because the panel soft-fails an unreachable catalog to "no tools", the
+  // symptom is a Browser section that silently never appears rather than an
+  // error anyone can see.
+  "/api/v1/built-in-tools/",
   // The org-settings Capabilities page reading the agent's op registry, so its
   // toggles cannot drift from the tools the server actually offers.
   "/api/v1/agent-ops",


### PR DESCRIPTION
Follow-up to #4791. That PR shipped the Browser section and it never appeared — the panel still read **"No server connected yet"** while the model called `browser_observe` and `browser_webmcp_tools` and found the page's three tools.

Two causes, and both failed *silently*, which is why the feature looked unbuilt rather than broken.

## The bearer

`/api/v1/*` gets the user's token only from a path-by-path allowlist in `session-token.ts`. The definitions route was not on it, so the fetch went out with no `Authorization` at all and the API answered "Bearer token required".

This is the fourth route that list has caught out — `/web/registry/*`, readiness, the eval-chain reads — and the first where nobody could see it. The panel soft-fails an unreachable catalog to "no tools", exactly as the harness catalog does, so a 401 renders as a section that simply is not there.

## The host

"Which host is this surface operating under" is **explicit-pick, else project-default** everywhere in the app. That is what `resolveEffectiveHost` exists for, and it is how the Browser *pane* in the right rail decides whether to offer a tab.

The hook keyed on the explicitly previewed host alone. On a project whose **default** host carries the browser and nothing was picked, the pane offered a live browser while the panel beside it said no server was connected — the exact pairing in the report. It now resolves through the same helper.

## One thing the tests found

Writing the hook test surfaced a real fragility: the page-read effect depended on the token-cache **object**, which is derived and therefore only as stable as the `mintToken` reference above it. An unstable reference upstream turned a tool list into an unbounded read loop against a metered box. The effect now keys on the stable facts (project, engine, consent, explicit refresh) and reaches the cache through a ref.

## Tests

- `session-token.built-in-tools.test.ts` — the bearer is attached to the definitions path with and without the engine query, and stays off sibling `/api/v1` routes and foreign origins. The negative half is the part that matters: it pins the grant at this catalog rather than at `/api/v1/`.
- `useBrowserTools.test.tsx` — the project-default fallback, the explicit pick overriding it, no requests at all when no host has a browser, the per-engine read, local consent gating, and that a refresh re-reads the page without re-fetching the static definitions.

`typecheck:client` clean, 161 tests pass across the touched suites.

## Not covered

Still not exercised against a live staging browser. Both fixes are verified by unit tests and by reading the deployed code path, not by a run against the real endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoCsWMzq4yfK7LTBAZttC5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth bearer scoping (must stay narrow) and browser tool loading; mistakes could leak tokens to wrong paths or spam hosted reads, but changes are guarded by existing allowlist rules and tests.
> 
> **Overview**
> Fixes the Tools panel **Browser** section staying empty while the right-rail Browser pane worked — two silent failures.
> 
> **Auth:** Adds `/api/v1/built-in-tools/` to the hosted bearer allowlist in `session-token.ts`, so fetches for browser tool definitions send `Authorization`. Without it the API 401s and the panel treats the catalog as unreachable (no visible error).
> 
> **Host:** `useBrowserTools` now resolves the active host with `resolveEffectiveHost` (explicit preview **or** project default via Convex `getProjectDefault`), matching the Browser pane. `attached` and downstream fetches key off that config instead of the explicit preview host only.
> 
> **Stability:** The page-read effect no longer depends on the derived token-cache object (uses a ref + `hostedReadable` boolean) to avoid re-fetch loops against hosted browser reads.
> 
> New Vitest coverage for allowlist scoping on built-in-tools paths and for host fallback, engine/consent behavior, and `refreshPage` semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40949f25e16c311f7982afa5451f9465664546af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Browser section in the Tools panel so it actually appears when the project's default host has a browser, and attaches the user's bearer to the built-in tools definitions route so the catalog fetch no longer 401s silently.

- Resolves the host through `resolveEffectiveHost` (explicit pick else project default) so the panel agrees with the Browser pane in the right rail.
- Adds `/api/v1/built-in-tools/` to the auth allowlist in `session-token.ts`.
- Keys the page-read effect on stable facts (project, engine, consent, refresh) and reaches the token cache via a ref, preventing an unbounded read loop.

<sup>Written for commit 40949f25e16c311f7982afa5451f9465664546af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

