### PR TITLE
Keep GitHub check recipe guidance visible

### DIFF
--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -912,28 +912,11 @@ export function GithubChecksRoute({
             Loading…
           </div>
         ) : rows.length === 0 ? (
-          <div className="space-y-3 px-4 py-8 text-sm text-muted-foreground">
+          <div className="px-4 py-8 text-sm text-muted-foreground">
             <p>
               No repositories connected yet. Connect a GitHub account above,
               then connect one of its repositories below to start running checks
               on its pull requests.
-            </p>
-            <p>
-              A repository can declare its check recipe in a{" "}
-              <code className="rounded bg-muted px-1 py-0.5 text-xs">
-                mcpjam.yaml
-              </code>{" "}
-              at the repo root. Without one, MCPJam detects a recipe
-              automatically.{" "}
-              <a
-                className="underline underline-offset-2 hover:text-foreground"
-                href="https://docs.mcpjam.com/github-checks"
-                target="_blank"
-                rel="noreferrer"
-              >
-                Read the docs
-              </a>
-              .
             </p>
           </div>
         ) : (
@@ -1104,6 +1087,23 @@ export function GithubChecksRoute({
             </div>
           ))
         )}
+        <p className="px-4 py-3 text-xs text-muted-foreground">
+          MCPJam detects how to build and start your server automatically. To
+          pin those commands, add{" "}
+          <code className="rounded bg-muted px-1 py-0.5 text-xs">
+            mcpjam.yaml
+          </code>{" "}
+          at the repository root.{" "}
+          <a
+            className="underline underline-offset-2 hover:text-foreground"
+            href="https://docs.mcpjam.com/github-checks"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Read the recipe docs
+          </a>
+          .
+        </p>
       </SettingsSection>
 
       <SettingsSection title="Connect a repository">

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -315,6 +315,10 @@ describe("GithubChecksRoute availability gate", () => {
     mockRepos.value = [ROW];
     renderRoute();
     expect(screen.getByText("mcpjam/mcp-check-fixture")).toBeInTheDocument();
+    expect(screen.getByText("mcpjam.yaml")).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: "Read the recipe docs" })
+    ).toHaveAttribute("href", "https://docs.mcpjam.com/github-checks");
   });
 
   it("shows the install-App empty state when there are no repos", () => {


### PR DESCRIPTION
The GitHub Checks page hid its `mcpjam.yaml` guidance as soon as the first repository was connected. Keep the automatic-detection explanation and recipe-doc link visible below Connected repositories in both empty and configured states.

Validation:
- Focused GitHub Checks route tests: 78 passed
- Inspector client typecheck
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the `mcpjam.yaml` recipe guidance on the GitHub Checks page visible after repositories are connected. Previously the guidance only appeared in the empty state and vanished once the first repository was connected; it now stays below the Connected repositories section in both empty and configured states.

<sup>Written for commit f3d8568d9d9b5fb9687b026592f1f2cb93be0ff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

