### PR TITLE
Fix GitHub checks for environment suites

### DIFF
--- a/mcpjam-inspector/server/routes/shared/__tests__/evals.test.ts
+++ b/mcpjam-inspector/server/routes/shared/__tests__/evals.test.ts
@@ -12,6 +12,7 @@ import {
   shouldSkipExecution,
   assertTestCaseRunWithinCap,
   authorEvalSuite,
+  buildGithubCheckRunEnvironmentOverride,
   buildManagerKeyToDisplayNameMap,
   fetchRunPinnedSkillsWithRetry,
   filterAndRemapReplayConfigs,
@@ -54,6 +55,38 @@ function buildTestCaseRequest(runs?: number): unknown {
     ...(runs === undefined ? {} : { testCaseOverrides: { runs } }),
   };
 }
+
+describe("GitHub check run environment override", () => {
+  it("targets the ephemeral PR server for an environment-backed suite", () => {
+    expect(
+      buildGithubCheckRunEnvironmentOverride({
+        source: "github_check",
+        resolvedServerIds: ["ephemeral-server-id"],
+        persistedServerRefs: ["ephemeral-server-id"],
+        serverNames: ["gh-check-trigger-1"],
+      })
+    ).toEqual({
+      servers: ["gh-check-trigger-1"],
+      serverBindings: [
+        {
+          serverName: "gh-check-trigger-1",
+          projectServerId: "ephemeral-server-id",
+        },
+      ],
+    });
+  });
+
+  it("does not override ordinary suite runs", () => {
+    expect(
+      buildGithubCheckRunEnvironmentOverride({
+        source: "ui",
+        resolvedServerIds: ["server-id"],
+        persistedServerRefs: ["server-id"],
+        serverNames: ["server"],
+      })
+    ).toBeUndefined();
+  });
+});
 
 describe("RunEvalsRequestSchema environmentId boundary", () => {
   it("accepts AND preserves environmentId (guards the silent-strip failure mode)", () => {

--- a/mcpjam-inspector/server/routes/shared/__tests__/evals.test.ts
+++ b/mcpjam-inspector/server/routes/shared/__tests__/evals.test.ts
@@ -12,7 +12,7 @@ import {
   shouldSkipExecution,
   assertTestCaseRunWithinCap,
   authorEvalSuite,
-  buildGithubCheckRunEnvironmentOverride,
+  buildGithubCheckServerOverride,
   buildManagerKeyToDisplayNameMap,
   fetchRunPinnedSkillsWithRetry,
   filterAndRemapReplayConfigs,
@@ -56,35 +56,39 @@ function buildTestCaseRequest(runs?: number): unknown {
   };
 }
 
-describe("GitHub check run environment override", () => {
-  it("targets the ephemeral PR server for an environment-backed suite", () => {
+describe("GitHub check server override", () => {
+  it("pairs the ephemeral PR server name and project row", () => {
     expect(
-      buildGithubCheckRunEnvironmentOverride({
+      buildGithubCheckServerOverride({
         source: "github_check",
-        resolvedServerIds: ["ephemeral-server-id"],
         persistedServerRefs: ["ephemeral-server-id"],
         serverNames: ["gh-check-trigger-1"],
       })
-    ).toEqual({
-      servers: ["gh-check-trigger-1"],
-      serverBindings: [
-        {
-          serverName: "gh-check-trigger-1",
-          projectServerId: "ephemeral-server-id",
-        },
-      ],
-    });
+    ).toEqual([
+      {
+        serverName: "gh-check-trigger-1",
+        projectServerId: "ephemeral-server-id",
+      },
+    ]);
   });
 
   it("does not override ordinary suite runs", () => {
     expect(
-      buildGithubCheckRunEnvironmentOverride({
+      buildGithubCheckServerOverride({
         source: "ui",
-        resolvedServerIds: ["server-id"],
         persistedServerRefs: ["server-id"],
         serverNames: ["server"],
       })
     ).toBeUndefined();
+  });
+
+  it("rejects incomplete PR server identity", () => {
+    expect(() =>
+      buildGithubCheckServerOverride({
+        source: "github_check",
+        persistedServerRefs: ["server-id"],
+      })
+    ).toThrow(WebRouteError);
   });
 });
 

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -644,6 +644,25 @@ type RunEvalsWithManagerRequest = RunEvalsRequest & {
   launchContext?: LaunchContext;
 } & EvalRunProvenance;
 
+/**
+ * GitHub checks must run against the ephemeral server built from the PR.
+ *
+ * A suite can also be attached to a project environment. Backend environment
+ * selection intentionally wins over the suite's legacy `environment` field,
+ * so rewriting that field does not redirect an environment-backed suite. A
+ * run-only override is the authoritative way to select the verified PR server
+ * without mutating the user's saved suite or environment.
+ */
+export function buildGithubCheckRunEnvironmentOverride(args: {
+  source: RunEvalsWithManagerRequest["source"];
+  resolvedServerIds: string[];
+  persistedServerRefs: string[];
+  serverNames?: string[];
+}) {
+  if (args.source !== "github_check") return undefined;
+  return buildPersistedSuiteEnvironment(args);
+}
+
 export const RunTestCaseRequestSchema = z.object({
   testCaseId: z.string(),
   model: z.string(),
@@ -2334,6 +2353,13 @@ export async function prepareEvalRun(
   const committedCases = authoredCaseUpsert.committed;
   const failedCases = authoredCaseUpsert.failed;
 
+  const environmentOverride = buildGithubCheckRunEnvironmentOverride({
+    source: request.source,
+    resolvedServerIds,
+    persistedServerRefs,
+    serverNames,
+  });
+
   const {
     runId,
     config,
@@ -2358,6 +2384,7 @@ export async function prepareEvalRun(
     namedHostId,
     runGroupId,
     environmentId,
+    environmentOverride,
     // All three preconditions come from the SAME resolution the tool snapshot
     // was captured against. The revision alone is not enough: an environment
     // pins a `hostId` and optionally an attachment, both dereferenced live, so

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -644,23 +644,44 @@ type RunEvalsWithManagerRequest = RunEvalsRequest & {
   launchContext?: LaunchContext;
 } & EvalRunProvenance;
 
-/**
- * GitHub checks must run against the ephemeral server built from the PR.
- *
- * A suite can also be attached to a project environment. Backend environment
- * selection intentionally wins over the suite's legacy `environment` field,
- * so rewriting that field does not redirect an environment-backed suite. A
- * run-only override is the authoritative way to select the verified PR server
- * without mutating the user's saved suite or environment.
- */
-export function buildGithubCheckRunEnvironmentOverride(args: {
+export type GithubCheckServerOverride = Array<{
+  serverName: string;
+  projectServerId: string;
+}>;
+
+/** Pair the temporary PR server's display name with its project server row. */
+export function buildGithubCheckServerOverride(args: {
   source: RunEvalsWithManagerRequest["source"];
-  resolvedServerIds: string[];
   persistedServerRefs: string[];
   serverNames?: string[];
-}) {
+}): GithubCheckServerOverride | undefined {
   if (args.source !== "github_check") return undefined;
-  return buildPersistedSuiteEnvironment(args);
+  if (
+    !args.serverNames?.length ||
+    args.serverNames.length !== args.persistedServerRefs.length
+  ) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "GitHub checks require one name for each temporary PR server",
+    );
+  }
+  const names = new Set(args.serverNames.map((name) => name.toLowerCase()));
+  const ids = new Set(args.persistedServerRefs);
+  if (
+    names.size !== args.serverNames.length ||
+    ids.size !== args.persistedServerRefs.length
+  ) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "GitHub checks require unique temporary PR server names and ids",
+    );
+  }
+  return args.serverNames.map((serverName, index) => ({
+    serverName,
+    projectServerId: args.persistedServerRefs[index],
+  }));
 }
 
 export const RunTestCaseRequestSchema = z.object({
@@ -2353,9 +2374,8 @@ export async function prepareEvalRun(
   const committedCases = authoredCaseUpsert.committed;
   const failedCases = authoredCaseUpsert.failed;
 
-  const environmentOverride = buildGithubCheckRunEnvironmentOverride({
+  const githubCheckServerOverride = buildGithubCheckServerOverride({
     source: request.source,
-    resolvedServerIds,
     persistedServerRefs,
     serverNames,
   });
@@ -2384,7 +2404,7 @@ export async function prepareEvalRun(
     namedHostId,
     runGroupId,
     environmentId,
-    environmentOverride,
+    ...(githubCheckServerOverride ? { githubCheckServerOverride } : {}),
     // All three preconditions come from the SAME resolution the tool snapshot
     // was captured against. The revision alone is not enough: an environment
     // pins a `hostId` and optionally an attachment, both dereferenced live, so

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker-source.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker-source.test.ts
@@ -76,7 +76,7 @@ describe("defaultRunEvalSuite provenance", () => {
     // The rest of the provenance-bearing contract, pinned alongside it:
     expect(request.idempotencyKey).toBe("trig-src");
     expect(request.suiteRerun).toBe(true);
-    expect(request.refreshSnapshot).toBe(true);
+    expect(request).not.toHaveProperty("refreshSnapshot");
     expect(result.result).toBe("passed");
   });
 

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -389,12 +389,7 @@ describe("executeClaimedCheck — happy path", () => {
     );
   });
 
-  it("targets the run at THIS check's server and refreshes the suite snapshot", async () => {
-    // `serverIds` alone is not enough: it never reaches the run-start mutation,
-    // so the run's configSnapshot.environment comes from the suite's persisted
-    // environment — which names the PREVIOUS check's deleted server unless the
-    // snapshot is refreshed. Without this the runner fails on a dead reference
-    // instead of testing the PR.
+  it("targets the run at THIS check's ephemeral server", async () => {
     const prepared: Array<Record<string, unknown>> = [];
     const h = harness({
       runEvalSuite: async (args) => {
@@ -404,10 +399,8 @@ describe("executeClaimedCheck — happy path", () => {
     });
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
 
-    // The suite-snapshot refresh itself lives in `defaultRunEvalSuite`, which
-    // needs a live Convex + connected manager and is covered by the end-to-end
-    // pass; what is checkable here is that the run is handed THIS check's
-    // freshly-created server rather than anything the suite has stored.
+    // `prepareEvalRun` converts this server into a run-only environment
+    // override for the `github_check` source.
     expect(prepared[0]).toMatchObject({
       serverId: "server-1",
       serverName: "gh-check-trig-1",
@@ -1337,11 +1330,8 @@ describe("startGithubChecksWorker loop", () => {
 });
 
 describe("verifyRunSnapshot", () => {
-  // The dedicated suite is shared and `refreshSnapshot` rewrites its environment
-  // before the run freezes it, so two concurrent checks can interleave and one can
-  // end up evaluating the other's server. This cannot prevent that; it decides when
-  // the theft is PROVEN, and when we simply could not look — a verdict about
-  // somebody else's PR being worse than no verdict.
+  // The run-only environment override prevents the former shared-suite rewrite
+  // race. This remains a final defense against a malformed or regressed snapshot.
   const clientWith = (snapshot: unknown) =>
     ({
       query: async () => ({ configSnapshot: { environment: snapshot } }),

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -389,7 +389,7 @@ describe("executeClaimedCheck — happy path", () => {
     );
   });
 
-  it("targets the run at THIS check's ephemeral server", async () => {
+  it("passes this check's temporary server identity to the suite runner", async () => {
     const prepared: Array<Record<string, unknown>> = [];
     const h = harness({
       runEvalSuite: async (args) => {
@@ -399,8 +399,6 @@ describe("executeClaimedCheck — happy path", () => {
     });
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
 
-    // `prepareEvalRun` converts this server into a run-only environment
-    // override for the `github_check` source.
     expect(prepared[0]).toMatchObject({
       serverId: "server-1",
       serverName: "gh-check-trig-1",

--- a/mcpjam-inspector/server/services/evals/__tests__/recorder.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/recorder.test.ts
@@ -6,6 +6,34 @@ import {
 } from "../recorder.js";
 
 describe("startSuiteRunWithRecorder", () => {
+  it("forwards the GitHub server replacement and omits undefined overrides", async () => {
+    const mutation = vi.fn().mockResolvedValue({ runId: "run-1", testCases: [] });
+    const githubCheckServerOverride = [
+      { serverName: "gh-check-trigger-1", projectServerId: "server-1" },
+    ];
+
+    await startSuiteRunWithRecorder({
+      convexClient: { mutation } as any,
+      suiteId: "suite-1",
+      source: "github_check",
+      githubCheckServerOverride,
+    });
+    expect(mutation.mock.calls[0][1]).toMatchObject({
+      source: "github_check",
+      githubCheckServerOverride,
+    });
+    expect(mutation.mock.calls[0][1]).not.toHaveProperty("environmentOverride");
+
+    mutation.mockClear();
+    await startSuiteRunWithRecorder({
+      convexClient: { mutation } as any,
+      suiteId: "suite-1",
+    });
+    expect(mutation.mock.calls[0][1]).not.toHaveProperty(
+      "githubCheckServerOverride"
+    );
+  });
+
   it("forwards per-run import approvals, and omits the key when there are none", async () => {
     // The mutation args are RECONSTRUCTED field by field in this function, so
     // a field nobody names here never reaches Convex — and an approval that

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -385,6 +385,7 @@ export const startSuiteRunWithRecorder = async ({
   replayedFromRunId,
   useCurrentSuiteConfig,
   environmentOverride,
+  githubCheckServerOverride,
   toolSnapshot,
   toolSnapshotDebug,
   iterationOverride,
@@ -428,6 +429,11 @@ export const startSuiteRunWithRecorder = async ({
     // object would silently drop it before Convex).
     computerEnvironmentId?: string;
   };
+  /** Replace only the MCP servers for a GitHub check run. */
+  githubCheckServerOverride?: Array<{
+    serverName: string;
+    projectServerId: string;
+  }>;
   toolSnapshot?: ServerToolSnapshot;
   toolSnapshotDebug?: Record<string, unknown>;
   /**
@@ -568,7 +574,10 @@ export const startSuiteRunWithRecorder = async ({
         passCriteria,
         replayedFromRunId,
         useCurrentSuiteConfig,
-        environmentOverride,
+        ...(environmentOverride ? { environmentOverride } : {}),
+        ...(githubCheckServerOverride
+          ? { githubCheckServerOverride }
+          : {}),
         toolSnapshot: sanitizeForConvexTransport(toolSnapshot),
         toolSnapshotDebug: sanitizeForConvexTransport(toolSnapshotDebug),
         iterationOverride,

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -951,25 +951,18 @@ async function runCompleted(
 }
 
 /**
- * Run the dedicated suite against the just-built server.
+ * Run the selected suite against the just-built server.
  *
- * The `serverIds` override is what makes this work at all: the suite is a
- * persisted `[github-checks] …` suite whose own saved server refs point at some
- * previous check's (now deleted) ephemeral row. Overriding on every run means
- * the suite's stored binding is never consulted — which is also why this suite
- * must never be launched from the UI.
+ * `prepareEvalRun` turns the `github_check` source plus these server ids into a
+ * run-only environment override. That override wins over any project
+ * environment attached to the suite, so the run always targets this PR's
+ * ephemeral server without rewriting the user's saved suite.
  */
 /**
  * Which check's server this run's frozen environment names.
  *
- * The dedicated suite is shared, and `refreshSnapshot: true` rewrites its stored
- * environment before the run-start mutation freezes it — two mutations, no
- * atomicity. Two checks running at once (two workers, or two replicas of one) can
- * therefore interleave as: A rewrites → B rewrites → A starts and freezes B's
- * server. A would then evaluate the wrong PR's server, or fail when B deletes it,
- * and either way report a verdict about somebody else's code.
- *
- * This does not fix that race — it detects the case it can prove. Every check names
+ * The run-only override removes the former shared-suite rewrite race. This
+ * remains a final defense against a malformed or regressed run snapshot. Every check names
  * its server `gh-check-<triggerId>`, so:
  *
  *   - the snapshot mentions OUR trigger → `ours`;
@@ -1093,21 +1086,6 @@ async function defaultRunEvalSuite(args: {
       serverIds: [args.serverId],
       serverNames: [args.serverName],
       suiteRerun: true,
-      // REQUIRED, not incidental. `serverIds` is honored by the manager and by
-      // cap math, but it is NOT forwarded to the run-start mutation — the run's
-      // `configSnapshot.environment` comes from the suite's PERSISTED
-      // environment, and `suiteRerun: true` alone suppresses updating it
-      // (`authorEvalSuite`: `shouldUpdateSnapshot = !suiteRerun ||
-      // refreshSnapshot`). Without this flag the snapshot keeps naming the
-      // previous check's ephemeral server, which no longer exists, and the
-      // runner fails against a dead reference instead of testing the PR.
-      //
-      // This is the "suite binding rewrite" the design already called out as
-      // expected: the dedicated suite's stored server ref is rewritten every
-      // run. Harmless because we always override `serverIds` too — and the
-      // reason this suite is named `[github-checks] …` and must never be
-      // launched from the UI.
-      refreshSnapshot: true,
       // Distinguishes check-triggered runs from real /api/v1 calls in run
       // history and heartbeat accounting (backend union accepts this value).
       source: "github_check",

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -951,18 +951,10 @@ async function runCompleted(
 }
 
 /**
- * Run the selected suite against the just-built server.
- *
- * `prepareEvalRun` turns the `github_check` source plus these server ids into a
- * run-only environment override. That override wins over any project
- * environment attached to the suite, so the run always targets this PR's
- * ephemeral server without rewriting the user's saved suite.
- */
-/**
  * Which check's server this run's frozen environment names.
  *
- * The run-only override removes the former shared-suite rewrite race. This
- * remains a final defense against a malformed or regressed run snapshot. Every check names
+ * The run-only server replacement removes the former shared-suite rewrite
+ * race. This remains a final defense against a malformed or regressed run snapshot. Every check names
  * its server `gh-check-<triggerId>`, so:
  *
  *   - the snapshot mentions OUR trigger → `ours`;
@@ -1057,6 +1049,11 @@ async function abandonPreparedRun(
   }
 }
 
+/**
+ * Run the selected suite against the just-built server. The backend replaces
+ * only the suite's MCP server binding, preserving its environment model,
+ * skills, plugins, host settings, and computer image.
+ */
 async function defaultRunEvalSuite(args: {
   claimed: ClaimedGithubCheck;
   bearer: string;
@@ -1096,12 +1093,9 @@ async function defaultRunEvalSuite(args: {
 
     const client = createConvexClient(args.bearer);
 
-    // The suite is SHARED by every check, and rewriting its environment then
-    // starting the run are two separate mutations. Another check's rewrite can
-    // land in between, so this run's frozen snapshot can name ITS ephemeral
-    // server instead of ours. Verified before anything is evaluated, because a
-    // verdict from a run that tested a different PR's server is worse than no
-    // verdict at all. See `verifyRunSnapshot` for what is provable.
+    // Verify the frozen run points at this check's temporary server before any
+    // case executes. A verdict from another PR's server is worse than no
+    // verdict. See `verifyRunSnapshot` for what is provable.
     const ownership = await verifyRunSnapshot(
       client,
       prepared.runId,


### PR DESCRIPTION
Environment-backed eval suites made GitHub checks ignore the verified PR server and reuse the suite's saved local server. Amazon-MCP built successfully, then all eight cases failed setup because the runner tried to connect to `amazon` instead of the temporary PR server.

This sends a server-only run override for `github_check` runs. The backend composes it with the suite's environment, preserving its model, skills, plugins, host settings, and computer image. The saved suite is never rewritten, which also removes the concurrent-check race.

Depends on MCPJam/mcpjam-backend#1292. Deploy the backend first because Convex rejects unknown mutation fields.

Validation:
- 170 focused server tests passed
- `npm run build:server` passed
