### PR TITLE
Fix team checkout handoff routing

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2493,6 +2493,8 @@ export function HomeRoute() {
 export default function App() {
   const activeTab = useActiveTab();
   const currentOrgRoute = useCurrentOrgRoute();
+  const billingLocation = useCurrentLocationParts();
+  const navigate = useAppNavigate();
   const [hostsTabSelectedHostId, setHostsTabSelectedHostId] = useState<
     string | null
   >(null);
@@ -2518,8 +2520,8 @@ export default function App() {
   const [pendingProjectReturnRecovery, setPendingProjectReturnRecovery] =
     useState<ProjectSignInReturnRecoveryIntent | null>(null);
   const callbackReturnConsumedRef = useRef(false);
-  const billingDeepLinkNavRef = useRef(false);
-  /** True after we read valid plan/interval from the URL and stripped query params; avoids clearing session on the next /billing tick. */
+  const billingSignInStartedRef = useRef(false);
+  /** True after we read valid plan/interval from the current billing entry. */
   const billingCheckoutQueryConsumedRef = useRef(false);
   const [pendingCheckoutIntent, setPendingCheckoutIntent] =
     useState<CheckoutIntent | null>(() => getInitialPendingCheckoutIntent());
@@ -2927,6 +2929,16 @@ export default function App() {
       return;
     }
 
+    // A guest session is also Convex-authenticated. For billing returns, wait
+    // for AuthKit to expose the real WorkOS user before consuming the return;
+    // otherwise the guest identity can restore `/billing` and start the same
+    // sign-in flow again while the successful login is still settling.
+    const isBillingReturnWaitingForWorkOs =
+      !!readPersistedCheckoutIntent() &&
+      !!readBillingSignInReturnPath() &&
+      !workOsUser;
+    if (isBillingReturnWaitingForWorkOs) return;
+
     // Select the return exactly once after AuthKit + Convex auth settle. A
     // project-scoped return stays on `/callback` until the database user and
     // first authoritative membership response are ready below.
@@ -3301,6 +3313,7 @@ export default function App() {
       readProjectPathSegment(window.location.pathname) !== null);
   const shouldRouteToFirstRunOnboarding =
     !isHostedChatRoute &&
+    pendingCheckoutIntent === null &&
     !isBareCaniuseRoute &&
     !isLoginInitiationRoute &&
     !hasHostTemplateVerifyParam &&
@@ -4200,8 +4213,7 @@ export default function App() {
     clearBillingSignInReturnPath();
     clearCheckoutIntentFromUrl();
     setPendingCheckoutIntent(null);
-    billingDeepLinkNavRef.current = false;
-    billingCheckoutQueryConsumedRef.current = false;
+    billingSignInStartedRef.current = false;
   }, []);
 
   const handleCheckoutIntentNavigationStarted = useCallback(() => {
@@ -4213,77 +4225,93 @@ export default function App() {
     if (isDebugCallback) return;
     if (isHostedChatRoute) return;
 
-    const path = window.location.pathname;
+    const path = billingLocation.pathname;
     if (!isBillingEntryPathname(path)) {
       billingCheckoutQueryConsumedRef.current = false;
     }
 
-    if (window.location.pathname === "/callback") return;
+    if (path === "/callback") return;
 
     const onBillingEntry = isBillingEntryPathname(path);
+    let checkoutIntent = pendingCheckoutIntent;
 
     if (onBillingEntry) {
-      billingDeepLinkNavRef.current = false;
-      const search = window.location.search;
+      const search = billingLocation.search;
       const invalid =
         hasInvalidCheckoutQueryParams(search) ||
         hasInvalidCheckoutIntervalParam(search);
 
       if (invalid) {
-        clearPersistedCheckoutIntent();
-        clearBillingSignInReturnPath();
-        setPendingCheckoutIntent(null);
-        billingCheckoutQueryConsumedRef.current = false;
-      } else {
-        const fromUrl = readCheckoutIntentFromSearch(search);
-        if (fromUrl) {
-          persistCheckoutIntent(fromUrl);
-          setPendingCheckoutIntent(fromUrl);
-          billingCheckoutQueryConsumedRef.current = true;
-        } else if (!new URLSearchParams(search).has("plan")) {
-          const persistedIntent = readPersistedCheckoutIntent();
-          if (persistedIntent) {
-            billingCheckoutQueryConsumedRef.current = true;
-            if (
-              pendingCheckoutIntent?.plan !== persistedIntent.plan ||
-              pendingCheckoutIntent?.interval !== persistedIntent.interval
-            ) {
-              setPendingCheckoutIntent(persistedIntent);
-            }
-          } else if (!billingCheckoutQueryConsumedRef.current) {
-            clearPersistedCheckoutIntent();
-            clearBillingSignInReturnPath();
-            setPendingCheckoutIntent(null);
-          }
-        }
-      }
-
-      clearCheckoutIntentFromUrl();
-
-      if (!isAuthenticated) {
-        if (!isAuthLoading) {
-          writeBillingSignInReturnPath(path);
-          void signIn();
-        }
+        consumeCheckoutIntent();
+        navigate(routePaths.root, { replace: true, unscoped: true });
         return;
       }
 
-      if (path !== routePaths.root && path !== "") {
-        navigateApp(routePaths.root, { replace: true });
+      const fromUrl = readCheckoutIntentFromSearch(search);
+      if (fromUrl && !billingCheckoutQueryConsumedRef.current) {
+        checkoutIntent = fromUrl;
+        persistCheckoutIntent(fromUrl);
+        if (
+          pendingCheckoutIntent?.plan !== fromUrl.plan ||
+          pendingCheckoutIntent?.interval !== fromUrl.interval
+        ) {
+          setPendingCheckoutIntent(fromUrl);
+        }
+        billingCheckoutQueryConsumedRef.current = true;
+      } else if (fromUrl) {
+        // The URL hook can trail a same-tick replaceState while checkout is
+        // being consumed. Do not restore the intent from that stale render.
+        checkoutIntent = pendingCheckoutIntent;
+      } else if (!new URLSearchParams(search).has("plan")) {
+        const persistedIntent = readPersistedCheckoutIntent();
+        if (persistedIntent) {
+          checkoutIntent = persistedIntent;
+          billingCheckoutQueryConsumedRef.current = true;
+          if (
+            pendingCheckoutIntent?.plan !== persistedIntent.plan ||
+            pendingCheckoutIntent?.interval !== persistedIntent.interval
+          ) {
+            setPendingCheckoutIntent(persistedIntent);
+          }
+        } else if (!billingCheckoutQueryConsumedRef.current) {
+          consumeCheckoutIntent();
+          navigate(routePaths.root, { replace: true, unscoped: true });
+          return;
+        }
       }
     }
 
-    if (!isAuthenticated || isAuthLoading) return;
-    if (isLoadingOrganizations) return;
+    if (!checkoutIntent) {
+      billingSignInStartedRef.current = false;
+      return;
+    }
 
     if (billingEntitlementsUiEnabled === false) {
+      toast.error("Checkout isn't available in this environment.");
+      consumeCheckoutIntent();
       return;
     }
 
-    if (!pendingCheckoutIntent) {
-      billingDeepLinkNavRef.current = false;
+    // Convex guest sessions are authenticated too, so WorkOS is the source of
+    // truth for whether this actor may begin a paid checkout.
+    if (!workOsUser) {
+      if (isWorkOsLoading || billingSignInStartedRef.current) return;
+      billingSignInStartedRef.current = true;
+      writeBillingSignInReturnPath(routePaths.billing);
+      void Promise.resolve()
+        .then(() => signIn())
+        .catch(() => {
+          billingSignInStartedRef.current = false;
+          toast.error("Could not start sign in. Try again.");
+          consumeCheckoutIntent();
+        });
       return;
     }
+    billingSignInStartedRef.current = false;
+
+    if (!isAuthenticated || isAuthLoading) return;
+    if (!isUserReady || currentUser?.isAnonymous === true) return;
+    if (isLoadingOrganizations) return;
 
     const projectOrgId = activeProject?.organizationId;
     const orgId = resolveCheckoutOrganizationId(
@@ -4305,22 +4333,26 @@ export default function App() {
       return;
     }
 
-    if (billingDeepLinkNavRef.current) {
-      return;
-    }
-
-    navigateApp(buildOrganizationPath(orgId, "billing"));
-    billingDeepLinkNavRef.current = true;
+    // The current route is the retry guard. If another redirect wins after
+    // this navigation, the changed route reruns the effect and resumes the
+    // handoff instead of leaving a lifetime ref latched until reload.
+    navigate(buildOrganizationPath(orgId, "billing"), { replace: true });
   }, [
     activeOrganizationId,
     activeProject?.organizationId,
+    billingLocation.pathname,
+    billingLocation.search,
     billingEntitlementsUiEnabled,
     consumeCheckoutIntent,
+    currentUser?.isAnonymous,
     isAuthLoading,
     isAuthenticated,
     isDebugCallback,
     isHostedChatRoute,
     isLoadingOrganizations,
+    isUserReady,
+    isWorkOsLoading,
+    navigate,
     pendingCheckoutIntent,
     routeOrganizationId,
     routeOrganizationSection,
@@ -4799,10 +4831,6 @@ export default function App() {
     return <LoadingScreen />;
   }
 
-  if (isBillingEntryHandoff) {
-    return <BillingHandoffLoading />;
-  }
-
   if (isLoading && !isHostedChatRoute) {
     return <LoadingScreen />;
   }
@@ -4848,6 +4876,10 @@ export default function App() {
         email={workOsUser?.email}
       />
     );
+  }
+
+  if (isBillingEntryHandoff) {
+    return <BillingHandoffLoading />;
   }
 
   const shouldShowActiveServerSelector =

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -8,7 +8,10 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { toast as sonnerToast } from "sonner";
+import { RouterProvider } from "react-router";
 import App from "../App";
+import { createAppRouter } from "../router";
+import { setAppRouter } from "../router-ref";
 import {
   clearHostedOAuthPendingState,
   writeHostedOAuthPendingMarker,
@@ -1757,6 +1760,7 @@ describe("App hosted OAuth callback handling", () => {
   it("shows billing handoff loading and triggers sign-in for guest billing entry", async () => {
     clearHostedOAuthPendingState();
     clearScenarioSession();
+    mockUnseenOnboardingState();
     window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
 
     const signIn = vi.fn();
@@ -1766,22 +1770,32 @@ describe("App hosted OAuth callback handling", () => {
       user: null,
       isLoading: false,
     });
+    mockUseFeatureFlagEnabled.mockImplementation(
+      (flag: string) => flag === "billing-entitlements-ui",
+    );
     mockUseConvexAuth.mockReturnValue({
-      isAuthenticated: false,
+      // Hosted guests have a real Convex identity. WorkOS user presence, not
+      // this flag, must decide whether paid checkout needs sign-in.
+      isAuthenticated: true,
       isLoading: false,
     });
+    mockFreshGuestUser();
 
-    render(<App />);
+    const view = render(<App />);
 
     expect(screen.getByTestId("billing-handoff-loading")).toBeInTheDocument();
     await waitFor(() => {
       expect(signIn).toHaveBeenCalled();
     });
+    view.rerender(<App />);
+    expect(signIn).toHaveBeenCalledTimes(1);
     expect(readPersistedCheckoutIntent()).toEqual({
       plan: "team",
       interval: "annual",
     });
     expect(readBillingSignInReturnPath()).toBe("/billing");
+    expect(window.location.pathname).toBe("/billing");
+    expect(screen.queryByTestId("playground-tab")).not.toBeInTheDocument();
     expect(mockOrganizationsTab).not.toHaveBeenCalled();
   });
 
@@ -1789,9 +1803,10 @@ describe("App hosted OAuth callback handling", () => {
     clearHostedOAuthPendingState();
     clearScenarioSession();
     sessionStorage.clear();
-    persistCheckoutIntent({ plan: "team", interval: "annual" });
+    persistCheckoutIntent({ plan: "team", interval: "monthly" });
     writeBillingSignInReturnPath("/billing");
     window.history.replaceState({}, "", "/callback?code=oauth-code");
+    mockWorkOsAuthState.user = { id: "workos-user-1" };
 
     mockUseFeatureFlagEnabled.mockImplementation(
       (flag: string) => flag === "billing-entitlements-ui",
@@ -1822,6 +1837,51 @@ describe("App hosted OAuth callback handling", () => {
       expect(screen.getByTestId("billing-handoff-overlay")).toBeInTheDocument();
     });
     expect(readBillingSignInReturnPath()).toBeNull();
+  });
+
+  it("waits for the WorkOS user before restoring a guest billing callback", async () => {
+    clearHostedOAuthPendingState();
+    clearScenarioSession();
+    sessionStorage.clear();
+    persistCheckoutIntent({ plan: "team", interval: "monthly" });
+    writeBillingSignInReturnPath("/billing");
+    window.history.replaceState({}, "", "/callback?code=oauth-code");
+    mockConvexAuthState.isAuthenticated = true;
+    mockWorkOsAuthState.user = null;
+    mockUseFeatureFlagEnabled.mockImplementation(
+      (flag: string) => flag === "billing-entitlements-ui",
+    );
+    mockUseQuery.mockImplementation((name: string) => {
+      if (name === "organizations:getMyOrganizations") {
+        return [
+          {
+            _id: "org-1",
+            name: "Org One",
+            updatedAt: 1,
+            createdAt: 1,
+            createdBy: "user-1",
+            myRole: "owner",
+          },
+        ];
+      }
+      return name === "users:getCurrentUser" ? existingConvexUser : undefined;
+    });
+
+    const view = render(<App />);
+
+    expect(window.location.pathname).toBe("/callback");
+    expect(readBillingSignInReturnPath()).toBe("/billing");
+
+    mockWorkOsAuthState.user = { id: "workos-user-1" };
+    view.rerender(<App />);
+
+    await waitFor(() =>
+      expect(window.location.pathname).toBe("/organizations/org-1/billing"),
+    );
+    expect(readPersistedCheckoutIntent()).toEqual({
+      plan: "team",
+      interval: "monthly",
+    });
   });
 
   it("falls back to the default callback destination when billing session intent is missing", async () => {
@@ -2300,6 +2360,7 @@ describe("App hosted OAuth callback handling", () => {
     sessionStorage.clear();
     persistCheckoutIntent({ plan: "team", interval: "annual" });
     window.history.replaceState({}, "", "/billing");
+    mockWorkOsAuthState.user = { id: "workos-user-1" };
 
     mockUseFeatureFlagEnabled.mockImplementation(
       (flag: string) => flag === "billing-entitlements-ui",
@@ -2360,6 +2421,7 @@ describe("App hosted OAuth callback handling", () => {
     writeBillingSignInReturnPath("/billing");
     writeScenarioSignInReturnPath("/user-testing/demo/token-123");
     window.history.replaceState({}, "", "/callback?code=oauth-code");
+    mockWorkOsAuthState.user = { id: "workos-user-1" };
 
     const replaceStateSpy = vi.spyOn(window.history, "replaceState");
 
@@ -2378,6 +2440,7 @@ describe("App hosted OAuth callback handling", () => {
     clearHostedOAuthPendingState();
     clearScenarioSession();
     window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
+    mockWorkOsAuthState.user = { id: "workos-user-1" };
 
     mockUseFeatureFlagEnabled.mockImplementation(
       (flag: string) => flag === "billing-entitlements-ui",
@@ -2407,6 +2470,7 @@ describe("App hosted OAuth callback handling", () => {
       expect(screen.getByTestId("billing-handoff-overlay")).toBeInTheDocument();
       expect(mockOrganizationsTab).toHaveBeenCalled();
     });
+    expect(window.location.pathname).toBe("/organizations/org-1/billing");
 
     expect(
       mockOrganizationsTab.mock.calls.some(
@@ -2432,10 +2496,101 @@ describe("App hosted OAuth callback handling", () => {
     ).toBe(true);
   });
 
+  it("stays on /billing until signed-in organization data is ready", async () => {
+    clearHostedOAuthPendingState();
+    clearScenarioSession();
+    window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
+    mockWorkOsAuthState.user = { id: "workos-user-1" };
+    mockUseFeatureFlagEnabled.mockImplementation(
+      (flag: string) => flag === "billing-entitlements-ui",
+    );
+    let organizationsLoaded = false;
+    mockUseQuery.mockImplementation((name: string) => {
+      if (name === "users:getCurrentUser") return existingConvexUser;
+      if (name === "organizations:getMyOrganizations") {
+        return organizationsLoaded
+          ? [
+              {
+                _id: "org-1",
+                name: "Org One",
+                updatedAt: 1,
+                createdAt: 1,
+                createdBy: "user-1",
+                myRole: "owner",
+              },
+            ]
+          : undefined;
+      }
+      return undefined;
+    });
+
+    const view = render(<App />);
+
+    expect(window.location.pathname).toBe("/billing");
+    expect(screen.getByTestId("billing-handoff-loading")).toBeInTheDocument();
+
+    organizationsLoaded = true;
+    view.rerender(<App />);
+
+    await waitFor(() =>
+      expect(window.location.pathname).toBe("/organizations/org-1/billing"),
+    );
+  });
+
+  it("retries checkout when another route interrupts billing navigation", async () => {
+    clearHostedOAuthPendingState();
+    clearScenarioSession();
+    window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
+    mockWorkOsAuthState.user = { id: "workos-user-1" };
+    mockUseFeatureFlagEnabled.mockImplementation(
+      (flag: string) => flag === "billing-entitlements-ui",
+    );
+    mockUseQuery.mockImplementation((name: string) => {
+      if (name === "organizations:getMyOrganizations") {
+        return [
+          {
+            _id: "org-1",
+            name: "Org One",
+            updatedAt: 1,
+            createdAt: 1,
+            createdBy: "user-1",
+            myRole: "owner",
+          },
+        ];
+      }
+      return name === "users:getCurrentUser" ? existingConvexUser : undefined;
+    });
+
+    const router = createAppRouter();
+    const view = render(<RouterProvider router={router} />);
+    try {
+      await waitFor(() =>
+        expect(window.location.pathname).toBe("/organizations/org-1/billing"),
+      );
+
+      await act(async () => {
+        await router.navigate("/home");
+      });
+
+      await waitFor(() =>
+        expect(window.location.pathname).toBe("/organizations/org-1/billing"),
+      );
+      expect(readPersistedCheckoutIntent()).toEqual({
+        plan: "team",
+        interval: "annual",
+      });
+    } finally {
+      view.unmount();
+      router.dispose();
+      setAppRouter(null);
+    }
+  });
+
   it("drops the billing overlay when checkout intent is consumed", async () => {
     clearHostedOAuthPendingState();
     clearScenarioSession();
     window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
+    mockWorkOsAuthState.user = { id: "workos-user-1" };
 
     mockUseFeatureFlagEnabled.mockImplementation(
       (flag: string) => flag === "billing-entitlements-ui",
@@ -2488,6 +2643,7 @@ describe("App hosted OAuth callback handling", () => {
     clearHostedOAuthPendingState();
     clearScenarioSession();
     window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
+    mockWorkOsAuthState.user = { id: "workos-user-1" };
 
     mockUseFeatureFlagEnabled.mockImplementation(
       (flag: string) => flag === "billing-entitlements-ui",
@@ -2543,6 +2699,7 @@ describe("App hosted OAuth callback handling", () => {
     clearHostedOAuthPendingState();
     clearScenarioSession();
     window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
+    mockWorkOsAuthState.user = { id: "workos-user-1" };
 
     mockUseFeatureFlagEnabled.mockImplementation(
       (flag: string) => flag === "billing-entitlements-ui",
@@ -2558,16 +2715,46 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(screen.getByTestId("home-tab")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("billing-handoff-loading"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("billing-handoff-overlay"),
+      ).not.toBeInTheDocument();
     });
+    expect(mockOrganizationsTab).not.toHaveBeenCalled();
+  });
 
+  it("clears billing handoff state when billing is unavailable", async () => {
+    clearHostedOAuthPendingState();
+    clearScenarioSession();
+    window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
+    mockWorkOsAuthState.user = { id: "workos-user-1" };
+    mockUseFeatureFlagEnabled.mockReturnValue(false);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("billing-handoff-loading"),
+      ).not.toBeInTheDocument();
+      expect(readPersistedCheckoutIntent()).toBeNull();
+    });
+    expect(sonnerToast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves billing usable when checkout parameters are invalid", async () => {
+    clearHostedOAuthPendingState();
+    clearScenarioSession();
+    window.history.replaceState({}, "", "/billing?plan=team&interval=weekly");
+
+    render(<App />);
+
+    await waitFor(() => expect(window.location.pathname).toBe("/"));
+    expect(readPersistedCheckoutIntent()).toBeNull();
     expect(
       screen.queryByTestId("billing-handoff-loading"),
     ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId("billing-handoff-overlay"),
-    ).not.toBeInTheDocument();
-    expect(mockOrganizationsTab).not.toHaveBeenCalled();
   });
 
   it("renders the organization route from the hash even before active org state catches up", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the team checkout handoff routing so billing returns after OAuth sign-in land on the correct organization billing page instead of restarting sign-in.

- Billing handoff now waits for the WorkOS user to appear before consuming the return, preventing guest sessions from re-triggering sign-in.
- Invalid checkout parameters now redirect to the root instead of leaving billing in a broken state.
- The handoff retries navigation when another route interrupts it, using route changes as the retry guard.

<sup>Written for commit 5e7ca4c1202fc67328fbae3de49833469e7106b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

