### PR TITLE
Say what each repository switch does

### DIFF
--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { Navigate } from "react-router";
 import { useConvexAuth } from "convex/react";
 import { ChevronLeft, Github, Plus, Trash2 } from "lucide-react";
@@ -93,6 +100,43 @@ interface GithubChecksRouteProps {
  * The page-level copy explains where recipes come from in general; when the
  * backend returns provenance per repo, it belongs here.
  */
+/**
+ * A switch with its name under it.
+ *
+ * The caption is `aria-hidden`, and that is the point rather than an
+ * oversight: the switch already carries a per-repository `aria-label`
+ * ("Enable checks for owner/repo"), which is strictly more useful in a list of
+ * repositories than a bare "Checks" repeated on every row. Exposing the
+ * caption too would just read the word twice.
+ *
+ * Callers must keep the caption a substring of that `aria-label` — see the
+ * call sites.
+ */
+function SwitchField({
+  label,
+  muted,
+  children,
+}: {
+  label: string;
+  /** Dim the caption alongside a switch that is disabled. */
+  muted?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      {children}
+      <span
+        aria-hidden
+        className={`text-[11px] leading-none whitespace-nowrap ${
+          muted ? "text-muted-foreground/50" : "text-muted-foreground"
+        }`}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
 function RepoCheckState({ enabled }: { enabled: boolean }) {
   return (
     <span className="text-xs text-muted-foreground">
@@ -988,23 +1032,44 @@ export function GithubChecksRoute({
                   </SelectContent>
                 </Select>
 
-                <Switch
-                  checked={row.enabled}
-                  disabled={pendingToggles.has(row._id) || !canManage}
-                  onCheckedChange={() => void handleToggle(row)}
-                  aria-label={`Enable checks for ${row.repoFullName}`}
-                />
+                {/* Each switch is captioned. Three bare switches in a row
+                    said nothing about which was which, and only a screen
+                    reader could tell them apart.
 
-                <Switch
-                  checked={row.conformanceEnabled === true}
-                  disabled={
-                    pendingConformance.has(row._id) ||
-                    !row.enabled ||
-                    !canManage
-                  }
-                  onCheckedChange={() => void handleConformanceToggle(row)}
-                  aria-label={`Enable conformance check for ${row.repoFullName}`}
-                />
+                    Every caption is a substring of its switch's `aria-label`,
+                    which is WCAG 2.5.3: a visible label that is not part of
+                    the accessible name leaves a speech-input user saying a
+                    word the control does not answer to. That is why the third
+                    reads "Comments" and not "PR comments" — keep it that way
+                    if the wording changes. */}
+                <SwitchField label="Checks">
+                  <Switch
+                    checked={row.enabled}
+                    disabled={pendingToggles.has(row._id) || !canManage}
+                    onCheckedChange={() => void handleToggle(row)}
+                    aria-label={`Enable checks for ${row.repoFullName}`}
+                  />
+                </SwitchField>
+
+                {/* Dimmed with its switch while checks are off, because it is
+                    a SUB-SETTING of them — the switch has always been
+                    disabled in that state, and a caption at full strength
+                    beside a dead control reads as a bug rather than a rule. */}
+                <SwitchField
+                  label="Conformance"
+                  muted={!row.enabled || !canManage}
+                >
+                  <Switch
+                    checked={row.conformanceEnabled === true}
+                    disabled={
+                      pendingConformance.has(row._id) ||
+                      !row.enabled ||
+                      !canManage
+                    }
+                    onCheckedChange={() => void handleConformanceToggle(row)}
+                    aria-label={`Enable conformance check for ${row.repoFullName}`}
+                  />
+                </SwitchField>
 
                 {/* `!== "off"` — ABSENT IS ON. Every row connected before
                     this existed, and every row nobody has touched since, is a
@@ -1012,14 +1077,19 @@ export function GithubChecksRoute({
                     tell an admin the opposite of what is happening on their
                     pull requests. Not gated on `row.enabled` the way
                     conformance is: this is a policy about what MCPJam may
-                    write, and it stays answerable while checks are paused. */}
-                <Switch
-                  checked={row.feedbackComments !== "off"}
-                  disabled={pendingFeedback.has(row._id) || !canManage}
-                  onCheckedChange={() => void handleFeedbackCommentsToggle(row)}
-                  aria-label={`Post feedback comments on pull requests for ${row.repoFullName}`}
-                  aria-describedby={`feedback-comments-note-${row._id}`}
-                />
+                    write, and it stays answerable while checks are paused —
+                    so its caption is NOT muted with the others. */}
+                <SwitchField label="Comments" muted={!canManage}>
+                  <Switch
+                    checked={row.feedbackComments !== "off"}
+                    disabled={pendingFeedback.has(row._id) || !canManage}
+                    onCheckedChange={() =>
+                      void handleFeedbackCommentsToggle(row)
+                    }
+                    aria-label={`Post feedback comments on pull requests for ${row.repoFullName}`}
+                    aria-describedby={`feedback-comments-note-${row._id}`}
+                  />
+                </SwitchField>
 
                 <Button
                   variant="ghost"

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -356,9 +356,17 @@ describe("GithubChecksRoute availability gate", () => {
     mockRepos.value = [ROW];
     renderRoute();
 
-    expect(screen.getByText("Checks")).toBeInTheDocument();
-    expect(screen.getByText("Conformance")).toBeInTheDocument();
-    expect(screen.getByText("Comments")).toBeInTheDocument();
+    // `toBeVisible`, not `toBeInTheDocument`: the claim is that a sighted user
+    // can READ these. `aria-hidden` does not affect it — that hides them from
+    // the accessibility tree, not from the screen.
+    //
+    // Its reach is narrower than it looks, though, and worth knowing before
+    // trusting it: jsdom loads no stylesheet, so a caption hidden by a utility
+    // class still passes here. It catches an inline `display: none` or the
+    // `hidden` attribute, and nothing a class could do. Verified both ways.
+    expect(screen.getByText("Checks")).toBeVisible();
+    expect(screen.getByText("Conformance")).toBeVisible();
+    expect(screen.getByText("Comments")).toBeVisible();
   });
 
   it("keeps each caption inside its switch's accessible name", () => {

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -342,6 +342,76 @@ describe("GithubChecksRoute availability gate", () => {
     });
   });
 
+  // ═════════════════════════════════════════════════════════════════════════
+  // THE SWITCHES SAY WHICH IS WHICH
+  // ═════════════════════════════════════════════════════════════════════════
+  //
+  // Three bare switches sat in a row with no visible names — only a sighted
+  // user who already knew the order could tell checks from conformance from
+  // comments, on a page that decides what runs on other people's pull
+  // requests.
+
+  it("names every switch on screen, not just for a screen reader", () => {
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = [ROW];
+    renderRoute();
+
+    expect(screen.getByText("Checks")).toBeInTheDocument();
+    expect(screen.getByText("Conformance")).toBeInTheDocument();
+    expect(screen.getByText("Comments")).toBeInTheDocument();
+  });
+
+  it("keeps each caption inside its switch's accessible name", () => {
+    // WCAG 2.5.3. A visible label that is not part of the accessible name
+    // leaves a speech-input user saying a word the control does not answer
+    // to — which is why the third caption is "Comments" and not "PR
+    // comments". Renaming a caption without renaming its `aria-label` breaks
+    // this and nothing else would catch it.
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = [ROW];
+    renderRoute();
+
+    const pairs: Array<[string, string]> = [
+      ["Checks", "Enable checks for mcpjam/mcp-check-fixture"],
+      [
+        "Conformance",
+        "Enable conformance check for mcpjam/mcp-check-fixture",
+      ],
+      [
+        "Comments",
+        "Post feedback comments on pull requests for mcpjam/mcp-check-fixture",
+      ],
+    ];
+
+    for (const [caption, accessibleName] of pairs) {
+      expect(screen.getByLabelText(accessibleName)).toBeInTheDocument();
+      expect(accessibleName.toLowerCase()).toContain(caption.toLowerCase());
+    }
+  });
+
+  it("dims the conformance caption with the switch it belongs to", () => {
+    // Conformance is a SUB-SETTING of checks: its switch has always been
+    // disabled while checks are off. A caption at full strength beside a dead
+    // control reads as a bug rather than a rule.
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = [{ ...ROW, enabled: false }];
+    renderRoute();
+
+    expect(
+      screen.getByLabelText(
+        "Enable conformance check for mcpjam/mcp-check-fixture",
+      ),
+    ).toBeDisabled();
+    expect(screen.getByText("Conformance").className).toContain(
+      "text-muted-foreground/50",
+    );
+    // Comments is NOT gated on `enabled` — it decides what MCPJam may write,
+    // not whether it runs — so it must stay at full strength here.
+    expect(screen.getByText("Comments").className).not.toContain(
+      "text-muted-foreground/50",
+    );
+  });
+
   it("the conformance switch is off by default and opt-in", () => {
     mockAvailability.value = { state: "enabled" };
     mockRepos.value = [ROW];


### PR DESCRIPTION
- Each connected repo had three switches in a row with no labels — you couldn't tell checks from conformance from PR comments unless you already knew the order.
- Now each one has its name under it: Checks, Conformance, Comments.
- The conformance label greys out when checks are off, because that switch is already disabled in that state and nothing said why.
- Comments deliberately doesn't grey out — it controls what MCPJam writes on a PR, not whether checks run, so it still works while checks are paused.
- The labels are wired to match what screen readers announce, and there's a test so renaming one without the other fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds visible labels to the three per-repository switches (Checks, Conformance, Comments) so admins can tell them apart without already knowing the order.

- Dims the Conformance label when checks are off, matching its disabled switch.
- Keeps the Comments label at full strength since that switch controls what MCPJam writes, not whether checks run.
- Makes each caption a substring of its switch's `aria-label` (WCAG 2.5.3), with a test that fails if one is renamed without the other.
- Tests assert the captions are visible on screen, not merely present in the DOM.

<sup>Written for commit 22255370d91a80cbf511871b90cad8fdc4b9111d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

