### PR TITLE
Answer a resumed tool call only after re-introducing it

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -75,6 +75,15 @@ vi.mock("../mcpjam-tool-helpers", () => ({
   serializeToolsForConvex: vi.fn(() => []),
 }));
 
+// The handler imports exactly one function from the harness runner, and that
+// module pulls in `@ai-sdk/harness/agent` at load time. Nothing in this suite
+// runs a harness turn, so the whole file used to fail to LOAD wherever that
+// optional package is absent — which is every checkout that has not installed
+// it, and this suite is the one that pins the approval and emit invariants.
+vi.mock("../harness/run-harness-turn", () => ({
+  runHarnessTurn: vi.fn(),
+}));
+
 vi.mock("../logger", () => ({
   logger: {
     error: vi.fn(),
@@ -3734,18 +3743,206 @@ describe("mcpjam-stream-handler", () => {
       });
     });
 
-    // NOTE: `emitInheritedToolCalls` also fires `onToolCall` after the
-    // PR 5b fix (the function's signature gained `tools` / `traceTurn`
-    // / `stepIndex` / `onToolCall` params, and the loop body now
-    // invokes the callback alongside the existing `writer.write({type:
-    // "tool-input-available", ...})`). That path is harder to trigger
-    // in isolation than the resumed-approval branch covered above —
-    // it requires the per-step path to reach the local tool-execution
-    // branch with prior unresolved tool-calls in scope, a
-    // multi-fixture setup that doesn't fit cleanly into the
-    // single-handler-call test shape used here. The code fix is
-    // covered by the same `tools` + `traceTurn` plumbing pattern as
-    // the approved-tools site above, which IS tested.
+    it("re-introduces an UNAPPROVED sibling before answering it on a resumed turn", async () => {
+      // The approval pause is whole-step: it drains only approval-free meta
+      // tools, so an ordinary tool the model emitted in the same assistant
+      // message is still unresolved when the approval comes back. The resume
+      // then executes EVERY unresolved call, so that sibling gets an answer —
+      // and the client, on a fresh response, has no tool part to attach it to
+      // unless the call was re-introduced first. It throws
+      // `No tool invocation found for tool call ID "…"` and ends the turn with
+      // a red banner, after both tools have already run.
+      //
+      // A page tool makes this the ordinary case: `webmcp_*` always pauses
+      // while the `browser_*` verbs follow their own floor, so one request
+      // emits one of each in a single step.
+      const stepTwo = [
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: "done" },
+        { type: "text-end", id: "text-1" },
+        {
+          type: "finish",
+          finishReason: "stop",
+          messageMetadata: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ];
+      global.fetch = vi.fn().mockResolvedValue(createSseResponse(stepTwo));
+
+      // ONE assistant message, TWO calls, ONE approval. The sibling has no
+      // approval parts at all — it never needed any.
+      const resumedMessages = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call-page-1",
+              toolName: "webmcp_add_topping",
+              input: { topping: "pepperoni" },
+            },
+            {
+              type: "tool-call",
+              toolCallId: "call-sibling-1",
+              toolName: "browser_observe",
+              input: {},
+            },
+            {
+              type: "tool-approval-request",
+              approvalId: "approval-page-1",
+              toolCallId: "call-page-1",
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-approval-response",
+              approvalId: "approval-page-1",
+              approved: true,
+            },
+          ],
+        },
+      ];
+
+      vi.mocked(hasUnresolvedToolCalls).mockReturnValue(false);
+      // What the real helper does: run every unresolved call in the history,
+      // not only the approved one.
+      vi.mocked(executeToolCallsFromMessages).mockImplementation(
+        async (messages: any[]) => {
+          const toolResultMessage = {
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: "call-page-1",
+                toolName: "webmcp_add_topping",
+                output: { type: "json", value: { ok: true } },
+              },
+              {
+                type: "tool-result",
+                toolCallId: "call-sibling-1",
+                toolName: "browser_observe",
+                output: { type: "json", value: { url: "https://pizza.test/" } },
+              },
+            ],
+          };
+          messages.push(toolResultMessage);
+          return [toolResultMessage] as any;
+        },
+      );
+
+      await handleMCPJamFreeChatModel({
+        messages: resumedMessages as any,
+        modelId: "openai/gpt-5-mini",
+        systemPrompt: "You are helpful",
+        tools: {
+          webmcp_add_topping: {},
+          browser_observe: {},
+        } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        requireToolApproval: true,
+      });
+
+      await lastExecution;
+
+      const indexOf = (type: string, toolCallId: string) =>
+        writtenChunks.findIndex(
+          (chunk) => chunk?.type === type && chunk?.toolCallId === toolCallId,
+        );
+
+      // The sibling is introduced, and BEFORE its answer. Either half missing
+      // is the bug: no input chunk at all was the original failure, and an
+      // input written after the output would still throw on the output.
+      const siblingInput = indexOf("tool-input-available", "call-sibling-1");
+      const siblingOutput = indexOf("tool-output-available", "call-sibling-1");
+      expect(siblingInput).toBeGreaterThanOrEqual(0);
+      expect(siblingOutput).toBeGreaterThanOrEqual(0);
+      expect(siblingInput).toBeLessThan(siblingOutput);
+
+      // And the approved call keeps the ordering it already had.
+      const pageInput = indexOf("tool-input-available", "call-page-1");
+      const pageOutput = indexOf("tool-output-available", "call-page-1");
+      expect(pageInput).toBeGreaterThanOrEqual(0);
+      expect(pageInput).toBeLessThan(pageOutput);
+    });
+
+    it("re-introduces a DENIED call before telling the client it was denied", async () => {
+      // Same rule, the other emission: `tool-output-denied` also asks the
+      // client for a tool part it does not have on a fresh response.
+      const stepTwo = [
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: "ok" },
+        { type: "text-end", id: "text-1" },
+        {
+          type: "finish",
+          finishReason: "stop",
+          messageMetadata: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ];
+      global.fetch = vi.fn().mockResolvedValue(createSseResponse(stepTwo));
+
+      const resumedMessages = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call-denied-2",
+              toolName: "browser_navigate",
+              input: { url: "https://pizza.test/" },
+            },
+            {
+              type: "tool-approval-request",
+              approvalId: "approval-denied-2",
+              toolCallId: "call-denied-2",
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-approval-response",
+              approvalId: "approval-denied-2",
+              approved: false,
+            },
+          ],
+        },
+      ];
+
+      vi.mocked(hasUnresolvedToolCalls).mockReturnValue(false);
+      vi.mocked(executeToolCallsFromMessages).mockResolvedValue([]);
+
+      await handleMCPJamFreeChatModel({
+        messages: resumedMessages as any,
+        modelId: "openai/gpt-5-mini",
+        systemPrompt: "You are helpful",
+        tools: { browser_navigate: {} } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        requireToolApproval: true,
+      });
+
+      await lastExecution;
+
+      const inputIdx = writtenChunks.findIndex(
+        (chunk) =>
+          chunk?.type === "tool-input-available" &&
+          chunk?.toolCallId === "call-denied-2",
+      );
+      const deniedIdx = writtenChunks.findIndex(
+        (chunk) =>
+          chunk?.type === "tool-output-denied" &&
+          chunk?.toolCallId === "call-denied-2",
+      );
+      expect(inputIdx).toBeGreaterThanOrEqual(0);
+      expect(deniedIdx).toBeGreaterThanOrEqual(0);
+      expect(inputIdx).toBeLessThan(deniedIdx);
+    });
 
     it("fires `onToolResult` for denied tools on resumed approval turns (PR 5b-pre review fix — Cursor Medium)", async () => {
       // Cursor PR 5b-pre review fix: `handlePendingApprovals` writes a

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -2500,6 +2500,44 @@ async function handlePendingApprovals(
     }
   }
 
+  // RE-INTRODUCE EVERY UNRESOLVED CALL BEFORE ANY ANSWER GOES OUT.
+  //
+  // This response is a NEW one. The client's reducer looks for a tool part on
+  // the message it is currently building, so every chunk below that names a
+  // tool call from the PREVIOUS response — `tool-output-denied`, and the
+  // results `emitToolResults` writes — needs that call re-introduced first or
+  // the client throws `No tool invocation found for tool call ID "…"` and ends
+  // the turn with a red banner, after the tools have already run.
+  //
+  // EVERY unresolved call, not only the approved ones. Two of the three
+  // reasons a call is sitting here unresolved are not "it was approved":
+  //
+  //   - A DENIED call. Its `tool-output-denied` is written below, and nothing
+  //     had introduced it.
+  //   - A SIBLING that never needed approval. The approval pause is
+  //     whole-step: it drains only approval-free meta tools, so an ordinary
+  //     tool the model emitted in the same assistant message waits here too —
+  //     and `executeToolCallsFromMessages` below runs EVERY unresolved call,
+  //     so a result for that sibling is written whether or not anyone approved
+  //     anything.
+  //
+  // The mixed step is now the ordinary case rather than a corner. A page tool
+  // always pauses while the `browser_*` verbs follow their own floor, so one
+  // "add pepperoni" emits a `webmcp_*` call and a `browser_observe` in a
+  // single step, approves one, and resumes into exactly this.
+  //
+  // Idempotent by construction: the helper skips any call that already has a
+  // result, so a second pass over the same history emits nothing.
+  emitInheritedToolCalls(
+    writer,
+    messageHistory,
+    messageHistory.length,
+    tools,
+    traceTurn,
+    stepIndex,
+    onToolCall,
+  );
+
   let didHandle = false;
 
   // Emit denied tool notifications to the client and add tool-result entries
@@ -2603,57 +2641,9 @@ async function handlePendingApprovals(
   );
 
   if (needsExecution) {
-    // Emit tool-input-available for approved tool calls so the AI SDK client
-    // can attach the upcoming tool-output-available chunks. Without this, the
-    // stream consumer throws "No tool invocation found for tool call ID …"
-    // because the matching tool-call was on a prior assistant message and
-    // this resumed stream hasn't introduced it yet.
-    for (const toolCallId of approvedToolCallIds) {
-      if (existingResultIds.has(toolCallId)) continue;
-      const assistantIdx = toolCallIdToAssistantIdx.get(toolCallId);
-      if (assistantIdx === undefined) continue;
-      const assistantMsg = messageHistory[
-        assistantIdx
-      ] as AssistantModelMessage;
-      if (!Array.isArray(assistantMsg.content)) continue;
-      for (const part of assistantMsg.content) {
-        if (part.type === "tool-call" && part.toolCallId === toolCallId) {
-          emitToolInput(writer, {
-            toolCallId: part.toolCallId,
-            toolName: part.toolName,
-            input: part.input ?? {},
-            ...(part.providerOptions
-              ? { providerMetadata: part.providerOptions }
-              : {}),
-          });
-          // PR 5b-pre review fix (Cursor Medium "Resumed approvals
-          // skip onToolCall"): fire `onToolCall` for resumed approved
-          // tools so PR 5b's eval wiring sees a matching `tool_call`
-          // before the `tool_result` `emitToolResults` produces below.
-          if (onToolCall && traceTurn && typeof stepIndex === "number") {
-            try {
-              onToolCall({
-                toolCallId: part.toolCallId,
-                toolName: part.toolName,
-                input: part.input,
-                stepIndex,
-                promptIndex: traceTurn.promptIndex,
-                serverId: readToolServerId(tools, part.toolName),
-              });
-            } catch (error) {
-              logger.warn(
-                "[mcpjam-stream-handler] onToolCall callback failed (approval)",
-                {
-                  error: error instanceof Error ? error.message : String(error),
-                },
-              );
-            }
-          }
-          break;
-        }
-      }
-    }
-
+    // The `tool-input-available` chunks these results attach to were written
+    // above, for every unresolved call rather than only the approved ones —
+    // see the comment there for why the difference matters.
     const newMessages = await executeToolCallsFromMessages(messageHistory, {
       tools: tools as Record<string, any>,
       modelVisibleMcpToolResults,


### PR DESCRIPTION
Approving one tool call ended the turn with a red banner:

> An error occurred: No tool invocation found for tool call ID "toolu_01R13bi4TncnQDn4XAHEvCQr".

Both tools had already run and the page had already changed. The failure was entirely in what the resumed response told the client.

## Why it happens

The client's stream reducer resolves a tool part on the message it is **currently building**. A resume is a NEW response, so any chunk naming a call from the previous one has to re-introduce that call first, or the reducer throws and the turn dies.

`handlePendingApprovals` re-introduced the **approved** calls only, while emitting answers for more than those:

- A **denied** call got `tool-output-denied` with nothing introducing it.
- `executeToolCallsFromMessages` runs **every** unresolved call in the history, so a **sibling** the model emitted in the same assistant message got a result too. The approval pause is whole-step and drains only approval-free meta tools, so an ordinary tool sitting beside a gated one is still unresolved when the approval comes back.

That mixed step is now the ordinary case rather than a corner. A page tool always pauses while the `browser_*` verbs follow their own floor, so one "add pepperoni" emits a `webmcp_*` call and a `browser_observe` in a single step, approves one, and resumes into exactly this.

## The fix

`emitInheritedToolCalls` already re-introduces every unresolved call, and already fires `onToolCall` for each. It just ran later, inside the step, which is after the damage. Calling it at the top of the resume covers all three cases in one pass and retires the approved-only loop. It skips anything that already has a result, so a second pass over the same history emits nothing.

The change is a net deletion in the handler: one helper call replaces a bespoke loop that did a narrower version of the same thing.

## Also: the suite could not load

The handler imports one function from the harness runner, and that module loads `@ai-sdk/harness/agent` at import time. `@ai-sdk/harness` is declared in `package.json` but absent from a plain install here, so `mcpjam-stream-handler.test.ts` — the file that pins the approval and emit invariants — failed to **load** rather than failing a test. Mocked, since nothing in the suite runs a harness turn.

Ten or so sibling suites in `server/utils/__tests__/` still fail to load for the same reason locally; they are unaffected by this change and run in CI.

## Verification

- `mcpjam-stream-handler.test.ts`: 65 pass, including two new cases.
- Both new tests assert **ordering**, not mere presence: an input written after the output would still throw on the output.
- Reverting just the fix fails both new tests plus the existing approved-tools `onToolCall` case, which is what confirms the helper now carries that behaviour.
- `npm run typecheck:client` clean; `tsc` clean for the handler.

## Not in this PR

The `browser_*` approval prompts are working as designed. Their floor is `always` on an interactive surface, and `requireToolApproval` deliberately cannot lower a floor — the Tool Approval tooltip says so ("Browser, page, local-machine and destructive UI actions always pause"). Making browser verbs follow the switch would be a product decision, not a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tool-approval resume streaming in `handlePendingApprovals`; wrong ordering or missed calls would still break the client reducer, but behavior is covered by new ordering tests and consolidates existing helper logic.
> 
> **Overview**
> Fixes resumed tool-approval turns that crashed the client with **No tool invocation found for tool call ID** after tools had already run. A resume starts a **new** stream, so any `tool-output-*` chunk must be preceded by `tool-input-available` for that call.
> 
> **Handler:** At the start of `handlePendingApprovals`, the stream now calls **`emitInheritedToolCalls`** for every unresolved call (denied tools, approval siblings like `browser_*` next to gated `webmcp_*`, and approved calls) **before** `tool-output-denied` or tool results. The approved-only `tool-input-available` loop is removed in favor of that single path (still fires `onToolCall`).
> 
> **Tests:** Mocks **`run-harness-turn`** so the suite loads without optional `@ai-sdk/harness`. Adds ordering tests: unapproved sibling and denied call must get `tool-input-available` before their output/denied chunks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbefc6bac0cd12b44375bc1c897d6d3d2f2b7d24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the resumed-turn approval flow: approving one tool call no longer ends the turn with a red banner. The client's stream reducer requires every tool call from the prior response to be re-introduced before any answer chunk, but `handlePendingApprovals` only re-introduced approved calls — denied calls and unapproved siblings emitted answers with nothing introducing them.

**Bug Fixes**
- Calling `emitInheritedToolCalls` at the top of the resume re-introduces every unresolved call, replacing the approved-only loop; it skips calls that already have results.
- The handler test suite now mocks the harness runner so it loads without `@ai-sdk/harness` installed.

<sup>Written for commit dbefc6bac0cd12b44375bc1c897d6d3d2f2b7d24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

