### PR TITLE
fix(evals): restore schedule settings tab

### DIFF
--- a/.changeset/eval-schedule-settings-tab.md
+++ b/.changeset/eval-schedule-settings-tab.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Restore the Triggers tab in eval suite settings so scheduled runs can be managed from the app.

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-settings-manifest.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-settings-manifest.test.tsx
@@ -402,7 +402,7 @@ describe("eval suite settings manifest — render parity", () => {
     expect(container.querySelector('[data-setting-key="computerEnvironment"]')).toBeNull();
   });
 
-  it("keeps triggers hidden without schedule permission", () => {
+  it("keeps the schedule visible but disabled without schedule permission", () => {
     mocks.capabilities.mockReturnValue(
       readyCapabilities({
         permissions: {
@@ -419,8 +419,13 @@ describe("eval suite settings manifest — render parity", () => {
       }),
     );
     const { container } = renderSettingsSheet();
-    expect(container.querySelector('[data-setting-key="schedule"]')).toBeNull();
-    expect(container.querySelector('nav[aria-label="Settings sections"]')?.textContent).not.toContain("Triggers");
+    showSettingsKey(container, "schedule");
+    const schedule = container.querySelector('[data-setting-key="schedule"]');
+    expect(schedule).toBeTruthy();
+    expect(schedule?.getAttribute("data-disabled-reason")).toBe(
+      "You don't have permission to change this",
+    );
+    expect(container.querySelector('nav[aria-label="Settings sections"]')?.textContent).toContain("Triggers");
   });
 
   it("behaves exactly as before when capabilities are unavailable", () => {
@@ -433,7 +438,10 @@ describe("eval suite settings manifest — render parity", () => {
     );
     const keys = collectAllSettingKeys(container);
     expect(keys).not.toContain("computerEnvironment");
-    expect(keys).not.toContain("schedule");
+    // Capabilities being unavailable preserves the pre-capabilities behavior:
+    // the row is still reachable because the settings group is visible, but
+    // it carries no refusal reason until the capability query answers.
+    expect(keys).toContain("schedule");
   });
 
   it("puts the setup client table on the Clients row", () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-triggers-schedule-gate.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-triggers-schedule-gate.test.tsx
@@ -143,12 +143,7 @@ function renderTriggersTab() {
   return container;
 }
 
-// SKIPPED: the Evaluate settings sheet hides the Triggers group
-// (`VISIBLE_SUITE_SETTINGS_GROUPS` in suite-settings-groups.ts), so there is
-// no nav button to reach the rows these cases assert on. The section itself
-// is retained behind `activeGroupId === "triggers"`; re-enable this block when
-// the group returns to the sheet.
-describe.skip("Triggers tab — Schedule flag", () => {
+describe("Triggers tab — Schedule flag", () => {
   beforeEach(() => {
     class FakeIntersectionObserver {
       observe() {}

--- a/mcpjam-inspector/client/src/components/evals/suite-settings-groups.ts
+++ b/mcpjam-inspector/client/src/components/evals/suite-settings-groups.ts
@@ -9,10 +9,8 @@ export const SUITE_SETTINGS_GROUPS = [
   { id: "triggers", label: "Triggers", rows: ["schedule", "githubChecks"] },
 ] as const;
 
-/** Trigger configuration is retained but hidden from suite settings. */
-export const VISIBLE_SUITE_SETTINGS_GROUPS = SUITE_SETTINGS_GROUPS.filter(
-  (group) => group.id !== "triggers",
-);
+/** All suite settings groups are reachable from the settings sheet. */
+export const VISIBLE_SUITE_SETTINGS_GROUPS = SUITE_SETTINGS_GROUPS;
 
 export type SuiteSettingsGroupId = (typeof SUITE_SETTINGS_GROUPS)[number]["id"];
 


### PR DESCRIPTION
## Summary

- restore the Triggers tab in eval suite settings so scheduled runs are reachable
- re-enable the schedule feature-flag regression suite
- assert capability-denied schedules remain visible with a clear disabled reason

## Testing

- npx vitest run client/src/components/evals/__tests__/suite-triggers-schedule-gate.test.tsx client/src/components/evals/__tests__/suite-settings-manifest.test.tsx client/src/components/evals/__tests__/suite-settings-groups.test.ts
- npm run typecheck:client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI visibility and test expectations only; schedule editing remains gated by permissions and feature flags.
> 
> **Overview**
> **Restores the Triggers settings group** in eval suite settings so **Schedule** and **GitHub Checks** are reachable from the sheet again. `VISIBLE_SUITE_SETTINGS_GROUPS` no longer hides `triggers`; it now matches all defined groups.
> 
> Tests are updated to match: users **without** `suite.schedule` still see the schedule row and **Triggers** nav, but the row is **disabled** with *"You don't have permission to change this"*. When capabilities are still loading, **schedule** remains in the reachable keys (no refusal reason until the query resolves).
> 
> The **Triggers tab — Schedule flag** regression suite is **un-skipped** now that the nav can open that group again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f2851025dc2d4602497a9b50da97c2e74afb533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Triggers tab in eval suite settings so scheduled runs are reachable again. Users without schedule permission now see the schedule setting disabled with a clear reason instead of it being hidden.

- Re-enables the previously skipped schedule flag regression suite.
- Updates settings manifest tests to expect the visible-but-disabled behavior.

<sup>Written for commit 2f2851025dc2d4602497a9b50da97c2e74afb533. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

