### PR TITLE
workos: test the AuthKit and API-key paths against a real API surface

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,14 +36,14 @@ Also join our [Discord channel](https://discord.com/invite/JEnDtz8X6z). That's w
 
 This is an **npm workspaces monorepo**. The main packages are:
 
-| Workspace | Package | Description |
-|-----------|---------|-------------|
-| `mcpjam-inspector/` | `@mcpjam/inspector` | Inspector app (client, server, Electron) |
-| `sdk/` | `@mcpjam/sdk` | MCP SDK for testing and evals |
-| `cli/` | `@mcpjam/cli` | CLI tool |
-| `design-system/` | `@mcpjam/design-system` | Shared UI components |
-| `soundcheck/` | `@mcpjam/soundcheck` | Soundcheck app |
-| `mcp/` | `@mcpjam/mcp` | MCP worker |
+| Workspace           | Package                 | Description                              |
+| ------------------- | ----------------------- | ---------------------------------------- |
+| `mcpjam-inspector/` | `@mcpjam/inspector`     | Inspector app (client, server, Electron) |
+| `sdk/`              | `@mcpjam/sdk`           | MCP SDK for testing and evals            |
+| `cli/`              | `@mcpjam/cli`           | CLI tool                                 |
+| `design-system/`    | `@mcpjam/design-system` | Shared UI components                     |
+| `soundcheck/`       | `@mcpjam/soundcheck`    | Soundcheck app                           |
+| `mcp/`              | `@mcpjam/mcp`           | MCP worker                               |
 
 Most contributions target the `mcpjam-inspector/` workspace.
 
@@ -146,6 +146,34 @@ npm run test -w @mcpjam/inspector
 npm run test -w @mcpjam/sdk
 npm run test -w @mcpjam/cli
 ```
+
+#### WorkOS contract tests
+
+The suites named `server/**/*.emulator.test.ts` boot
+[`@workos/emulate`](https://github.com/workos/emulate) — WorkOS's own in-memory
+API server — in-process and drive the real code paths against it, rather than
+stubbing `fetch` and mocking token verification. That is what lets them assert
+things only WorkOS can settle: that a spent refresh token is refused, that a
+revoked API key stops validating immediately, that a forged JWT fails against
+the issuer's real JWKS.
+
+```bash
+npm run test -w @mcpjam/inspector -- server/routes/web/__tests__/api-keys.emulator.test.ts
+```
+
+Each file starts its own emulator on port 0 in `beforeAll`, so nothing special
+is needed in CI and the six shards cannot collide. The helper
+(`server/test/support/workos-emulator.ts`) sets `WORKOS_API_BASE_URL` and the
+other env itself — do not export that variable from your shell, and see
+`mcpjam-inspector/HOSTED_DEPLOYMENT.md` for why it is loopback-only.
+
+Requires **Node >= 22.11** (the emulator's floor; CI runs 24.x). The helper says
+so explicitly rather than failing with a stack trace on an older runtime.
+
+The pre-existing mocked suites (`api-keys.test.ts`, `bearer-auth.test.ts`,
+`workos-authkit.test.ts`) are still the right place for logic that does not need
+a server — they are faster, and they are also the regression guard proving the
+default path still points at `api.workos.com`.
 
 ## Code Style
 

--- a/mcpjam-inspector/AGENTS.md
+++ b/mcpjam-inspector/AGENTS.md
@@ -25,7 +25,7 @@ logger.debug("Processing request", requestData);
 - `logger.error` → Sentry **and** Axiom. This is the server's single Sentry
   capture path for free-form errors. `logger.ts` owns every
   `Sentry.captureException` call in the server; the error-origin policy
-  (`error-origin-capture.ts`) decides *whether* to capture and then calls
+  (`error-origin-capture.ts`) decides _whether_ to capture and then calls
   `captureOriginErrorToSentry` here, so there is one policy module and one
   mechanism, not two of each.
 - Route catch-sites use `reportRouteFailure` (`utils/route-error-report.ts`),
@@ -87,6 +87,7 @@ Tests live in `__tests__/` directories next to source files. Use existing tests 
 - **Factories** (`client/src/test/factories.ts`): `createServer()`, `createTool()`, `createMany()`, etc.
 - **Mock presets** (`client/src/test/mocks/`): `mcpApiPresets`, `storePresets`
 - **Server helpers** (`server/routes/mcp/__tests__/helpers/`): `createTestApp()`, `createMockMcpClientManager()`, `postJson()`, `expectError()`
+- **WorkOS emulator** (`server/test/support/workos-emulator.ts`): `startWorkosEmulator()`, `loginWithPkce()`, `mintUserApiKey()`. The `*.emulator.test.ts` suites drive the real WorkOS paths against a local `@workos/emulate` server instead of stubbing `fetch` — use them when the assertion depends on what WorkOS actually does (a rotated refresh token, a revoked key, a real JWKS). One emulator per file on port 0; see the WorkOS contract tests section in `../CONTRIBUTING.md`.
 
 ### Checklist
 

--- a/mcpjam-inspector/HOSTED_DEPLOYMENT.md
+++ b/mcpjam-inspector/HOSTED_DEPLOYMENT.md
@@ -162,3 +162,37 @@ Use a local or explicitly approved non-production environment for verification;
 temporary test values must not be persisted into deployment configuration.
 Before expanding beyond debugger use, track KMS-backed signing or stored
 per-organization keys with dual-key rotation.
+
+## WorkOS API base URL (tests and local development only)
+
+`WORKOS_API_BASE_URL` redirects every server-side WorkOS call — the AuthKit
+session proxy, `sk_` API-key validation, and the key-management routes — at a
+local [`@workos/emulate`](https://github.com/workos/emulate) instance instead of
+`api.workos.com`. The `*.emulator.test.ts` suites set it themselves; you would
+only set it by hand to run the inspector against an emulator locally.
+
+**Never set it on a deployment.** It accepts loopback origins only —
+`localhost`, `127.0.0.1`, `[::1]` — and any other value makes the server throw
+at boot rather than at a user's first sign-in:
+
+```
+WORKOS_API_BASE_URL must be a loopback http(s) origin such as
+http://127.0.0.1:4820 (got "https://example.com")
+```
+
+The restriction is a mechanism, not a convention. `WORKOS_API_KEY` — the admin
+key that mints and revokes API keys — travels in an `Authorization` header on
+every one of those requests, so a base URL naming another host would send it
+there. Railway makes that worse than it sounds: preview environments are
+duplicated from staging wholesale (`pr-preview.yml`), and
+`.github/scripts/railway-set-vars.sh` can only set a variable, never unset one.
+A value written once to staging would therefore reach every future preview with
+no way to withdraw it. Refusing the value in code is the only durable defence.
+
+Unset — which is every deployment — the resolver returns `https://api.workos.com`
+and the SDK client is constructed with no options at all, exactly as it was
+before this variable existed.
+
+Not to be confused with `WORKOS_API_HOSTNAME`, which is a _browser_-facing
+hostname served in `window.__MCP_RUNTIME_CONFIG__` for `@workos-inc/authkit-js`.
+That one is unrelated and is documented by its use in `server/env.ts`.

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -245,6 +245,7 @@
     "@typescript-eslint/parser": "^8.68.0",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "^3.2.7",
+    "@workos/emulate": "0.12.0",
     "autoprefixer": "^10.5.4",
     "concurrently": "^9.1.0",
     "cross-env": "^10.1.0",

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -36,6 +36,7 @@ import { registerXaaClientMetadataRoute } from "./routes/xaa-client-metadata.js"
 import { registerXaaConfidentialCimdRoute } from "./routes/xaa-confidential-cimd.js";
 import { createXaaWebRouter } from "./routes/web/xaa.js";
 import workosAuthkitRoutes from "./routes/workos-authkit.js";
+import { resolveWorkosApiBaseUrl } from "./services/workos-api-base.js";
 import { MCPClientManager } from "@mcpjam/sdk";
 import { initElicitationCallback } from "./routes/mcp/elicitation.js";
 import { rpcLogBus } from "./services/rpc-log-bus.js";
@@ -429,6 +430,12 @@ export async function createHonoApp() {
     }),
   );
   app.route("/api/v1", v1Routes);
+
+  // Fail the deploy, not the user's first sign-in: `WORKOS_API_BASE_URL` is a
+  // loopback-only test hook, and this is the earliest point that can refuse a
+  // value which would otherwise send the admin API key to another host. Unset
+  // (every deployment) this is a no-op.
+  resolveWorkosApiBaseUrl(process.env);
 
   // Mounted in every runtime, hosted included — see the mirror of this mount
   // in server/index.ts for why the gate had to go.

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -182,6 +182,7 @@ import { registerXaaClientMetadataRoute } from "./routes/xaa-client-metadata";
 import { registerXaaConfidentialCimdRoute } from "./routes/xaa-confidential-cimd";
 import { createXaaWebRouter } from "./routes/web/xaa";
 import workosAuthkitRoutes from "./routes/workos-authkit";
+import { resolveWorkosApiBaseUrl } from "./services/workos-api-base.js";
 import { rpcLogBus } from "./services/rpc-log-bus";
 import { tunnelManager } from "./services/tunnel-manager";
 import { shutdownRunningJourneyRuns } from "./services/sessionSimulation/swarm-runner";
@@ -633,6 +634,11 @@ app.route("/api/v1", v1Routes);
 // Slack account-link bridge (mirror of the mount in server/app.ts).
 app.route("/api/slack/link", slackLinkRoutes);
 app.route("/api/surface-link", surfaceLinkRoutes);
+
+// Same fail-fast as server/app.ts: refuse a non-loopback `WORKOS_API_BASE_URL`
+// at boot rather than at the first WorkOS call. Unset — every deployment — this
+// is a no-op.
+resolveWorkosApiBaseUrl(process.env);
 
 // Mounted in EVERY runtime, hosted included. AuthKit's `initialize()` makes no
 // network call at all unless the page's own cookies carry `workos-has-session`

--- a/mcpjam-inspector/server/middleware/__tests__/bearer-auth.emulator.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/bearer-auth.emulator.test.ts
@@ -1,0 +1,213 @@
+/**
+ * The `sk_` branch of bearer auth, against a real WorkOS API.
+ *
+ * The sibling suite (`bearer-auth.test.ts`) replaces the SDK entirely:
+ *
+ *   vi.mock("../../services/workos-client.js", () => ({
+ *     getWorkOSClient: () => ({ apiKeys: { createValidation: mock } }),
+ *   }));
+ *
+ * That is the right shape for the rate-limiter and orphan-binding cases it
+ * covers, and it cannot tell us whether `createValidation` is called correctly
+ * or whether a revoked key stops validating — the mock answers whatever the
+ * test told it to. Here the SDK is REAL and the key is one the emulator
+ * actually minted, so "valid key" means WorkOS said so.
+ *
+ * Identity and org-binding lookups stay mocked: both are HTTP calls to the
+ * Convex backend, which is a different service and out of scope.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { Hono } from "hono";
+
+const { resolveUserByExternalIdMock, lookupWorkosKeyBindingMock } = vi.hoisted(
+  () => ({
+    resolveUserByExternalIdMock: vi.fn(),
+    lookupWorkosKeyBindingMock: vi.fn(),
+  }),
+);
+
+vi.mock("../../services/identity.js", () => ({
+  resolveUserByExternalId: resolveUserByExternalIdMock,
+}));
+
+vi.mock("../../services/workos-key-bindings.js", () => ({
+  lookupWorkosKeyBinding: lookupWorkosKeyBindingMock,
+}));
+
+// Only the sk_ branch is under test; the real guest validator does network I/O.
+vi.mock("../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: vi.fn(async () => ({
+    valid: false,
+    reason: "not_guest",
+  })),
+}));
+
+import {
+  bearerAuthMiddleware,
+  resetWorkOSRateLimitForTests,
+} from "../bearer-auth.js";
+import {
+  SEED,
+  emulatorRest,
+  mintUserApiKey,
+  startWorkosEmulator,
+  type WorkosEmulatorHandle,
+} from "../../test/support/workos-emulator.js";
+
+let h: WorkosEmulatorHandle;
+let key: { id: string; value: string };
+
+beforeAll(async () => {
+  h = await startWorkosEmulator();
+  key = await mintUserApiKey(h, {
+    userId: SEED.user.id,
+    organizationId: SEED.org.id,
+  });
+}, 30_000);
+
+afterAll(async () => {
+  await h?.close();
+});
+
+beforeEach(() => {
+  resolveUserByExternalIdMock.mockReset();
+  lookupWorkosKeyBindingMock.mockReset();
+  resolveUserByExternalIdMock.mockResolvedValue({ _id: "mcpjam_user_1" });
+  lookupWorkosKeyBindingMock.mockResolvedValue({
+    mcpjamOrganizationId: "org_convex_1",
+  });
+  resetWorkOSRateLimitForTests();
+});
+
+function createApp(): Hono {
+  const app = new Hono();
+  app.use("*", bearerAuthMiddleware);
+  app.get("/test", (c) =>
+    c.json({
+      authMethod: c.get("authMethod") ?? null,
+      workosApiKeyId: c.get("workosApiKeyId") ?? null,
+      workosUserId: c.get("workosUserId") ?? null,
+      mcpjamUserId: c.get("mcpjamUserId") ?? null,
+      mcpjamOrganizationId: c.get("mcpjamOrganizationId") ?? null,
+    }),
+  );
+  return app;
+}
+
+const request = (token: string) =>
+  createApp().request("/test", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+describe("sk_ validation against a real WorkOS", () => {
+  it("admits a key WorkOS recognises and populates the request context", async () => {
+    const res = await request(key.value);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      authMethod: "workos_api_key",
+      workosApiKeyId: key.id,
+      // The owner id comes back from WorkOS, not from our own fixture — which
+      // is what makes this a check of the call and not of the test.
+      workosUserId: SEED.user.id,
+      mcpjamUserId: "mcpjam_user_1",
+      mcpjamOrganizationId: "org_convex_1",
+    });
+    expect(resolveUserByExternalIdMock).toHaveBeenCalledWith(SEED.user.id);
+    expect(lookupWorkosKeyBindingMock).toHaveBeenCalledWith(key.id);
+  }, 30_000);
+
+  it("rejects a well-formed key WorkOS has never issued", async () => {
+    const res = await request("sk_test_never_issued");
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ message: "Invalid API key" });
+    // Nothing downstream should be consulted for a key that does not exist.
+    expect(resolveUserByExternalIdMock).not.toHaveBeenCalled();
+  }, 30_000);
+
+  it("stops admitting a key the moment it is revoked", async () => {
+    // No cross-request caching of a validation result: revocation has to take
+    // effect immediately, not at the next deploy.
+    const revocable = await mintUserApiKey(h, {
+      userId: SEED.user.id,
+      organizationId: SEED.org.id,
+      name: "revocable",
+    });
+    expect((await request(revocable.value)).status).toBe(200);
+
+    const { status } = await emulatorRest(
+      h,
+      "DELETE",
+      `/api_keys/${revocable.id}`,
+    );
+    expect(status).toBe(204);
+
+    expect((await request(revocable.value)).status).toBe(401);
+  }, 30_000);
+
+  it("fails closed when WorkOS is down, and recovers when it returns", async () => {
+    const hook = h.emulator.addErrorHook({
+      method: "POST",
+      path: "/api_keys/validations",
+      status: 503,
+    });
+    try {
+      const res = await request(key.value);
+      expect(res.status).toBe(401);
+      expect(await res.json()).toMatchObject({ message: "Invalid API key" });
+    } finally {
+      h.emulator.removeErrorHook(hook.id);
+    }
+
+    // The outage must not be sticky — the same key works once WorkOS answers.
+    expect((await request(key.value)).status).toBe(200);
+  }, 30_000);
+
+  it("reports an upstream rate limit as an invalid key", async () => {
+    // Pinning CURRENT behaviour, not endorsing it: a 429 from WorkOS reaches
+    // the caller as 401 "Invalid API key", which is indistinguishable from a
+    // revoked key and will send them to rotate a credential that is fine. Our
+    // OWN per-key limit is the separate 429 covered in bearer-auth.test.ts.
+    // Worth fixing; deliberately not folded into a test-infrastructure change.
+    const hook = h.emulator.addErrorHook({
+      method: "POST",
+      path: "/api_keys/validations",
+      status: 429,
+    });
+    try {
+      const res = await request(key.value);
+      expect(res.status).toBe(401);
+    } finally {
+      h.emulator.removeErrorHook(hook.id);
+    }
+  }, 30_000);
+
+  it("rejects a valid key that is bound to no organization", async () => {
+    lookupWorkosKeyBindingMock.mockResolvedValue(null);
+
+    const res = await request(key.value);
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({
+      details: { reason: "ORPHANED_KEY" },
+    });
+  }, 30_000);
+
+  it("rejects a valid key whose WorkOS user has no MCPJam account", async () => {
+    resolveUserByExternalIdMock.mockResolvedValue(null);
+
+    const res = await request(key.value);
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ message: "Unknown user" });
+  }, 30_000);
+});

--- a/mcpjam-inspector/server/routes/__tests__/workos-authkit.emulator.test.ts
+++ b/mcpjam-inspector/server/routes/__tests__/workos-authkit.emulator.test.ts
@@ -1,0 +1,257 @@
+/**
+ * The AuthKit session bridge (`server/routes/workos-authkit.ts`) driven end to
+ * end against a real WorkOS API.
+ *
+ * The sibling suite stubs `global.fetch` and hands the route a canned
+ * `{ access_token, refresh_token }`, which is enough to prove the cookie jar is
+ * written and is silent on everything the proxy exists for: that a PKCE code
+ * actually exchanges, that the token it returns verifies against the issuer's
+ * JWKS, that a refresh really rotates, and that replaying a spent refresh token
+ * is refused so the jar gets cleared. Those are all WorkOS behaviours, and a
+ * stub can only assert we believe in them.
+ *
+ * Requests target `http://localhost:6274` deliberately: that is what
+ * `isLocalHttpUrl` keys the multi-origin cookie jar off, and the hosted branch
+ * writes a different cookie entirely.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { decodeJwt } from "jose";
+import workosAuthkitRoutes from "../workos-authkit.js";
+import { verifyAuthKitToken } from "../../services/authkit-jwt.js";
+import {
+  SEED,
+  cookieHeaderFrom,
+  createPkcePair,
+  setCookieFor,
+  startWorkosEmulator,
+  type WorkosEmulatorHandle,
+} from "../../test/support/workos-emulator.js";
+
+const ORIGIN = "http://localhost:6274";
+const REDIRECT_URI = `${ORIGIN}/callback`;
+const SESSION_COOKIE = "mcpjam_workos_sessions";
+const HAS_SESSION_COOKIE = "workos-has-session";
+
+let h: WorkosEmulatorHandle;
+
+beforeAll(async () => {
+  h = await startWorkosEmulator();
+}, 30_000);
+
+afterAll(async () => {
+  await h?.close();
+});
+
+function createApp(): Hono {
+  const app = new Hono();
+  app.route("/user_management", workosAuthkitRoutes);
+  return app;
+}
+
+/** Front-channel through the proxy, ending at the code the callback receives. */
+async function authorizeThroughProxy(app: Hono, state = "test-state") {
+  const { verifier, challenge } = createPkcePair();
+  const query = new URLSearchParams({
+    client_id: h.clientId,
+    redirect_uri: REDIRECT_URI,
+    response_type: "code",
+    provider: "authkit",
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+    state,
+    login_hint: SEED.user.email,
+  });
+
+  const redirect = await app.request(
+    `${ORIGIN}/user_management/authorize?${query.toString()}`,
+  );
+  const location = redirect.headers.get("location");
+  if (!location) throw new Error(`no redirect: ${redirect.status}`);
+
+  const upstream = await fetch(location, { redirect: "manual" });
+  const callback = new URL(upstream.headers.get("location") ?? "");
+  return { verifier, redirect, location, callback };
+}
+
+async function exchangeThroughProxy(
+  app: Hono,
+  args: { code: string; verifier: string },
+) {
+  return app.request(`${ORIGIN}/user_management/authenticate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_id: h.clientId,
+      grant_type: "authorization_code",
+      code: args.code,
+      code_verifier: args.verifier,
+    }),
+  });
+}
+
+describe("authorize", () => {
+  it("forwards the browser to WorkOS with the query intact", async () => {
+    const app = createApp();
+    const { redirect, location, callback } = await authorizeThroughProxy(
+      app,
+      "xyz",
+    );
+
+    expect(redirect.status).toBe(302);
+    const forwarded = new URL(location);
+    expect(`${forwarded.origin}${forwarded.pathname}`).toBe(
+      `${h.url}/user_management/authorize`,
+    );
+    // The PKCE challenge and client id must survive the hop, or the exchange
+    // below fails with an error that looks like a client bug.
+    expect(forwarded.searchParams.get("client_id")).toBe(h.clientId);
+    expect(forwarded.searchParams.get("code_challenge_method")).toBe("S256");
+
+    // ...and WorkOS sends the browser back to us with a code.
+    expect(callback.origin).toBe(ORIGIN);
+    expect(callback.pathname).toBe("/callback");
+    expect(callback.searchParams.get("code")).toEqual(expect.any(String));
+    expect(callback.searchParams.get("state")).toBe("xyz");
+  }, 30_000);
+});
+
+describe("code exchange", () => {
+  it("returns a verifiable session and stores the refresh token in an HttpOnly cookie", async () => {
+    const app = createApp();
+    const { verifier, callback } = await authorizeThroughProxy(app);
+
+    const res = await exchangeThroughProxy(app, {
+      code: callback.searchParams.get("code")!,
+      verifier,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      access_token: string;
+      refresh_token: string;
+      user: { email: string };
+    };
+    expect(body.user.email).toBe(SEED.user.email);
+
+    // The issuer is the one `authkitIssuerJwks` already trusts, and the JWKS
+    // now resolves through WORKOS_API_BASE_URL — so this proves the token our
+    // own verifier accepts is the token the flow actually produced.
+    const claims = decodeJwt(body.access_token);
+    expect(claims.iss).toBe(
+      `https://api.workos.com/user_management/${h.clientId}`,
+    );
+    expect(claims.aud).toBe(h.clientId);
+    await expect(verifyAuthKitToken(body.access_token)).resolves.toMatchObject({
+      sub: SEED.user.id,
+    });
+
+    // The refresh token must not be readable by scripts on the page; that is
+    // the entire reason this proxy holds it instead of the browser.
+    expect(setCookieFor(res, SESSION_COOKIE)).toContain("HttpOnly");
+    expect(setCookieFor(res, HAS_SESSION_COOKIE)).toContain(
+      `${HAS_SESSION_COOKIE}=true`,
+    );
+  }, 30_000);
+});
+
+describe("refresh", () => {
+  it("rotates on a cookie-only refresh, and clears the jar when a spent token is replayed", async () => {
+    const app = createApp();
+    const { verifier, callback } = await authorizeThroughProxy(app);
+    const exchanged = await exchangeThroughProxy(app, {
+      code: callback.searchParams.get("code")!,
+      verifier,
+    });
+    const firstJar = cookieHeaderFrom(exchanged, [SESSION_COOKIE]);
+    const firstBody = (await exchanged.json()) as { refresh_token: string };
+
+    // No refresh_token in the body: the whole point is that the client does
+    // not hold one and the proxy supplies it from the cookie.
+    const refreshed = await app.request(
+      `${ORIGIN}/user_management/authenticate`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Cookie: firstJar },
+        body: JSON.stringify({
+          client_id: h.clientId,
+          grant_type: "refresh_token",
+        }),
+      },
+    );
+    expect(refreshed.status).toBe(200);
+    const refreshedBody = (await refreshed.json()) as { refresh_token: string };
+    expect(refreshedBody.refresh_token).not.toBe(firstBody.refresh_token);
+
+    // Replay the now-spent token by sending the STALE jar. WorkOS rotates on
+    // every refresh, so this is what a stolen or duplicated cookie looks like.
+    const replayed = await app.request(
+      `${ORIGIN}/user_management/authenticate`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Cookie: firstJar },
+        body: JSON.stringify({
+          client_id: h.clientId,
+          grant_type: "refresh_token",
+        }),
+      },
+    );
+    expect(replayed.status).toBe(400);
+    expect(await replayed.json()).toMatchObject({ error: "invalid_grant" });
+
+    // A dead session must not leave a jar behind, or the app renders
+    // signed-in chrome over a connection WorkOS has already de-authenticated.
+    expect(setCookieFor(replayed, SESSION_COOKIE)).toContain("Max-Age=0");
+    expect(setCookieFor(replayed, HAS_SESSION_COOKIE)).toContain("Max-Age=0");
+  }, 30_000);
+
+  it("refuses a refresh when no session cookie is present", async () => {
+    const res = await createApp().request(
+      `${ORIGIN}/user_management/authenticate`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_id: h.clientId,
+          grant_type: "refresh_token",
+        }),
+      },
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error_description: "No local WorkOS session",
+    });
+  }, 30_000);
+});
+
+describe("logout", () => {
+  it("clears the jar and hands the browser on to WorkOS", async () => {
+    const app = createApp();
+    const { verifier, callback } = await authorizeThroughProxy(app);
+    const exchanged = await exchangeThroughProxy(app, {
+      code: callback.searchParams.get("code")!,
+      verifier,
+    });
+    const jar = cookieHeaderFrom(exchanged, [SESSION_COOKIE]);
+    const { sid } = decodeJwt(
+      ((await exchanged.json()) as { access_token: string }).access_token,
+    ) as { sid?: string };
+
+    const res = await app.request(
+      `${ORIGIN}/user_management/sessions/logout?session_id=${sid ?? "session_x"}&return_to=${encodeURIComponent(`${ORIGIN}/`)}`,
+      { headers: { Cookie: jar } },
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain(
+      `${h.url}/user_management/sessions/logout`,
+    );
+    expect(setCookieFor(res, SESSION_COOKIE)).toContain("Max-Age=0");
+
+    // And WorkOS really does send the browser back where we asked.
+    const upstream = await fetch(res.headers.get("location")!, {
+      redirect: "manual",
+    });
+    expect(upstream.headers.get("location")).toContain(ORIGIN);
+  }, 30_000);
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/api-keys.emulator.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/api-keys.emulator.test.ts
@@ -1,0 +1,245 @@
+/**
+ * `/api/web/api-keys` against a real WorkOS API, authenticated by a real
+ * AuthKit token.
+ *
+ * The sibling suite (`api-keys.test.ts`) mocks `verifyAuthKitToken` to a fixed
+ * `sub` and stubs `global.fetch` with a matcher keyed on pathname alone. That
+ * is deliberate there — it isolates the ownership-walk logic — and it means the
+ * suite would pass unchanged if the route sent its requests to the wrong host,
+ * with the wrong method, or with a body WorkOS rejects. Here the token is
+ * minted by the emulator through a genuine PKCE login and every WorkOS call is
+ * really served, so the mint/list/revoke round trip is checked against the API
+ * rather than against a fixture of it.
+ *
+ * The Convex-facing helpers (identity, org readiness, key bindings) stay
+ * mocked: they are HTTP calls to the backend service, not to WorkOS.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { SignJWT, generateKeyPair } from "jose";
+import { createWebTestApp, expectJson } from "./helpers/test-app.js";
+import {
+  createWorkosKeyBinding,
+  removeWorkosKeyBinding,
+  WorkosKeyBindingError,
+} from "../../../services/workos-key-bindings.js";
+
+vi.mock("../../../services/workos-key-bindings.js", async (importOriginal) => {
+  const actual = await importOriginal<object>();
+  return {
+    ...actual, // keeps the real WorkosKeyBindingError class
+    createWorkosKeyBinding: vi.fn().mockResolvedValue(undefined),
+    removeWorkosKeyBinding: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock("../../../services/identity.js", async (importOriginal) => {
+  const actual = await importOriginal<object>();
+  return {
+    ...actual,
+    resolveUserByExternalId: vi
+      .fn()
+      .mockResolvedValue({ _id: "mcpjam_user_1" }),
+  };
+});
+
+const mockResolveApiKeyReadiness = vi.fn();
+vi.mock("../../../services/organizations.js", async (importOriginal) => {
+  const actual = await importOriginal<object>();
+  return {
+    ...actual,
+    resolveApiKeyReadiness: (...args: unknown[]) =>
+      mockResolveApiKeyReadiness(...args),
+  };
+});
+
+// The bearer here is an AuthKit JWT, so the guest branch of bearerAuthMiddleware
+// would otherwise try to validate it over the network.
+vi.mock("../../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: vi.fn(async () => ({
+    valid: false,
+    reason: "not_guest",
+  })),
+}));
+
+import {
+  SEED,
+  listUserApiKeys,
+  loginWithPkce,
+  startWorkosEmulator,
+  type WorkosEmulatorHandle,
+} from "../../../test/support/workos-emulator.js";
+
+let h: WorkosEmulatorHandle;
+let bearer: string;
+
+beforeAll(async () => {
+  h = await startWorkosEmulator();
+  const session = await loginWithPkce(h, { email: SEED.user.email });
+  bearer = session.accessToken;
+}, 30_000);
+
+afterAll(async () => {
+  await h?.close();
+});
+
+beforeEach(() => {
+  vi.mocked(createWorkosKeyBinding).mockReset().mockResolvedValue(undefined);
+  vi.mocked(removeWorkosKeyBinding).mockReset().mockResolvedValue(undefined);
+  mockResolveApiKeyReadiness.mockReset().mockResolvedValue({
+    ready: true,
+    workosOrganizationId: SEED.org.id,
+  });
+});
+
+/** `bearer` is assigned in beforeAll, so the header is built per call. */
+function authHeader() {
+  return { Authorization: `Bearer ${bearer}` };
+}
+
+function app() {
+  return createWebTestApp().app;
+}
+
+async function mint(name = "ci key") {
+  return app().request("/api/web/api-keys", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeader() },
+    body: JSON.stringify({ name, organizationId: "org_convex_1" }),
+  });
+}
+
+describe("mint", () => {
+  it("creates a key at WorkOS and binds it to the caller's organization", async () => {
+    const { status, data } = await expectJson<{ id: string; value: string }>(
+      await mint(),
+    );
+
+    expect(status).toBe(200);
+    expect(data.id).toMatch(/^api_key_/);
+    expect(data.value).toMatch(/^sk_/);
+    expect(createWorkosKeyBinding).toHaveBeenCalledWith({
+      workosApiKeyId: data.id,
+      mcpjamOrganizationId: "org_convex_1",
+      mintedByUserId: "mcpjam_user_1",
+    });
+
+    // WorkOS agrees the key exists and belongs to this user — the fixture
+    // cannot fake this.
+    const keys = await listUserApiKeys(h, SEED.user.id);
+    expect(keys.map((k) => k.id)).toContain(data.id);
+  }, 30_000);
+
+  it("revokes the WorkOS key when the org binding is refused", async () => {
+    // A key with no binding is an orphan: it authenticates nothing and cannot
+    // be revoked from the UI, so the route must not leave one behind.
+    const before = await listUserApiKeys(h, SEED.user.id);
+    vi.mocked(createWorkosKeyBinding).mockRejectedValueOnce(
+      new WorkosKeyBindingError(409, "already bound"),
+    );
+
+    const { status, data } = await expectJson<{ code: string }>(
+      await mint("doomed"),
+    );
+
+    expect(status).toBe(409);
+    expect(data.code).toBe("CONFLICT");
+    const after = await listUserApiKeys(h, SEED.user.id);
+    expect(after).toHaveLength(before.length);
+  }, 30_000);
+
+  it("maps a WorkOS rate limit to a rate-limit response", async () => {
+    const hook = h.emulator.addErrorHook({
+      method: "POST",
+      path: `/user_management/users/${SEED.user.id}/api_keys`,
+      status: 429,
+    });
+    try {
+      const { status, data } = await expectJson<{ code: string }>(
+        await mint("throttled"),
+      );
+      expect(status).toBe(429);
+      expect(data.code).toBe("RATE_LIMITED");
+    } finally {
+      h.emulator.removeErrorHook(hook.id);
+    }
+  }, 30_000);
+});
+
+describe("list and revoke", () => {
+  it("lists a freshly minted key and revokes it for real", async () => {
+    const { data: created } = await expectJson<{ id: string; value: string }>(
+      await mint("round-trip"),
+    );
+
+    const listed = await expectJson<{ items: Array<{ id: string }> }>(
+      await app().request("/api/web/api-keys", { headers: authHeader() }),
+    );
+    expect(listed.status).toBe(200);
+    expect(listed.data.items.map((k) => k.id)).toContain(created.id);
+
+    const revoked = await app().request(`/api/web/api-keys/${created.id}`, {
+      method: "DELETE",
+      headers: authHeader(),
+    });
+    expect(revoked.status).toBe(200);
+    expect(removeWorkosKeyBinding).toHaveBeenCalledWith(
+      created.id,
+      "mcpjam_user_1",
+    );
+
+    // Gone at WorkOS, not merely delisted by us.
+    const remaining = await listUserApiKeys(h, SEED.user.id);
+    expect(remaining.map((k) => k.id)).not.toContain(created.id);
+  }, 30_000);
+
+  it("reports an unknown key as not found rather than calling WorkOS", async () => {
+    // The ownership walk is the authorization check: an id the caller does not
+    // own must read as absent, whether it never existed or belongs elsewhere.
+    const res = await app().request("/api/web/api-keys/api_key_not_yours", {
+      method: "DELETE",
+      headers: authHeader(),
+    });
+
+    const { status, data } = await expectJson<{ code: string }>(res);
+    expect(status).toBe(404);
+    expect(data.code).toBe("NOT_FOUND");
+  }, 30_000);
+});
+
+describe("session verification", () => {
+  it("rejects a forged token carrying the right issuer and audience", async () => {
+    // The payload is entirely valid-looking; only the signing key is wrong.
+    // Before verification was added here, a token like this drove key
+    // lifecycle operations against the named `sub`.
+    const { privateKey } = await generateKeyPair("RS256");
+    const forged = await new SignJWT({})
+      .setProtectedHeader({ alg: "RS256" })
+      .setIssuer(`https://api.workos.com/user_management/${h.clientId}`)
+      .setAudience(h.clientId)
+      .setSubject(SEED.user.id)
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(privateKey);
+
+    const before = await listUserApiKeys(h, SEED.user.id);
+    const res = await app().request("/api/web/api-keys", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${forged}`,
+      },
+      body: JSON.stringify({ name: "forged", organizationId: "org_convex_1" }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(await listUserApiKeys(h, SEED.user.id)).toHaveLength(before.length);
+  }, 30_000);
+});

--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -12,6 +12,7 @@ import {
 } from "./errors.js";
 import { handleRoute } from "./auth.js";
 import { resolveUserByExternalId } from "../../services/identity.js";
+import { resolveWorkosApiBaseUrl } from "../../services/workos-api-base.js";
 import {
   createWorkosKeyBinding,
   removeWorkosKeyBinding,
@@ -75,8 +76,6 @@ apiKeys.use("*", async (c, next) => {
 // so this sub-router must explicitly require a bearer.
 apiKeys.use("*", bearerAuthMiddleware);
 
-const WORKOS_BASE_URL = "https://api.workos.com";
-
 function getWorkOSRestKey(): string {
   const key = process.env.WORKOS_API_KEY;
   if (!key) {
@@ -135,7 +134,10 @@ async function callWorkOS(
   body?: unknown,
 ): Promise<{ status: number; body: any }> {
   const key = getWorkOSRestKey();
-  const response = await fetch(`${WORKOS_BASE_URL}${path}`, {
+  // Resolved per call so a test that stubs the env after this module
+  // loaded is still honoured.
+  const baseUrl = resolveWorkosApiBaseUrl(process.env).baseUrl;
+  const response = await fetch(`${baseUrl}${path}`, {
     method,
     headers: {
       Authorization: `Bearer ${key}`,

--- a/mcpjam-inspector/server/routes/workos-authkit.ts
+++ b/mcpjam-inspector/server/routes/workos-authkit.ts
@@ -7,10 +7,14 @@ import {
   randomBytes,
 } from "crypto";
 import { getOrCreateLocalSecret } from "../utils/local-secret-store.js";
+import { resolveWorkosApiBaseUrl } from "../services/workos-api-base.js";
 
-const WORKOS_AUTHENTICATE_URL =
-  "https://api.workos.com/user_management/authenticate";
-const WORKOS_BASE_URL = "https://api.workos.com";
+// Resolved per call, not captured at module load: a test stubs
+// `WORKOS_API_BASE_URL` long after this module is imported. Unset, both are
+// exactly the api.workos.com URLs they were before.
+const workosBaseUrl = () => resolveWorkosApiBaseUrl(process.env).baseUrl;
+const workosAuthenticateUrl = () =>
+  `${workosBaseUrl()}/user_management/authenticate`;
 const WORKOS_SESSION_COOKIE = "__Host-mcpjam_workos_session";
 const LOCAL_WORKOS_SESSION_COOKIE = "mcpjam_workos_sessions";
 const LEGACY_LOCAL_WORKOS_SESSION_COOKIE = "mcpjam_workos_session";
@@ -279,7 +283,7 @@ function getStoredSession(c: Context) {
 }
 
 async function postToWorkos(body: Record<string, unknown>) {
-  return fetch(WORKOS_AUTHENTICATE_URL, {
+  return fetch(workosAuthenticateUrl(), {
     method: "POST",
     headers: {
       Accept: "application/json, text/plain, */*",
@@ -315,7 +319,7 @@ function isTransientWorkosFailure(status: number): boolean {
 
 function redirectToWorkos(c: Context, path: string) {
   const source = new URL(c.req.url);
-  const target = new URL(path, WORKOS_BASE_URL);
+  const target = new URL(path, workosBaseUrl());
   target.search = source.search;
   return c.redirect(target.toString(), 302);
 }

--- a/mcpjam-inspector/server/services/__tests__/workos-api-base.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/workos-api-base.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The guard on `WORKOS_API_BASE_URL`.
+ *
+ * Two properties, both load-bearing: unset yields NO sdk options, so every
+ * caller constructs exactly what it constructed before; and a non-loopback
+ * value throws rather than pointing an admin-key-bearing client at another
+ * host. The second matters more here than in the backend — Railway previews
+ * are duplicated from staging wholesale and the deploy script cannot unset a
+ * variable, so a value set once would propagate with no way to withdraw it.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_WORKOS_API_BASE_URL,
+  resolveWorkosApiBaseUrl,
+} from "../workos-api-base.js";
+
+const resolve = (value?: string) =>
+  resolveWorkosApiBaseUrl(
+    value === undefined ? {} : { WORKOS_API_BASE_URL: value },
+  );
+
+describe("resolveWorkosApiBaseUrl — unset", () => {
+  it("defaults to the real API and asks for no SDK options", () => {
+    expect(resolve()).toEqual({ baseUrl: DEFAULT_WORKOS_API_BASE_URL });
+    expect(resolve().sdkOptions).toBeUndefined();
+  });
+
+  it("treats empty and whitespace-only values as unset", () => {
+    // A deploy tool that writes `KEY=` must read as "not configured", not take
+    // the service down on a parse failure.
+    expect(resolve("")).toEqual({ baseUrl: DEFAULT_WORKOS_API_BASE_URL });
+    expect(resolve("   ")).toEqual({ baseUrl: DEFAULT_WORKOS_API_BASE_URL });
+  });
+});
+
+describe("resolveWorkosApiBaseUrl — accepted loopback origins", () => {
+  it("splits a loopback origin into SDK host options", () => {
+    expect(resolve("http://127.0.0.1:4820")).toEqual({
+      baseUrl: "http://127.0.0.1:4820",
+      sdkOptions: { apiHostname: "127.0.0.1", https: false, port: 4820 },
+    });
+  });
+
+  it("normalizes a trailing slash away from baseUrl", () => {
+    // Callers build `${baseUrl}${path}`; a kept slash yields `//user_management`.
+    expect(resolve("http://localhost:4820/").baseUrl).toBe(
+      "http://localhost:4820",
+    );
+  });
+
+  it("omits the port when the URL uses the protocol default", () => {
+    // `Number('')` is 0, which the SDK would append as `:0`.
+    expect(resolve("https://localhost").sdkOptions).toEqual({
+      apiHostname: "localhost",
+      https: true,
+      port: undefined,
+    });
+  });
+
+  it("keeps the brackets on an IPv6 loopback host", () => {
+    expect(resolve("http://[::1]:4820").sdkOptions?.apiHostname).toBe("[::1]");
+  });
+});
+
+describe("resolveWorkosApiBaseUrl — rejected values", () => {
+  it.each([
+    ["a remote host", "https://api.workos.com"],
+    ["a staging host", "http://staging.example.com:8080"],
+    [
+      "a host that merely starts with a loopback label",
+      "http://127.0.0.1.evil.com",
+    ],
+    ["a lookalike subdomain", "https://localhost.evil.com"],
+    ["a non-http scheme", "ftp://127.0.0.1"],
+    ["a bare hostname with no scheme", "127.0.0.1:4820"],
+    ["unparseable text", "not a url"],
+    ["a path callers would double", "http://127.0.0.1:4820/v1"],
+    ["a query the SDK would drop", "http://127.0.0.1:4820/?x=1"],
+    ["embedded credentials", "http://user:pass@127.0.0.1:4820"],
+  ])("rejects %s", (_label, value) => {
+    expect(() => resolve(value)).toThrow(
+      /WORKOS_API_BASE_URL must be a loopback/,
+    );
+  });
+
+  it("names the offending value so the misconfiguration is diagnosable", () => {
+    expect(() => resolve("https://api.workos.com")).toThrow(
+      /\(got "https:\/\/api\.workos\.com"\)/,
+    );
+  });
+});

--- a/mcpjam-inspector/server/services/authkit-jwt.ts
+++ b/mcpjam-inspector/server/services/authkit-jwt.ts
@@ -5,6 +5,7 @@ import {
   type JWTVerifyGetKey,
   type KeyLike,
 } from "jose";
+import { resolveWorkosApiBaseUrl } from "./workos-api-base.js";
 
 /**
  * WorkOS AuthKit access-token verification for the `/api/web/api-keys`
@@ -97,7 +98,11 @@ export function authkitIssuerJwks(
   env: NodeJS.ProcessEnv = process.env,
 ): Map<string, string> {
   const map = new Map<string, string>();
-  const workosJwks = `https://api.workos.com/sso/jwks/${clientId}`;
+  // The issuer KEYS below stay literal — they are what WorkOS stamps on a
+  // token and what we agree to trust. Only the URL we fetch keys FROM follows
+  // the base, so an emulator issuing `https://api.workos.com/...` tokens can
+  // still have its JWKS reached.
+  const workosJwks = `${resolveWorkosApiBaseUrl(env).baseUrl}/sso/jwks/${clientId}`;
   const mcpjamJwks = `https://api.mcpjam.com/sso/jwks/${clientId}`;
   const authJwks = `https://auth.mcpjam.com/sso/jwks/${clientId}`;
   map.set("https://api.workos.com/", workosJwks);
@@ -115,6 +120,11 @@ export function authkitIssuerJwks(
 
 // One remote JWKS per URL (jose caches the fetched keys internally per set).
 const jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+
+/** Test-only: drop cached key sets so a new emulator's JWKS is fetched fresh. */
+export function resetAuthKitJwksCacheForTests(): void {
+  jwksCache.clear();
+}
 function remoteJwks(url: string): ReturnType<typeof createRemoteJWKSet> {
   let set = jwksCache.get(url);
   if (!set) {

--- a/mcpjam-inspector/server/services/workos-api-base.ts
+++ b/mcpjam-inspector/server/services/workos-api-base.ts
@@ -1,0 +1,90 @@
+/**
+ * Where this server sends its WorkOS traffic.
+ *
+ * Production reads nothing here: with `WORKOS_API_BASE_URL` unset every caller
+ * resolves to `https://api.workos.com` and behaves exactly as it did before
+ * this module existed. The variable exists so a test can point the server at a
+ * local `@workos/emulate` instance and exercise the AuthKit proxy, API-key
+ * validation and key management against a real API surface.
+ *
+ * LOOPBACK ONLY, and here that rule earns its keep more than anywhere else in
+ * the codebase. Every management call carries `WORKOS_API_KEY` — the admin key
+ * — in an `Authorization` header, and preview environments on Railway are
+ * duplicated from staging wholesale (`pr-preview.yml`), while
+ * `railway-set-vars.sh` can only set a variable and never unset one. So a value
+ * set once on staging would propagate to every future preview with no way to
+ * withdraw it. The only durable defence is refusing the value here.
+ *
+ * Rejecting a path or query is not pedantry: callers append their own paths to
+ * `baseUrl`, and the SDK composes `${protocol}://${apiHostname}[:${port}]` and
+ * drops everything else, so a base URL with a path would be silently truncated
+ * in one caller and doubled in another.
+ *
+ * NOT to be confused with `WORKOS_API_HOSTNAME` (server/env.ts), which is a
+ * BROWSER-facing hostname serialized into `window.__MCP_RUNTIME_CONFIG__` for
+ * `@workos-inc/authkit-js`. This one is server-only and must never be added to
+ * `InspectorClientRuntimeConfig`.
+ */
+
+export const DEFAULT_WORKOS_API_BASE_URL = "https://api.workos.com";
+
+/** `[::1]` keeps its brackets — that is what `URL.hostname` reports. */
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+/** The subset of `WorkOSOptions` that redirects the SDK at another host. */
+export interface WorkosSdkHostOptions {
+  apiHostname: string;
+  https: boolean;
+  port?: number;
+}
+
+export interface ResolvedWorkosApiBase {
+  /** Origin, never with a trailing slash; callers concatenate paths onto it. */
+  baseUrl: string;
+  /**
+   * Options for `new WorkOS(key, options)`, or `undefined` when the override is
+   * unset — the client is then constructed with no options at all, so the
+   * default path is byte-for-byte what it was.
+   */
+  sdkOptions?: WorkosSdkHostOptions;
+}
+
+function reject(value: string): never {
+  throw new Error(
+    `WORKOS_API_BASE_URL must be a loopback http(s) origin such as ` +
+      `http://127.0.0.1:4820 (got "${value}")`,
+  );
+}
+
+export function resolveWorkosApiBaseUrl(
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedWorkosApiBase {
+  const raw = env.WORKOS_API_BASE_URL?.trim();
+  if (!raw) {
+    return { baseUrl: DEFAULT_WORKOS_API_BASE_URL };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    reject(raw);
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") reject(raw);
+  if (!LOOPBACK_HOSTNAMES.has(url.hostname)) reject(raw);
+  if (url.pathname !== "/") reject(raw);
+  if (url.search || url.hash) reject(raw);
+  if (url.username || url.password) reject(raw);
+
+  return {
+    baseUrl: url.origin,
+    sdkOptions: {
+      apiHostname: url.hostname,
+      https: url.protocol === "https:",
+      // '' for a protocol-default port; `Number('')` is 0, which the SDK would
+      // dutifully append as `:0`.
+      port: url.port ? Number(url.port) : undefined,
+    },
+  };
+}

--- a/mcpjam-inspector/server/services/workos-client.ts
+++ b/mcpjam-inspector/server/services/workos-client.ts
@@ -1,4 +1,5 @@
 import { WorkOS } from "@workos-inc/node";
+import { resolveWorkosApiBaseUrl } from "./workos-api-base.js";
 
 /**
  * Server-side WorkOS Node SDK client.
@@ -29,7 +30,14 @@ export function getWorkOSClient(): WorkOS {
       "WORKOS_API_KEY is not set — required for WorkOS API key validation and management."
     );
   }
-  cachedClient = new WorkOS(apiKey);
+  // Unset `WORKOS_API_BASE_URL` means no options at all, so the production
+  // path is the same single-argument construction as before; a loopback value
+  // points the SDK at a test emulator, and anything else throws here rather
+  // than shipping the admin key to another host.
+  const { sdkOptions } = resolveWorkosApiBaseUrl(process.env);
+  cachedClient = sdkOptions
+    ? new WorkOS(apiKey, sdkOptions)
+    : new WorkOS(apiKey);
   return cachedClient;
 }
 

--- a/mcpjam-inspector/server/test/support/workos-emulator.ts
+++ b/mcpjam-inspector/server/test/support/workos-emulator.ts
@@ -1,0 +1,287 @@
+/**
+ * Boots `@workos/emulate` in-process so a suite can drive the server's real
+ * WorkOS paths — the AuthKit proxy, `sk_` key validation, key management —
+ * against an API instead of a `vi.stubGlobal("fetch", ...)` matcher.
+ *
+ * The existing suites stub fetch by pathname and mock `verifyAuthKitToken`, so
+ * they assert our own beliefs: that WorkOS 409s a duplicate, that a reused
+ * refresh token is refused, that a JWT signed by the right key verifies. The
+ * emulator settles those by answering, and it signs real RS256 tokens against
+ * a JWKS endpoint our verifier can actually fetch.
+ *
+ * Lifecycle: one emulator per test FILE, port 0, `beforeAll`/`afterAll`.
+ * Vitest's forks pool gives each file its own process, which keeps ports from
+ * colliding across the six CI shards and contains the global `Request`/
+ * `Response` objects that `@hono/node-server` replaces when imported — a
+ * mutation this repo already warns about in
+ * `server/routes/web/__tests__/fixtures/xaa-node-adapter.ts`.
+ */
+import {
+  createEmulator,
+  type Emulator,
+  type EmulatorSeedConfig,
+} from "@workos/emulate";
+import { createHash, randomBytes } from "node:crypto";
+import { vi } from "vitest";
+import { resetAuthKitJwksCacheForTests } from "../../services/authkit-jwt.js";
+import { resetWorkOSClientForTests } from "../../services/workos-client.js";
+
+const MINIMUM_NODE = { major: 22, minor: 11 };
+
+export const EMULATOR_CLIENT_ID = "client_01EMULATOR0000000000000000";
+
+/**
+ * Fixed ids so assertions can name them.
+ *
+ * `SEED.user.id` doubles as the WorkOS `sub`, which the bearer middleware
+ * stores as `workosUserId` and the key routes interpolate into
+ * `/user_management/users/{id}/api_keys`.
+ */
+export const SEED = {
+  user: {
+    id: "user_01EMULATORUSER00000000000000",
+    email: "dev@emulator.test",
+    password: "test123",
+  },
+  org: {
+    id: "org_01EMULATORORG000000000000000",
+    name: "Emulator Org",
+  },
+} as const;
+
+export function emulatorSeed(): EmulatorSeedConfig {
+  return {
+    users: [
+      {
+        id: SEED.user.id,
+        email: SEED.user.email,
+        first_name: "Dev",
+        password: SEED.user.password,
+        email_verified: true,
+      },
+    ],
+    organizations: [
+      {
+        id: SEED.org.id,
+        name: SEED.org.name,
+        memberships: [{ email: SEED.user.email }],
+      },
+    ],
+  };
+}
+
+export interface WorkosEmulatorHandle {
+  emulator: Emulator;
+  url: string;
+  apiKey: string;
+  clientId: string;
+  close: () => Promise<void>;
+}
+
+function assertNodeVersion(): void {
+  const [major, minor] = process.versions.node.split(".").map(Number);
+  if (
+    major < MINIMUM_NODE.major ||
+    (major === MINIMUM_NODE.major && minor < MINIMUM_NODE.minor)
+  ) {
+    throw new Error(
+      `@workos/emulate requires Node >= ${MINIMUM_NODE.major}.${MINIMUM_NODE.minor} ` +
+        `(running ${process.versions.node}). CI runs 24.x; upgrade your local Node to run these suites.`,
+    );
+  }
+}
+
+export async function startWorkosEmulator(opts?: {
+  seed?: EmulatorSeedConfig;
+  clientId?: string;
+}): Promise<WorkosEmulatorHandle> {
+  assertNodeVersion();
+  const clientId = opts?.clientId ?? EMULATOR_CLIENT_ID;
+
+  const emulator = await createEmulator({
+    port: 0,
+    hostname: "127.0.0.1",
+    seed: opts?.seed ?? emulatorSeed(),
+    // Tokens then carry `iss = https://api.workos.com/user_management/<id>`,
+    // which is already an entry in `authkitIssuerJwks`'s trusted map. Only the
+    // JWKS URL follows the base — so this exercises the real issuer allow-list
+    // rather than widening it for the test.
+    issuer: "https://api.workos.com",
+    allowedRedirectHosts: ["localhost", "127.0.0.1"],
+  });
+
+  vi.stubEnv("WORKOS_API_KEY", emulator.apiKey);
+  vi.stubEnv("WORKOS_API_BASE_URL", emulator.url);
+  vi.stubEnv("WORKOS_CLIENT_ID", clientId);
+  vi.stubEnv("MCPJAM_WORKOS_SESSION_SECRET", "test-workos-session-secret");
+  // Both are module-level singletons that would otherwise hold a client (and a
+  // JWKS) pointed at whatever the previous file configured.
+  resetWorkOSClientForTests();
+  resetAuthKitJwksCacheForTests();
+
+  return {
+    emulator,
+    url: emulator.url,
+    apiKey: emulator.apiKey,
+    clientId,
+    close: async () => {
+      await emulator.close();
+      vi.unstubAllEnvs();
+      resetWorkOSClientForTests();
+      resetAuthKitJwksCacheForTests();
+    },
+  };
+}
+
+/** Admin-key request straight at the emulator, for arrange/assert steps. */
+export async function emulatorRest(
+  h: WorkosEmulatorHandle,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: any }> {
+  const response = await fetch(`${h.url}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${h.apiKey}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  let parsed: any = null;
+  try {
+    parsed = await response.json();
+  } catch {
+    // 204s carry no body.
+  }
+  return { status: response.status, body: parsed };
+}
+
+export async function mintUserApiKey(
+  h: WorkosEmulatorHandle,
+  args: { userId: string; organizationId: string; name?: string },
+): Promise<{ id: string; value: string }> {
+  const { status, body } = await emulatorRest(
+    h,
+    "POST",
+    `/user_management/users/${encodeURIComponent(args.userId)}/api_keys`,
+    { name: args.name ?? "test key", organization_id: args.organizationId },
+  );
+  if (status >= 300) {
+    throw new Error(
+      `Could not mint an API key (${status}): ${JSON.stringify(body)}`,
+    );
+  }
+  return { id: body.id, value: body.value };
+}
+
+export async function listUserApiKeys(
+  h: WorkosEmulatorHandle,
+  userId: string,
+): Promise<Array<{ id: string }>> {
+  const { body } = await emulatorRest(
+    h,
+    "GET",
+    `/user_management/users/${encodeURIComponent(userId)}/api_keys?limit=100`,
+  );
+  return Array.isArray(body?.data) ? body.data : [];
+}
+
+export function createPkcePair(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+/**
+ * The real front-channel: authorize with PKCE, follow the redirect for the
+ * code, exchange it. Returns a genuinely signed access token, so a route that
+ * verifies one is exercised rather than mocked.
+ */
+export async function loginWithPkce(
+  h: WorkosEmulatorHandle,
+  args: { email: string; redirectUri?: string; state?: string },
+): Promise<{
+  accessToken: string;
+  refreshToken: string;
+  code: string;
+  user: any;
+}> {
+  const redirectUri = args.redirectUri ?? "http://localhost:6274/callback";
+  const { verifier, challenge } = createPkcePair();
+  const query = new URLSearchParams({
+    client_id: h.clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    provider: "authkit",
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+    state: args.state ?? "test-state",
+    login_hint: args.email,
+  });
+
+  const authorize = await fetch(
+    `${h.url}/user_management/authorize?${query.toString()}`,
+    { redirect: "manual" },
+  );
+  const location = authorize.headers.get("location");
+  if (!location) {
+    throw new Error(
+      `authorize did not redirect (${authorize.status}): ${await authorize.text()}`,
+    );
+  }
+  const code = new URL(location).searchParams.get("code");
+  if (!code) throw new Error(`authorize redirect carried no code: ${location}`);
+
+  const exchange = await fetch(`${h.url}/user_management/authenticate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_id: h.clientId,
+      grant_type: "authorization_code",
+      code,
+      code_verifier: verifier,
+    }),
+  });
+  const body = await exchange.json();
+  if (!exchange.ok) {
+    throw new Error(
+      `code exchange failed (${exchange.status}): ${JSON.stringify(body)}`,
+    );
+  }
+  return {
+    accessToken: body.access_token,
+    refreshToken: body.refresh_token,
+    code,
+    user: body.user,
+  };
+}
+
+/**
+ * The ONE `Set-Cookie` header carrying `name`, with its own attributes.
+ *
+ * `headers.get("set-cookie")` joins every cookie into one string, so asserting
+ * `HttpOnly` against that says only that SOME cookie in the response has it.
+ * Mirrors the helper in server/routes/__tests__/workos-authkit.test.ts.
+ */
+export function setCookieFor(response: Response, name: string): string {
+  const entry = response.headers
+    .getSetCookie()
+    .find((cookie) => cookie.startsWith(`${name}=`));
+  if (!entry) throw new Error(`Missing Set-Cookie for ${name}`);
+  return entry;
+}
+
+/** `name=value` pairs joined for a `Cookie` request header. */
+export function cookieHeaderFrom(response: Response, names: string[]): string {
+  return names
+    .map((name) => {
+      const entry = response.headers
+        .getSetCookie()
+        .find((cookie) => cookie.startsWith(`${name}=`));
+      return entry ? entry.split(";")[0] : null;
+    })
+    .filter((pair): pair is string => Boolean(pair))
+    .join("; ");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -544,6 +544,7 @@
         "@typescript-eslint/parser": "^8.68.0",
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/coverage-v8": "^3.2.7",
+        "@workos/emulate": "0.12.0",
         "autoprefixer": "^10.5.4",
         "concurrently": "^9.1.0",
         "cross-env": "^10.1.0",
@@ -17069,6 +17070,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@workos/emulate": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@workos/emulate/-/emulate-0.12.0.tgz",
+      "integrity": "sha512-J7kVy1riKg6eyIZ7L4QVQPF8IKzD/k+ZWImcIt9kzh0yGkBYnNPkNK0FrVxAbyFby/9Nwmt6VApawJQo9HWgig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1",
+        "chalk": "^5.6.2",
+        "hono": "^4",
+        "semver": "^7.7.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "workos-emulate": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.11"
+      }
+    },
+    "node_modules/@workos/emulate/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@xmldom/is-dom-node": {


### PR DESCRIPTION
Prompted by [Testing WorkOS in CI/CD](https://workos.com/blog/testing-workos-in-ci-cd). Companion to MCPJam/mcpjam-backend#1290 — same variable, same loopback rule, independent PRs.

## Why

The WorkOS-facing server tests stub `global.fetch` on pathname and mock `verifyAuthKitToken` to a fixed `sub`. That's correct isolation for the ownership-walk and rate-limit logic they cover, and it has two consequences:

- those suites would pass unchanged if a route sent its request to the wrong host, with the wrong method, or with a body WorkOS rejects;
- the questions the proxy exists to answer can't be asked at all, because each is a WorkOS behaviour — is a spent refresh token refused, does a revoked key stop validating, does a forged JWT fail against the issuer's real JWKS.

`@workos/emulate` is WorkOS's own in-memory API server. These suites boot one per file on port 0 and drive the real paths against it.

## What's covered

| Suite | What it exercises |
| --- | --- |
| `bearer-auth.emulator.test.ts` | the `sk_` branch with a key the emulator actually minted; unknown key; **revocation taking effect immediately**; a 503 failing closed then recovering; orphaned binding; unknown MCPJam user |
| `workos-authkit.emulator.test.ts` | a full PKCE login through the proxy — authorize → code → exchange → **cookie-only refresh rotation** → **replay of a spent token cleared the jar** → logout. Also verifies the returned token with our own `verifyAuthKitToken` |
| `api-keys.emulator.test.ts` | mint/list/revoke authenticated by a **real** access token; rollback on binding failure; 429 and 404 mapping; a forged JWT rejected |

Two tests pin behaviour worth knowing rather than behaviour we chose:

- **A WorkOS 429 on key validation reaches the caller as 401 "Invalid API key"** — indistinguishable from a revoked key, and likely to send someone rotating a credential that is fine. The test says so plainly and doesn't dress it up as intended. Worth a follow-up; not folded into a test-infrastructure change.
- **The binding-failure case asserts the WorkOS key is really gone afterwards.** An unbound key authenticates nothing and can't be revoked from the UI, so "we called delete" isn't the property that matters.

## The runtime change

One variable, `WORKOS_API_BASE_URL`, resolved in `server/services/workos-api-base.ts` and read by the four places that had `https://api.workos.com` inline (`workos-client.ts`, both constants in `workos-authkit.ts`, `api-keys.ts`, and the JWKS URL in `authkit-jwt.ts`).

Unset — every deployment — every caller resolves to that same constant and the SDK client is constructed with no options at all. Anything that is not a loopback origin **throws at boot**, from both entrypoints.

That rule matters more here than in the backend. `WORKOS_API_KEY` — the admin key that mints and revokes API keys — travels in an `Authorization` header on these requests, and Railway previews are duplicated from staging wholesale (`pr-preview.yml`) while `railway-set-vars.sh` can only *set* a variable, never unset one. A value written once to staging would reach every future preview with no way to withdraw it. Refusing it in code is the only durable defence.

**The issuer allow-list is deliberately not widened.** The literal `api.workos.com` issuers in `authkitIssuerJwks` stay exactly as they were; only the URL we fetch keys *from* follows the base. So emulator-issued tokens are accepted through the same trust rules production uses, not through a test-only branch.

Also note `WORKOS_API_BASE_URL` is server-only and deliberately kept out of `InspectorClientRuntimeConfig` — not to be confused with `WORKOS_API_HOSTNAME`, which is browser-facing.

## Verification

```
npm run typecheck                       # 0
npm run typecheck:client -w @mcpjam/inspector   # 0
npm run build:inspector                 # 0
```

New suites plus the mocked ones they sit beside, together — the old suites are the regression guard proving the default still points at `api.workos.com`:

```
npx vitest run --project server \
  server/services/__tests__/workos-api-base.test.ts \
  server/{middleware,routes,routes/web}/__tests__/*.emulator.test.ts \
  server/routes/__tests__/workos-authkit.test.ts server/routes/web/__tests__/api-keys.test.ts \
  server/middleware/__tests__/bearer-auth.test.ts server/services/__tests__/authkit-jwt.test.ts \
  server/__tests__/hosted-authkit-proxy.test.ts server/__tests__/env.test.ts
# 10 files, 98 passed
```

`hosted-authkit-proxy.test.ts` boots the whole app, so it also covers the new boot-time check.

## Notes for review

- **No workflow change.** Each file starts its own emulator on port 0, so the six shards can't collide.
- **Lockfile is 34 pure insertions.** Installing with `--legacy-peer-deps` rewrote ~90 unrelated `dev`/`devOptional`/`peer` flags; installing without it does not, so that's how the dep was added. CI's `npm ci --legacy-peer-deps` is unaffected — `ci` doesn't rewrite the lockfile.
- **Node >= 22.11** for the emulator (CI runs 24.x). The helper says so rather than failing with a stack trace.
- Docs: a `WORKOS_API_BASE_URL` section in `HOSTED_DEPLOYMENT.md`, a WorkOS contract-tests section in `CONTRIBUTING.md`, and a pointer in `mcpjam-inspector/AGENTS.md`.

Out of scope: the blog's browser-login E2E. Convex verifies AuthKit JWTs against public JWKS and can't reach a loopback emulator; closing that needs a self-hosted Convex container in CI or a deployment pinned to a published signing key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJt33hxn7VRkR5tobjh5Pp

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJt33hxn7VRkR5tobjh5Pp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server-side WorkOS routing and boot-time env validation on auth-critical paths, but production defaults are unchanged and loopback-only enforcement limits credential exfiltration risk from misconfiguration.
> 
> **Overview**
> Adds **WorkOS contract tests** that boot in-process [`@workos/emulate`](https://github.com/workos/emulate) (via `server/test/support/workos-emulator.ts`) and exercise real AuthKit proxy, `sk_` bearer validation, and `/api/web/api-keys` flows—covering revocation, refresh rotation, spent refresh replay, JWKS verification, and forged JWT rejection. Existing mocked suites stay as fast regression guards for default `api.workos.com` behavior.
> 
> Introduces **`WORKOS_API_BASE_URL`** resolved in `server/services/workos-api-base.ts` and wired through the WorkOS SDK client, AuthKit proxy, API-key REST calls, and JWKS fetch in `authkit-jwt.ts`. Unset in production behaves exactly as before; **non-loopback values throw at boot** in both `server/app.ts` and `server/index.ts` so a mis-set env cannot redirect admin `WORKOS_API_KEY` traffic. Docs updated in `CONTRIBUTING.md`, `AGENTS.md`, and `HOSTED_DEPLOYMENT.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ba92d0d5f5f7d551b5be571d1cd3295883b376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
WorkOS-facing server tests now run against `@workos/emulate`, WorkOS's own in-memory API server, replacing stubbed `fetch` and mocked token verification. The new suites can settle questions the old stubs couldn't — whether a revoked key stops validating immediately, whether a spent refresh token is refused, whether a forged JWT fails against the real JWKS.

**Runtime change**

- Adds `WORKOS_API_BASE_URL`, resolved in `server/services/workos-api-base.ts` and read by the four call sites that had `https://api.workos.com` inline.
- Unset — every deployment — means identical behavior to before: same URLs, SDK client constructed with no options.
- Accepts loopback origins only; any other value throws at boot from both entrypoints.
- The loopback rule is load-bearing: `WORKOS_API_KEY` rides in an `Authorization` header, and Railway previews inherit staging env with no way to unset a variable, so rejecting non-loopback values in code is the only durable defense.
- The issuer allow-list in `authkit-jwt.ts` is not widened; only the JWKS fetch URL follows the base.
- Requires Node >= 22.11 to run the new suites (CI runs 24.x); the test helper errors clearly otherwise.

**Tests**

- `bearer-auth.emulator.test.ts`: valid, unknown, and revoked keys; 503 fail-closed with recovery; orphaned bindings; unknown users.
- `workos-authkit.emulator.test.ts`: full PKCE login through the proxy, cookie-only refresh rotation, replaying a spent token clears the jar, logout.
- `api-keys.emulator.test.ts`: mint/list/revoke authenticated by a real access token, rollback when binding fails, 429/404 mapping, forged JWT rejected.
- Two tests pin current behavior rather than endorsing it: a WorkOS 429 on key validation surfaces as 401 "Invalid API key" (indistinguishable from revocation), and the binding-failure test asserts the key is truly gone from WorkOS.
- The existing mocked suites are untouched and double as the regression guard proving the default still points at `api.workos.com`.

<sup>Written for commit 07ba92d0d5f5f7d551b5be571d1cd3295883b376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

