### PR TITLE
Iterate Evaluate suite and run results

### DIFF
--- a/mcpjam-inspector/client/src/components/EvaluateTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvaluateTab.tsx
@@ -454,6 +454,10 @@ function EvaluateTabContent({
   const [createSuitePrefillServerId, setCreateSuitePrefillServerId] = useState<
     string | null
   >(null);
+  const existingSuiteNames = useMemo(
+    () => visibleSuites.map((entry) => entry.suite.name),
+    [visibleSuites],
+  );
 
   const emptyHeroServers = useMemo(
     () =>
@@ -471,10 +475,9 @@ function EvaluateTabContent({
 
   const handleEvalServer = useCallback(
     (server: { id: string; name: string }) => {
-      navigatePlaygroundEvalsRoute({
-        type: "eval-server",
-        serverId: server.id,
-      });
+      setCreateSuitePrefillName(server.name);
+      setCreateSuitePrefillServerId(server.id);
+      navigatePlaygroundEvalsRoute({ type: "create" });
     },
     [],
   );
@@ -1283,6 +1286,37 @@ function EvaluateTabContent({
     }
 
     const isLandingList = route.type === "list";
+    const landingLoading = (
+      <div className="flex min-h-0 flex-1 items-center justify-center">
+        <div className="text-center">
+          <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary" />
+          <p className="mt-4 text-sm text-muted-foreground">
+            Loading suites...
+          </p>
+        </div>
+      </div>
+    );
+    // First-run is the same on Runs and Suites: nothing has been authored
+    // yet, so the next step is create / eval-my-server, not an empty table.
+    const landingEmpty = (
+      <EvalsEmptyHero
+        onCreateSuite={handleOpenCreateSuite}
+        onEvalServer={handleEvalServer}
+        onQuickstart={() => void handleExcalidrawQuickstart()}
+        isQuickstartRunning={isQuickstartRunning}
+        showQuickstart={showQuickstart}
+        servers={emptyHeroServers}
+        serversLoading={isProjectServersLoading}
+      />
+    );
+
+    if (isLandingList && overviewQueries.isOverviewLoading) {
+      return landingLoading;
+    }
+
+    if (isLandingList && visibleSuites.length === 0) {
+      return landingEmpty;
+    }
 
     if (isLandingList && landingView === "runs") {
       return projectId && shouldQueryProjectId(projectId) ? (
@@ -1295,6 +1329,7 @@ function EvaluateTabContent({
             projectId={projectId}
             onSelectRun={handleSelectRunFromAllRuns}
             decisionSummaryEnabled={decisionSummaryEnabled}
+            emptyState={landingEmpty}
           />
         </div>
       ) : (
@@ -1307,30 +1342,11 @@ function EvaluateTabContent({
     }
 
     if (overviewQueries.isOverviewLoading) {
-      return (
-        <div className="flex min-h-0 flex-1 items-center justify-center">
-          <div className="text-center">
-            <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary" />
-            <p className="mt-4 text-sm text-muted-foreground">
-              Loading suites...
-            </p>
-          </div>
-        </div>
-      );
+      return landingLoading;
     }
 
     if (visibleSuites.length === 0) {
-      return (
-        <EvalsEmptyHero
-          onCreateSuite={handleOpenCreateSuite}
-          onEvalServer={handleEvalServer}
-          onQuickstart={() => void handleExcalidrawQuickstart()}
-          isQuickstartRunning={isQuickstartRunning}
-          showQuickstart={showQuickstart}
-          servers={emptyHeroServers}
-          serversLoading={isProjectServersLoading}
-        />
-      );
+      return landingEmpty;
     }
 
     if (hasDetailRoute) {
@@ -1558,6 +1574,7 @@ function EvaluateTabContent({
               projectId={projectId}
               initialName={createSuitePrefillName}
               initialServerId={createSuitePrefillServerId}
+              existingSuiteNames={existingSuiteNames}
             />
           </div>
         ) : (

--- a/mcpjam-inspector/client/src/components/__tests__/EvaluateTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvaluateTab.test.tsx
@@ -643,7 +643,7 @@ describe("EvaluateTab", () => {
     );
   });
 
-  it("shows the runs table from the empty landing when Runs is selected", async () => {
+  it("shows the empty hero on Runs when there are no suites", () => {
     mocks.route.current = { type: "list" };
     mocks.useEvalQueries.mockImplementation(() => ({
       ...makeQueryState(null),
@@ -651,17 +651,21 @@ describe("EvaluateTab", () => {
       suiteOverview: [],
     }));
 
-    const user = userEvent.setup();
     render(<EvaluateTab projectId="ws-1" />);
 
-    await user.click(screen.getByRole("button", { name: /^runs$/i }));
-
-    expect(screen.queryByTestId("evals-empty-hero")).toBeNull();
-    expect(screen.getByTestId("evals-runs-landing")).toBeInTheDocument();
-    expect(screen.getByTestId("project-runs-table")).toBeInTheDocument();
+    expect(screen.getByTestId("evals-empty-hero")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Eval my server: server-a" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("evals-runs-landing")).toBeNull();
+    expect(screen.queryByTestId("project-runs-table")).toBeNull();
+    expect(screen.getByRole("button", { name: /^runs$/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
   });
 
-  it("opens the first-run preview from Eval my server, and Create suite still uses the form", async () => {
+  it("opens Create suite from Eval my server with that server prefilled, and header Create suite stays blank", async () => {
     mocks.route.current = { type: "list" };
     mocks.useEvalQueries.mockImplementation(() => ({
       ...makeQueryState(null),
@@ -677,28 +681,37 @@ describe("EvaluateTab", () => {
       screen.getByRole("button", { name: "Eval my server: server-a" }),
     );
     expect(mocks.navigatePlaygroundEvalsRoute).toHaveBeenCalledWith({
-      type: "eval-server",
-      serverId: "srv-a",
+      type: "create",
     });
 
+    mocks.route.current = { type: "create" };
+    view.rerender(<EvaluateTab projectId="ws-1" />);
+
+    expect(screen.getByTestId("create-suite-page")).toBeInTheDocument();
+    expect(screen.queryByTestId("evals-empty-hero")).toBeNull();
+    expect(mocks.createSuitePage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialName: "server-a",
+        initialServerId: "srv-a",
+      }),
+    );
+
+    mocks.route.current = { type: "list" };
+    view.rerender(<EvaluateTab projectId="ws-1" />);
+    await user.click(screen.getByRole("button", { name: /^suites$/i }));
     await user.click(screen.getByRole("button", { name: /^create suite$/i }));
     expect(mocks.navigatePlaygroundEvalsRoute).toHaveBeenCalledWith({
       type: "create",
     });
 
-    mocks.route.current = { type: "eval-server", serverId: "srv-a" };
+    mocks.route.current = { type: "create" };
     view.rerender(<EvaluateTab projectId="ws-1" />);
-
-    expect(
-      screen.getByTestId("suite-case-generation-workspace"),
-    ).toBeInTheDocument();
-    expect(screen.queryByTestId("evals-empty-hero")).toBeNull();
-    expect(screen.queryByTestId("create-suite-page")).toBeNull();
-    expect(
-      screen.getByRole("heading", {
-        name: "Generate test cases",
+    expect(mocks.createSuitePage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        initialName: null,
+        initialServerId: null,
       }),
-    ).toBeInTheDocument();
+    );
   });
 
   it("opens today's case editor from a first-run case and can return", async () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/metric-strip-sparkline.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/metric-strip-sparkline.test.tsx
@@ -136,6 +136,16 @@ describe("MetricStrip sparkline hover", () => {
     expect(within(sparkline).getByText("Run 1")).toBeInTheDocument();
   });
 
+  it("omits failed-iteration and point-change chips in history context", () => {
+    render(
+      <MetricStrip data={sampleData} context="history" testId="metric-strip" />,
+    );
+    expect(screen.queryByText(/failed iteration/)).toBeNull();
+    expect(screen.queryByText(/pp/)).toBeNull();
+    expect(screen.getByText("50%")).toBeInTheDocument();
+    expect(screen.getByText("1/2 passed")).toBeInTheDocument();
+  });
+
   it("renders card sparkline tooltips below the chart", () => {
     render(<MetricStrip data={sampleData} testId="metric-strip" />);
     const sparkline = screen.getByTestId("metric-sparkline-latency");

--- a/mcpjam-inspector/client/src/components/evals/__tests__/project-runs-table.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/project-runs-table.test.tsx
@@ -58,6 +58,10 @@ import {
   ProjectRunsTable,
   PROJECT_RUNS_PAGE_SIZE,
 } from "../project-runs-table";
+import {
+  formatRunHistoryDate,
+  formatRunHistoryDateRange,
+} from "../../evaluate/suite-detail-model";
 
 function makeRow(overrides: Partial<ProjectRunRow> = {}): ProjectRunRow {
   return {
@@ -384,6 +388,19 @@ describe("ProjectRunsTable", () => {
     expect(screen.getByText("No runs yet")).toBeTruthy();
   });
 
+  it("renders a caller-supplied empty instead of the default", () => {
+    setRows([]);
+    render(
+      <ProjectRunsTable
+        projectId="proj_1"
+        onSelectRun={vi.fn()}
+        emptyState={<div data-testid="custom-runs-empty">Start here</div>}
+      />,
+    );
+    expect(screen.getByTestId("custom-runs-empty")).toBeTruthy();
+    expect(screen.queryByText("No runs yet")).toBeNull();
+  });
+
   it("shows a spinner, not an empty state, while the first page loads", () => {
     setRows([], "LoadingFirstPage");
     render(<ProjectRunsTable projectId="proj_1" onSelectRun={vi.fn()} />);
@@ -472,9 +489,15 @@ describe("project run history metrics", () => {
         historyMetricsEnabled
       />,
     );
+    expect(screen.getByRole("heading", { name: "All Runs" })).toBeVisible();
+    const headers = inTable()
+      .getAllByRole("columnheader")
+      .map((header) => header.textContent);
+    expect(headers.slice(0, 2)).toEqual(["Date", "Run"]);
     expect(
-      inTable().getByRole("columnheader", { name: "Suite / Run / Date" }),
+      inTable().getByRole("columnheader", { name: "Date" }),
     ).toBeVisible();
+    expect(inTable().getByRole("columnheader", { name: "Run" })).toBeVisible();
     expect(
       inTable().getByRole("columnheader", { name: "Status" }),
     ).toBeVisible();
@@ -507,9 +530,16 @@ describe("project run history metrics", () => {
         decisionSummaryEnabled
       />,
     );
-    expect(
-      inTable().getByRole("button", { name: "Collapse suite Checkout suite" }),
-    ).toBeVisible();
+    const suite = inTable().getByRole("button", {
+      name: "Collapse suite Checkout suite",
+    });
+    expect(suite).toBeVisible();
+    expect(suite.closest("td")).toBe(
+      suite.closest("tr")!.querySelectorAll("td")[0],
+    );
+    expect(suite).toHaveTextContent(
+      formatRunHistoryDateRange(1_700_000_000_000, 1_700_000_000_000),
+    );
     await waitFor(() =>
       expect(mocks.query).toHaveBeenCalledWith(
         "testSuites:listTestSuiteRunIterations",
@@ -578,7 +608,7 @@ describe("project run history metrics", () => {
         historyMetricsEnabled
       />,
     );
-    await screen.findByText(/trends across 2 filtered runs/);
+    await screen.findByTestId("project-run-history-metrics");
     await user.click(
       screen.getByRole("button", { name: "Filter by platform" }),
     );
@@ -586,9 +616,11 @@ describe("project run history metrics", () => {
       screen.getByRole("menuitemcheckbox", { name: "SDK", exact: true }),
     );
     await user.keyboard("{Escape}");
-    await screen.findByText(/trends across 1 filtered runs/);
+    await screen.findByText(/1 of 1 loaded runs/);
     const metrics = screen.getByTestId("project-run-history-metrics");
     expect(within(metrics).getByText("2/2 passed")).toBeVisible();
+    expect(within(metrics).queryByText(/failed iteration/)).toBeNull();
+    expect(within(metrics).queryByText(/ pp$/)).toBeNull();
     expect(inTable().queryByText("UI suite")).toBeNull();
     expect(screen.getByText(/1 of 1 loaded runs/)).toBeVisible();
   });
@@ -667,7 +699,8 @@ describe("project run history metrics", () => {
       screen.getByRole("combobox", { name: "Filter by server" }),
     );
     await user.click(screen.getByRole("option", { name: "Beta", exact: true }));
-    expect(screen.getByText(/trends across 1 filtered runs/)).toBeVisible();
+    expect(screen.getByTestId("project-run-history-metrics")).toBeVisible();
+    expect(screen.getByText(/1 of 2 loaded runs/)).toBeVisible();
     await user.click(
       screen.getByRole("combobox", { name: "Filter by server" }),
     );
@@ -678,7 +711,7 @@ describe("project run history metrics", () => {
     expect(screen.queryByTestId("project-run-history-metrics")).toBeNull();
     await user.click(screen.getByRole("button", { name: "Clear filters" }));
     expect(screen.getByText(/2 of 2 loaded runs/)).toBeVisible();
-    expect(screen.getByText(/trends across 2 filtered runs/)).toBeVisible();
+    expect(screen.getByTestId("project-run-history-metrics")).toBeVisible();
   });
 
   it("shows one complete run per row, preserves pairings when filtering, and opens its report", async () => {
@@ -716,27 +749,38 @@ describe("project run history metrics", () => {
     const suite = screen.getByRole("button", {
       name: "Collapse suite Checkout suite",
     });
+    const suiteCells = suite.closest("tr")!.querySelectorAll("td");
+    expect(suite.closest("td")).toBe(suiteCells[0]);
+    expect(suiteCells[0]).toHaveTextContent(
+      formatRunHistoryDateRange(1000, 2000),
+    );
+    expect(suiteCells[0].querySelector("svg")).not.toBeNull();
+    expect(suiteCells[1]).toHaveTextContent("Checkout suite");
+    expect(suiteCells[1].querySelector("svg")).toBeNull();
+    expect(suiteCells[1]).not.toHaveTextContent(
+      formatRunHistoryDateRange(1000, 2000),
+    );
     expect(within(suite.closest("tr")!).getByText("75%")).toBeVisible();
     expect(within(suite.closest("tr")!).getByText("3/4 passed")).toBeVisible();
     const run = screen.getByRole("button", { name: "Run #1", exact: true });
+    const runCells = run.querySelectorAll("td");
+    expect(runCells[0]).toHaveTextContent(formatRunHistoryDate(1000));
+    expect(runCells[0]).not.toHaveTextContent("Run #");
+    expect(runCells[1]).toHaveTextContent("Run #1");
+    expect(runCells[1]).not.toHaveTextContent(formatRunHistoryDate(1000));
     expect(screen.queryByText(/Run group/)).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Run new", exact: true }),
     ).toBeNull();
     expect(screen.getByText("1 of 1 loaded runs")).toBeVisible();
-    const mapping = within(run).getByRole("button", {
-      name: /Client model mapping/,
-    });
-    expect(mapping.querySelectorAll("img")).toHaveLength(2);
-    await user.click(mapping);
-    const popup = screen.getByRole("dialog");
-    expect(within(popup).getByText("Cursor").parentElement).toHaveTextContent(
-      "claude-fable-5",
-    );
-    expect(within(popup).getByText("ChatGPT").parentElement).toHaveTextContent(
-      "gpt-5.1",
-    );
-    await user.keyboard("{Escape}");
+    expect(within(run).getByText(/Cursor/)).toBeVisible();
+    expect(within(run).getByText(/claude-fable-5/)).toBeVisible();
+    expect(within(run).getByText(/ChatGPT/)).toBeVisible();
+    expect(within(run).getByText(/gpt-5.1/)).toBeVisible();
+    expect(
+      within(run).queryByRole("button", { name: /Client model mapping/ }),
+    ).toBeNull();
+    expect(within(run).queryByText(/client : model pairings/i)).toBeNull();
     expect(onSelectRun).not.toHaveBeenCalled();
     await user.click(
       screen.getByRole("combobox", { name: "Filter by client" }),
@@ -747,24 +791,64 @@ describe("project run history metrics", () => {
     expect(
       within(
         screen.getByRole("button", { name: "Run #1", exact: true }),
-      ).getByText("Cursor, ChatGPT"),
+      ).getByText(/Cursor/),
+    ).toBeVisible();
+    expect(
+      within(
+        screen.getByRole("button", { name: "Run #1", exact: true }),
+      ).getByText(/ChatGPT/),
     ).toBeVisible();
     expect(screen.getByText("1 of 1 loaded runs")).toBeVisible();
+    expect(screen.queryByText(/roll-ups across matching loaded runs/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Collapse all" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Expand all" })).toBeNull();
     await user.click(suite);
     expect(
       screen.queryByRole("button", { name: "Run #1", exact: true }),
     ).toBeNull();
-    await user.click(screen.getByRole("button", { name: "Expand all" }));
+    await user.click(
+      screen.getByRole("button", { name: "Expand suite Checkout suite" }),
+    );
     screen.getByRole("button", { name: "Run #1", exact: true }).focus();
     await user.keyboard("{Enter}");
     expect(onSelectRun).toHaveBeenCalledWith({
       suiteId: "suite_1",
       runId: "old",
     });
-    await user.click(screen.getByRole("button", { name: "Collapse all" }));
+    await user.click(
+      screen.getByRole("button", { name: "Collapse suite Checkout suite" }),
+    );
     expect(
       screen.getByRole("button", { name: "Expand suite Checkout suite" }),
     ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("shows a date range on the suite group when runs span days", async () => {
+    arrangeHistory();
+    const earliest = new Date(2026, 8, 8, 15, 25).getTime();
+    const latest = new Date(2026, 8, 10, 12, 0).getTime();
+    const rows = [
+      makeRow({ _id: "late", createdAt: latest, runNumber: 2 }),
+      makeRow({ _id: "early", createdAt: earliest, runNumber: 1 }),
+    ];
+    setRows(rows);
+    mocks.query.mockImplementation(async (name, args: any) =>
+      name === "testSuites:getTestSuiteRun"
+        ? { ...rows.find((row) => row._id === args.runId), effectiveModelId: "gpt-5.1" }
+        : { page: [], isDone: true, continueCursor: "" },
+    );
+    render(
+      <ProjectRunsTable
+        projectId="proj_1"
+        historyMetricsEnabled
+        onSelectRun={vi.fn()}
+      />,
+    );
+    const suite = await screen.findByRole("button", {
+      name: "Collapse suite Checkout suite",
+    });
+    expect(suite).toHaveTextContent(formatRunHistoryDateRange(earliest, latest));
+    expect(suite).not.toHaveTextContent("Checkout suite");
   });
 
   it("limits long suite histories and preserves expansion when loading another page", async () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-clients-cell.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-clients-cell.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { renderWithProviders, screen, userEvent } from "@/test";
+import { RunClientsCell } from "../run-clients-cell";
+import type { SuiteRunHistoryRow } from "../../evaluate/suite-detail-model";
+
+const row = (
+  client: string,
+  models: string[],
+): SuiteRunHistoryRow =>
+  ({
+    client,
+    models,
+  }) as SuiteRunHistoryRow;
+
+describe("RunClientsCell", () => {
+  it("lists pairings inline without an expand control", () => {
+    renderWithProviders(
+      <RunClientsCell
+        rows={[row("Claude", ["gpt-5-nano"]), row("Cursor", ["haiku"])]}
+      />,
+    );
+    expect(screen.getByLabelText("Claude · gpt-5-nano, Cursor · haiku")).toBeVisible();
+    expect(screen.getByText(/Claude/)).toBeVisible();
+    expect(screen.getByText(/gpt-5-nano/)).toBeVisible();
+    expect(screen.getByText(/Cursor/)).toBeVisible();
+    expect(screen.getByText(/haiku/)).toBeVisible();
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByText(/client : model pairings/i)).toBeNull();
+    expect(screen.queryByText("+1")).toBeNull();
+  });
+
+  it("overflows extra pairings behind a hover +N listing", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <RunClientsCell
+        rows={[
+          row("Claude", ["gpt-5-nano"]),
+          row("Cursor", ["haiku"]),
+          row("ChatGPT", ["gpt-5.1"]),
+        ]}
+      />,
+    );
+    expect(screen.getByText(/Claude/)).toBeVisible();
+    expect(screen.getByText(/Cursor/)).toBeVisible();
+    expect(screen.queryByText(/ChatGPT/)).toBeNull();
+    const more = screen.getByLabelText("1 more client and model pairings");
+    expect(more).toHaveTextContent("+1");
+    await user.hover(more);
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("ChatGPT · gpt-5.1");
+    expect(tooltip).toHaveTextContent("Claude · gpt-5-nano");
+    expect(tooltip).toHaveTextContent("Cursor · haiku");
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/create-suite-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/evals/create-suite-dialog.tsx
@@ -320,7 +320,7 @@ export function CreateSuiteDialog({
             <Input
               value={name}
               onChange={(event) => setName(event.target.value)}
-              placeholder="Customer support workflows"
+              placeholder="Suite 1"
             />
           </div>
 

--- a/mcpjam-inspector/client/src/components/evals/eval-list-filter.tsx
+++ b/mcpjam-inspector/client/src/components/evals/eval-list-filter.tsx
@@ -9,43 +9,68 @@ import { runHistoryFilterClass } from "./run-history-table";
 
 export const ALL_EVAL_FILTER_VALUES = "__all__";
 
+export const evalListFilterHeaderClass =
+  "h-auto max-w-full gap-1 rounded-sm border-0 bg-transparent px-0 py-0 text-xs font-medium text-muted-foreground shadow-none hover:bg-transparent hover:text-foreground focus-visible:border-0 focus-visible:ring-2 focus-visible:ring-ring dark:bg-transparent dark:hover:bg-transparent data-[size=sm]:h-auto";
+
+export type EvalListFilterLabel =
+  | "Client"
+  | "Model"
+  | "Server"
+  | "Repository"
+  | "Branch"
+  | "Status";
+
+function allOptionLabel(label: EvalListFilterLabel) {
+  if (label === "Repository") return "All repositories";
+  if (label === "Branch") return "All branches";
+  if (label === "Status") return "All statuses";
+  return `All ${label.toLowerCase()}s`;
+}
+
 export function EvalListFilter({
   label,
   value,
   options,
   onChange,
   disabled = false,
+  variant = "chip",
   className,
+  formatOption,
 }: {
-  label: "Client" | "Model" | "Server" | "Repository" | "Branch";
+  label: EvalListFilterLabel;
   value: string;
   options: string[];
   onChange: (value: string) => void;
   disabled?: boolean;
+  /** `header` is a ghost trigger that matches a muted column label. */
+  variant?: "chip" | "header";
   className?: string;
+  formatOption?: (option: string) => string;
 }) {
+  const display = (option: string) => formatOption?.(option) ?? option;
   return (
     <Select value={value} onValueChange={onChange} disabled={disabled}>
       <SelectTrigger
         size="sm"
         aria-label={`Filter by ${label.toLowerCase()}`}
-        className={cn(runHistoryFilterClass, className)}
+        className={cn(
+          variant === "header"
+            ? evalListFilterHeaderClass
+            : runHistoryFilterClass,
+          className,
+        )}
       >
         <span className="truncate">
-          {value === ALL_EVAL_FILTER_VALUES ? label : value}
+          {value === ALL_EVAL_FILTER_VALUES ? label : display(value)}
         </span>
       </SelectTrigger>
       <SelectContent>
         <SelectItem value={ALL_EVAL_FILTER_VALUES}>
-          {label === "Repository"
-            ? "All repositories"
-            : label === "Branch"
-              ? "All branches"
-              : `All ${label.toLowerCase()}s`}
+          {allOptionLabel(label)}
         </SelectItem>
         {options.map((option) => (
           <SelectItem key={option} value={option}>
-            {option}
+            {display(option)}
           </SelectItem>
         ))}
       </SelectContent>

--- a/mcpjam-inspector/client/src/components/evals/metric-strip.tsx
+++ b/mcpjam-inspector/client/src/components/evals/metric-strip.tsx
@@ -386,10 +386,12 @@ export function MetricStrip({
         )
       ) : (
         <>
-          <div className="flex flex-wrap items-center gap-2">
-            {verdictBadge}
-            {deltaBadge}
-          </div>
+          {context !== "history" && (
+            <div className="flex flex-wrap items-center gap-2">
+              {verdictBadge}
+              {deltaBadge}
+            </div>
+          )}
           <div className="flex items-baseline gap-2">
             {passRateHeadline}
             <span className="text-[11px] tabular-nums text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/evals/project-run-suite-groups.tsx
+++ b/mcpjam-inspector/client/src/components/evals/project-run-suite-groups.tsx
@@ -11,6 +11,8 @@ import { RunClientsCell } from "./run-clients-cell";
 import { RunPlatformBadge } from "./run-git-metadata";
 import {
   buildSuiteRunHistoryAggregates,
+  formatRunHistoryDate,
+  formatRunHistoryDateRange,
   formatRunHistoryMetric,
   type SuiteRunHistoryRow,
 } from "../evaluate/suite-detail-model";
@@ -138,7 +140,7 @@ export function ProjectRunSuiteGroup({
       {expanded && !ready && (
         <TableRow>
           <TableCell
-            colSpan={8 + (shared.showGitContext ? 1 : 0)}
+            colSpan={9 + (shared.showGitContext ? 1 : 0)}
             className="h-16 px-7"
           >
             {loading ? (
@@ -169,15 +171,7 @@ export function ProjectRunSuiteGroup({
               {...shared}
               rows={launch.runs}
               label={`Run #${representative.runNumber}`}
-              detail={new Date(representative.createdAt).toLocaleString(
-                undefined,
-                {
-                  month: "short",
-                  day: "numeric",
-                  hour: "numeric",
-                  minute: "2-digit",
-                },
-              )}
+              date={formatRunHistoryDate(representative.createdAt)}
               onOpen={
                 representative.suiteName !== null
                   ? () =>
@@ -192,7 +186,7 @@ export function ProjectRunSuiteGroup({
         })}
       {expanded && ready && group.launches.length > 5 && (
         <TableRow>
-          <TableCell colSpan={8 + (shared.showGitContext ? 1 : 0)}>
+          <TableCell colSpan={9 + (shared.showGitContext ? 1 : 0)}>
             <Button
               variant="ghost"
               size="sm"
@@ -217,6 +211,7 @@ export function GroupSummaryRow({
   showGitContext,
   label,
   detail,
+  date,
   expanded,
   onToggle,
   suite = false,
@@ -226,7 +221,8 @@ export function GroupSummaryRow({
 }: SharedProps & {
   rows: ProjectRunRow[];
   label: string;
-  detail: string;
+  detail?: string;
+  date?: string;
   expanded?: boolean;
   onToggle?: () => void;
   onOpen?: () => void;
@@ -242,6 +238,14 @@ export function GroupSummaryRow({
     ...new Set(rows.map((row) => row.source ?? row.suiteSource ?? "ui")),
   ];
   const Icon = expanded ? ChevronDown : ChevronRight;
+  const dateLabel =
+    date ??
+    (rows.length > 0
+      ? formatRunHistoryDateRange(
+          Math.min(...rows.map((row) => row.createdAt)),
+          Math.max(...rows.map((row) => row.createdAt)),
+        )
+      : undefined);
   return (
     <TableRow
       data-testid={testId}
@@ -267,37 +271,43 @@ export function GroupSummaryRow({
           }
         : {})}
     >
-      <TableCell className="max-w-80">
+      <TableCell className="whitespace-nowrap text-muted-foreground">
         {suite ? (
           <button
             type="button"
             aria-label={`${expanded ? "Collapse" : "Expand"} suite ${label}`}
             aria-expanded={expanded}
             onClick={onToggle}
-            className="flex w-full items-start gap-2 rounded-sm text-left focus-visible:outline-ring"
+            className="flex items-center gap-2 rounded-sm text-left focus-visible:outline-ring"
           >
             <Icon
-              className="mt-0.5 size-3.5 shrink-0 text-muted-foreground"
+              className="size-3.5 shrink-0 text-muted-foreground"
               aria-hidden
             />
-            <span className="min-w-0">
-              <span className="block truncate text-xs font-semibold">
-                {label}
-              </span>
+            <span>{dateLabel}</span>
+          </button>
+        ) : (
+          dateLabel
+        )}
+      </TableCell>
+      <TableCell className="max-w-80">
+        {suite ? (
+          <span className="min-w-0">
+            <span className="block truncate text-xs font-semibold">
+              {label}
+            </span>
+            {detail ? (
               <span
                 className="mt-1 block truncate text-[10px] text-muted-foreground"
                 title={detail}
               >
                 {detail}
               </span>
-            </span>
-          </button>
+            ) : null}
+          </span>
         ) : (
           <div className="pl-5">
             <span className="block text-xs font-medium">{label}</span>
-            <span className="mt-1 block text-[10px] text-muted-foreground">
-              {detail}
-            </span>
           </div>
         )}
       </TableCell>

--- a/mcpjam-inspector/client/src/components/evals/project-runs-table.tsx
+++ b/mcpjam-inspector/client/src/components/evals/project-runs-table.tsx
@@ -19,6 +19,7 @@ import {
 } from "./metric-strip-data";
 import {
   buildSuiteRunHistoryRows,
+  formatRunHistoryDate,
   formatRunHistoryMetric,
   type SuiteRunHistoryRow,
 } from "../evaluate/suite-detail-model";
@@ -46,7 +47,7 @@ import {
   DropdownMenuContent,
   DropdownMenuCheckboxItem,
 } from "@mcpjam/design-system/dropdown-menu";
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { usePaginatedQuery } from "convex/react";
 import { ChevronDown, GitBranch, Loader2 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
@@ -202,11 +203,17 @@ export function ProjectRunsTable({
   decisionSummaryEnabled = false,
   embedded = false,
   historyMetricsEnabled = false,
+  emptyState,
 }: {
   projectId: string;
   historyMetricsEnabled?: boolean;
   /** Use the parent page scroll when shown below the suite cards. */
   embedded?: boolean;
+  /**
+   * First-run empty. Evaluate shares the Suites hero here so a project
+   * that has never run does not grow a second empty.
+   */
+  emptyState?: ReactNode;
   onSelectRun: (args: { suiteId: string; runId: string }) => void;
   /**
    * Read D9's canonical verdict and counts for terminal rows, one row at a
@@ -512,9 +519,6 @@ export function ProjectRunsTable({
   ]);
   const isSuiteExpanded = (suiteId: string) =>
     suiteExpansion.get(suiteId) ?? true;
-  const allSuitesExpanded = suiteGroups.every((group) =>
-    isSuiteExpanded(group.suiteId),
-  );
   const renderRun = (row: ProjectRunRow, nested = false) => (
     <ProjectRunTableRow
       key={row._id}
@@ -570,6 +574,9 @@ export function ProjectRunsTable({
   }
 
   if (rows.length === 0 && !isLoadingFirstPage && !isFiltering) {
+    if (emptyState) {
+      return emptyState;
+    }
     return (
       <div className="flex flex-1 items-center justify-center">
         <div className="mx-auto max-w-md p-6 text-center">
@@ -600,36 +607,12 @@ export function ProjectRunsTable({
         aria-label="Project run history"
       >
         <div className={runHistoryToolbarClass}>
-          {historyMetricsEnabled ? (
-            <div className="flex items-center gap-3">
-              <span className="text-xs text-muted-foreground">
-                {suiteGroups.length} suites · roll-ups across matching loaded
-                runs
-              </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 text-[11px]"
-                onClick={() =>
-                  setSuiteExpansion(
-                    new Map(
-                      suiteGroups.map((group) => [
-                        group.suiteId,
-                        !allSuitesExpanded,
-                      ]),
-                    ),
-                  )
-                }
-              >
-                {allSuitesExpanded ? "Collapse all" : "Expand all"}
-              </Button>
-            </div>
-          ) : embedded ? (
+          {embedded && !historyMetricsEnabled ? (
             <h2 className="text-xs font-semibold text-secondary-foreground">
               Run history
             </h2>
           ) : (
-            <span />
+            <h2 className="text-xs font-semibold text-foreground">All Runs</h2>
           )}
           <div className="flex flex-wrap items-center gap-1.5">
             <DropdownMenu>
@@ -771,13 +754,6 @@ export function ProjectRunsTable({
             className="@container/history-metrics border-b border-border/50"
             aria-label="Filtered run metrics"
           >
-            <p className="px-5 pt-3 text-[10px] text-muted-foreground">
-              {history.loading || isLoadingFirstPage
-                ? "Loading run metrics…"
-                : metricData
-                ? `Latest measured run · trends across ${metricData.series.length} filtered runs`
-                : "No measured iterations in these runs."}
-            </p>
             {history.errorCount > 0 && (
               <p className="px-5 py-2 text-xs text-muted-foreground">
                 Metrics unavailable for {history.errorCount} runs.
@@ -830,9 +806,14 @@ export function ProjectRunsTable({
           <RunHistoryTable aria-label="Project runs">
             <TableHeader>
               <TableRow>
-                <TableHead className="min-w-[180px]">
-                  {historyMetricsEnabled ? "Suite / Run / Date" : "Suite / Run"}
-                </TableHead>
+                {historyMetricsEnabled ? (
+                  <>
+                    <TableHead className="min-w-[120px]">Date</TableHead>
+                    <TableHead className="min-w-[140px]">Run</TableHead>
+                  </>
+                ) : (
+                  <TableHead className="min-w-[180px]">Suite / Run</TableHead>
+                )}
                 <TableHead className="min-w-[120px]">
                   {historyMetricsEnabled ? "Client : model" : "Platform"}
                 </TableHead>
@@ -867,7 +848,9 @@ export function ProjectRunsTable({
               {isLoadingFirstPage ? (
                 <TableRow>
                   <TableCell
-                    colSpan={8 + (showGitContext ? 1 : 0)}
+                    colSpan={
+                      (historyMetricsEnabled ? 9 : 7) + (showGitContext ? 1 : 0)
+                    }
                     className="h-32 text-center text-muted-foreground"
                   >
                     <span role="status">Loading runs…</span>
@@ -877,7 +860,7 @@ export function ProjectRunsTable({
                 <TableRow>
                   <TableCell
                     colSpan={
-                      (historyMetricsEnabled ? 8 : 7) + (showGitContext ? 1 : 0)
+                      (historyMetricsEnabled ? 9 : 7) + (showGitContext ? 1 : 0)
                     }
                     className="h-24 text-center text-sm text-muted-foreground"
                   >
@@ -1078,6 +1061,13 @@ function ProjectRunTableRow({
         : {})}
       className={canOpen ? "cursor-pointer" : undefined}
     >
+      {historyMetricsEnabled ? (
+        <TableCell className="whitespace-nowrap text-muted-foreground">
+          <span title={formatTime(row.createdAt)}>
+            {formatRunHistoryDate(row.createdAt)}
+          </span>
+        </TableCell>
+      ) : null}
       <TableCell className="max-w-[240px] text-xs">
         <div className={grouped ? (nested ? "pl-12" : "pl-5") : undefined}>
           <span className="block truncate font-medium">
@@ -1096,16 +1086,6 @@ function ProjectRunTableRow({
             {grouped
               ? formatRunId(row._id)
               : `#${row.runNumber} · ${formatRunId(row._id)}`}
-            {historyMetricsEnabled && (
-              <span className="block" title={formatTime(row.createdAt)}>
-                {new Date(row.createdAt).toLocaleString(undefined, {
-                  month: "short",
-                  day: "numeric",
-                  hour: "numeric",
-                  minute: "2-digit",
-                })}
-              </span>
-            )}
           </span>
         </div>
       </TableCell>

--- a/mcpjam-inspector/client/src/components/evals/run-clients-cell.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-clients-cell.tsx
@@ -1,13 +1,25 @@
-import { ChevronDown } from "lucide-react";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@mcpjam/design-system/popover";
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
 import { resolveHostLogoByName } from "@/lib/host-logo";
 import { compactModelIdTail } from "@/lib/environment-label";
 import { usePreferencesStoreWithDefaults } from "@/stores/preferences/preferences-provider";
 import type { SuiteRunHistoryRow } from "../evaluate/suite-detail-model";
+
+export const VISIBLE_RUN_CLIENT_PAIRINGS = 2;
+
+type ClientModelPairing = {
+  client: string;
+  models: string[];
+};
+
+function pairingLabel(mapping: ClientModelPairing): string {
+  const models =
+    mapping.models.map(compactModelIdTail).join(", ") || "Model not recorded";
+  return `${mapping.client} · ${models}`;
+}
 
 /** Recorded client/model pairs, never a cross product of two independent lists. */
 export function RunClientsCell({ rows }: { rows: SuiteRunHistoryRow[] }) {
@@ -21,73 +33,68 @@ export function RunClientsCell({ rows }: { rows: SuiteRunHistoryRow[] }) {
     ).values(),
   ];
   if (!mappings.length) return <span className="text-muted-foreground">—</span>;
-  const clients = [...new Set(mappings.map((mapping) => mapping.client))];
-  const modelLabel = (models: string[]) =>
-    models.map(compactModelIdTail).join(", ") || "Model not recorded";
+
+  const visible = mappings.slice(0, VISIBLE_RUN_CLIENT_PAIRINGS);
+  const hidden = mappings.slice(VISIBLE_RUN_CLIENT_PAIRINGS);
+  const allLabels = mappings.map(pairingLabel);
+
   const logo = (client: string) => (
-    <span className="inline-flex size-6 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border/50 bg-background ring-1 ring-background">
+    <span className="inline-flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-sm border border-border/50 bg-background">
       <img
         src={resolveHostLogoByName(client, theme)}
         alt=""
-        className="size-3.5 object-contain"
+        className="size-2.5 object-contain"
       />
     </span>
   );
+
   return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className="flex max-w-64 items-center gap-2 rounded-md text-left outline-offset-4 hover:text-foreground focus-visible:outline-ring"
-          aria-label={`Client model mapping: ${clients.join(", ")}`}
-          onClick={(event) => event.stopPropagation()}
-          onKeyDown={(event) => event.stopPropagation()}
+    <span
+      className="flex min-w-0 max-w-80 items-center gap-2"
+      aria-label={allLabels.join(", ")}
+    >
+      {visible.map((mapping, index) => (
+        <span
+          key={`${mapping.client}-${mapping.models.join(",")}-${index}`}
+          className="inline-flex min-w-0 items-center gap-1.5"
         >
-          <span className="flex shrink-0 -space-x-1.5">
-            {clients.slice(0, 3).map((client) => (
-              <span key={client}>{logo(client)}</span>
-            ))}
-            {clients.length > 3 && (
-              <span className="inline-flex size-6 items-center justify-center rounded-md border bg-background text-[10px]">
-                +{clients.length - 3}
-              </span>
-            )}
-          </span>
-          <span className="min-w-0">
-            <span className="block truncate text-xs">{clients.join(", ")}</span>
-            <span className="block truncate text-[10px] text-muted-foreground">
-              {mappings.length === 1
-                ? modelLabel(mappings[0].models)
-                : `${mappings.length} client : model pairings`}
+          {logo(mapping.client)}
+          <span className="truncate text-xs">
+            {mapping.client}
+            <span className="text-muted-foreground">
+              {" "}
+              · {mapping.models.map(compactModelIdTail).join(", ") ||
+                "Model not recorded"}
             </span>
           </span>
-          <ChevronDown
-            className="size-3 shrink-0 text-muted-foreground"
-            aria-hidden
-          />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className="w-80 p-3"
-        onClick={(event) => event.stopPropagation()}
-        onKeyDown={(event) => event.stopPropagation()}
-      >
-        <p className="mb-3 text-xs font-semibold">Client : model</p>
-        <div className="max-h-64 space-y-3 overflow-y-auto">
-          {mappings.map((mapping, index) => (
-            <div key={index} className="flex items-start gap-2 text-xs">
-              {logo(mapping.client)}
-              <div className="min-w-0">
-                <p className="font-medium">{mapping.client}</p>
-                <p className="break-words text-muted-foreground">
-                  {mapping.models.join(", ") || "Model not recorded"}
-                </p>
-              </div>
-            </div>
-          ))}
-        </div>
-      </PopoverContent>
-    </Popover>
+        </span>
+      ))}
+      {hidden.length > 0 ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              tabIndex={0}
+              className="inline-flex h-5 shrink-0 items-center rounded-sm px-1 text-[10px] font-medium text-muted-foreground outline-none hover:text-foreground focus-visible:outline-ring"
+              aria-label={`${hidden.length} more client and model pairings`}
+            >
+              +{hidden.length}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent
+            align="start"
+            variant="muted"
+            side="bottom"
+            sideOffset={6}
+            className="max-w-xs text-left"
+          >
+            <ul className="space-y-1">
+              {allLabels.map((label) => (
+                <li key={label}>{label}</li>
+              ))}
+            </ul>
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
+    </span>
   );
 }

--- a/mcpjam-inspector/client/src/components/evals/run-history-table.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-history-table.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 export const runHistorySurfaceClass =
   "shrink-0 overflow-hidden rounded-xl border border-border bg-card";
 export const runHistoryToolbarClass =
-  "flex flex-wrap items-center justify-between gap-3 border-b border-border/60 bg-muted/45 px-[18px] py-3";
+  "flex min-h-14 flex-wrap items-center justify-between gap-3 border-b border-border/60 bg-muted/55 px-4 py-3";
 export const runHistoryFilterClass =
   "h-7 max-w-52 gap-1 rounded-full border-border bg-card px-2.5 text-[11px] font-medium shadow-none";
 export const runHistoryFooterClass =

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/combined-run-content.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/combined-run-content.test.tsx
@@ -33,7 +33,12 @@ vi.mock("@/hooks/use-eval-run-iteration-chains", () => ({
   useEvalRunIterationChains: () => ({ chains: new Map(), status: "ready" }),
 }));
 
-function run(id: string, client: string, model: string): EvalSuiteRun {
+function run(
+  id: string,
+  client: string,
+  model: string,
+  overrides: Partial<EvalSuiteRun> = {},
+): EvalSuiteRun {
   return {
     _id: id,
     suiteId: "suite",
@@ -41,9 +46,11 @@ function run(id: string, client: string, model: string): EvalSuiteRun {
     namedHostId: client,
     effectiveModelId: model,
     runNumber: Number(id),
+    createdAt: Number(id) * 1000,
     status: "completed",
     result: "passed",
     configSnapshot: { tests: [], environment: { servers: [] } },
+    ...overrides,
   } as EvalSuiteRun;
 }
 function iteration(id: string, runId: string, result: string): EvalIteration {
@@ -121,16 +128,76 @@ describe("combined run report", () => {
       </EvaluateRunPage>,
     );
     expect(
-      await screen.findByText("All 3 client/model pairings"),
+      await screen.findByRole("textbox", { name: "Find a test case" }),
     ).toBeVisible();
-    const hero = screen.getByTestId("run-verdict-hero");
+    expect(screen.queryByText(/All \d+ client\/model pairings/)).toBeNull();
+    expect(screen.queryByText(/\d+ of \d+ client\/model pairings/)).toBeNull();
+    const matrix = screen.getByTestId("run-results-matrix");
+    const toolbar = within(matrix).getByTestId("run-results-toolbar");
+    const toolbarControls = [
+      within(toolbar).getByRole("textbox", { name: "Find a test case" }),
+      within(toolbar).getByRole("combobox", { name: "Filter by status" }),
+      within(toolbar).getByRole("combobox", { name: "Filter by client" }),
+      within(toolbar).getByRole("combobox", { name: "Filter by model" }),
+    ];
     expect(
-      screen.getByRole("button", { name: "Clear filters" }),
-    ).toBeDisabled();
+      toolbarControls.map((control) =>
+        toolbarControls[0].compareDocumentPosition(control),
+      ),
+    ).toEqual([
+      0,
+      Node.DOCUMENT_POSITION_FOLLOWING,
+      Node.DOCUMENT_POSITION_FOLLOWING,
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    ]);
+    expect(toolbarControls[1].compareDocumentPosition(toolbarControls[2])).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(
+      within(matrix).queryByRole("button", { name: "Clear filters" }),
+    ).toBeNull();
+    const hero = screen.getByTestId("run-verdict-hero");
+    expect(within(hero).queryByTestId("run-verdict-stat-delta")).toBeNull();
     expect(screen.queryByTestId("run-verdict-word")).toBeNull();
-    const verdict = screen.getByTestId("run-header-verdict").textContent;
-    expect(within(hero).getByText("1 of 3")).toBeVisible();
+    expect(screen.queryByTestId("run-header-verdict")).toBeNull();
+    const pairingDecisions = screen
+      .getAllByTestId("run-header-pairing-decision")
+      .map((node) => node.textContent);
+    expect(pairingDecisions).toEqual(["SHIP"]);
+    const shipPill = screen.getByTestId("run-header-decision-pill");
+    expect(shipPill).toHaveAttribute("data-decision", "ship");
+    expect(within(shipPill).getAllByRole("img")).toHaveLength(3);
+    const pairingRows = within(hero).getAllByTestId("run-verdict-pairing");
+    expect(pairingRows).toHaveLength(3);
+    expect(pairingRows[0]).toHaveTextContent("Cursor");
+    expect(pairingRows[0]).toHaveTextContent("1 passed");
+    expect(pairingRows[0]).toHaveTextContent("0 failed");
+    expect(within(pairingRows[0]).getByTestId("result-count-bar")).toBeVisible();
+    expect(pairingRows[1]).toHaveTextContent("0 passed");
+    expect(pairingRows[1]).toHaveTextContent("1 failed");
+    expect(pairingRows[2]).toHaveTextContent("ChatGPT");
+    expect(pairingRows[2]).toHaveTextContent("0 passed");
+    expect(pairingRows[2]).toHaveTextContent("1 failed");
+    expect(within(hero).queryByText("1 of 3")).toBeNull();
+    expect(within(hero).queryByText(/ of /)).toBeNull();
+    expect(
+      within(hero).getByTestId("run-verdict-stats").textContent,
+    ).not.toMatch(/Passed/i);
+    expect(
+      pairingRows[0].compareDocumentPosition(
+        within(hero).getByTestId("run-verdict-stats"),
+      ),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(screen.getAllByRole("columnheader")).toHaveLength(4);
+    expect(screen.getByRole("heading", { name: /Test cases/ })).toBeVisible();
+    expect(screen.queryByText("Run results")).toBeNull();
+    expect(
+      screen.queryByText(
+        /Cases down the rows. Clients and models across the columns/,
+      ),
+    ).toBeNull();
+    expect(within(matrix).queryByLabelText(/loaded iterations/)).toBeNull();
+    expect(within(matrix).queryByTestId("result-count-bar")).toBeNull();
     for (const run of runs)
       expect(mocks.decision).toHaveBeenCalledWith(
         expect.objectContaining({ runId: run._id, enabled: true }),
@@ -141,24 +208,41 @@ describe("combined run report", () => {
     await user.click(
       screen.getByRole("option", { name: "Cursor", exact: true }),
     );
-    expect(screen.getByText("2 of 3 client/model pairings")).toBeVisible();
-    expect(within(hero).getByText("1 of 2")).toBeVisible();
+    expect(
+      within(matrix).getByRole("button", { name: "Clear filters" }),
+    ).toBeVisible();
+    expect(screen.queryByText(/client\/model pairing/)).toBeNull();
+    expect(within(hero).getAllByTestId("run-verdict-pairing")).toHaveLength(2);
+    expect(within(hero).queryByText("1 of 2")).toBeNull();
     expect(screen.getAllByRole("columnheader")).toHaveLength(3);
     await user.click(screen.getByRole("combobox", { name: "Filter by model" }));
     await user.click(
       screen.getByRole("option", { name: "gpt-5.1", exact: true }),
     );
-    expect(within(hero).getByText("0 of 1")).toBeVisible();
-    expect(screen.getByTestId("run-header-verdict")).toHaveTextContent(
-      verdict!,
-    );
+    const filteredPairing = within(hero).getByTestId("run-verdict-pairing");
+    expect(filteredPairing).toHaveTextContent("0 passed");
+    expect(filteredPairing).toHaveTextContent("1 failed");
+    expect(
+      screen
+        .getAllByTestId("run-header-pairing-decision")
+        .map((node) => node.textContent),
+    ).toEqual(pairingDecisions);
+    expect(
+      within(screen.getByTestId("run-header-decision-pill")).getAllByRole(
+        "img",
+      ),
+    ).toHaveLength(3);
     expect(
       screen.queryByRole("heading", { name: "Filtered results" }),
     ).toBeNull();
     expect(screen.getAllByRole("columnheader")).toHaveLength(2);
     expect(screen.queryByRole("button", { name: /Client report/ })).toBeNull();
     await user.click(screen.getByRole("button", { name: "Clear filters" }));
-    expect(within(hero).getByText("1 of 3")).toBeVisible();
+    expect(
+      within(matrix).queryByRole("button", { name: "Clear filters" }),
+    ).toBeNull();
+    expect(within(hero).getAllByTestId("run-verdict-pairing")).toHaveLength(3);
+    expect(within(hero).queryByText("1 of 3")).toBeNull();
     expect(screen.getAllByRole("columnheader")).toHaveLength(4);
   });
 
@@ -183,6 +267,62 @@ describe("combined run report", () => {
       screen.getByRole("button", { name: "Retry results" }),
     );
     expect(mocks.history.retry).toHaveBeenCalled();
+  });
+
+  it("shows metric deltas against the previous combined launch", () => {
+    const previousLaunch = [
+      run("p1", "cursor", "anthropic/sonnet", {
+        runGroupId: "prev",
+        runNumber: 1,
+        createdAt: 1000,
+      }),
+      run("p2", "cursor", "gpt-5.1", {
+        runGroupId: "prev",
+        runNumber: 1,
+        createdAt: 1100,
+      }),
+      run("p3", "chatgpt", "gpt-5.1", {
+        runGroupId: "prev",
+        runNumber: 1,
+        createdAt: 1200,
+      }),
+    ];
+    const previousIterations = previousLaunch.map((member, index) => ({
+      ...iteration(`prev-${index}`, member._id, "passed"),
+      tokensUsed: 100,
+      startedAt: 1000,
+      updatedAt: 1500,
+    }));
+    render(
+      <EvaluateRunPage
+        run={runs[0]}
+        otherRuns={runs}
+        hostNamesById={names}
+        defaultCompareRunId={null}
+        onCompareWithRun={vi.fn()}
+      >
+        <CombinedRunContent
+          {...props}
+          siblingRuns={[...previousLaunch, ...runs]}
+          allIterations={[...previousIterations, ...iterations]}
+          previousRunId="p1"
+        />
+      </EvaluateRunPage>,
+    );
+    const hero = screen.getByTestId("run-verdict-hero");
+    const pairingRows = within(hero).getAllByTestId("run-verdict-pairing");
+    expect(within(pairingRows[0]).queryByTestId("run-verdict-stat-delta")).toBeNull();
+    expect(within(pairingRows[0]).queryByText("=")).toBeNull();
+    const pairingDeltas = pairingRows.flatMap((row) =>
+      within(row).queryAllByTestId("run-verdict-stat-delta"),
+    );
+    expect(pairingDeltas.map((node) => node.textContent)).toEqual([
+      "−1",
+      "−1",
+    ]);
+    expect(pairingDeltas[0]).toHaveClass("text-destructive");
+    expect(pairingDeltas[1]).toHaveClass("text-destructive");
+    expect(within(hero).queryByLabelText("−2 vs previous run")).toBeNull();
   });
 
   it("does not turn mixed or unreadable member decisions into a passing run", () => {

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/combined-run-content.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/combined-run-content.test.tsx
@@ -166,7 +166,7 @@ describe("combined run report", () => {
     expect(pairingDecisions).toEqual(["SHIP"]);
     const shipPill = screen.getByTestId("run-header-decision-pill");
     expect(shipPill).toHaveAttribute("data-decision", "ship");
-    expect(within(shipPill).getAllByRole("img")).toHaveLength(3);
+    expect(within(shipPill).getAllByLabelText(/ · /)).toHaveLength(3);
     const pairingRows = within(hero).getAllByTestId("run-verdict-pairing");
     expect(pairingRows).toHaveLength(3);
     expect(pairingRows[0]).toHaveTextContent("Cursor");
@@ -228,8 +228,8 @@ describe("combined run report", () => {
         .map((node) => node.textContent),
     ).toEqual(pairingDecisions);
     expect(
-      within(screen.getByTestId("run-header-decision-pill")).getAllByRole(
-        "img",
+      within(screen.getByTestId("run-header-decision-pill")).getAllByLabelText(
+        / · /,
       ),
     ).toHaveLength(3);
     expect(

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/create-suite-page.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/create-suite-page.test.tsx
@@ -412,6 +412,40 @@ describe("CreateSuitePage", () => {
     );
   });
 
+  it("keeps an edited suite name when a later initialName arrives", () => {
+    const { rerender } = render(
+      <CreateSuitePage
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+        hostsEnabled
+        projectId="proj-1"
+        existingSuiteNames={["Suite 1"]}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("create-suite-name"), {
+      target: { value: "My checkout suite" },
+    });
+    expect(screen.getByTestId("create-suite-name")).toHaveValue(
+      "My checkout suite",
+    );
+
+    rerender(
+      <CreateSuitePage
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+        hostsEnabled
+        projectId="proj-1"
+        initialName="checkout-server"
+        existingSuiteNames={["Suite 1"]}
+      />,
+    );
+
+    expect(screen.getByTestId("create-suite-name")).toHaveValue(
+      "My checkout suite",
+    );
+  });
+
   it("Cancel returns to the Evaluate list", () => {
     render(
       <CreateSuitePage

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/create-suite-page.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/create-suite-page.test.tsx
@@ -341,6 +341,33 @@ describe("CreateSuitePage", () => {
     });
   });
 
+  it("increments Suite N from existing numbered suite names", () => {
+    const { rerender } = render(
+      <CreateSuitePage
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+        hostsEnabled
+        projectId="proj-1"
+        existingSuiteNames={["Suite 1", "Checkout", "Suite 2"]}
+      />,
+    );
+
+    const nameInput = screen.getByTestId("create-suite-name");
+    expect(nameInput).toHaveValue("Suite 3");
+    expect(nameInput).toHaveAttribute("placeholder", "Suite 3");
+
+    rerender(
+      <CreateSuitePage
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+        hostsEnabled
+        projectId="proj-1"
+        existingSuiteNames={["Suite 1", "Checkout", "Suite 2", "Suite 3"]}
+      />,
+    );
+    expect(screen.getByTestId("create-suite-name")).toHaveValue("Suite 4");
+  });
+
   it("disables Continue again if the default name is cleared", async () => {
     render(
       <CreateSuitePage
@@ -376,6 +403,7 @@ describe("CreateSuitePage", () => {
         projectId="proj-1"
         initialName="checkout-server"
         initialServerId="srv-a"
+        existingSuiteNames={["Suite 1"]}
       />,
     );
 

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/create-suite-prefill.test.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/create-suite-prefill.test.ts
@@ -1,20 +1,58 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_CREATE_SUITE_NAME,
+  nextUnusedSuiteName,
   pickServerAttachmentIdForServer,
   seedCreateSuiteName,
 } from "../create-suite-prefill";
 
-describe("seedCreateSuiteName", () => {
-  it("uses the default when there is no initialName prefill", () => {
-    expect(seedCreateSuiteName()).toBe(DEFAULT_CREATE_SUITE_NAME);
-    expect(seedCreateSuiteName(null)).toBe(DEFAULT_CREATE_SUITE_NAME);
-    expect(seedCreateSuiteName("")).toBe(DEFAULT_CREATE_SUITE_NAME);
-    expect(seedCreateSuiteName("   ")).toBe(DEFAULT_CREATE_SUITE_NAME);
+describe("nextUnusedSuiteName", () => {
+  it("starts at Suite 1 when nothing is numbered", () => {
+    expect(nextUnusedSuiteName()).toBe("Suite 1");
+    expect(nextUnusedSuiteName([])).toBe("Suite 1");
+    expect(nextUnusedSuiteName(["Checkout", "Untitled suite"])).toBe(
+      "Suite 1",
+    );
+    expect(DEFAULT_CREATE_SUITE_NAME).toBe("Suite 1");
   });
 
-  it("lets empty-hero / URL prefill override the default", () => {
+  it("increments from the highest exact Suite N", () => {
+    expect(nextUnusedSuiteName(["Suite 1"])).toBe("Suite 2");
+    expect(nextUnusedSuiteName(["Suite 1", "Suite 2"])).toBe("Suite 3");
+    expect(nextUnusedSuiteName(["Suite 2", "Suite 1", "Checkout"])).toBe(
+      "Suite 3",
+    );
+    expect(nextUnusedSuiteName(["Suite 10"])).toBe("Suite 11");
+    expect(nextUnusedSuiteName(["Suite 1", "Suite 3"])).toBe("Suite 4");
+  });
+
+  it("ignores names that are not an exact Suite N", () => {
+    expect(
+      nextUnusedSuiteName([
+        "Suite 1 extra",
+        "suite 1",
+        "Suite 1 ",
+        "My Suite 1",
+        "Suite",
+      ]),
+    ).toBe("Suite 1");
+  });
+});
+
+describe("seedCreateSuiteName", () => {
+  it("uses the next unused Suite N when there is no initialName prefill", () => {
+    expect(seedCreateSuiteName()).toBe("Suite 1");
+    expect(seedCreateSuiteName(null)).toBe("Suite 1");
+    expect(seedCreateSuiteName("")).toBe("Suite 1");
+    expect(seedCreateSuiteName("   ")).toBe("Suite 1");
+    expect(seedCreateSuiteName(null, ["Suite 1", "Suite 2"])).toBe("Suite 3");
+  });
+
+  it("lets empty-hero / URL prefill override the numbered default", () => {
     expect(seedCreateSuiteName("checkout-server")).toBe("checkout-server");
+    expect(seedCreateSuiteName("checkout-server", ["Suite 1"])).toBe(
+      "checkout-server",
+    );
   });
 });
 

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/evals-empty-hero.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/evals-empty-hero.test.tsx
@@ -58,7 +58,7 @@ describe("EvalsEmptyHero", () => {
     ).toBeTruthy();
   });
 
-  it("starts the first-run preview from Eval my server, not Create suite", () => {
+  it("starts Create suite from Eval my server with that server, not the blank form", () => {
     const onEvalServer = vi.fn();
     render(
       <EvalsEmptyHero

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/evals-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/evals-header.test.tsx
@@ -15,7 +15,7 @@ describe("EvalsHeader", () => {
     expect(screen.getByRole("heading", { name: "Evaluate" })).toBeTruthy();
     expect(
       screen.getByText(
-        "The manual pass you'd do before a ship, automated and run whenever the server changes.",
+        "Build a durable test suite from the prompts you already run by hand and automatically measure performance over time.",
       ),
     ).toBeTruthy();
     expect(screen.queryByRole("button", { name: /^suites$/i })).toBeNull();
@@ -49,7 +49,7 @@ describe("EvalsHeader", () => {
     expect(runs).not.toHaveAttribute("aria-current");
     expect(
       screen.getByText(
-        "The manual pass you'd do before a ship, automated and run whenever the server changes.",
+        "Build a durable test suite from the prompts you already run by hand and automatically measure performance over time.",
       ),
     ).toBeTruthy();
 
@@ -67,7 +67,7 @@ describe("EvalsHeader", () => {
 
     expect(screen.queryByRole("heading", { name: "Evaluate" })).toBeNull();
     expect(
-      screen.queryByText(/manual pass you'd do before a ship/i),
+      screen.queryByText(/durable test suite from the prompts/i),
     ).toBeNull();
     expect(screen.queryByRole("button", { name: /^suites$/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /^runs$/i })).toBeNull();

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/evaluate-run-content.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/evaluate-run-content.test.tsx
@@ -314,6 +314,26 @@ describe("EvaluateRunContent", () => {
     expect(screen.getByTestId("run-verdict-sentence")).toHaveTextContent(
       "Draw and share a diagram broke at Selection: an expected tool call was never made.",
     );
+    const pairings = screen.getByTestId("run-verdict-pairings");
+    expect(within(pairings).getAllByTestId("run-verdict-pairing")).toHaveLength(
+      1,
+    );
+    expect(within(pairings).getByText("1 passed")).toBeVisible();
+    expect(within(pairings).getByText("1 failed")).toBeVisible();
+    expect(within(pairings).getByTestId("result-count-bar")).toBeVisible();
+    expect(within(pairings).queryByText("1 of 2")).toBeNull();
+    expect(
+      pairings.compareDocumentPosition(
+        screen.getByRole("heading", { name: "What broke" }),
+      ),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(screen.getByRole("heading", { name: "What broke" })).toHaveClass(
+      "text-sm",
+      "font-semibold",
+    );
+    expect(
+      screen.getByRole("heading", { name: /How to fix|Next step/ }),
+    ).toHaveClass("text-sm", "font-semibold");
     expect(screen.queryByTestId("run-grading-peek")).toBeNull();
     expect(screen.queryByTestId("run-verdict-caveats")).toBeNull();
   });

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/evaluate-run-content.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/evaluate-run-content.test.tsx
@@ -336,6 +336,55 @@ describe("EvaluateRunContent", () => {
     ).toHaveClass("text-sm", "font-semibold");
     expect(screen.queryByTestId("run-grading-peek")).toBeNull();
     expect(screen.queryByTestId("run-verdict-caveats")).toBeNull();
+    expect(within(pairings).getByTestId("result-count-bar")).toHaveAttribute(
+      "role",
+      "img",
+    );
+  });
+
+  it("pairs hero deltas to a fallback previous launch when previousRunId is omitted", () => {
+    const current = {
+      _id: "run_2",
+      status: "running",
+      result: "pending",
+      namedHostId: "host-1",
+      effectiveModelId: "sonnet",
+      runNumber: 2,
+      createdAt: 2_000,
+    } as unknown as EvalSuiteRun;
+    const previous = {
+      _id: "run_1",
+      status: "completed",
+      result: "failed",
+      namedHostId: "host-1",
+      effectiveModelId: "sonnet",
+      runNumber: 1,
+      createdAt: 1_000,
+    } as unknown as EvalSuiteRun;
+    const previousRows = [
+      {
+        _id: "prev_1",
+        suiteRunId: "run_1",
+        result: "failed",
+        status: "completed",
+      },
+      {
+        _id: "prev_2",
+        suiteRunId: "run_1",
+        result: "failed",
+        status: "completed",
+      },
+    ] as unknown as EvalIteration[];
+
+    renderContent({
+      run: current,
+      iterations: ITERATIONS,
+      previousRunId: null,
+      siblingRuns: [previous, current],
+      allIterations: previousRows,
+    });
+
+    expect(screen.getByTestId("run-verdict-stat-delta")).toHaveTextContent("+1");
   });
 
   it("says nothing about a verdict while the read is in flight", () => {

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/evaluate-run-page.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/evaluate-run-page.test.tsx
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { EvaluateRunPage } from "../evaluate-run-page";
+import {
+  EvaluateRunPage,
+  pairingDecision,
+  useEvaluateRunPageHeaderActions,
+} from "../evaluate-run-page";
 import type { EvalSuiteRun, EvalSuite } from "../../evals/types";
 
 vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
@@ -31,7 +35,7 @@ function makeRun(
 const hostNamesById = new Map<string, string | null>([["host-1", "Claude"]]);
 
 describe("EvaluateRunPage", () => {
-  it("uses a simple Paper header with secondary actions in a menu", async () => {
+  it("uses a simple Paper header with Compare as a visible action", () => {
     render(
       <EvaluateRunPage
         run={makeRun({ _id: "n57cvtk9tsmnbj5tpcvnmdgkwn8dnjeq" })}
@@ -53,26 +57,51 @@ describe("EvaluateRunPage", () => {
     const header = screen.getByTestId("evaluate-run-header");
     expect(
       within(header).getByRole("heading", { name: "Run #1 Results" }),
+    ).toHaveClass("text-2xl", "font-bold", "tracking-tight");
+    expect(
+      within(header).getByRole("heading", { name: "Run #1 Results" }),
     ).not.toHaveClass("font-mono");
     expect(within(header).queryByText("Report for")).toBeNull();
     expect(
       within(header).queryByTestId("evaluate-run-launch-context"),
     ).toBeNull();
-    expect(screen.queryByTestId("evaluate-run-compare-open")).toBeNull();
-    await userEvent
-      .setup()
-      .click(screen.getByRole("button", { name: "Run actions" }));
-    expect(
-      screen.getByRole("menuitem", { name: "Compare runs" }),
-    ).not.toHaveAttribute("aria-disabled", "true");
+    const compare = screen.getByRole("button", { name: "Compare runs" });
+    expect(compare).toBeVisible();
+    expect(compare).not.toBeDisabled();
+    expect(screen.getByTestId("evaluate-run-compare-open")).toBe(compare);
+    expect(screen.queryByRole("button", { name: "Export report" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Run again" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Run actions" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Run details" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "New run" })).toBeNull();
+    expect(within(header).queryByText("Failed")).toBeNull();
+    expect(within(header).queryByText("Passed")).toBeNull();
+    const pill = screen.getByTestId("run-header-decision-pill");
+    expect(pill).toHaveAttribute("data-decision", "hold");
+    expect(within(header).queryByText(/\d+ of \d+/)).toBeNull();
+    expect(pill).toHaveClass("h-8", "rounded-full");
+    expect(pill).toHaveClass("border-warning/30", "bg-warning/10", "text-warning");
+    expect(pill).not.toHaveClass("border-destructive/30", "text-destructive");
+    expect(within(pill).getByTestId("run-header-pairing-decision")).toHaveTextContent(
+      "HOLD",
+    );
+    const logo = within(pill).getByRole("img", {
+      name: "Claude · Client default",
+    });
+    expect(logo.parentElement).toHaveClass("bg-background", "rounded-full");
+    expect(screen.queryByTestId("run-header-pairing")).toBeNull();
   });
 
   it.each([
-    ["timed_out", "pending", "Timed out"],
+    ["completed", "failed", "HOLD"],
+    ["completed", "passed", "SHIP"],
+    ["timed_out", "pending", "HOLD"],
+    ["failed", "pending", "HOLD"],
     ["grading", "pending", "Grading"],
+    ["running", "pending", "Running"],
     ["completed", "inconclusive", "Inconclusive"],
   ] as const)(
-    "reports %s without relabeling it pending",
+    "maps %s/%s to %s: with the logo inside that pill",
     (status, result, label) => {
       render(
         <EvaluateRunPage
@@ -85,7 +114,19 @@ describe("EvaluateRunPage", () => {
           body
         </EvaluateRunPage>,
       );
-      expect(screen.getByText(label, { exact: true })).toBeInTheDocument();
+      const header = screen.getByTestId("evaluate-run-header");
+      const pill = within(header).getByTestId("run-header-decision-pill");
+      expect(pill).toHaveClass("h-8", "rounded-full");
+      expect(within(pill).getByTestId("run-header-pairing-decision")).toHaveTextContent(
+        label,
+      );
+      expect(within(pill).getByRole("img")).toBeVisible();
+      expect(within(pill).getByRole("img").parentElement).toHaveClass(
+        "bg-background",
+      );
+      expect(within(header).queryByText("Failed")).toBeNull();
+      expect(within(header).queryByText("Passed")).toBeNull();
+      expect(within(header).queryByTestId("run-header-verdict")).toBeNull();
     },
   );
 
@@ -104,6 +145,7 @@ describe("EvaluateRunPage", () => {
             _id: "sibling",
             runGroupId: "launch",
             effectiveModelId: "opus",
+            result: "passed",
           }),
           makeRun({
             _id: "old",
@@ -120,16 +162,91 @@ describe("EvaluateRunPage", () => {
     expect(
       screen.getByRole("heading", { name: "Run #1 Results" }),
     ).toBeVisible();
-    expect(screen.getByText("2 client/model pairings")).toBeVisible();
+    expect(screen.queryByText(/client\/model pairing/)).toBeNull();
+    const pairings = screen.getByTestId("run-header-pairings");
+    const pills = within(pairings).getAllByTestId("run-header-decision-pill");
+    expect(pills).toHaveLength(2);
+    expect(pills[0]).toHaveAttribute("data-decision", "hold");
+    expect(pills[1]).toHaveAttribute("data-decision", "ship");
+    expect(pills[0]).toHaveClass("h-8", "rounded-full");
+    expect(pills[1]).toHaveClass("h-8", "rounded-full");
+    expect(pills[0]).toHaveClass("border-warning/30", "bg-warning/10", "text-warning");
+    expect(pills[0]).not.toHaveClass("text-destructive");
+    expect(pills[1]).toHaveClass("border-success/30", "bg-success/10");
+    expect(
+      within(pills[0]).getByTestId("run-header-pairing-decision"),
+    ).toHaveTextContent("HOLD");
+    expect(
+      within(pills[1]).getByTestId("run-header-pairing-decision"),
+    ).toHaveTextContent("SHIP");
+    expect(
+      within(pills[0]).getByRole("img", { name: "Claude · sonnet" }),
+    ).toBeVisible();
+    expect(
+      within(pills[0]).getByRole("img", { name: "Claude · sonnet" })
+        .parentElement,
+    ).toHaveClass("bg-background", "rounded-full");
+    expect(
+      within(pills[1]).getByRole("img", { name: "Claude · opus" }),
+    ).toBeVisible();
+    expect(within(pills[0]).queryByRole("img", { name: "Claude · opus" })).toBeNull();
+    expect(within(pills[1]).queryByRole("img", { name: "Claude · sonnet" })).toBeNull();
+    await user.hover(
+      within(pills[0]).getByRole("img", { name: "Claude · sonnet" }),
+    );
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Claude · sonnet",
+    );
     expect(screen.queryByRole("button", { name: /Client report/ })).toBeNull();
-    await user.click(screen.getByRole("button", { name: "Run actions" }));
-    await user.click(screen.getByRole("menuitem", { name: "Run details" }));
-    expect(screen.getByText("sonnet")).toBeVisible();
-    expect(screen.getByText("opus")).toBeVisible();
-    expect(screen.queryByText("other")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Run actions" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Run details" })).toBeNull();
+    expect(screen.queryByText("sonnet")).toBeNull();
+    expect(screen.queryByText("opus")).toBeNull();
   });
 
-  it("keeps launch metadata in run details instead of the header", async () => {
+  it("stacks every Hold client in one pill and omits an empty Ship pill", () => {
+    render(
+      <EvaluateRunPage
+        run={makeRun({
+          _id: "current",
+          runGroupId: "launch",
+          namedHostId: "host-1",
+          effectiveModelId: "sonnet",
+        })}
+        hostNamesById={
+          new Map([
+            ["host-1", "Claude"],
+            ["host-2", "Cursor"],
+          ])
+        }
+        otherRuns={[
+          makeRun({
+            _id: "sibling",
+            runGroupId: "launch",
+            namedHostId: "host-2",
+            effectiveModelId: "opus",
+            result: "failed",
+          }),
+        ]}
+        defaultCompareRunId={null}
+        onCompareWithRun={vi.fn()}
+      >
+        body
+      </EvaluateRunPage>,
+    );
+    const pills = screen.getAllByTestId("run-header-decision-pill");
+    expect(pills).toHaveLength(1);
+    expect(pills[0]).toHaveAttribute("data-decision", "hold");
+    expect(within(pills[0]).getAllByRole("img")).toHaveLength(2);
+    expect(screen.queryByText("SHIP")).toBeNull();
+    expect(screen.queryByText("Hold:")).toBeNull();
+    expect(screen.queryByText("HOLD:")).toBeNull();
+    expect(
+      within(pills[0]).getByTestId("run-header-pairing-decision"),
+    ).toHaveTextContent("HOLD");
+  });
+
+  it("keeps launch metadata out of the header", () => {
     render(
       <EvaluateRunPage
         run={makeRun({
@@ -149,16 +266,8 @@ describe("EvaluateRunPage", () => {
     );
 
     expect(screen.queryByTestId("evaluate-run-launch-context")).toBeNull();
-    const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: "Run actions" }));
-    await user.click(screen.getByRole("menuitem", { name: "Run details" }));
-    expect(screen.getByRole("dialog", { name: "Run details" })).toBeVisible();
-    expect(screen.getByTestId("evaluate-run-launch-context")).toHaveTextContent(
-      "Server",
-    );
-    expect(screen.getByTestId("evaluate-run-servers")).toHaveTextContent(
-      "Excalidraw (App)",
-    );
+    expect(screen.queryByTestId("evaluate-run-servers")).toBeNull();
+    expect(screen.queryByText("Excalidraw (App)")).toBeNull();
   });
 
   it("disables Compare when there is no other run", async () => {
@@ -174,11 +283,8 @@ describe("EvaluateRunPage", () => {
       </EvaluateRunPage>,
     );
 
-    await userEvent
-      .setup()
-      .click(screen.getByRole("button", { name: "Run actions" }));
-    const compare = screen.getByTestId("evaluate-run-compare-open");
-    expect(compare).toHaveAttribute("aria-disabled", "true");
+    const compare = screen.getByRole("button", { name: "Compare runs" });
+    expect(compare).toBeDisabled();
     expect(compare).toHaveAttribute("title", "Need at least two runs");
   });
 
@@ -204,8 +310,8 @@ describe("EvaluateRunPage", () => {
       <EvaluateRunPage {...props} run={makeRun({ _id: "old" })} />,
     );
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: "Run actions" }));
-    await user.click(screen.getByRole("menuitem", { name: "New run" }));
+    expect(screen.getByRole("button", { name: "Run again" })).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Run again" }));
     expect(screen.getByRole("dialog")).toBeVisible();
     rerender(
       <EvaluateRunPage
@@ -239,13 +345,76 @@ describe("EvaluateRunPage", () => {
       </EvaluateRunPage>,
     );
 
-    expect(screen.getByRole("button", { name: "Export report" })).toBeTruthy();
-    await user.click(screen.getByRole("button", { name: "Run actions" }));
-    await user.click(screen.getByTestId("evaluate-run-compare-open"));
+    expect(screen.queryByRole("button", { name: "Export report" })).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Compare runs" }));
     expect(screen.getByTestId("evaluate-run-compare")).toBeTruthy();
     expect(screen.queryByText("run body")).toBeNull();
 
     await user.click(screen.getByTestId("evaluate-run-compare-confirm"));
     expect(onCompareWithRun).toHaveBeenCalledWith("prev-run");
+  });
+
+  it("keeps overflow only when header actions remain", async () => {
+    function HeaderActionChild({ onImprove }: { onImprove?: () => void }) {
+      useEvaluateRunPageHeaderActions(onImprove ? { onImprove } : null);
+      return <div>run body</div>;
+    }
+
+    const pageProps = {
+      run: makeRun({ _id: "this-run" }),
+      hostNamesById,
+      otherRuns: [makeRun({ _id: "other-run" })],
+      defaultCompareRunId: "other-run",
+      onCompareWithRun: vi.fn(),
+    };
+    const { rerender } = render(
+      <EvaluateRunPage {...pageProps}>
+        <HeaderActionChild />
+      </EvaluateRunPage>,
+    );
+
+    expect(screen.getByRole("button", { name: "Compare runs" })).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Run actions" })).toBeNull();
+
+    rerender(
+      <EvaluateRunPage {...pageProps}>
+        <HeaderActionChild onImprove={vi.fn()} />
+      </EvaluateRunPage>,
+    );
+
+    const overflow = await screen.findByRole("button", { name: "Run actions" });
+    expect(overflow).toBeVisible();
+    await userEvent.setup().click(overflow);
+    expect(
+      screen.getByRole("menuitem", { name: "Prompt to improve" }),
+    ).toBeVisible();
+    expect(screen.queryByRole("menuitem", { name: "Compare runs" })).toBeNull();
+  });
+});
+
+describe("pairingDecision", () => {
+  it("maps the run's stored verdict, and withholds Hold/Ship while in flight", () => {
+    expect(pairingDecision(makeRun({ _id: "a", result: "passed" }))).toEqual({
+      word: "Ship",
+      tone: "ship",
+    });
+    expect(pairingDecision(makeRun({ _id: "b", result: "failed" }))).toEqual({
+      word: "Hold",
+      tone: "hold",
+    });
+    expect(
+      pairingDecision(makeRun({ _id: "c", status: "timed_out", result: "pending" })),
+    ).toEqual({ word: "Hold", tone: "hold" });
+    expect(
+      pairingDecision(makeRun({ _id: "d", status: "running", result: "pending" })),
+    ).toEqual({ word: "Running", tone: "pending" });
+    expect(
+      pairingDecision(makeRun({ _id: "e", status: "grading", result: "pending" })),
+    ).toEqual({ word: "Grading", tone: "pending" });
+    expect(
+      pairingDecision(
+        makeRun({ _id: "f", status: "completed", result: "inconclusive" }),
+      ),
+    ).toEqual({ word: "Inconclusive", tone: "pending" });
   });
 });

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/evaluate-run-page.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/evaluate-run-page.test.tsx
@@ -6,7 +6,7 @@ import {
   pairingDecision,
   useEvaluateRunPageHeaderActions,
 } from "../evaluate-run-page";
-import type { EvalSuiteRun, EvalSuite } from "../../evals/types";
+import type { EvalIteration, EvalSuiteRun, EvalSuite } from "../../evals/types";
 
 vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
   useProjectEnvironmentsEnabled: () => false,
@@ -85,10 +85,9 @@ describe("EvaluateRunPage", () => {
     expect(within(pill).getByTestId("run-header-pairing-decision")).toHaveTextContent(
       "HOLD",
     );
-    const logo = within(pill).getByRole("img", {
-      name: "Claude · Client default",
-    });
-    expect(logo.parentElement).toHaveClass("bg-background", "rounded-full");
+    const mark = within(pill).getByLabelText("Claude · Client default");
+    expect(mark).toHaveClass("bg-background", "rounded-full");
+    expect(mark.querySelector("img")).toHaveAttribute("alt", "");
     expect(screen.queryByTestId("run-header-pairing")).toBeNull();
   });
 
@@ -120,10 +119,10 @@ describe("EvaluateRunPage", () => {
       expect(within(pill).getByTestId("run-header-pairing-decision")).toHaveTextContent(
         label,
       );
-      expect(within(pill).getByRole("img")).toBeVisible();
-      expect(within(pill).getByRole("img").parentElement).toHaveClass(
-        "bg-background",
-      );
+      const mark = within(pill).getByLabelText("Claude · Client default");
+      expect(mark).toBeVisible();
+      expect(mark).toHaveClass("bg-background");
+      expect(mark.querySelector("img")).toBeVisible();
       expect(within(header).queryByText("Failed")).toBeNull();
       expect(within(header).queryByText("Passed")).toBeNull();
       expect(within(header).queryByTestId("run-header-verdict")).toBeNull();
@@ -179,24 +178,18 @@ describe("EvaluateRunPage", () => {
     expect(
       within(pills[1]).getByTestId("run-header-pairing-decision"),
     ).toHaveTextContent("SHIP");
-    expect(
-      within(pills[0]).getByRole("img", { name: "Claude · sonnet" }),
-    ).toBeVisible();
-    expect(
-      within(pills[0]).getByRole("img", { name: "Claude · sonnet" })
-        .parentElement,
-    ).toHaveClass("bg-background", "rounded-full");
-    expect(
-      within(pills[1]).getByRole("img", { name: "Claude · opus" }),
-    ).toBeVisible();
-    expect(within(pills[0]).queryByRole("img", { name: "Claude · opus" })).toBeNull();
-    expect(within(pills[1]).queryByRole("img", { name: "Claude · sonnet" })).toBeNull();
-    await user.hover(
-      within(pills[0]).getByRole("img", { name: "Claude · sonnet" }),
+    expect(within(pills[0]).getByLabelText("Claude · sonnet")).toBeVisible();
+    expect(within(pills[0]).getByLabelText("Claude · sonnet")).toHaveClass(
+      "bg-background",
+      "rounded-full",
     );
-    expect(await screen.findByRole("tooltip")).toHaveTextContent(
-      "Claude · sonnet",
-    );
+    expect(within(pills[1]).getByLabelText("Claude · opus")).toBeVisible();
+    expect(within(pills[0]).queryByLabelText("Claude · opus")).toBeNull();
+    expect(within(pills[1]).queryByLabelText("Claude · sonnet")).toBeNull();
+    await user.hover(within(pills[0]).getByLabelText("Claude · sonnet"));
+    expect(
+      await screen.findByRole("tooltip", { hidden: true }),
+    ).toHaveTextContent("Claude · sonnet");
     expect(screen.queryByRole("button", { name: /Client report/ })).toBeNull();
     expect(screen.queryByRole("button", { name: "Run actions" })).toBeNull();
     expect(screen.queryByRole("menuitem", { name: "Run details" })).toBeNull();
@@ -237,13 +230,40 @@ describe("EvaluateRunPage", () => {
     const pills = screen.getAllByTestId("run-header-decision-pill");
     expect(pills).toHaveLength(1);
     expect(pills[0]).toHaveAttribute("data-decision", "hold");
-    expect(within(pills[0]).getAllByRole("img")).toHaveLength(2);
+    expect(within(pills[0]).getAllByLabelText(/ · /)).toHaveLength(2);
     expect(screen.queryByText("SHIP")).toBeNull();
     expect(screen.queryByText("Hold:")).toBeNull();
     expect(screen.queryByText("HOLD:")).toBeNull();
     expect(
       within(pills[0]).getByTestId("run-header-pairing-decision"),
     ).toHaveTextContent("HOLD");
+  });
+
+  it("recovers the pairing model from iterations when the run omitted it", () => {
+    render(
+      <EvaluateRunPage
+        run={makeRun({ _id: "run-1" })}
+        iterations={
+          [
+            {
+              suiteRunId: "run-1",
+              testCaseSnapshot: { model: "anthropic/claude-haiku-4.5" },
+            },
+          ] as EvalIteration[]
+        }
+        hostNamesById={hostNamesById}
+        otherRuns={[]}
+        defaultCompareRunId={null}
+        onCompareWithRun={vi.fn()}
+      >
+        body
+      </EvaluateRunPage>,
+    );
+    expect(
+      within(screen.getByTestId("run-header-decision-pill")).getByLabelText(
+        "Claude · claude-haiku-4.5",
+      ),
+    ).toBeVisible();
   });
 
   it("keeps launch metadata out of the header", () => {

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/run-results-matrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/run-results-matrix.test.tsx
@@ -252,6 +252,37 @@ describe("run results matrix", () => {
     ).toEqual(["25%", "25%", "25%", "25%"]);
   });
 
+  it("does not treat a whitespace-only search as an active filter", async () => {
+    const user = userEvent.setup();
+    render(
+      <RunResultsMatrix
+        run={run("one")}
+        iterations={[
+          iteration("pass", "one", {
+            testCaseSnapshot: {
+              title: "Checkout",
+              model: "sonnet",
+              provider: "anthropic",
+              query: "Checkout",
+              expectedToolCalls: [],
+            },
+          }),
+        ]}
+        hostNamesById={names}
+      />,
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "Find a test case" }),
+      " ",
+    );
+    expect(
+      screen.getByRole("button", {
+        name: "Inspect Checkout on Claude · sonnet",
+      }),
+    ).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Clear filters" })).toBeNull();
+  });
+
   it("filters cases and opens the correct evidence when switching client/model in the drawer", async () => {
     const user = userEvent.setup();
     const open = vi.fn();

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/run-results-matrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/run-results-matrix.test.tsx
@@ -180,6 +180,42 @@ describe("run results matrix", () => {
     expect(cell.getByText("2K")).toBeVisible();
     expect(cell.queryByText("Cost")).toBeNull();
     expect(cell.getByText("Tool calls")).toBeVisible();
+    expect(screen.getByText("Test case")).toBeVisible();
+    const title = screen.getByRole("heading", { name: /Test cases/ });
+    expect(title).toBeVisible();
+    expect(title.compareDocumentPosition(screen.getByTestId("run-results-toolbar"))).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(screen.queryByText("Run results")).toBeNull();
+    expect(
+      screen.queryByText(
+        /Cases down the rows. Clients and models across the columns/,
+      ),
+    ).toBeNull();
+    expect(screen.queryByLabelText(/loaded iterations/)).toBeNull();
+    expect(screen.queryByTestId("result-count-bar")).toBeNull();
+    expect(screen.queryByText("1 passed")).toBeNull();
+    expect(screen.queryByText("1 failed")).toBeNull();
+    expect(screen.queryByText("Failures first")).toBeNull();
+    expect(
+      screen.queryByText(/Showing recorded iterations from this run/),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Clear filters" }),
+    ).toBeNull();
+    const toolbar = screen.getByTestId("run-results-toolbar");
+    const search = within(toolbar).getByRole("textbox", {
+      name: "Find a test case",
+    });
+    const status = within(toolbar).getByRole("combobox", {
+      name: "Filter by status",
+    });
+    expect(search.compareDocumentPosition(status)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(screen.queryByRole("button", { name: "All cases" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "With failures" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "In progress" })).toBeNull();
   });
 
   it("keeps unfinished and cancelled iterations distinct in the result bar", () => {
@@ -235,6 +271,9 @@ describe("run results matrix", () => {
       />,
     );
     expect(screen.getAllByRole("columnheader")).toHaveLength(3);
+    expect(
+      screen.queryByRole("button", { name: "Clear filters" }),
+    ).toBeNull();
     await user.type(
       screen.getByRole("textbox", { name: "Find a test case" }),
       "not present",
@@ -243,7 +282,14 @@ describe("run results matrix", () => {
       screen.getByText("No cases match these filters."),
     ).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Clear filters" }));
-    await user.click(screen.getByRole("button", { name: "With failures" }));
+    await user.click(
+      screen.getByRole("combobox", { name: "Filter by status" }),
+    );
+    expect(screen.getByRole("option", { name: "Failures" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Passed" })).toBeVisible();
+    expect(screen.queryByRole("option", { name: "Pending" })).toBeNull();
+    await user.click(screen.getByRole("option", { name: "Failures" }));
+    expect(screen.getByRole("button", { name: "Clear filters" })).toBeVisible();
     await user.click(
       screen.getByRole("button", {
         name: "Inspect Refund order on Claude · sonnet",
@@ -258,4 +304,73 @@ describe("run results matrix", () => {
       iterationId: "fail",
     });
   });
+
+  it("keeps Pending while a run is live and hides it once every run is terminal", async () => {
+    const user = userEvent.setup();
+    const live = run("one", { status: "running" });
+    const { rerender } = render(
+      <RunResultsMatrix
+        run={live}
+        iterations={[
+          iteration("pass", "one"),
+          iteration("pending", "one", { status: "running", result: "pending" }),
+        ]}
+        hostNamesById={names}
+      />,
+    );
+    await user.click(
+      screen.getByRole("combobox", { name: "Filter by status" }),
+    );
+    expect(screen.getByRole("option", { name: "Pending" })).toBeVisible();
+    await user.click(screen.getByRole("option", { name: "Pending" }));
+    expect(
+      screen.getByRole("combobox", { name: "Filter by status" }),
+    ).toHaveTextContent("Pending");
+    expect(screen.getByRole("button", { name: "Clear filters" })).toBeVisible();
+    rerender(
+      <RunResultsMatrix
+        run={run("one", { status: "completed" })}
+        iterations={[
+          iteration("pass", "one"),
+          iteration("fail", "one", { result: "failed" }),
+        ]}
+        hostNamesById={names}
+      />,
+    );
+    expect(
+      screen.getByRole("combobox", { name: "Filter by status" }),
+    ).toHaveTextContent("Status");
+    expect(
+      screen.queryByRole("button", { name: "Clear filters" }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", {
+        name: "Inspect Refund order on Claude · sonnet",
+      }),
+    ).toBeVisible();
+    await user.click(
+      screen.getByRole("combobox", { name: "Filter by status" }),
+    );
+    expect(screen.queryByRole("option", { name: "Pending" })).toBeNull();
+    expect(screen.getByRole("option", { name: "Failures" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Passed" })).toBeVisible();
+  });
+
+  it.each(["pending", "running", "grading"] as const)(
+    "offers Pending while status is %s",
+    async (status) => {
+      const user = userEvent.setup();
+      render(
+        <RunResultsMatrix
+          run={run("one", { status })}
+          iterations={[iteration("one", "one")]}
+          hostNamesById={names}
+        />,
+      );
+      await user.click(
+        screen.getByRole("combobox", { name: "Filter by status" }),
+      );
+      expect(screen.getByRole("option", { name: "Pending" })).toBeVisible();
+    },
+  );
 });

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/run-verdict-hero-deltas.test.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/run-verdict-hero-deltas.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildHeroPairings,
+  buildHeroStatDeltas,
+  buildPassedDelta,
+  previousCompletedRunOf,
+  previousHeroIterations,
+} from "../run-verdict-hero-deltas";
+import type { HeroStats } from "../run-verdict-hero-model";
+import type { EvalIteration, EvalSuiteRun } from "../../evals/types";
+
+function stats(overrides: Partial<HeroStats> = {}): HeroStats {
+  return {
+    cases: { kind: "unavailable" },
+    iterations: { passed: 18, total: 48 },
+    latencyP50Ms: 19_000,
+    latencyP95Ms: 67_000,
+    tokens: 1_000_000,
+    toolCalls: 70,
+    ...overrides,
+  };
+}
+
+function run(
+  overrides: Partial<EvalSuiteRun> & { _id: string },
+): EvalSuiteRun {
+  return {
+    suiteId: "suite",
+    createdBy: "u1",
+    runNumber: 1,
+    configRevision: "1",
+    configSnapshot: { tests: [], environment: { servers: [] } },
+    status: "completed",
+    createdAt: 1_000,
+    namedHostId: "cursor",
+    effectiveModelId: "gpt-5.1",
+    ...overrides,
+  } as EvalSuiteRun;
+}
+
+describe("buildHeroStatDeltas", () => {
+  it("treats more passes as progress and higher latency as regression", () => {
+    const deltas = buildHeroStatDeltas(
+      stats({
+        iterations: { passed: 21, total: 48 },
+        latencyP50Ms: 27_000,
+        tokens: 1_012_000,
+        toolCalls: 65,
+      }),
+      stats(),
+    );
+    expect(deltas.passed).toEqual({
+      label: "+3",
+      direction: "up",
+      tone: "progress",
+    });
+    expect(deltas.latency).toEqual({
+      label: "+8.0s",
+      direction: "up",
+      tone: "regression",
+    });
+    expect(deltas.tokens).toMatchObject({
+      direction: "up",
+      tone: "regression",
+    });
+    expect(deltas.toolCalls).toEqual({
+      label: "−5",
+      direction: "down",
+      tone: "progress",
+    });
+  });
+
+  it("treats fewer passes as regression and lower latency as progress", () => {
+    const deltas = buildHeroStatDeltas(
+      stats({
+        iterations: { passed: 16, total: 48 },
+        latencyP50Ms: 11_000,
+        tokens: 800_000,
+        toolCalls: 80,
+      }),
+      stats(),
+    );
+    expect(deltas.passed).toMatchObject({
+      direction: "down",
+      tone: "regression",
+    });
+    expect(deltas.latency).toMatchObject({
+      direction: "down",
+      tone: "progress",
+    });
+    expect(deltas.tokens).toMatchObject({
+      direction: "down",
+      tone: "progress",
+    });
+    expect(deltas.toolCalls).toMatchObject({
+      direction: "up",
+      tone: "regression",
+    });
+  });
+
+  it("keeps an unchanged metric quiet", () => {
+    const deltas = buildHeroStatDeltas(stats(), stats());
+    expect(deltas.passed).toEqual({
+      label: "=",
+      direction: "same",
+      tone: "same",
+    });
+    expect(deltas.latency?.tone).toBe("same");
+  });
+
+  it("does not compare a case count to an iteration fallback", () => {
+    const deltas = buildHeroStatDeltas(
+      stats({
+        cases: { kind: "cases", passed: 21, total: 48, inconclusive: 0 },
+      }),
+      stats(),
+    );
+    expect(deltas.passed).toBeNull();
+    expect(deltas.latency).not.toBeNull();
+  });
+
+  it("omits a metric when either side did not record it", () => {
+    const deltas = buildHeroStatDeltas(
+      stats({ tokens: null, toolCalls: 10 }),
+      stats({ tokens: 100, toolCalls: null }),
+    );
+    expect(deltas.tokens).toBeNull();
+    expect(deltas.toolCalls).toBeNull();
+  });
+});
+
+describe("previous completed run", () => {
+  const current = run({
+    _id: "run-3",
+    runNumber: 3,
+    createdAt: 3_000,
+    runGroupId: "g3",
+  });
+  const previous = run({
+    _id: "run-2",
+    runNumber: 2,
+    createdAt: 2_000,
+    runGroupId: "g2",
+  });
+  const older = run({
+    _id: "run-1",
+    runNumber: 1,
+    createdAt: 1_000,
+    runGroupId: "g1",
+  });
+  const otherHost = run({
+    _id: "run-2b",
+    runNumber: 2,
+    createdAt: 2_100,
+    namedHostId: "chatgpt",
+    runGroupId: "g2",
+  });
+  const sameGroup = run({
+    _id: "run-3b",
+    runNumber: 3,
+    createdAt: 3_100,
+    namedHostId: "chatgpt",
+    runGroupId: "g3",
+  });
+
+  it("picks the immediately earlier completed run of the same host and model", () => {
+    expect(
+      previousCompletedRunOf(current, [
+        current,
+        previous,
+        older,
+        otherHost,
+        sameGroup,
+      ])?._id,
+    ).toBe("run-2");
+  });
+
+  it("returns nothing for the first run of a pairing", () => {
+    expect(previousCompletedRunOf(older, [older, current])).toBeNull();
+  });
+
+  it("uses the previous launch aggregate even when a current pairing is new", () => {
+    const previousRow = {
+      _id: "it-prev",
+      suiteRunId: "run-2",
+      result: "passed",
+    } as EvalIteration;
+    expect(
+      previousHeroIterations({
+        selectedRuns: [current, sameGroup],
+        suiteRuns: [current, previous, sameGroup],
+        allIterations: [previousRow],
+      }),
+    ).toEqual([previousRow]);
+  });
+
+  it("returns every previous-launch iteration, not one pairing", () => {
+    const previousRows = [
+      {
+        _id: "it-prev-cursor",
+        suiteRunId: "run-2",
+        result: "passed",
+      } as EvalIteration,
+      {
+        _id: "it-prev-chatgpt",
+        suiteRunId: "run-2b",
+        result: "failed",
+      } as EvalIteration,
+    ];
+    expect(
+      previousHeroIterations({
+        selectedRuns: [current, sameGroup],
+        suiteRuns: [current, previous, older, otherHost, sameGroup],
+        allIterations: previousRows,
+        previousRunId: "run-2",
+      }),
+    ).toEqual(previousRows);
+  });
+
+  it("returns the previous run's iterations when history is on the page", () => {
+    const previousRow = {
+      _id: "it-prev",
+      suiteRunId: "run-2",
+      result: "passed",
+    } as EvalIteration;
+    expect(
+      previousHeroIterations({
+        selectedRuns: [current],
+        suiteRuns: [current, previous],
+        allIterations: [previousRow],
+        previousRunId: "run-2",
+      }),
+    ).toEqual([previousRow]);
+  });
+});
+
+describe("buildHeroPairings", () => {
+  it("compares each pairing to its previous-launch twin, not the aggregate", () => {
+    const cursor = run({
+      _id: "now-cursor",
+      namedHostId: "cursor",
+      effectiveModelId: "gpt-5.1",
+    });
+    const chatgpt = run({
+      _id: "now-chatgpt",
+      namedHostId: "chatgpt",
+      effectiveModelId: "gpt-5.1",
+    });
+    const prevCursor = run({
+      _id: "prev-cursor",
+      namedHostId: "cursor",
+      effectiveModelId: "gpt-5.1",
+    });
+    const prevChatgpt = run({
+      _id: "prev-chatgpt",
+      namedHostId: "chatgpt",
+      effectiveModelId: "gpt-5.1",
+    });
+    const pairings = buildHeroPairings({
+      targets: [
+        {
+          key: "cursor",
+          run: cursor,
+          client: "Cursor",
+          modelId: "gpt-5.1",
+          model: "gpt-5.1",
+          iterations: [
+            { result: "passed", status: "completed", resultSource: "reported" } as EvalIteration,
+            { result: "passed", status: "completed", resultSource: "reported" } as EvalIteration,
+            { result: "failed", status: "completed", resultSource: "reported" } as EvalIteration,
+          ],
+        },
+        {
+          key: "chatgpt",
+          run: chatgpt,
+          client: "ChatGPT",
+          modelId: "gpt-5.1",
+          model: "gpt-5.1",
+          iterations: [
+            { result: "failed", status: "completed", resultSource: "reported" } as EvalIteration,
+          ],
+        },
+      ],
+      previousLaunch: [prevCursor, prevChatgpt],
+      previousIterations: [
+        { suiteRunId: "prev-cursor", result: "passed" } as EvalIteration,
+        { suiteRunId: "prev-chatgpt", result: "passed" } as EvalIteration,
+      ],
+    });
+    expect(pairings[0]).toMatchObject({
+      client: "Cursor",
+      passed: 2,
+      failed: 1,
+      total: 3,
+      delta: { label: "+1", direction: "up", tone: "progress" },
+    });
+    expect(pairings[1]).toMatchObject({
+      client: "ChatGPT",
+      passed: 0,
+      failed: 1,
+      total: 1,
+      delta: { label: "−1", direction: "down", tone: "regression" },
+    });
+  });
+
+  it("omits a delta when that pairing has no previous twin", () => {
+    const pairings = buildHeroPairings({
+      targets: [
+        {
+          key: "new",
+          run: run({
+            _id: "now-new",
+            namedHostId: "claude",
+            effectiveModelId: "opus",
+          }),
+          client: "Claude",
+          modelId: "opus",
+          model: "opus",
+          iterations: [
+            { result: "passed", status: "completed", resultSource: "reported" } as EvalIteration,
+          ],
+        },
+      ],
+      previousLaunch: [
+        run({
+          _id: "prev-cursor",
+          namedHostId: "cursor",
+          effectiveModelId: "gpt-5.1",
+        }),
+      ],
+      previousIterations: [
+        { suiteRunId: "prev-cursor", result: "passed" } as EvalIteration,
+      ],
+    });
+    expect(pairings[0].delta).toBeNull();
+    expect(pairings[0]).toMatchObject({ passed: 1, total: 1 });
+  });
+
+  it("does not invent a first-launch zero", () => {
+    expect(
+      buildPassedDelta(21, null),
+    ).toBeNull();
+    const pairings = buildHeroPairings({
+      targets: [
+        {
+          key: "solo",
+          run: run({ _id: "first" }),
+          client: "Cursor",
+          modelId: "gpt-5.1",
+          model: "gpt-5.1",
+          iterations: [
+            { result: "passed", status: "completed", resultSource: "reported" } as EvalIteration,
+          ],
+        },
+      ],
+      previousLaunch: null,
+      previousIterations: null,
+    });
+    expect(pairings[0].delta).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/run-verdict-hero-deltas.test.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/run-verdict-hero-deltas.test.ts
@@ -233,6 +233,30 @@ describe("previous completed run", () => {
       }),
     ).toEqual([previousRow]);
   });
+
+  it("keeps only the selected pairing when filtering the previous launch", () => {
+    const previousRows = [
+      {
+        _id: "it-prev-cursor",
+        suiteRunId: "run-2",
+        result: "passed",
+      } as EvalIteration,
+      {
+        _id: "it-prev-chatgpt",
+        suiteRunId: "run-2b",
+        result: "failed",
+      } as EvalIteration,
+    ];
+    expect(
+      previousHeroIterations({
+        selectedRuns: [current],
+        suiteRuns: [current, previous, older, otherHost, sameGroup],
+        allIterations: previousRows,
+        previousRunId: "run-2",
+        matchSelectedPairings: true,
+      }),
+    ).toEqual([previousRows[0]]);
+  });
 });
 
 describe("buildHeroPairings", () => {

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/run-verdict-hero-model.test.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/run-verdict-hero-model.test.ts
@@ -429,6 +429,45 @@ describe("the numbers beside it", () => {
     expect(view.stats.iterations).toEqual({ passed: 1, total: 1 });
   });
 
+  it("attaches no deltas when this is the first run", () => {
+    expect(buildRunVerdictHero(input()).deltas).toBeNull();
+  });
+
+  it("compares iteration measurements to the previous run", () => {
+    const view = buildRunVerdictHero(
+      input({
+        decision: { status: "disabled", summary: null, diagnostics: [] },
+        iterations: [
+          iteration({
+            tokensUsed: 2000,
+            actualToolCalls: [
+              { toolName: "a", arguments: {} },
+              { toolName: "b", arguments: {} },
+            ],
+          }),
+        ],
+        previous: {
+          iterations: [
+            iteration({
+              _id: "it_prev",
+              result: "failed",
+              tokensUsed: 1000,
+              actualToolCalls: [{ toolName: "create_view", arguments: {} }],
+            }),
+          ],
+        },
+      }),
+    );
+    expect(view.deltas?.passed).toMatchObject({
+      label: "+1",
+      tone: "progress",
+    });
+    expect(view.deltas?.tokens).toMatchObject({
+      direction: "up",
+      tone: "regression",
+    });
+  });
+
   it("sums tokens and tool calls, and leaves them absent when unrecorded", () => {
     const withData = buildRunVerdictHero(
       input({ iterations: [iteration(), iteration({ tokensUsed: 500 })] }),

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/run-verdict-hero.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/run-verdict-hero.test.tsx
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+
+import { RunVerdictHero } from "../run-verdict-hero";
+import type { HeroStatDeltas } from "../run-verdict-hero-deltas";
+import type { RunVerdictHeroView } from "../run-verdict-hero-model";
+
+function view(overrides: Partial<RunVerdictHeroView> = {}): RunVerdictHeroView {
+  return {
+    verdict: { word: "Failed", tone: "failed", undecidedLine: null },
+    focus: null,
+    sentence: {
+      kind: "brokeAt",
+      text: "Create and export a diagram to Excalidraw broke at Selection.",
+      expected: [],
+      observed: [],
+    },
+    stats: {
+      cases: { kind: "cases", passed: 2, total: 3, inconclusive: 0 },
+      iterations: { passed: 2, total: 3 },
+      latencyP50Ms: 100,
+      latencyP95Ms: 200,
+      tokens: 1000,
+      toolCalls: 4,
+    },
+    pairings: [],
+    deltas: null,
+    pending: false,
+    ...overrides,
+  };
+}
+
+describe("RunVerdictHero", () => {
+  it("labels each insight as AI generated, not the body or heading icon", () => {
+    render(<RunVerdictHero view={view()} />);
+
+    const sentence = screen.getByTestId("run-verdict-sentence");
+    const remedy = screen.getByTestId("run-verdict-remedy");
+    expect(within(sentence).queryByText("AI generated")).toBeNull();
+    expect(within(remedy).queryByText("AI generated")).toBeNull();
+    expect(screen.getAllByText("AI generated")).toHaveLength(2);
+    expect(screen.getAllByTestId("run-verdict-ai-insight")).toHaveLength(2);
+
+    const whatBroke = screen.getByRole("heading", { name: "What broke" });
+    const howToFix = screen.getByRole("heading", { name: "Next step" });
+    expect(whatBroke).not.toHaveTextContent("AI generated");
+    expect(howToFix).not.toHaveTextContent("AI generated");
+    expect(sentence).toHaveTextContent(
+      "Create and export a diagram to Excalidraw broke at Selection.",
+    );
+    expect(sentence.querySelector("svg")).toBeNull();
+    expect(remedy.querySelector("svg")).toBeNull();
+
+    const insights = screen.getByTestId("run-verdict-insights");
+    expect(insights).toHaveClass("divide-border/40", "border-t", "border-border/60");
+    expect(insights).not.toHaveClass("gap-4");
+    expect(sentence.parentElement).not.toHaveClass("rounded-lg", "border-border");
+    expect(remedy.parentElement).not.toHaveClass("rounded-lg", "border-border");
+  });
+
+  it("does not mark the loading skeletons as generated", () => {
+    render(
+      <RunVerdictHero
+        view={view({
+          pending: true,
+          sentence: { kind: "unavailable", text: "" },
+          verdict: { word: "Running", tone: "neutral", undecidedLine: null },
+        })}
+      />,
+    );
+
+    const loading = screen.getByTestId("run-summary-loading");
+    expect(loading).toBeInTheDocument();
+    expect(loading).toHaveClass("divide-border/40", "border-t", "border-border/60");
+    expect(loading.querySelector(".rounded-lg")).toBeNull();
+    expect(screen.queryByTestId("run-verdict-ai-insight")).toBeNull();
+  });
+
+  it("shows no metric deltas when there is no previous run", () => {
+    render(<RunVerdictHero view={view()} />);
+    expect(screen.queryByTestId("run-verdict-stat-delta")).toBeNull();
+  });
+
+  it("lists each pairing's pass count above the insight cards, not as a Passed tile", () => {
+    render(
+      <RunVerdictHero
+        view={view({
+          pairings: [
+            {
+              key: "cursor-sonnet",
+              client: "Cursor",
+              model: "sonnet",
+              passed: 21,
+              failed: 3,
+              pending: 0,
+              cancelled: 0,
+              total: 24,
+              delta: { label: "+12", direction: "up", tone: "progress" },
+            },
+          ],
+        })}
+      />,
+    );
+
+    const pairings = screen.getByTestId("run-verdict-pairings");
+    const whatBroke = screen.getByRole("heading", { name: "What broke" });
+    expect(pairings.compareDocumentPosition(whatBroke)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(within(pairings).getByText("Cursor")).toBeVisible();
+    expect(within(pairings).getByText("· sonnet")).toBeVisible();
+    expect(within(pairings).queryByText("21 of 24")).toBeNull();
+    expect(within(pairings).queryByText("=")).toBeNull();
+    expect(within(pairings).getByText("21 passed")).toBeVisible();
+    expect(within(pairings).getByText("3 failed")).toBeVisible();
+    expect(within(pairings).getByTestId("result-count-bar")).toBeVisible();
+    const name = within(pairings).getByText("Cursor");
+    const key = within(pairings).getByTestId("result-count-key");
+    const bar = within(pairings).getByTestId("result-count-bar");
+    expect(name.compareDocumentPosition(key)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(key.compareDocumentPosition(bar)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(within(pairings).getByTestId("run-verdict-pairing")).toHaveClass(
+      "py-4",
+    );
+    expect(within(pairings).getByTestId("run-verdict-stat-delta")).toHaveTextContent(
+      "+12",
+    );
+    expect(within(pairings).getByTestId("run-verdict-stat-delta")).toHaveClass(
+      "text-success",
+    );
+    expect(within(screen.getByTestId("run-verdict-stats")).queryByText("Passed")).toBeNull();
+  });
+
+  it("paints a pairing pass increase as progress and a latency increase as regression", () => {
+    const deltas: HeroStatDeltas = {
+      passed: { label: "+3", direction: "up", tone: "progress" },
+      latency: { label: "+8s", direction: "up", tone: "regression" },
+      tokens: { label: "−12k", direction: "down", tone: "progress" },
+      toolCalls: { label: "+4", direction: "up", tone: "regression" },
+    };
+    render(
+      <RunVerdictHero
+        view={view({
+          deltas,
+          pairings: [
+            {
+              key: "cursor-sonnet",
+              client: "Cursor",
+              model: "sonnet",
+              passed: 21,
+              failed: 3,
+              pending: 0,
+              cancelled: 0,
+              total: 24,
+              delta: deltas.passed,
+            },
+          ],
+        })}
+      />,
+    );
+
+    const pairingDelta = within(
+      screen.getByTestId("run-verdict-pairings"),
+    ).getByTestId("run-verdict-stat-delta");
+    expect(pairingDelta).toHaveTextContent("+3");
+    expect(pairingDelta).toHaveClass("text-success");
+    expect(pairingDelta).toHaveAccessibleName("+3 vs previous run");
+
+    const strip = screen.getByTestId("run-verdict-stats");
+    const marks = within(strip).getAllByTestId("run-verdict-stat-delta");
+    expect(marks).toHaveLength(3);
+    expect(marks[0]).toHaveTextContent("+8s");
+    expect(marks[0]).toHaveClass("text-destructive");
+    expect(marks[1]).toHaveTextContent("−12k");
+    expect(marks[1]).toHaveClass("text-success");
+    expect(marks[2]).toHaveTextContent("+4");
+    expect(marks[2]).toHaveClass("text-destructive");
+    expect(within(strip).queryByText("Passed")).toBeNull();
+  });
+
+  it("paints a pairing pass drop as regression and a latency drop as progress", () => {
+    const deltas: HeroStatDeltas = {
+      passed: { label: "−2", direction: "down", tone: "regression" },
+      latency: { label: "−8s", direction: "down", tone: "progress" },
+      tokens: { label: "+12k", direction: "up", tone: "regression" },
+      toolCalls: { label: "−3", direction: "down", tone: "progress" },
+    };
+    render(
+      <RunVerdictHero
+        view={view({
+          deltas,
+          pairings: [
+            {
+              key: "cursor-sonnet",
+              client: "Cursor",
+              model: "sonnet",
+              passed: 16,
+              failed: 8,
+              pending: 0,
+              cancelled: 0,
+              total: 24,
+              delta: deltas.passed,
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(
+      within(screen.getByTestId("run-verdict-pairings")).getByTestId(
+        "run-verdict-stat-delta",
+      ),
+    ).toHaveClass("text-destructive");
+    const marks = within(screen.getByTestId("run-verdict-stats")).getAllByTestId(
+      "run-verdict-stat-delta",
+    );
+    expect(marks[0]).toHaveTextContent("−8s");
+    expect(marks[0]).toHaveClass("text-success");
+    expect(marks[1]).toHaveClass("text-destructive");
+    expect(marks[2]).toHaveClass("text-success");
+  });
+
+  it("does not show a lonely equals on an unchanged pairing", () => {
+    render(
+      <RunVerdictHero
+        view={view({
+          pairings: [
+            {
+              key: "cursor-sonnet",
+              client: "Cursor",
+              model: "sonnet",
+              passed: 21,
+              failed: 3,
+              pending: 0,
+              cancelled: 0,
+              total: 24,
+              delta: { label: "=", direction: "same", tone: "same" },
+            },
+          ],
+        })}
+      />,
+    );
+
+    const pairings = screen.getByTestId("run-verdict-pairings");
+    expect(within(pairings).queryByTestId("run-verdict-stat-delta")).toBeNull();
+    expect(within(pairings).queryByText("=")).toBeNull();
+    expect(within(pairings).getByText("21 passed")).toBeVisible();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-detail-model.test.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-detail-model.test.ts
@@ -561,6 +561,18 @@ describe("SUITE_RUN_HISTORY_PAGE_SIZE", () => {
       ).toLocaleString(undefined, day)}`,
     );
   });
+
+  it("treats a missing timestamp as unavailable", () => {
+    const morning = new Date(2026, 8, 8, 9, 0).getTime();
+    expect(formatRunHistoryDate(0)).toBe("-");
+    expect(formatRunHistoryDateRange(0, 0)).toBe("-");
+    expect(formatRunHistoryDateRange(0, morning)).toBe(
+      new Date(morning).toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+      }),
+    );
+  });
 });
 
 describe("resolveRunHistoryVerdict — a run held for its judge", () => {

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-detail-model.test.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-detail-model.test.ts
@@ -6,6 +6,8 @@ import {
   buildSuiteRunHistoryRows,
   buildSuiteTestCaseRows,
   filterSuiteRunHistoryRows,
+  formatRunHistoryDate,
+  formatRunHistoryDateRange,
   formatSuiteIdentitySubline,
   resolveRunHistoryVerdict,
   runHistoryFilterOptions,
@@ -529,6 +531,35 @@ describe("suiteRunBlockedReason", () => {
 describe("SUITE_RUN_HISTORY_PAGE_SIZE", () => {
   it("caps the default table", () => {
     expect(SUITE_RUN_HISTORY_PAGE_SIZE).toBe(8);
+  });
+
+  it("formats a run timestamp as a short date and time", () => {
+    expect(formatRunHistoryDate(1_700_000_000_000)).toBe(
+      new Date(1_700_000_000_000).toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      }),
+    );
+  });
+
+  it("collapses a same-day suite range and spans different days", () => {
+    const morning = new Date(2026, 8, 8, 9, 0).getTime();
+    const evening = new Date(2026, 8, 8, 17, 30).getTime();
+    const later = new Date(2026, 8, 10, 12, 0).getTime();
+    const day = {
+      month: "short" as const,
+      day: "numeric" as const,
+    };
+    expect(formatRunHistoryDateRange(evening, morning)).toBe(
+      new Date(morning).toLocaleString(undefined, day),
+    );
+    expect(formatRunHistoryDateRange(morning, later)).toBe(
+      `${new Date(morning).toLocaleString(undefined, day)} – ${new Date(
+        later,
+      ).toLocaleString(undefined, day)}`,
+    );
   });
 });
 

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-detail-overview.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-detail-overview.test.tsx
@@ -14,6 +14,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders, screen, userEvent } from "@/test";
 import { SuiteDetailOverview } from "../suite-detail-overview";
+import { formatRunHistoryDate } from "../suite-detail-model";
 import type {
   EvalCase,
   EvalIteration,
@@ -179,17 +180,25 @@ describe("SuiteDetailOverview", () => {
     const table = within(
       screen.getByRole("table", { name: "Suite run history" }),
     );
+    const headers = table
+      .getAllByRole("columnheader")
+      .map((header) => header.textContent);
+    expect(headers.slice(0, 2)).toEqual(["Date", "Run"]);
     expect(table.getAllByRole("button", { name: /^Run #/ })).toHaveLength(2);
     expect(screen.queryByTestId("suite-run-row-two")).toBeNull();
     const row = within(screen.getByTestId("suite-run-row-one"));
+    const cells = screen.getByTestId("suite-run-row-one").querySelectorAll("td");
+    expect(cells[0]).toHaveTextContent(formatRunHistoryDate(1000));
+    expect(cells[0]).not.toHaveTextContent("Run #");
+    expect(cells[1]).toHaveTextContent("Run #1");
+    expect(cells[1]).not.toHaveTextContent(formatRunHistoryDate(1000));
     expect(row.getByText("25%")).toBeVisible();
     expect(row.getByText("1/4 passed")).toBeVisible();
-    expect(
-      row.getByRole("button", { name: /Client model mapping:.*Claude/ }),
-    ).toBeVisible();
-    expect(screen.getByTestId("suite-run-history-snapshot")).toHaveTextContent(
-      "trends across 2 runs",
-    );
+    expect(row.getByText(/Claude/)).toBeVisible();
+    expect(row.queryByRole("button", { name: /Client model mapping/ })).toBeNull();
+    expect(row.queryByText(/client : model pairings/i)).toBeNull();
+    expect(screen.getByTestId("suite-run-history-snapshot")).toBeVisible();
+    expect(screen.queryByText(/trends across/)).toBeNull();
     await user.click(
       screen.getByRole("combobox", { name: "Filter by client" }),
     );
@@ -276,9 +285,7 @@ describe("SuiteDetailOverview", () => {
     expect(screen.queryByLabelText("Filter by verdict")).toBeNull();
     expect(screen.getByLabelText("Filter by client")).toBeTruthy();
     expect(screen.getByLabelText("Filter by model")).toBeTruthy();
-    expect(screen.getByTestId("suite-run-history-snapshot")).toHaveTextContent(
-      "1 failed iteration",
-    );
+    expect(screen.getByTestId("suite-run-history-snapshot")).toBeVisible();
     expect(screen.getByTestId("suite-run-history-snapshot")).toHaveTextContent(
       "0/1 passed",
     );

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-run-history-snapshot.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-run-history-snapshot.test.tsx
@@ -72,10 +72,10 @@ describe("SuiteRunHistorySnapshot", () => {
 
     const root = screen.getByTestId("suite-run-history-snapshot");
     expect(screen.queryByTestId("suite-metric-strip")).toBeNull();
-    expect(within(root).getByText("1 failed iteration")).toBeTruthy();
+    expect(within(root).queryByText(/failed iteration/)).toBeNull();
     expect(within(root).getByText("50%")).toBeTruthy();
     expect(within(root).getByText("1/2 passed")).toBeTruthy();
-    expect(within(root).getByText("Latest run")).toBeTruthy();
+    expect(within(root).queryByText("Latest run")).toBeNull();
 
     const latency = within(root).getByTestId("metric-strip-latency");
     expect(within(latency).getByText("P50")).toBeTruthy();
@@ -119,7 +119,8 @@ describe("SuiteRunHistorySnapshot", () => {
       />,
     );
 
-    expect(screen.getByText("Latest run · trends across 2 runs")).toBeTruthy();
+    expect(screen.queryByText(/Latest run/)).toBeNull();
+    expect(screen.queryByText(/trends across/)).toBeNull();
     expect(screen.getByText("0%")).toBeTruthy();
   });
   it("shows measured history trends with real run labels and leaves unpriced cost blank", () => {
@@ -176,7 +177,7 @@ describe("SuiteRunHistorySnapshot", () => {
       }
       expect(screen.queryByTestId("metric-sparkline-cost")).toBeNull();
       expect(screen.getByText("not priced")).toBeVisible();
-      expect(screen.getByText("↓100 pp")).toBeVisible();
+      expect(screen.queryByText(/ pp$/)).toBeNull();
       const latency = screen.getByTestId("metric-sparkline-latency");
       fireEvent.mouseMove(latency, { clientX: 0 });
       expect(within(latency).getByText(/Run #7/)).toBeVisible();
@@ -202,7 +203,9 @@ describe("SuiteRunHistorySnapshot", () => {
         allIterations={[iteration({ result: "pending", status: "running" })]}
       />,
     );
-    expect(screen.getByText("No failed iterations")).toBeVisible();
+    expect(screen.queryByText(/failed iteration/)).toBeNull();
     expect(screen.queryByText("All iterations passed")).toBeNull();
+    expect(screen.getByText("0%")).toBeVisible();
+    expect(screen.getByText("0/1 passed")).toBeVisible();
   });
 });

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-run-review.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-run-review.test.tsx
@@ -49,6 +49,13 @@ describe("suite run review", () => {
     );
     // Seeded from the suite floor (minIterations 5), not the flat default.
     expect(screen.getByRole("spinbutton")).toHaveValue(5);
+    expect(screen.getByLabelText("Iterations per case")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Fewer iterations" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "More iterations" })).toBeVisible();
+    expect(screen.queryByText("1–10 repetitions")).toBeNull();
+    expect(
+      screen.queryByText("Repeat every case to check consistency."),
+    ).toBeNull();
     expect(screen.getByText("80%")).toBeVisible();
     await user.click(screen.getByRole("checkbox", { name: "Claude · sonnet" }));
     await user.clear(screen.getByRole("spinbutton"));
@@ -109,5 +116,28 @@ describe("suite run review", () => {
     expect(
       screen.getByRole("checkbox", { name: "Claude · opus" }),
     ).toBeChecked();
+  });
+
+  it("opens suite settings from the grading policy action", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onEditSettings = vi.fn();
+    render(
+      <SuiteRunReview
+        suite={suite}
+        cases={cases}
+        environments={environments}
+        hostNamesById={names}
+        onStart={vi.fn()}
+        onClose={onClose}
+        onEditSettings={onEditSettings}
+      />,
+    );
+    expect(screen.queryByRole("link", { name: "Edit suite settings" })).toBeNull();
+    await user.click(
+      screen.getByRole("button", { name: "Edit suite settings" }),
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onEditSettings).toHaveBeenCalledOnce();
   });
 });

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/suites-overview.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/suites-overview.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type {
   EvalSuite,
@@ -93,11 +93,30 @@ describe("SuitesOverview", () => {
       />,
     );
 
-    expect(screen.getByText("Suite")).toBeInTheDocument();
-    expect(screen.getAllByText("Client")).toHaveLength(2);
-    expect(screen.getAllByText("Server")).toHaveLength(2);
-    expect(screen.getByText("Pass rate")).toBeInTheDocument();
-    expect(screen.getByText("Last run")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Suite" })).toBeVisible();
+    expect(
+      screen.getByRole("columnheader", { name: "Pass rate" }),
+    ).toBeVisible();
+    expect(screen.getByRole("columnheader", { name: "Last run" })).toBeVisible();
+    const clientHeader = screen.getByRole("columnheader", { name: "Client" });
+    const serverHeader = screen.getByRole("columnheader", { name: "Server" });
+    const clientFilter = within(clientHeader).getByRole("combobox", {
+      name: "Filter by client",
+    });
+    const serverFilter = within(serverHeader).getByRole("combobox", {
+      name: "Filter by server",
+    });
+    expect(clientFilter).toBeVisible();
+    expect(serverFilter).toBeVisible();
+    expect(clientFilter).toHaveClass("text-muted-foreground", "border-0");
+    expect(clientFilter).not.toHaveClass("rounded-full");
+    expect(serverFilter).toHaveClass("text-muted-foreground", "border-0");
+    expect(serverFilter).not.toHaveClass("rounded-full");
+    expect(screen.getAllByText("Client")).toHaveLength(1);
+    expect(screen.getAllByText("Server")).toHaveLength(1);
+    expect(
+      screen.queryByRole("button", { name: "Clear filters" }),
+    ).not.toBeInTheDocument();
 
     expect(screen.getByText("Excalidraw Draw Small House")).toBeInTheDocument();
     expect(screen.getByText("Cursor")).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/evaluate/combined-run-content.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/combined-run-content.tsx
@@ -20,8 +20,15 @@ import { buildRunResultsMatrix } from "./run-results-matrix-model";
 import { RunResultsMatrix } from "./run-results-matrix";
 import {
   buildRunVerdictHero,
+  heroStatsFor,
   type RunVerdictHeroView,
 } from "./run-verdict-hero-model";
+import {
+  buildHeroPairings,
+  buildHeroStatDeltas,
+  previousHeroIterations,
+  previousLaunchRuns,
+} from "./run-verdict-hero-deltas";
 import { RunVerdictHero } from "./run-verdict-hero";
 import type { SingleRunContent } from "./evaluate-run-content";
 
@@ -36,6 +43,9 @@ export function CombinedRunContent({
   runs,
   projectId,
   hostNamesById = new Map(),
+  siblingRuns = [],
+  allIterations,
+  previousRunId,
   decisionSummaryEnabled,
   onOpenIteration,
 }: Parameters<typeof SingleRunContent>[0] & { runs: EvalSuiteRun[] }) {
@@ -77,22 +87,59 @@ export function CombinedRunContent({
   );
   const isFiltered =
     client !== ALL_EVAL_FILTER_VALUES || model !== ALL_EVAL_FILTER_VALUES;
-  const view = combinedReportView(
+  const suiteRuns = siblingRuns.length > 0 ? siblingRuns : hydratedRuns;
+  const previousIterations = previousHeroIterations({
     selectedRuns,
-    selectedIterations,
-    selectedReports.map((report) => report.view),
-    isFiltered,
+    suiteRuns,
+    allIterations,
+    previousRunId,
+    matchSelectedPairings: isFiltered,
+  });
+  const previousLaunch = previousLaunchRuns(
+    selectedRuns,
+    suiteRuns,
+    previousRunId,
   );
+  const pairings = buildHeroPairings({
+    targets,
+    previousLaunch,
+    previousIterations,
+  });
+  const view = {
+    ...combinedReportView(
+      selectedRuns,
+      selectedIterations,
+      selectedReports.map((report) => report.view),
+      isFiltered,
+      previousIterations,
+    ),
+    pairings,
+  };
   const fullVerdict = combinedReportView(
     hydratedRuns,
     iterations,
     hydratedRuns.flatMap((run) => reports.get(run._id)?.view ?? []),
     false,
+    previousIterations,
   ).verdict;
   const diagnostics = selectedReports.flatMap((report) => report.diagnostics);
   const chains = new Map(
     selectedReports.flatMap((report) => [...report.chains]),
   );
+  const clearPairingFilters = () => {
+    setClient(ALL_EVAL_FILTER_VALUES);
+    setModel(ALL_EVAL_FILTER_VALUES);
+  };
+  const pairingFilterProps = {
+    client,
+    model,
+    clientOptions: [...new Set(matrix.targets.map((target) => target.client))],
+    modelOptions: [...new Set(matrix.targets.map((target) => target.modelId))],
+    isFiltered,
+    onClientChange: setClient,
+    onModelChange: setModel,
+    onClear: clearPairingFilters,
+  };
   return (
     <div
       className="flex min-h-0 flex-1 flex-col overflow-y-auto"
@@ -111,49 +158,13 @@ export function CombinedRunContent({
           />
         ) : null;
       })}
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/50 px-5 py-3">
-        <p className="text-xs text-muted-foreground">
-          {isFiltered
-            ? `${targets.length} of ${matrix.targets.length}`
-            : `All ${matrix.targets.length}`}{" "}
-          client/model pairings
-        </p>
-        <div className="flex items-center gap-2">
-          <EvalListFilter
-            label="Client"
-            className="w-28"
-            value={client}
-            options={[
-              ...new Set(matrix.targets.map((target) => target.client)),
-            ]}
-            onChange={setClient}
-          />
-          <EvalListFilter
-            label="Model"
-            className="w-40"
-            value={model}
-            options={[
-              ...new Set(matrix.targets.map((target) => target.modelId)),
-            ]}
-            onChange={setModel}
-          />
-          <Button
-            disabled={!isFiltered}
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              setClient(ALL_EVAL_FILTER_VALUES);
-              setModel(ALL_EVAL_FILTER_VALUES);
-            }}
-          >
-            Clear filters
-          </Button>
-        </div>
-      </div>
       {history.loading && runs.some((run) => !history.details.has(run._id)) ? (
-        <p role="status" className="p-5 text-sm text-muted-foreground">
-          Loading results for every client and model…
-        </p>
+        <div className="px-5 py-3">
+          <PairingFilters {...pairingFilterProps} showClear />
+          <p role="status" className="pt-2 text-sm text-muted-foreground">
+            Loading results for every client and model…
+          </p>
+        </div>
       ) : history.errorCount ? (
         <div role="alert" className="p-5 text-sm">
           Results unavailable for {history.errorCount} client/model pairings.{" "}
@@ -162,9 +173,12 @@ export function CombinedRunContent({
           </Button>
         </div>
       ) : !targets.length ? (
-        <p className="p-5 text-sm text-muted-foreground">
-          No results match these filters.
-        </p>
+        <div className="px-5 py-3">
+          <PairingFilters {...pairingFilterProps} showClear />
+          <p className="pt-2 text-sm text-muted-foreground">
+            No results match these filters.
+          </p>
+        </div>
       ) : (
         <>
           <RunVerdictHero view={view} headerVerdict={fullVerdict} />
@@ -178,10 +192,64 @@ export function CombinedRunContent({
               chains={chains}
               onOpenIteration={onOpenIteration}
               modelIds={model === ALL_EVAL_FILTER_VALUES ? undefined : [model]}
+              toolbarExtra={<PairingFilters {...pairingFilterProps} />}
+              extraFiltersActive={isFiltered}
+              onClearExtraFilters={clearPairingFilters}
             />
           </div>
         </>
       )}
+    </div>
+  );
+}
+
+function PairingFilters({
+  client,
+  model,
+  clientOptions,
+  modelOptions,
+  isFiltered,
+  onClientChange,
+  onModelChange,
+  onClear,
+  showClear = false,
+}: {
+  client: string;
+  model: string;
+  clientOptions: string[];
+  modelOptions: string[];
+  isFiltered: boolean;
+  onClientChange: (value: string) => void;
+  onModelChange: (value: string) => void;
+  onClear: () => void;
+  showClear?: boolean;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <EvalListFilter
+        label="Client"
+        className="w-28"
+        value={client}
+        options={clientOptions}
+        onChange={onClientChange}
+      />
+      <EvalListFilter
+        label="Model"
+        className="w-40"
+        value={model}
+        options={modelOptions}
+        onChange={onModelChange}
+      />
+      {showClear && isFiltered ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 text-[11px]"
+          onClick={onClear}
+        >
+          Clear filters
+        </Button>
+      ) : null}
     </div>
   );
 }
@@ -241,6 +309,7 @@ export function combinedReportView(
   iterations: EvalIteration[],
   views: RunVerdictHeroView[],
   filtered: boolean,
+  previousIterations?: EvalIteration[] | null,
 ): RunVerdictHeroView {
   const fallback = buildRunVerdictHero({
     run: runs[0] ?? ({ status: "pending" } as EvalSuiteRun),
@@ -257,6 +326,18 @@ export function combinedReportView(
         view.focus &&
         (!filtered || iterationIds.has(view.focus.diagnostic.iterationId)),
     ) ?? (filtered ? undefined : views[0]);
+  const stats = { ...fallback.stats, cases: { kind: "unavailable" as const } };
+  const previousStats =
+    previousIterations && previousIterations.length > 0
+      ? {
+          ...heroStatsFor({
+            run: runs[0] ?? ({ status: "pending" } as EvalSuiteRun),
+            iterations: previousIterations,
+            decision: { status: "disabled", summary: null, diagnostics: [] },
+          }),
+          cases: { kind: "unavailable" as const },
+        }
+      : null;
   return {
     ...fallback,
     pending,
@@ -291,6 +372,8 @@ export function combinedReportView(
         : fallback.sentence),
     // Iteration measurements span precisely the visible population. Do not add
     // canonical case counts from different clients as though they were unique cases.
-    stats: { ...fallback.stats, cases: { kind: "unavailable" } },
+    stats,
+    pairings: fallback.pairings,
+    deltas: previousStats ? buildHeroStatDeltas(stats, previousStats) : null,
   };
 }

--- a/mcpjam-inspector/client/src/components/evaluate/create-suite-page.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/create-suite-page.tsx
@@ -48,7 +48,7 @@ import { toast } from "@/lib/toast";
 import { EvalTargetMatrix } from "./eval-target-matrix";
 import type { HostAttachmentDraft } from "../evals/client-attachments-editor";
 import {
-  DEFAULT_CREATE_SUITE_NAME,
+  nextUnusedSuiteName,
   pickServerAttachmentIdForServer,
   seedCreateSuiteName,
 } from "./create-suite-prefill";
@@ -95,6 +95,11 @@ type CreateSuitePageProps = {
    * Name-only prefills (the agent command) leave this unset on purpose.
    */
   initialServerId?: string | null;
+  /**
+   * Suite names already in this project. Used only when `initialName` is
+   * empty, to seed the next unused "Suite N".
+   */
+  existingSuiteNames?: readonly string[];
 };
 
 export function CreateSuitePage({
@@ -104,8 +109,12 @@ export function CreateSuitePage({
   projectId = null,
   initialName = null,
   initialServerId = null,
+  existingSuiteNames = [],
 }: CreateSuitePageProps) {
-  const [name, setName] = useState(() => seedCreateSuiteName(initialName));
+  const seededName = seedCreateSuiteName(initialName, existingSuiteNames);
+  const numberedDefault = nextUnusedSuiteName(existingSuiteNames);
+  const [name, setName] = useState(seededName);
+  const nameEditedRef = useRef(false);
   const [isSaving, setIsSaving] = useState(false);
   const [target, setTarget] =
     useState<EnvironmentComposerState>(emptyComposerState);
@@ -143,12 +152,14 @@ export function CreateSuitePage({
     shouldFetchDefaults ? projectId : null,
   );
 
-  const appliedInitialNameRef = useRef(initialName);
   useEffect(() => {
-    if (!initialName || initialName === appliedInitialNameRef.current) return;
-    appliedInitialNameRef.current = initialName;
-    setName(initialName);
-  }, [initialName]);
+    if (initialName?.trim()) {
+      setName(initialName);
+      return;
+    }
+    if (nameEditedRef.current) return;
+    setName(seededName);
+  }, [initialName, seededName]);
 
   const appliedInitialServerRef = useRef(false);
   useEffect(() => {
@@ -434,8 +445,11 @@ export function CreateSuitePage({
                 data-testid="create-suite-name"
                 aria-required
                 value={name}
-                onChange={(event) => setName(event.target.value)}
-                placeholder={DEFAULT_CREATE_SUITE_NAME}
+                onChange={(event) => {
+                  nameEditedRef.current = true;
+                  setName(event.target.value);
+                }}
+                placeholder={numberedDefault}
                 disabled={isSaving}
               />
             </div>

--- a/mcpjam-inspector/client/src/components/evaluate/create-suite-page.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/create-suite-page.tsx
@@ -153,11 +153,11 @@ export function CreateSuitePage({
   );
 
   useEffect(() => {
+    if (nameEditedRef.current) return;
     if (initialName?.trim()) {
       setName(initialName);
       return;
     }
-    if (nameEditedRef.current) return;
     setName(seededName);
   }, [initialName, seededName]);
 

--- a/mcpjam-inspector/client/src/components/evaluate/create-suite-prefill.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/create-suite-prefill.ts
@@ -1,16 +1,46 @@
 /**
- * Seeded into the name field when there is no empty-hero / URL / agent
- * prefill, so Continue is enabled on first paint. Also used as the
- * empty-after-clear placeholder.
+ * Exact "Suite 1", "Suite 2", … names. Anything else (including
+ * "Suite 1 extra" or a server-card prefill) is ignored when incrementing.
  */
-export const DEFAULT_CREATE_SUITE_NAME = "Customer support workflows";
+const NUMBERED_SUITE_NAME = /^Suite (\d+)$/;
+
+/**
+ * Fallback when no numbered suites exist yet. Also the empty-after-clear
+ * placeholder when the caller does not pass existing names.
+ */
+export const DEFAULT_CREATE_SUITE_NAME = "Suite 1";
+
+/**
+ * Next unused "Suite N" from existing names. Takes one past the highest
+ * exact match; names that do not match `/^Suite (\d+)$/` are ignored.
+ */
+export function nextUnusedSuiteName(
+  existingNames: ReadonlyArray<string> = [],
+): string {
+  let highest = 0;
+  for (const name of existingNames) {
+    const match = NUMBERED_SUITE_NAME.exec(name);
+    if (!match) continue;
+    const n = Number(match[1]);
+    if (Number.isFinite(n) && n > highest) {
+      highest = n;
+    }
+  }
+  return `Suite ${highest + 1}`;
+}
 
 /**
  * Empty-hero server cards and URL/agent prefills win; otherwise the
- * page starts with a real default so the user can Continue immediately.
+ * page starts with the next unused "Suite N" so Continue is enabled
+ * on first paint.
  */
-export function seedCreateSuiteName(initialName?: string | null): string {
-  return initialName?.trim() ? initialName : DEFAULT_CREATE_SUITE_NAME;
+export function seedCreateSuiteName(
+  initialName?: string | null,
+  existingNames: ReadonlyArray<string> = [],
+): string {
+  return initialName?.trim()
+    ? initialName
+    : nextUnusedSuiteName(existingNames);
 }
 
 /**

--- a/mcpjam-inspector/client/src/components/evaluate/evals-empty-hero.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/evals-empty-hero.tsx
@@ -35,13 +35,13 @@ export function EvalsEmptyHero({
   const visibleServers = servers.slice(0, EVALS_EMPTY_HERO_MAX_SERVERS);
   const showServerCards = visibleServers.length > 0;
   // Sample-suite lives down here because it has no other entry point. A
-  // blank suite does: the header Create suite. Server cards start the
-  // first-run preview, not that form. Loading withholds the row so it
-  // does not reflow when servers arrive.
+  // blank suite does: the header Create suite. Server cards open that
+  // same form with the server and a name already filled in. Loading
+  // withholds the row so it does not reflow when servers arrive.
   const showCtas = !serversLoading;
   // Without `onEvalServer` the card can only open the blank suite form, so it
-  // must say so: a card that reads "Eval my server" and opens Create suite
-  // promises a preview it cannot start.
+  // must say so: a card that reads "Eval my server" and opens a blank form
+  // promises a server-scoped start it cannot provide.
   const cardAction = onEvalServer ? "Eval my server" : "Create suite";
 
   return (
@@ -104,7 +104,7 @@ export function EvalsEmptyHero({
 
 /**
  * When server cards are up, only the sample suite stays here. Create suite
- * lives in the header. The cards start the first-run preview.
+ * lives in the header. The cards open that form with the server prefilled.
  */
 function EmptyHeroCtas({
   onCreateSuite,

--- a/mcpjam-inspector/client/src/components/evaluate/evals-header.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/evals-header.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/shared/view-mode-selector";
 
 const EVALUATE_HEADER_DESCRIPTION =
-  "The manual pass you'd do before a ship, automated and run whenever the server changes.";
+  "Build a durable test suite from the prompts you already run by hand and automatically measure performance over time.";
 
 export const EVAL_LANDING_VIEW_OPTIONS = [
   { value: "runs", label: "Runs" },
@@ -155,7 +155,7 @@ export function EvalsHeader({
               </Button>
             ) : null}
           </div>
-          <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+          <p className="mt-2 w-full text-sm text-muted-foreground">
             {EVALUATE_HEADER_DESCRIPTION}
           </p>
         </>

--- a/mcpjam-inspector/client/src/components/evaluate/evaluate-run-content.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/evaluate-run-content.tsx
@@ -24,6 +24,7 @@ import { Copy } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@mcpjam/design-system/button";
 
+import { compactModelIdTail } from "@/lib/environment-label";
 import { cn } from "@/lib/utils";
 import { copyToClipboard } from "@/lib/clipboard";
 import { useEvalRunDecisionDetail } from "@/hooks/use-eval-run-decision-summary";
@@ -80,6 +81,10 @@ import {
 import { remedyForDiagnostic } from "./stage-remedy";
 import { RunVerdictHero } from "./run-verdict-hero";
 import { buildRunVerdictHero } from "./run-verdict-hero-model";
+import {
+  buildHeroPairings,
+  previousCompletedRunOf,
+} from "./run-verdict-hero-deltas";
 import { CombinedRunContent } from "./combined-run-content";
 import { launchRuns } from "./run-results-matrix-model";
 
@@ -137,9 +142,52 @@ export function SingleRunContent({
     revision: evalRunDecisionRevision(run),
   });
 
+  const previousIterations = useMemo(() => {
+    if (!previousRunId || !allIterations) return null;
+    const rows = allIterations.filter(
+      (iteration) => iteration.suiteRunId === previousRunId,
+    );
+    return rows.length > 0 ? rows : null;
+  }, [allIterations, previousRunId]);
+
+  const pairings = useMemo(() => {
+    const names = hostNamesById ?? new Map();
+    const modelId = run.effectiveModelId ?? "Client default";
+    const previousLaunch = previousRunId
+      ? siblingRuns.filter((candidate) => candidate._id === previousRunId)
+      : (() => {
+          const previous = previousCompletedRunOf(run, siblingRuns);
+          return previous ? [previous] : [];
+        })();
+    return buildHeroPairings({
+      targets: [
+        {
+          key: run._id,
+          run,
+          client: run.namedHostId
+            ? (names.get(run.namedHostId) ??
+              `Client …${run.namedHostId.slice(-6)}`)
+            : "Suite client",
+          modelId,
+          model: compactModelIdTail(modelId),
+          iterations,
+        },
+      ],
+      previousLaunch: previousLaunch.length > 0 ? previousLaunch : null,
+      previousIterations,
+    });
+  }, [
+    run,
+    iterations,
+    hostNamesById,
+    previousRunId,
+    siblingRuns,
+    previousIterations,
+  ]);
+
   const view = useMemo(
-    () =>
-      buildRunVerdictHero({
+    () => ({
+      ...buildRunVerdictHero({
         run,
         iterations,
         decision: {
@@ -147,8 +195,21 @@ export function SingleRunContent({
           summary: detail.summary,
           diagnostics: detail.diagnostics,
         },
+        previous: previousIterations
+          ? { iterations: previousIterations }
+          : null,
       }),
-    [run, iterations, detail.status, detail.summary, detail.diagnostics],
+      pairings,
+    }),
+    [
+      run,
+      iterations,
+      detail.status,
+      detail.summary,
+      detail.diagnostics,
+      previousIterations,
+      pairings,
+    ],
   );
 
   // Chains for the iterations D9 does not describe. Diagnostics cover the

--- a/mcpjam-inspector/client/src/components/evaluate/evaluate-run-content.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/evaluate-run-content.tsx
@@ -142,23 +142,26 @@ export function SingleRunContent({
     revision: evalRunDecisionRevision(run),
   });
 
+  const previousLaunch = useMemo(() => {
+    if (previousRunId) {
+      return siblingRuns.filter((candidate) => candidate._id === previousRunId);
+    }
+    const previous = previousCompletedRunOf(run, siblingRuns);
+    return previous ? [previous] : [];
+  }, [previousRunId, siblingRuns, run]);
+
   const previousIterations = useMemo(() => {
-    if (!previousRunId || !allIterations) return null;
+    const previousId = previousLaunch[0]?._id;
+    if (!previousId || !allIterations) return null;
     const rows = allIterations.filter(
-      (iteration) => iteration.suiteRunId === previousRunId,
+      (iteration) => iteration.suiteRunId === previousId,
     );
     return rows.length > 0 ? rows : null;
-  }, [allIterations, previousRunId]);
+  }, [allIterations, previousLaunch]);
 
   const pairings = useMemo(() => {
     const names = hostNamesById ?? new Map();
     const modelId = run.effectiveModelId ?? "Client default";
-    const previousLaunch = previousRunId
-      ? siblingRuns.filter((candidate) => candidate._id === previousRunId)
-      : (() => {
-          const previous = previousCompletedRunOf(run, siblingRuns);
-          return previous ? [previous] : [];
-        })();
     return buildHeroPairings({
       targets: [
         {
@@ -176,14 +179,7 @@ export function SingleRunContent({
       previousLaunch: previousLaunch.length > 0 ? previousLaunch : null,
       previousIterations,
     });
-  }, [
-    run,
-    iterations,
-    hostNamesById,
-    previousRunId,
-    siblingRuns,
-    previousIterations,
-  ]);
+  }, [run, iterations, hostNamesById, previousLaunch, previousIterations]);
 
   const view = useMemo(
     () => ({

--- a/mcpjam-inspector/client/src/components/evaluate/evaluate-run-page.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/evaluate-run-page.tsx
@@ -20,11 +20,10 @@ import { launchRuns } from "./run-results-matrix-model";
 import {
   ArrowUpRight,
   Copy,
-  GitCompareArrows,
   Play,
   Download,
   MoreHorizontal,
-  Info,
+  TrendingUp,
 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { cn } from "@/lib/utils";
@@ -33,19 +32,21 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
 } from "@mcpjam/design-system/dropdown-menu";
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from "@mcpjam/design-system/sheet";
 import { formatRunId } from "../evals/helpers";
 import type { EvalIteration, EvalSuiteRun } from "../evals/types";
 import { EvaluateRunCompare } from "./evaluate-run-compare";
-import { RunLaunchContext } from "./run-launch-context";
+import { resolveHostLogoByName } from "@/lib/host-logo";
+import { compactModelIdTail } from "@/lib/environment-label";
+import { usePreferencesStoreWithDefaults } from "@/stores/preferences/preferences-provider";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+
+/** Hidden until we are ready to expose report export on this page. */
+const SHOW_EXPORT_REPORT = false;
 
 export type EvaluateRunPageHeaderActions = {
   onImprove?: () => void;
@@ -102,7 +103,6 @@ export function EvaluateRunPage({
   defaultCompareRunId,
   onCompareWithRun,
   onExport,
-  iterations,
   launchReview,
   children,
 }: {
@@ -120,17 +120,13 @@ export function EvaluateRunPage({
 }) {
   const [comparing, setComparing] = useState(false);
   const [reviewing, setReviewing] = useState(false);
-  const [showDetails, setShowDetails] = useState(false);
   useEffect(() => {
     setReviewing(false);
-    setShowDetails(false);
   }, [run._id]);
   const targets = launchRuns(run, relatedRuns ?? otherRuns);
   const [headerActions, setHeaderActions] =
     useState<EvaluateRunPageHeaderActions | null>(null);
-  const [headerVerdict, setHeaderVerdict] = useState<HeaderVerdict | null>(
-    null,
-  );
+  const [, setHeaderVerdict] = useState<HeaderVerdict | null>(null);
   const canCompare = otherRuns.length >= 1;
 
   return (
@@ -144,42 +140,21 @@ export function EvaluateRunPage({
             className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3 px-5 py-4"
             data-testid="evaluate-run-header"
           >
-            <div className="flex min-w-0 items-center gap-2">
-              <h2 className="text-base font-semibold tracking-tight text-foreground">
+            <div className="flex min-w-0 items-center gap-3">
+              <h2 className="text-2xl font-bold leading-8 tracking-tight text-foreground">
                 Run{" "}
                 {targets[0].runNumber
                   ? `#${targets[0].runNumber}`
                   : formatRunId(targets[0]._id)}{" "}
                 Results
               </h2>
-              {headerVerdict && (
-                <span
-                  data-testid="run-header-verdict"
-                  title={headerVerdict.undecidedLine ?? undefined}
-                  className={cn(
-                    "rounded border px-2 py-0.5 text-[11px] font-medium",
-                    headerVerdict.tone === "passed"
-                      ? "border-success/30 bg-success/10"
-                      : headerVerdict.tone === "failed"
-                      ? "border-destructive/30 bg-destructive/10"
-                      : headerVerdict.tone === "caution"
-                      ? "border-warning/30 bg-warning/10"
-                      : "border-border bg-muted/40",
-                  )}
-                >
-                  {headerVerdict.word}
-                </span>
-              )}
-              {targets.length === 1 && !headerVerdict ? (
-                <RunOutcomeBadge run={run} />
-              ) : targets.length > 1 ? (
-                <span className="text-xs text-muted-foreground">
-                  {targets.length} client/model pairings
-                </span>
-              ) : null}
+              <RunPairingDecisions
+                targets={targets}
+                hostNamesById={hostNamesById}
+              />
             </div>
             <div className="flex min-w-0 flex-wrap items-center gap-1">
-              {onExport && (
+              {SHOW_EXPORT_REPORT && onExport && (
                 <Button
                   type="button"
                   variant="ghost"
@@ -190,62 +165,66 @@ export function EvaluateRunPage({
                   Export report
                 </Button>
               )}
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="size-8"
-                    aria-label="Run actions"
-                  >
-                    <MoreHorizontal className="size-4" aria-hidden />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  {launchReview && (
-                    <DropdownMenuItem
-                      disabled={Boolean(launchReview.disabledReason)}
-                      title={launchReview.disabledReason ?? undefined}
-                      onSelect={() => setReviewing(true)}
+              {launchReview && (
+                <Button
+                  type="button"
+                  variant="default"
+                  size="sm"
+                  disabled={Boolean(launchReview.disabledReason)}
+                  title={launchReview.disabledReason ?? undefined}
+                  onClick={() => setReviewing(true)}
+                >
+                  <Play className="size-3.5" aria-hidden />
+                  Run again
+                </Button>
+              )}
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={!canCompare}
+                title={
+                  canCompare ? "Compare two runs" : "Need at least two runs"
+                }
+                onClick={() => setComparing(true)}
+                data-testid="evaluate-run-compare-open"
+              >
+                <TrendingUp className="size-3.5" aria-hidden />
+                Compare runs
+              </Button>
+              {(headerActions?.onImprove ||
+                headerActions?.onOpenFailingTrace) && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-8"
+                      aria-label="Run actions"
                     >
-                      <Play aria-hidden /> New run
-                    </DropdownMenuItem>
-                  )}
-                  <DropdownMenuItem
-                    disabled={!canCompare}
-                    title={
-                      canCompare ? "Compare two runs" : "Need at least two runs"
-                    }
-                    onSelect={() => setComparing(true)}
-                    data-testid="evaluate-run-compare-open"
-                  >
-                    <GitCompareArrows aria-hidden /> Compare runs
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => setShowDetails(true)}>
-                    <Info aria-hidden /> Run details
-                  </DropdownMenuItem>
-                  {(headerActions?.onImprove ||
-                    headerActions?.onOpenFailingTrace) && (
-                    <DropdownMenuSeparator />
-                  )}
-                  {headerActions?.onImprove && (
-                    <DropdownMenuItem
-                      onSelect={headerActions.onImprove}
-                      data-testid="run-verdict-improve"
-                    >
-                      <Copy aria-hidden /> Prompt to improve
-                    </DropdownMenuItem>
-                  )}
-                  {headerActions?.onOpenFailingTrace && (
-                    <DropdownMenuItem
-                      onSelect={headerActions.onOpenFailingTrace}
-                      data-testid="run-verdict-open-trace"
-                    >
-                      <ArrowUpRight aria-hidden /> Open failing trace
-                    </DropdownMenuItem>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
+                      <MoreHorizontal className="size-4" aria-hidden />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {headerActions.onImprove && (
+                      <DropdownMenuItem
+                        onSelect={headerActions.onImprove}
+                        data-testid="run-verdict-improve"
+                      >
+                        <Copy aria-hidden /> Prompt to improve
+                      </DropdownMenuItem>
+                    )}
+                    {headerActions.onOpenFailingTrace && (
+                      <DropdownMenuItem
+                        onSelect={headerActions.onOpenFailingTrace}
+                        data-testid="run-verdict-open-trace"
+                      >
+                        <ArrowUpRight aria-hidden /> Open failing trace
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
             </div>
           </header>
 
@@ -266,30 +245,6 @@ export function EvaluateRunPage({
               children
             )}
           </div>
-          <Sheet open={showDetails} onOpenChange={setShowDetails}>
-            <SheetContent>
-              <SheetHeader>
-                <SheetTitle>Run details</SheetTitle>
-                <SheetDescription>
-                  The client, models, and servers used for this report.
-                </SheetDescription>
-              </SheetHeader>
-              <div className="px-4 py-5">
-                <div className="space-y-5">
-                  {targets.map((target) => (
-                    <RunLaunchContext
-                      key={target._id}
-                      run={target}
-                      hostNamesById={hostNamesById}
-                      iterations={iterations?.filter(
-                        (item) => item.suiteRunId === target._id,
-                      )}
-                    />
-                  ))}
-                </div>
-              </div>
-            </SheetContent>
-          </Sheet>
           {reviewing && launchReview && (
             <SuiteRunReview
               {...launchReview}
@@ -302,38 +257,159 @@ export function EvaluateRunPage({
   );
 }
 
-function RunOutcomeBadge({ run }: { run: EvalSuiteRun }) {
-  const outcome = ["pending", "running", "grading"].includes(run.status)
+function pairingClientName(
+  target: EvalSuiteRun,
+  hostNamesById: Map<string, string | null>,
+): string {
+  if (!target.namedHostId) return "Suite client";
+  return (
+    hostNamesById.get(target.namedHostId) ??
+    `Client …${target.namedHostId.slice(-6)}`
+  );
+}
+
+const IN_FLIGHT_STATUSES = new Set(["pending", "running", "grading"]);
+
+export type PairingDecisionTone = "ship" | "hold" | "pending";
+
+export type PairingDecision = {
+  word: string;
+  tone: PairingDecisionTone;
+};
+
+/**
+ * Per-client decision for the run header. Uses the run's own stored verdict —
+ * the same result the page already settled for that pairing — and never
+ * invents Hold/Ship while the run is still in flight.
+ */
+export function pairingDecision(run: EvalSuiteRun): PairingDecision {
+  const outcome = IN_FLIGHT_STATUSES.has(run.status)
     ? run.status
     : run.result && run.result !== "pending"
-    ? run.result
-    : run.status;
+      ? run.result
+      : run.status;
+  if (outcome === "passed") return { word: "Ship", tone: "ship" };
+  if (outcome === "failed" || outcome === "timed_out") {
+    return { word: "Hold", tone: "hold" };
+  }
   const labels: Record<string, string> = {
-    passed: "Passed",
-    failed: "Failed",
-    inconclusive: "Inconclusive",
-    completed: "Completed",
     running: "Running",
     grading: "Grading",
-    cancelled: "Cancelled",
-    timed_out: "Timed out",
     pending: "Pending",
+    cancelled: "Cancelled",
+    inconclusive: "Inconclusive",
+    completed: "Completed",
   };
-  const label = labels[outcome] ?? "Unknown";
-  const tone =
-    outcome === "passed"
-      ? "bg-success/10 text-success"
-      : outcome === "failed"
-      ? "bg-destructive/10 text-destructive"
-      : "bg-muted text-muted-foreground";
+  return { word: labels[outcome] ?? "Pending", tone: "pending" };
+}
+
+function pairingPillClass(tone: PairingDecisionTone): string {
+  if (tone === "ship") return "border-success/30 bg-success/10 text-success";
+  if (tone === "hold") return "border-warning/30 bg-warning/10 text-warning";
+  return "border-border bg-muted/40 text-muted-foreground";
+}
+
+function pairingPillLabel(word: string, tone: PairingDecisionTone): string {
+  return tone === "pending" ? word : word.toUpperCase();
+}
+
+const DECISION_PILL_ORDER: PairingDecisionTone[] = ["hold", "ship", "pending"];
+
+type PairingMark = {
+  key: string;
+  label: string;
+  client: string;
+};
+
+function groupPairingsByDecision(
+  targets: readonly EvalSuiteRun[],
+  hostNamesById: Map<string, string | null>,
+): Array<{
+  tone: PairingDecisionTone;
+  word: string;
+  marks: PairingMark[];
+}> {
+  const buckets = new Map<
+    PairingDecisionTone,
+    { word: string; marks: PairingMark[] }
+  >();
+  for (const target of targets) {
+    const decision = pairingDecision(target);
+    const client = pairingClientName(target, hostNamesById);
+    const model = compactModelIdTail(
+      target.effectiveModelId ?? "Client default",
+    );
+    const mark = {
+      key: target._id,
+      label: `${client} · ${model}`,
+      client,
+    };
+    const bucket = buckets.get(decision.tone);
+    if (!bucket) {
+      buckets.set(decision.tone, { word: decision.word, marks: [mark] });
+      continue;
+    }
+    bucket.marks.push(mark);
+    if (decision.tone === "pending" && bucket.word !== decision.word) {
+      bucket.word = "Pending";
+    }
+  }
+  return DECISION_PILL_ORDER.flatMap((tone) => {
+    const bucket = buckets.get(tone);
+    return bucket ? [{ tone, ...bucket }] : [];
+  });
+}
+
+function RunPairingDecisions({
+  targets,
+  hostNamesById,
+}: {
+  targets: readonly EvalSuiteRun[];
+  hostNamesById: Map<string, string | null>;
+}) {
+  const theme = usePreferencesStoreWithDefaults((state) => state.themeMode);
+  const groups = groupPairingsByDecision(targets, hostNamesById);
+  if (!groups.length) return null;
   return (
     <span
-      className={cn(
-        "rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
-        tone,
-      )}
+      className="flex min-w-0 flex-wrap items-center gap-2"
+      data-testid="run-header-pairings"
     >
-      {label}
+      {groups.map((group) => (
+        <span
+          key={group.tone}
+          data-testid="run-header-decision-pill"
+          data-decision={group.tone}
+          className={cn(
+            "inline-flex h-8 items-center gap-1.5 rounded-full border py-0 pl-2.5 pr-1.5 text-[12px] font-medium",
+            pairingPillClass(group.tone),
+          )}
+        >
+          <span data-testid="run-header-pairing-decision">
+            {pairingPillLabel(group.word, group.tone)}
+          </span>
+          <span className="flex items-center -space-x-1.5">
+            {group.marks.map((mark) => (
+              <Tooltip key={mark.key}>
+                <TooltipTrigger asChild>
+                  <span
+                    title={mark.label}
+                    tabIndex={0}
+                    className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-background"
+                  >
+                    <img
+                      src={resolveHostLogoByName(mark.client, theme)}
+                      alt={mark.label}
+                      className="size-3.5 object-contain"
+                    />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent variant="muted">{mark.label}</TooltipContent>
+              </Tooltip>
+            ))}
+          </span>
+        </span>
+      ))}
     </span>
   );
 }

--- a/mcpjam-inspector/client/src/components/evaluate/evaluate-run-page.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/evaluate-run-page.tsx
@@ -37,7 +37,7 @@ import { formatRunId } from "../evals/helpers";
 import type { EvalIteration, EvalSuiteRun } from "../evals/types";
 import { EvaluateRunCompare } from "./evaluate-run-compare";
 import { resolveHostLogoByName } from "@/lib/host-logo";
-import { compactModelIdTail } from "@/lib/environment-label";
+import { modelsFromRun } from "./run-launch-context";
 import { usePreferencesStoreWithDefaults } from "@/stores/preferences/preferences-provider";
 import {
   Tooltip,
@@ -103,6 +103,7 @@ export function EvaluateRunPage({
   defaultCompareRunId,
   onCompareWithRun,
   onExport,
+  iterations,
   launchReview,
   children,
 }: {
@@ -151,6 +152,7 @@ export function EvaluateRunPage({
               <RunPairingDecisions
                 targets={targets}
                 hostNamesById={hostNamesById}
+                iterations={iterations}
               />
             </div>
             <div className="flex min-w-0 flex-wrap items-center gap-1">
@@ -321,9 +323,21 @@ type PairingMark = {
   client: string;
 };
 
+function pairingModel(
+  target: EvalSuiteRun,
+  iterations: readonly EvalIteration[] | undefined,
+): string {
+  const recovered = modelsFromRun(
+    target,
+    (iterations ?? []).filter((iteration) => iteration.suiteRunId === target._id),
+  );
+  return recovered[0] ?? "Client default";
+}
+
 function groupPairingsByDecision(
   targets: readonly EvalSuiteRun[],
   hostNamesById: Map<string, string | null>,
+  iterations?: readonly EvalIteration[],
 ): Array<{
   tone: PairingDecisionTone;
   word: string;
@@ -336,9 +350,7 @@ function groupPairingsByDecision(
   for (const target of targets) {
     const decision = pairingDecision(target);
     const client = pairingClientName(target, hostNamesById);
-    const model = compactModelIdTail(
-      target.effectiveModelId ?? "Client default",
-    );
+    const model = pairingModel(target, iterations);
     const mark = {
       key: target._id,
       label: `${client} · ${model}`,
@@ -363,12 +375,14 @@ function groupPairingsByDecision(
 function RunPairingDecisions({
   targets,
   hostNamesById,
+  iterations,
 }: {
   targets: readonly EvalSuiteRun[];
   hostNamesById: Map<string, string | null>;
+  iterations?: readonly EvalIteration[];
 }) {
   const theme = usePreferencesStoreWithDefaults((state) => state.themeMode);
-  const groups = groupPairingsByDecision(targets, hostNamesById);
+  const groups = groupPairingsByDecision(targets, hostNamesById, iterations);
   if (!groups.length) return null;
   return (
     <span
@@ -393,18 +407,20 @@ function RunPairingDecisions({
               <Tooltip key={mark.key}>
                 <TooltipTrigger asChild>
                   <span
-                    title={mark.label}
+                    aria-label={mark.label}
                     tabIndex={0}
                     className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-background"
                   >
                     <img
                       src={resolveHostLogoByName(mark.client, theme)}
-                      alt={mark.label}
+                      alt=""
                       className="size-3.5 object-contain"
                     />
                   </span>
                 </TooltipTrigger>
-                <TooltipContent variant="muted">{mark.label}</TooltipContent>
+                <TooltipContent variant="muted" aria-hidden="true">
+                  {mark.label}
+                </TooltipContent>
               </Tooltip>
             ))}
           </span>

--- a/mcpjam-inspector/client/src/components/evaluate/result-count-bar.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/result-count-bar.tsx
@@ -28,6 +28,13 @@ export function resultBarTotal(counts: ResultBarCounts): number {
   return counts.passed + counts.failed + counts.pending + counts.cancelled;
 }
 
+function resultBarLabel(counts: ResultBarCounts): string {
+  const parts = [`${counts.passed} passed`, `${counts.failed} failed`];
+  if (counts.pending > 0) parts.push(`${counts.pending} pending`);
+  if (counts.cancelled > 0) parts.push(`${counts.cancelled} cancelled`);
+  return parts.join(", ");
+}
+
 export function ResultCountBar({
   counts,
   className,
@@ -43,7 +50,8 @@ export function ResultCountBar({
         "flex h-1.5 overflow-hidden rounded-full bg-muted",
         className,
       )}
-      aria-label={`${counts.passed} passed, ${counts.failed} failed`}
+      role="img"
+      aria-label={resultBarLabel(counts)}
       data-testid="result-count-bar"
     >
       {SEGMENTS.map((status) =>

--- a/mcpjam-inspector/client/src/components/evaluate/result-count-bar.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/result-count-bar.tsx
@@ -1,0 +1,82 @@
+/**
+ * The thin pass/fail bar and its key. Used on pairing rows (and nowhere else
+ * as a second style — the matrix cells keep their own taller bar).
+ */
+import { Check, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type ResultBarCounts = {
+  passed: number;
+  failed: number;
+  pending: number;
+  cancelled: number;
+};
+
+const SEGMENTS = ["passed", "failed", "pending", "cancelled"] as const;
+
+function segmentClass(status: (typeof SEGMENTS)[number]) {
+  return status === "passed"
+    ? "bg-success"
+    : status === "failed"
+      ? "bg-destructive"
+      : status === "pending"
+        ? "bg-pending/60"
+        : "bg-muted-foreground/40";
+}
+
+export function resultBarTotal(counts: ResultBarCounts): number {
+  return counts.passed + counts.failed + counts.pending + counts.cancelled;
+}
+
+export function ResultCountBar({
+  counts,
+  className,
+}: {
+  counts: ResultBarCounts;
+  className?: string;
+}) {
+  const total = resultBarTotal(counts);
+  if (total <= 0) return null;
+  return (
+    <div
+      className={cn(
+        "flex h-1.5 overflow-hidden rounded-full bg-muted",
+        className,
+      )}
+      aria-label={`${counts.passed} passed, ${counts.failed} failed`}
+      data-testid="result-count-bar"
+    >
+      {SEGMENTS.map((status) =>
+        counts[status] > 0 ? (
+          <span
+            key={status}
+            className={segmentClass(status)}
+            style={{ width: `${(counts[status] / total) * 100}%` }}
+          />
+        ) : null,
+      )}
+    </div>
+  );
+}
+
+export function ResultCountKey({
+  counts,
+}: {
+  counts: Pick<ResultBarCounts, "passed" | "failed">;
+}) {
+  return (
+    <div
+      className="flex items-center gap-2 text-[11px] tabular-nums"
+      data-testid="result-count-key"
+    >
+      <span className="flex items-center gap-1 text-success">
+        <Check className="size-3" aria-hidden />
+        {counts.passed} passed
+      </span>
+      <span className="flex items-center gap-1 text-destructive">
+        <X className="size-3" aria-hidden />
+        {counts.failed} failed
+      </span>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evaluate/run-results-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/run-results-matrix.tsx
@@ -4,15 +4,9 @@ import type {
 } from "@mcpjam/sdk/contract";
 import { toTrialCardViews } from "./stage-trial-model";
 import { TrialChainPanel } from "./trial-chain-panel";
-import { useMemo, useState } from "react";
-import {
-  ArrowUpRight,
-  ChevronRight,
-  Check,
-  Clock3,
-  Search,
-  X,
-} from "lucide-react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { isTerminalEvalRunStatus } from "@/lib/evals/eval-decision-summary-store";
+import { ArrowUpRight, ChevronRight, Search } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import {
@@ -34,12 +28,23 @@ import { formatRunCaseLatencyMs } from "../evals/run-case-groups";
 import { computeIterationResult } from "../evals/pass-criteria";
 import type { EvalIteration, EvalSuiteRun } from "../evals/types";
 import {
+  ALL_EVAL_FILTER_VALUES,
+  EvalListFilter,
+} from "../evals/eval-list-filter";
+import { runHistoryFilterClass } from "../evals/run-history-table";
+import {
   buildRunResultsMatrix,
   resultCounts,
   type RunResultsMatrixData,
 } from "./run-results-matrix-model";
 
-type Filter = "all" | "failed" | "pending";
+type StatusFilter = "failed" | "passed" | "pending" | "cancelled";
+const STATUS_LABEL: Record<StatusFilter, string> = {
+  failed: "Failures",
+  passed: "Passed",
+  pending: "Pending",
+  cancelled: "Cancelled",
+};
 const outcomeLabel = (result: string) =>
   ({
     passed: "Passed",
@@ -184,6 +189,9 @@ export function RunResultsMatrix({
   chains,
   onOpenIteration,
   modelIds,
+  toolbarExtra,
+  extraFiltersActive = false,
+  onClearExtraFilters,
 }: {
   modelIds?: readonly string[];
   run: EvalSuiteRun;
@@ -196,6 +204,9 @@ export function RunResultsMatrix({
     testCaseId: string;
     iterationId: string;
   }) => void;
+  toolbarExtra?: ReactNode;
+  extraFiltersActive?: boolean;
+  onClearExtraFilters?: () => void;
 }) {
   const theme = usePreferencesStoreWithDefaults((state) => state.themeMode);
   const data = useMemo(() => {
@@ -213,24 +224,58 @@ export function RunResultsMatrix({
     };
   }, [run, runs, iterations, hostNamesById, modelIds]);
   const [search, setSearch] = useState("");
-  const [filter, setFilter] = useState<Filter>("all");
-  const [selection, setSelection] = useState<{
-    caseKey: string;
-    targetKey: string;
-  } | null>(null);
-  const rows = data.rows.filter(
-    (row) =>
-      row.title.toLowerCase().includes(search.toLowerCase()) &&
-      (filter === "all" ||
-        data.targets.some(
-          (target) => resultCounts(target.cells.get(row.key) ?? [])[filter] > 0,
-        )),
+  const [status, setStatus] = useState(ALL_EVAL_FILTER_VALUES);
+  const showPending = [run, ...runs].some(
+    (item) => !isTerminalEvalRunStatus(item.status),
   );
   const counts = resultCounts(
     data.targets.flatMap((target) => target.iterations),
   );
-  const total =
-    counts.passed + counts.failed + counts.pending + counts.cancelled;
+  const statusOptions = (
+    ["failed", "passed", "pending", "cancelled"] as const
+  ).filter((value) =>
+    value === "pending"
+      ? showPending
+      : value === "cancelled"
+        ? counts.cancelled > 0
+        : true,
+  );
+  useEffect(() => {
+    if (status === "pending" && !showPending)
+      setStatus(ALL_EVAL_FILTER_VALUES);
+    if (status === "cancelled" && counts.cancelled === 0)
+      setStatus(ALL_EVAL_FILTER_VALUES);
+  }, [showPending, status, counts.cancelled]);
+  const [selection, setSelection] = useState<{
+    caseKey: string;
+    targetKey: string;
+  } | null>(null);
+  const activeStatus =
+    status === "pending" && !showPending
+      ? ALL_EVAL_FILTER_VALUES
+      : status === "cancelled" && counts.cancelled === 0
+        ? ALL_EVAL_FILTER_VALUES
+        : status;
+  const rows = data.rows.filter(
+    (row) =>
+      row.title.toLowerCase().includes(search.toLowerCase()) &&
+      (activeStatus === ALL_EVAL_FILTER_VALUES ||
+        data.targets.some(
+          (target) =>
+            resultCounts(target.cells.get(row.key) ?? [])[
+              activeStatus as StatusFilter
+            ] > 0,
+        )),
+  );
+  const hasActiveFilters =
+    Boolean(search.trim()) ||
+    activeStatus !== ALL_EVAL_FILTER_VALUES ||
+    extraFiltersActive;
+  const clearFilters = () => {
+    setSearch("");
+    setStatus(ALL_EVAL_FILTER_VALUES);
+    onClearExtraFilters?.();
+  };
   const selectedRow = data.rows.find((row) => row.key === selection?.caseKey);
   const selectedTarget = data.targets.find(
     (target) => target.key === selection?.targetKey,
@@ -242,97 +287,52 @@ export function RunResultsMatrix({
       aria-label="Test case results"
       data-testid="run-results-matrix"
     >
-      <div className="flex flex-wrap items-end justify-between gap-3">
-        <div>
-          <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-            Run results
+      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+        <h3 className="text-lg font-semibold tracking-tight">
+          Test cases{" "}
+          <span className="ml-1 font-mono text-sm font-normal text-muted-foreground">
+            {data.rows.length}
+          </span>
+        </h3>
+        <div
+          className="flex flex-wrap items-center gap-2"
+          data-testid="run-results-toolbar"
+        >
+          <div className="relative w-56 max-w-full">
+            <Search
+              aria-hidden
+              className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              className={cn(
+                runHistoryFilterClass,
+                "w-full max-w-none pl-8 md:text-[11px] dark:bg-card",
+              )}
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Find a test case…"
+              aria-label="Find a test case"
+            />
           </div>
-          <h3 className="text-lg font-semibold tracking-tight">
-            Test cases{" "}
-            <span className="ml-1 font-mono text-sm font-normal text-muted-foreground">
-              {data.rows.length}
-            </span>
-          </h3>
-          <p className="mt-1 text-xs text-muted-foreground">
-            Cases down the rows. Clients and models across the columns. Open a
-            cell to inspect its iterations.
-          </p>
-        </div>
-        <div
-          className="flex items-center gap-4 text-xs tabular-nums"
-          aria-live="polite"
-        >
-          <span className="flex items-center gap-1.5">
-            <Check className="size-3.5 text-success" />
-            {counts.passed} passed
-          </span>
-          <span className="flex items-center gap-1.5">
-            <X className="size-3.5 text-destructive" />
-            {counts.failed} failed
-          </span>
-          {counts.pending > 0 && (
-            <span className="flex items-center gap-1.5">
-              <Clock3 className="size-3.5 text-pending" />
-              {counts.pending} pending
-            </span>
-          )}
-          {counts.cancelled > 0 && <span>{counts.cancelled} cancelled</span>}
-        </div>
-      </div>
-      {total > 0 && (
-        <div
-          className="flex h-1 overflow-hidden rounded-full bg-muted"
-          aria-label={`${total} loaded iterations`}
-        >
-          {(["passed", "failed", "pending", "cancelled"] as const).map(
-            (status) => (
-              <span
-                key={status}
-                className={cn(
-                  status === "passed"
-                    ? "bg-success"
-                    : status === "failed"
-                      ? "bg-destructive"
-                      : status === "pending"
-                        ? "bg-pending/60"
-                        : "bg-muted-foreground/40",
-                )}
-                style={{ width: `${(counts[status] / total) * 100}%` }}
-              />
-            ),
-          )}
-        </div>
-      )}
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex gap-1" aria-label="Filter test cases">
-          {(["all", "failed", "pending"] as const).map((value) => (
+          <EvalListFilter
+            label="Status"
+            className="w-32"
+            value={activeStatus}
+            options={[...statusOptions]}
+            formatOption={(value) => STATUS_LABEL[value as StatusFilter] ?? value}
+            onChange={setStatus}
+          />
+          {toolbarExtra}
+          {hasActiveFilters && (
             <Button
-              key={value}
+              variant="ghost"
               size="sm"
-              variant={filter === value ? "secondary" : "ghost"}
-              aria-pressed={filter === value}
-              onClick={() => setFilter(value)}
+              className="h-7 text-[11px]"
+              onClick={clearFilters}
             >
-              {value === "all"
-                ? "All cases"
-                : value === "failed"
-                  ? "With failures"
-                  : "In progress"}
+              Clear filters
             </Button>
-          ))}
-        </div>
-        <div className="relative w-full sm:w-60">
-          <Search
-            aria-hidden
-            className="absolute left-2.5 top-2.5 size-3.5 text-muted-foreground"
-          />
-          <Input
-            className="h-8 pl-8 text-xs"
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            placeholder="Find a test case…"
-            aria-label="Find a test case"
-          />
+          )}
         </div>
       </div>
       <div className="overflow-x-auto rounded-lg border border-border">
@@ -359,9 +359,6 @@ export function RunResultsMatrix({
                 <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
                   Test case
                 </span>
-                <p className="mt-1 font-normal text-muted-foreground">
-                  Failures first
-                </p>
               </th>
               {data.targets.map((target) => (
                 <th
@@ -470,26 +467,9 @@ export function RunResultsMatrix({
             {data.rows.length
               ? "No cases match these filters."
               : "Waiting for the first test case results."}
-            {(search || filter !== "all") && (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="ml-2"
-                onClick={() => {
-                  setSearch("");
-                  setFilter("all");
-                }}
-              >
-                Clear filters
-              </Button>
-            )}
           </div>
         )}
       </div>
-      <p className="text-[11px] text-muted-foreground">
-        Showing recorded iterations from this run. Case verdicts and thresholds
-        are reported separately in diagnostics.
-      </p>
       <Sheet
         open={Boolean(selectedRow && selectedTarget)}
         onOpenChange={(open) => {

--- a/mcpjam-inspector/client/src/components/evaluate/run-results-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/run-results-matrix.tsx
@@ -256,9 +256,10 @@ export function RunResultsMatrix({
       : status === "cancelled" && counts.cancelled === 0
         ? ALL_EVAL_FILTER_VALUES
         : status;
+  const query = search.trim().toLowerCase();
   const rows = data.rows.filter(
     (row) =>
-      row.title.toLowerCase().includes(search.toLowerCase()) &&
+      row.title.toLowerCase().includes(query) &&
       (activeStatus === ALL_EVAL_FILTER_VALUES ||
         data.targets.some(
           (target) =>
@@ -268,7 +269,7 @@ export function RunResultsMatrix({
         )),
   );
   const hasActiveFilters =
-    Boolean(search.trim()) ||
+    Boolean(query) ||
     activeStatus !== ALL_EVAL_FILTER_VALUES ||
     extraFiltersActive;
   const clearFilters = () => {

--- a/mcpjam-inspector/client/src/components/evaluate/run-verdict-hero-deltas.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/run-verdict-hero-deltas.ts
@@ -303,7 +303,7 @@ export function previousHeroIterations({
     previousIds = [previousRunId];
   }
   if (matchSelectedPairings && launch) {
-    const wanted = new Set(selectedRuns.map(pairingKey));
+    const wanted = new Set(selectedRuns.map((run) => pairingKey(run)));
     previousIds = launch
       .filter((run) => wanted.has(pairingKey(run)))
       .map((run) => run._id);

--- a/mcpjam-inspector/client/src/components/evaluate/run-verdict-hero-deltas.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/run-verdict-hero-deltas.ts
@@ -1,0 +1,318 @@
+/**
+ * Compact previous-run deltas for the hero metric strip.
+ *
+ * Colour is progress vs regression, not "up = green". The arrow follows the
+ * number; the tone follows whether that movement helped.
+ */
+import { compareRunsBySequence } from "../evals/helpers";
+import { formatRunCaseLatencyMs } from "../evals/run-case-groups";
+import type { EvalIteration, EvalSuiteRun } from "../evals/types";
+import type { HeroStats } from "./run-verdict-hero-model";
+import { resultCounts } from "./run-results-matrix-model";
+
+export type HeroDeltaTone = "progress" | "regression" | "same";
+export type HeroDeltaDirection = "up" | "down" | "same";
+
+export type HeroStatDelta = {
+  label: string;
+  direction: HeroDeltaDirection;
+  tone: HeroDeltaTone;
+};
+
+export type HeroStatDeltas = {
+  passed: HeroStatDelta | null;
+  latency: HeroStatDelta | null;
+  tokens: HeroStatDelta | null;
+  toolCalls: HeroStatDelta | null;
+};
+
+/** One client/model pairing's pass/fail counts, for the hero list above the insights. */
+export type HeroPairingPass = {
+  key: string;
+  client: string;
+  model: string;
+  passed: number;
+  failed: number;
+  pending: number;
+  cancelled: number;
+  total: number;
+  delta: HeroStatDelta | null;
+};
+
+export type HeroPairingSource = {
+  key: string;
+  run: EvalSuiteRun;
+  client: string;
+  modelId: string;
+  model: string;
+  iterations: readonly EvalIteration[];
+};
+
+export function formatHeroCount(value: number): string {
+  if (value >= 1000) {
+    const thousands = value / 1000;
+    return `${
+      thousands >= 100 ? Math.round(thousands) : thousands.toFixed(1)
+    }k`;
+  }
+  return String(value);
+}
+
+function signed(delta: number, formattedAbs: string): string {
+  if (delta === 0) return "=";
+  return `${delta > 0 ? "+" : "−"}${formattedAbs}`;
+}
+
+function directionOf(delta: number): HeroDeltaDirection {
+  if (delta === 0) return "same";
+  return delta > 0 ? "up" : "down";
+}
+
+/** `invert` is true when a smaller number is progress (latency, tokens, tools). */
+function toneOf(delta: number, invert: boolean): HeroDeltaTone {
+  if (delta === 0) return "same";
+  const improved = invert ? delta < 0 : delta > 0;
+  return improved ? "progress" : "regression";
+}
+
+function deltaOf(
+  current: number | null,
+  previous: number | null,
+  formatAbs: (value: number) => string,
+  invert: boolean,
+): HeroStatDelta | null {
+  if (current == null || previous == null) return null;
+  const delta = current - previous;
+  return {
+    label: signed(delta, formatAbs(Math.abs(delta))),
+    direction: directionOf(delta),
+    tone: toneOf(delta, invert),
+  };
+}
+
+function passedCount(stats: HeroStats): number | null {
+  if (stats.cases.kind === "cases") return stats.cases.passed;
+  if (stats.cases.kind === "trials") return stats.cases.passed;
+  if (stats.cases.kind === "unavailable") return stats.iterations.passed;
+  return null;
+}
+
+/**
+ * Compare two hero strips that already use the same population.
+ *
+ * Passed only compares when both sides share a count basis — mixing a
+ * case-variant total with an iteration fallback would paint a false arrow.
+ */
+export function buildHeroStatDeltas(
+  current: HeroStats,
+  previous: HeroStats,
+): HeroStatDeltas {
+  const samePassedBasis =
+    current.cases.kind === previous.cases.kind ||
+    (current.cases.kind === "unavailable" &&
+      previous.cases.kind === "unavailable");
+
+  return {
+    passed: samePassedBasis
+      ? deltaOf(passedCount(current), passedCount(previous), String, false)
+      : null,
+    latency: deltaOf(
+      current.latencyP50Ms,
+      previous.latencyP50Ms,
+      (ms) => formatRunCaseLatencyMs(ms).replace("—", ""),
+      true,
+    ),
+    tokens: deltaOf(current.tokens, previous.tokens, formatHeroCount, true),
+    toolCalls: deltaOf(
+      current.toolCalls,
+      previous.toolCalls,
+      formatHeroCount,
+      true,
+    ),
+  };
+}
+
+/**
+ * The immediately earlier completed run of the same suite, host, and model.
+ *
+ * Used when the strip is one pairing. A combined report uses the previous
+ * launch instead — see {@link previousLaunchRuns}.
+ */
+export function previousCompletedRunOf(
+  current: EvalSuiteRun,
+  suiteRuns: readonly EvalSuiteRun[],
+): EvalSuiteRun | null {
+  return (
+    [...suiteRuns]
+      .filter(
+        (run) =>
+          run._id !== current._id &&
+          run.status === "completed" &&
+          run.namedHostId === current.namedHostId &&
+          run.effectiveModelId === current.effectiveModelId &&
+          (!current.runGroupId || run.runGroupId !== current.runGroupId) &&
+          compareRunsBySequence(run, current) < 0,
+      )
+      .sort((a, b) => compareRunsBySequence(b, a))[0] ?? null
+  );
+}
+
+export function pairingKey(run: EvalSuiteRun, modelId?: string): string {
+  return `${run.namedHostId ?? ""}::${modelId ?? run.effectiveModelId ?? ""}`;
+}
+
+/** Passed polarity: more is progress, fewer is regression. No fake zeros. */
+export function buildPassedDelta(
+  current: number,
+  previous: number | null,
+): HeroStatDelta | null {
+  return deltaOf(current, previous, String, false);
+}
+
+/**
+ * Per-pairing pass rows for the hero. Each target is one client/model on this
+ * page; the previous launch contributes a delta only when that same host+model
+ * ran before.
+ */
+export function buildHeroPairings({
+  targets,
+  previousLaunch,
+  previousIterations,
+}: {
+  targets: readonly HeroPairingSource[];
+  previousLaunch: readonly EvalSuiteRun[] | null;
+  previousIterations: readonly EvalIteration[] | null;
+}): HeroPairingPass[] {
+  return targets.map((target) => {
+    const counts = resultCounts(target.iterations);
+    const previousPassed = previousPassedFor(
+      target,
+      previousLaunch,
+      previousIterations,
+      targets.length,
+    );
+    return {
+      key: target.key,
+      client: target.client,
+      model: target.model,
+      passed: counts.passed,
+      failed: counts.failed,
+      pending: counts.pending,
+      cancelled: counts.cancelled,
+      total: target.iterations.length,
+      delta: buildPassedDelta(counts.passed, previousPassed),
+    };
+  });
+}
+
+function previousPassedFor(
+  target: HeroPairingSource,
+  previousLaunch: readonly EvalSuiteRun[] | null,
+  previousIterations: readonly EvalIteration[] | null,
+  targetCount: number,
+): number | null {
+  if (!previousIterations || previousIterations.length === 0) return null;
+  if (previousLaunch && previousLaunch.length > 0) {
+    const key = pairingKey(target.run, target.modelId);
+    const twin = previousLaunch.find((run) => pairingKey(run) === key);
+    if (!twin) return null;
+    const rows = previousIterations.filter(
+      (iteration) => iteration.suiteRunId === twin._id,
+    );
+    if (rows.length === 0) return null;
+    return rows.filter((iteration) => iteration.result === "passed").length;
+  }
+  // Single-run page: previous rows are already scoped to that pairing.
+  // Never roll a multi-pairing launch into every row.
+  if (targetCount !== 1) return null;
+  return previousIterations.filter((iteration) => iteration.result === "passed")
+    .length;
+}
+
+/**
+ * The previous completed launch of this suite — the whole group, not one
+ * client/model pairing.
+ *
+ * Combined hero numbers are aggregates ("21 of 48 iterations on this page").
+ * Comparing that strip to a single previous pairing, or requiring every
+ * current pairing to have a twin, leaves the arrows off.
+ */
+export function previousLaunchRuns(
+  selectedRuns: readonly EvalSuiteRun[],
+  suiteRuns: readonly EvalSuiteRun[],
+  previousRunId?: string | null,
+): EvalSuiteRun[] | null {
+  if (selectedRuns.length === 0) return null;
+  const currentIds = new Set(selectedRuns.map((run) => run._id));
+  const newest = [...selectedRuns].sort((a, b) =>
+    compareRunsBySequence(b, a),
+  )[0];
+
+  let anchor =
+    (previousRunId
+      ? (suiteRuns.find((run) => run._id === previousRunId) ?? null)
+      : null) ??
+    [...suiteRuns]
+      .filter(
+        (run) =>
+          run.status === "completed" &&
+          !currentIds.has(run._id) &&
+          (newest.suiteId == null || run.suiteId === newest.suiteId) &&
+          (!newest.runGroupId || run.runGroupId !== newest.runGroupId) &&
+          compareRunsBySequence(run, newest) < 0,
+      )
+      .sort((a, b) => compareRunsBySequence(b, a))[0] ??
+    null;
+
+  if (!anchor) return null;
+  if (anchor.runGroupId) {
+    const group = suiteRuns.filter(
+      (run) =>
+        run.runGroupId === anchor.runGroupId && run.status === "completed",
+    );
+    if (group.length > 0) return group;
+  }
+  return [anchor];
+}
+
+/**
+ * Iteration rows for the previous consecutive suite launch.
+ *
+ * Unfiltered combined reports use the whole previous launch. A client/model
+ * filter keeps only that pairing's previous counterpart. Null when this is
+ * the first launch, or when those rows are not on the page.
+ */
+export function previousHeroIterations({
+  selectedRuns,
+  suiteRuns,
+  allIterations,
+  previousRunId,
+  matchSelectedPairings = false,
+}: {
+  selectedRuns: readonly EvalSuiteRun[];
+  suiteRuns: readonly EvalSuiteRun[];
+  allIterations: readonly EvalIteration[] | undefined;
+  previousRunId?: string | null;
+  matchSelectedPairings?: boolean;
+}): EvalIteration[] | null {
+  if (!allIterations || selectedRuns.length === 0) return null;
+
+  const launch = previousLaunchRuns(selectedRuns, suiteRuns, previousRunId);
+  let previousIds = launch?.map((run) => run._id) ?? [];
+  if (previousIds.length === 0 && previousRunId) {
+    previousIds = [previousRunId];
+  }
+  if (matchSelectedPairings && launch) {
+    const wanted = new Set(selectedRuns.map(pairingKey));
+    previousIds = launch
+      .filter((run) => wanted.has(pairingKey(run)))
+      .map((run) => run._id);
+  }
+  if (previousIds.length === 0) return null;
+
+  const rows = allIterations.filter(
+    (iteration) =>
+      iteration.suiteRunId != null && previousIds.includes(iteration.suiteRunId),
+  );
+  return rows.length > 0 ? rows : null;
+}

--- a/mcpjam-inspector/client/src/components/evaluate/run-verdict-hero-model.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/run-verdict-hero-model.ts
@@ -33,6 +33,11 @@ import {
 
 import type { EvalIteration, EvalSuiteRun } from "../evals/types";
 import { iterationLatencyP50, iterationLatencyP95 } from "../evals/helpers";
+import {
+  buildHeroStatDeltas,
+  type HeroPairingPass,
+  type HeroStatDeltas,
+} from "./run-verdict-hero-deltas";
 
 /**
  * The word at the top, and how loudly to say it.
@@ -104,6 +109,10 @@ export type RunVerdictHeroView = {
   focus: HeroFocus | null;
   sentence: HeroSentence;
   stats: HeroStats;
+  /** One row per client/model on this page. Empty only before the page has targets. */
+  pairings: HeroPairingPass[];
+  /** Null when there is no previous consecutive run on the page to compare. */
+  deltas: HeroStatDeltas | null;
   /** True when the decision read is still in flight; the view stays honest meanwhile. */
   pending: boolean;
 };
@@ -116,6 +125,8 @@ export type RunVerdictHeroInput = {
     summary: EvalRunDecisionSummary | null;
     diagnostics: readonly EvalRunDecisionDiagnostic[];
   };
+  /** Same-suite previous run, already resolved by the page. */
+  previous?: { iterations: readonly EvalIteration[] } | null;
 };
 
 /** Lifecycle statuses that are not a verdict and must not be painted as one. */
@@ -317,7 +328,7 @@ function sentenceFor(
   };
 }
 
-function statsFor(input: RunVerdictHeroInput): HeroStats {
+export function heroStatsFor(input: RunVerdictHeroInput): HeroStats {
   const iterations = input.iterations;
   const passed = iterations.filter(
     (iteration) => iteration.result === "passed",
@@ -376,11 +387,23 @@ export function buildRunVerdictHero(
     input.decision.status === "ready"
       ? selectHeroFocus(input.decision.diagnostics)
       : null;
+  const stats = heroStatsFor(input);
+  const previousIterations = input.previous?.iterations;
+  const previousStats =
+    previousIterations && previousIterations.length > 0
+      ? heroStatsFor({
+          run: input.run,
+          iterations: previousIterations,
+          decision: { status: "disabled", summary: null, diagnostics: [] },
+        })
+      : null;
   return {
     verdict,
     focus,
     sentence: sentenceFor(input, verdict, focus),
-    stats: statsFor(input),
+    stats,
+    pairings: [],
+    deltas: previousStats ? buildHeroStatDeltas(stats, previousStats) : null,
     pending: input.decision.status === "loading",
   };
 }

--- a/mcpjam-inspector/client/src/components/evaluate/run-verdict-hero.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/run-verdict-hero.tsx
@@ -1,25 +1,39 @@
 /**
- * The verdict, the sentence, the action — then the numbers.
+ * Pairing pass/fail bars, the sentence, the action — then the page measurements.
  *
- * Reading order IS the design here. The old page opened with a 67% and four
- * metric tiles, so the first thing a reader met was an arithmetic summary of a
- * run whose one interesting fact (a case broke, here, for this reason) was
- * three panels down behind a "Show more". This block inverts that: decision,
- * then the failing case in one sentence, then what to do about it, and the
- * measurements last and small.
+ * Reading order IS the design here. Pass/fail is a per-client decision, so it
+ * sits with the pairing — logo, name, bar, and key — not as one rolled-up
+ * PASSED tile. Insights follow. Latency, tokens, and tool calls stay a
+ * page-level strip at the bottom.
  *
  * Every string comes from {@link buildRunVerdictHero}. The view chooses type
  * and colour; it never decides what is true.
  */
 import { useRunHeaderVerdict } from "./evaluate-run-page";
 import { remedyForDiagnostic } from "./stage-remedy";
-import { ArrowUpRight } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpRight,
+  CircleAlert,
+  CircleCheck,
+  Lightbulb,
+  TriangleAlert,
+  Wrench,
+} from "lucide-react";
 import { Skeleton } from "@mcpjam/design-system/skeleton";
-import { measurementUnitLabel } from "@mcpjam/sdk/contract";
 import { Button } from "@mcpjam/design-system/button";
 import { cn } from "@/lib/utils";
+import { resolveHostLogoByName } from "@/lib/host-logo";
+import { usePreferencesStoreWithDefaults } from "@/stores/preferences/preferences-provider";
 
 import { formatRunCaseLatencyMs } from "../evals/run-case-groups";
+import {
+  formatHeroCount,
+  type HeroPairingPass,
+  type HeroStatDelta,
+} from "./run-verdict-hero-deltas";
+import { ResultCountBar, ResultCountKey } from "./result-count-bar";
 import type {
   HeroVerdictTone,
   RunVerdictHeroView,
@@ -36,31 +50,58 @@ const VERDICT_TONE_CLASS: Record<HeroVerdictTone, string> = {
 
 function formatCount(value: number | null): string {
   if (value === null) return "not recorded";
-  if (value >= 1000) {
-    const thousands = value / 1000;
-    return `${
-      thousands >= 100 ? Math.round(thousands) : thousands.toFixed(1)
-    }k`;
-  }
-  return String(value);
+  return formatHeroCount(value);
+}
+
+const DELTA_TONE_CLASS = {
+  progress: "text-success",
+  regression: "text-destructive",
+  same: "text-muted-foreground",
+} as const;
+
+function StatDelta({ delta }: { delta: HeroStatDelta }) {
+  const Arrow =
+    delta.direction === "up"
+      ? ArrowUp
+      : delta.direction === "down"
+        ? ArrowDown
+        : null;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-0.5 text-[11.5px] font-medium tabular-nums",
+        DELTA_TONE_CLASS[delta.tone],
+      )}
+      aria-label={`${delta.label} vs previous run`}
+      data-testid="run-verdict-stat-delta"
+    >
+      {Arrow ? <Arrow className="size-3" aria-hidden /> : null}
+      {delta.label}
+    </span>
+  );
 }
 
 function Stat({
   label,
   value,
   detail,
+  delta,
 }: {
   label: string;
   value: string;
   detail?: string;
+  delta?: HeroStatDelta | null;
 }) {
   return (
     <div className="min-w-0 px-4 py-2 first:pl-0">
       <div className="text-[10.5px] font-medium uppercase tracking-wide text-muted-foreground">
         {label}
       </div>
-      <div className="mt-0.5 text-[15px] font-semibold tabular-nums text-foreground">
-        {value}
+      <div className="mt-0.5 flex flex-wrap items-baseline gap-x-1.5">
+        <div className="text-[15px] font-semibold tabular-nums text-foreground">
+          {value}
+        </div>
+        {delta ? <StatDelta delta={delta} /> : null}
       </div>
       {detail ? (
         <div className="text-[11.5px] text-muted-foreground">{detail}</div>
@@ -69,48 +110,64 @@ function Stat({
   );
 }
 
-/**
- * The unit is `measurementUnitLabel`'s word, never a literal.
- *
- * A 3-case suite fanned out over 2 models has 6 CASE VARIANTS, so "6 of 6
- * cases" beside a Cases list showing 3 is a number contradicting the page it
- * sits on. And a legacy run's counts are TRIALS — the one thing this hero must
- * never call cases. The contract owns both spellings; this only renders them.
- */
-function caseStatText(view: RunVerdictHeroView): {
-  value: string;
-  detail: string;
-} {
-  const { cases, iterations } = view.stats;
-  if (cases.kind === "cases") {
-    const unit = measurementUnitLabel("caseVariant", cases.total);
-    return {
-      value: `${cases.passed} of ${cases.total}`,
-      detail:
-        cases.inconclusive > 0
-          ? `${unit} · ${cases.inconclusive} inconclusive`
-          : unit,
-    };
-  }
-  if (cases.kind === "trials") {
-    if (cases.passed === null || cases.total === null) {
-      // Absent stays absent. A run that recorded no total has not recorded a
-      // total of zero, and "0 of 0" would be a claim it never made. Plural,
-      // because there is no count to agree with.
-      return {
-        value: "not recorded",
-        detail: measurementUnitLabel("trial", 0),
-      };
-    }
-    return {
-      value: `${cases.passed} of ${cases.total}`,
-      detail: `${measurementUnitLabel("trial", cases.total)}, not ${measurementUnitLabel("caseVariant", 0)}`,
-    };
-  }
-  return {
-    value: `${iterations.passed} of ${iterations.total}`,
-    detail: `${measurementUnitLabel("trial", iterations.total)} on this page`,
-  };
+function AiGeneratedLabel() {
+  return (
+    <span
+      className="shrink-0 text-[10.5px] font-medium text-muted-foreground"
+      data-testid="run-verdict-ai-insight"
+    >
+      AI generated
+    </span>
+  );
+}
+
+function PairingPassList({ pairings }: { pairings: HeroPairingPass[] }) {
+  const theme = usePreferencesStoreWithDefaults((state) => state.themeMode);
+  return (
+    <ul
+      className="divide-y divide-border/60"
+      data-testid="run-verdict-pairings"
+    >
+      {pairings.map((pairing) => {
+        const counts = {
+          passed: pairing.passed,
+          failed: pairing.failed,
+          pending: pairing.pending,
+          cancelled: pairing.cancelled,
+        };
+        const showDelta =
+          pairing.delta != null && pairing.delta.direction !== "same";
+        return (
+          <li
+            key={pairing.key}
+            className="flex min-w-0 items-center gap-4 py-4"
+            data-testid="run-verdict-pairing"
+          >
+            <div className="flex w-44 shrink-0 items-center gap-2">
+              <img
+                src={resolveHostLogoByName(pairing.client, theme)}
+                alt=""
+                className="size-4 shrink-0 object-contain"
+              />
+              <span className="min-w-0 truncate text-[13px] leading-none">
+                <span className="font-medium text-foreground">
+                  {pairing.client}
+                </span>
+                <span className="text-muted-foreground"> · {pairing.model}</span>
+              </span>
+            </div>
+            <div className="flex w-40 shrink-0 items-center gap-2">
+              <ResultCountKey counts={counts} />
+              {showDelta && pairing.delta ? (
+                <StatDelta delta={pairing.delta} />
+              ) : null}
+            </div>
+            <ResultCountBar counts={counts} className="min-w-0 flex-1" />
+          </li>
+        );
+      })}
+    </ul>
+  );
 }
 
 export function RunVerdictHero({
@@ -127,7 +184,8 @@ export function RunVerdictHero({
 }) {
   const inHeader = useRunHeaderVerdict(headerVerdict);
   const showVerdict = !inHeader && view.verdict.word !== "Running";
-  const caseStat = caseStatText(view);
+  const pairings = view.pairings ?? [];
+  const hasPairings = pairings.length > 0;
   const remedy = view.focus ? remedyForDiagnostic(view.focus.diagnostic) : null;
   const hasSentence = view.sentence.text.trim().length > 0;
   const summaryLoading =
@@ -161,17 +219,23 @@ export function RunVerdictHero({
           </div>
         ) : null}
 
+        {hasPairings ? (
+          <div className={cn(showVerdict && "mt-4")}>
+            <PairingPassList pairings={pairings} />
+          </div>
+        ) : null}
+
         {summaryLoading ? (
           <div
-            className={cn("grid gap-4 lg:grid-cols-2", showVerdict && "mt-5")}
+            className="grid divide-y divide-border/40 border-t border-border/60 pt-3 lg:grid-cols-2 lg:divide-x lg:divide-y-0"
             role="status"
             aria-label="Loading run summary"
             data-testid="run-summary-loading"
           >
-            {[0, 1].map((card) => (
+            {[0, 1].map((column) => (
               <div
-                key={card}
-                className="space-y-3 rounded-lg border border-border p-4"
+                key={column}
+                className="min-w-0 space-y-3 py-3 lg:px-4 lg:py-2 lg:first:pl-0"
                 aria-hidden="true"
               >
                 <Skeleton className="h-3 w-24" />
@@ -182,16 +246,36 @@ export function RunVerdictHero({
           </div>
         ) : hasSentence ? (
           <div
-            className={cn("grid gap-4 lg:grid-cols-2", showVerdict && "mt-5")}
+            className="grid divide-y divide-border/40 border-t border-border/60 pt-3 lg:grid-cols-2 lg:divide-x lg:divide-y-0"
+            data-testid="run-verdict-insights"
           >
-            <div className="rounded-lg border border-border p-4">
-              <h4 className="text-xs font-semibold">
-                {view.sentence.kind === "noFailure"
-                  ? "What passed"
-                  : view.sentence.kind === "brokeAt"
-                    ? "What broke"
-                    : "What happened"}
-              </h4>
+            <div className="min-w-0 py-3 lg:px-4 lg:py-2 lg:first:pl-0">
+              <div className="flex items-baseline justify-between gap-3">
+                <h4 className="flex min-w-0 items-center gap-2 text-sm font-semibold">
+                  {view.sentence.kind === "noFailure" ? (
+                    <CircleCheck
+                      className="size-4 text-muted-foreground"
+                      aria-hidden
+                    />
+                  ) : view.sentence.kind === "brokeAt" ? (
+                    <TriangleAlert
+                      className="size-4 text-muted-foreground"
+                      aria-hidden
+                    />
+                  ) : (
+                    <CircleAlert
+                      className="size-4 text-muted-foreground"
+                      aria-hidden
+                    />
+                  )}
+                  {view.sentence.kind === "noFailure"
+                    ? "What passed"
+                    : view.sentence.kind === "brokeAt"
+                      ? "What broke"
+                      : "What happened"}
+                </h4>
+                <AiGeneratedLabel />
+              </div>
               {hasSentence ? (
                 <p
                   className="mt-2 max-w-[72ch] text-sm leading-relaxed text-foreground"
@@ -201,11 +285,28 @@ export function RunVerdictHero({
                 </p>
               ) : null}
             </div>
-            <div className="rounded-lg border border-border p-4">
-              <h4 className="text-xs font-semibold">
-                {remedy ? "How to fix" : "Next step"}
-              </h4>
-              <p className="mt-2 text-sm leading-relaxed text-foreground">
+            <div className="min-w-0 py-3 lg:px-4 lg:py-2">
+              <div className="flex items-baseline justify-between gap-3">
+                <h4 className="flex min-w-0 items-center gap-2 text-sm font-semibold">
+                  {remedy ? (
+                    <Wrench
+                      className="size-4 text-muted-foreground"
+                      aria-hidden
+                    />
+                  ) : (
+                    <Lightbulb
+                      className="size-4 text-muted-foreground"
+                      aria-hidden
+                    />
+                  )}
+                  {remedy ? "How to fix" : "Next step"}
+                </h4>
+                <AiGeneratedLabel />
+              </div>
+              <p
+                className="mt-2 text-sm leading-relaxed text-foreground"
+                data-testid="run-verdict-remedy"
+              >
                 {remedy?.text ??
                   (view.pending
                     ? "Results are still arriving. Inspect the live case matrix below as iterations complete."
@@ -237,15 +338,26 @@ export function RunVerdictHero({
         ) : null}
       </div>
 
-      <div className="grid grid-cols-2 divide-x divide-border/40 border-t border-border/60 pt-3 sm:grid-cols-4">
-        <Stat label="Passed" value={caseStat.value} detail={caseStat.detail} />
+      <div
+        className="grid grid-cols-3 divide-x divide-border/40 border-t border-border/60 pt-3"
+        data-testid="run-verdict-stats"
+      >
         <Stat
           label="Latency p50"
           value={formatRunCaseLatencyMs(view.stats.latencyP50Ms)}
           detail={`p95 ${formatRunCaseLatencyMs(view.stats.latencyP95Ms)}`}
+          delta={view.deltas?.latency}
         />
-        <Stat label="Tokens" value={formatCount(view.stats.tokens)} />
-        <Stat label="Tool calls" value={formatCount(view.stats.toolCalls)} />
+        <Stat
+          label="Tokens"
+          value={formatCount(view.stats.tokens)}
+          delta={view.deltas?.tokens}
+        />
+        <Stat
+          label="Tool calls"
+          value={formatCount(view.stats.toolCalls)}
+          delta={view.deltas?.toolCalls}
+        />
       </div>
     </section>
   );

--- a/mcpjam-inspector/client/src/components/evaluate/suite-detail-model.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/suite-detail-model.ts
@@ -367,6 +367,7 @@ const RUN_HISTORY_DAY: Intl.DateTimeFormatOptions = {
 };
 
 export function formatRunHistoryDate(timestamp: number): string {
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return "-";
   return new Date(timestamp).toLocaleString(undefined, {
     ...RUN_HISTORY_DAY,
     hour: "numeric",
@@ -379,8 +380,12 @@ export function formatRunHistoryDateRange(
   earliest: number,
   latest: number,
 ): string {
-  const start = new Date(Math.min(earliest, latest));
-  const end = new Date(Math.max(earliest, latest));
+  const timestamps = [earliest, latest].filter(
+    (timestamp) => Number.isFinite(timestamp) && timestamp > 0,
+  );
+  if (timestamps.length === 0) return "-";
+  const start = new Date(Math.min(...timestamps));
+  const end = new Date(Math.max(...timestamps));
   const startLabel = start.toLocaleString(undefined, RUN_HISTORY_DAY);
   const sameDay =
     start.getFullYear() === end.getFullYear() &&

--- a/mcpjam-inspector/client/src/components/evaluate/suite-detail-model.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/suite-detail-model.ts
@@ -361,6 +361,35 @@ export function formatRunHistoryMetric(
   return formatCompactNumber(value);
 }
 
+const RUN_HISTORY_DAY: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+};
+
+export function formatRunHistoryDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleString(undefined, {
+    ...RUN_HISTORY_DAY,
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/** Earliest → latest calendar day for a suite group. Same day collapses to one date. */
+export function formatRunHistoryDateRange(
+  earliest: number,
+  latest: number,
+): string {
+  const start = new Date(Math.min(earliest, latest));
+  const end = new Date(Math.max(earliest, latest));
+  const startLabel = start.toLocaleString(undefined, RUN_HISTORY_DAY);
+  const sameDay =
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate();
+  if (sameDay) return startLabel;
+  return `${startLabel} – ${end.toLocaleString(undefined, RUN_HISTORY_DAY)}`;
+}
+
 export type SuiteTestCaseRow = {
   caseId: string;
   title: string;

--- a/mcpjam-inspector/client/src/components/evaluate/suite-detail-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/suite-detail-overview.tsx
@@ -59,6 +59,7 @@ import {
   runHistoryFilterOptions,
   suiteRunBlockedReason,
   runTimestamp,
+  formatRunHistoryDate,
 } from "./suite-detail-model";
 import type {
   EvalCase,
@@ -512,7 +513,10 @@ export function SuiteDetailOverview({
                 <TableHeader>
                   <TableRow className="hover:bg-transparent border-border/30">
                     <TableHead className={runHistoryHeadClass}>
-                      Run / Date
+                      Date
+                    </TableHead>
+                    <TableHead className={runHistoryHeadClass}>
+                      Run
                     </TableHead>
                     <TableHead className={runHistoryHeadClass}>
                       Client : model
@@ -560,14 +564,7 @@ export function SuiteDetailOverview({
                         historyRows={rowMap}
                         showGitContext={false}
                         label={`Run #${representative.runNumber}`}
-                        detail={new Date(
-                          representative.createdAt,
-                        ).toLocaleString(undefined, {
-                          month: "short",
-                          day: "numeric",
-                          hour: "numeric",
-                          minute: "2-digit",
-                        })}
+                        date={formatRunHistoryDate(representative.createdAt)}
                         onOpen={() => onRunClick(representative._id)}
                       />
                     );
@@ -617,7 +614,7 @@ export function SuiteDetailOverview({
           <div
             className={cn(
               evalSurfaceHeaderClass,
-              "flex items-center justify-between gap-3 px-4 py-3",
+              "flex items-center justify-between gap-3 bg-muted/55 px-4 py-3",
             )}
           >
             <h3 className="text-sm font-semibold text-foreground">

--- a/mcpjam-inspector/client/src/components/evaluate/suite-run-history-snapshot.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/suite-run-history-snapshot.tsx
@@ -71,11 +71,6 @@ export function SuiteRunHistorySnapshot({
       data-testid="suite-run-history-snapshot"
       className="@container/history-metrics border-b border-border/50"
     >
-      <p className="px-5 pt-3 text-[10px] text-muted-foreground">
-        {data.series.length === 1
-          ? "Latest run"
-          : `Latest run · trends across ${data.series.length} runs`}
-      </p>
       <MetricStrip
         data={data}
         surface="embedded"

--- a/mcpjam-inspector/client/src/components/evaluate/suite-run-review.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/suite-run-review.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useRef, useState } from "react";
-import { ArrowRight, Loader2, Minus, Play, Plus } from "lucide-react";
+import { Loader2, Minus, Play, Plus } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { Checkbox } from "@mcpjam/design-system/checkbox";
 import { Input } from "@mcpjam/design-system/input";
@@ -240,17 +240,12 @@ export function SuiteRunReviewContent({
         </SheetHeader>
         <div className="flex-1 space-y-8 overflow-y-auto p-6">
           <section>
-            <div className="mb-3 flex items-center justify-between">
-              <label
-                htmlFor="suite-run-iterations"
-                className="text-sm font-semibold"
-              >
-                Iterations per case
-              </label>
-              <span className="text-xs text-muted-foreground">
-                1–10 repetitions
-              </span>
-            </div>
+            <label
+              htmlFor="suite-run-iterations"
+              className="mb-3 block text-sm font-semibold"
+            >
+              Iterations per case
+            </label>
             <div className="flex items-center gap-2">
               <Button
                 variant="outline"
@@ -282,9 +277,6 @@ export function SuiteRunReviewContent({
               >
                 <Plus className="size-4" />
               </Button>
-              <span className="ml-2 text-xs text-muted-foreground">
-                Repeat every case to check consistency.
-              </span>
             </div>
             {!validCount && (
               <p role="alert" className="mt-2 text-xs text-destructive">
@@ -348,12 +340,12 @@ export function SuiteRunReviewContent({
               )}
             </section>
           )}
-          <section className="border-t border-border pt-5">
+          <section>
             <div className="flex items-center justify-between">
               <h3 className="text-sm font-semibold">Grading policy</h3>
               {onEditSettings && (
                 <Button
-                  variant="ghost"
+                  variant="secondary"
                   size="sm"
                   disabled={starting}
                   onClick={() => {
@@ -361,7 +353,7 @@ export function SuiteRunReviewContent({
                     onEditSettings();
                   }}
                 >
-                  Edit suite settings <ArrowRight className="size-3.5" />
+                  Edit suite settings
                 </Button>
               )}
             </div>

--- a/mcpjam-inspector/client/src/components/evaluate/suites-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/suites-overview.tsx
@@ -118,47 +118,64 @@ function OverviewBody({
 
   return (
     <div className="min-w-0" data-testid="evals-suites-overview">
-      <div className="mb-4 flex flex-wrap items-center justify-end gap-1.5">
-        <EvalListFilter
-          label="Client"
-          value={clientFilter}
-          options={clientOptions}
-          onChange={setClientFilter}
-        />
-        <EvalListFilter
-          label="Server"
-          value={serverFilter}
-          options={serverOptions}
-          onChange={setServerFilter}
-        />
-        {isFiltering && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 text-[11px]"
-            onClick={() => {
-              setClientFilter(ALL_EVAL_FILTER_VALUES);
-              setServerFilter(ALL_EVAL_FILTER_VALUES);
-            }}
-          >
-            Clear filters
-          </Button>
-        )}
-      </div>
       <div
-        className={cn(
-          ROW_PAD,
-          "border-b border-border/40 pb-2 text-xs font-medium text-muted-foreground",
-        )}
+        className={cn(ROW_PAD, "border-b border-border/40 pb-3")}
+        role="row"
       >
         <div className={DATA_COLS}>
-          <span>Suite</span>
-          <span>Client</span>
-          <span>Server</span>
-          <span className="text-right">Pass rate</span>
-          <span className="text-right">Last run</span>
+          <span
+            role="columnheader"
+            className="text-xs font-medium text-muted-foreground"
+          >
+            Suite
+          </span>
+          <div role="columnheader" aria-label="Client" className="min-w-0">
+            <EvalListFilter
+              label="Client"
+              variant="header"
+              value={clientFilter}
+              options={clientOptions}
+              onChange={setClientFilter}
+            />
+          </div>
+          <div role="columnheader" aria-label="Server" className="min-w-0">
+            <EvalListFilter
+              label="Server"
+              variant="header"
+              value={serverFilter}
+              options={serverOptions}
+              onChange={setServerFilter}
+            />
+          </div>
+          <span
+            role="columnheader"
+            className="text-right text-xs font-medium text-muted-foreground"
+          >
+            Pass rate
+          </span>
+          <span
+            role="columnheader"
+            className="text-right text-xs font-medium text-muted-foreground"
+          >
+            Last run
+          </span>
         </div>
-        <span className={ACTION_COL} aria-hidden />
+        <div className={ACTION_COL}>
+          {isFiltering ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-[11px]"
+              aria-label="Clear filters"
+              onClick={() => {
+                setClientFilter(ALL_EVAL_FILTER_VALUES);
+                setServerFilter(ALL_EVAL_FILTER_VALUES);
+              }}
+            >
+              Clear
+            </Button>
+          ) : null}
+        </div>
       </div>
       <ul className="mt-1">
         {filteredOverview.map((entry) => (


### PR DESCRIPTION
## Summary
- Tightens Evaluate (New) so suite lists, run history, and run results share one visual language: header filters, less duplicate chrome, and Hold/Ship decisions per client.
- Run pages show per-pairing pass/fail bars with last-launch deltas, and the matrix section is just Test cases plus filters.
- Empty states, create-suite naming, and suite/run tables (Date first, inline pairings) are updated so engineering can iterate from a single branch.

## Test plan
- [ ] Suites tab: Client/Server filters live in the column headers (not pills); header has a bit more space above the first row
- [ ] Runs tab: All Runs title, no roll-up/Collapse all/failed-iterations/pp caption; Date then Run; group rows show a date range + chevron on the left; pairings are inline with +N hover
- [ ] Empty evaluate: same hero on Runs and Suites; Eval my server cards open create suite; new suite names increment (Suite 1, Suite 2)
- [ ] Run page: HOLD/SHIP grouped pills (warning yellow / success green, no colon); Compare runs next to Run again; pairing rows are name → counts → bar
- [ ] Consecutive suite launches show per-metric deltas and per-pairing pass deltas; first launch has none
- [ ] Matrix: Test cases + search/Status/Client/Model on one row; no master bar or RUN RESULTS eyebrow
- [ ] Suite detail: Test Cases and Runs headers match height/fill


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlines the Evaluate suite and run results so suite lists, run history, and run pages share consistent visual patterns: filters live in column headers, decisions are shown per client (Hold/Ship), and consecutive runs show pass and metric deltas.

**Run pages**
- Shows Hold/Ship as grouped pills per client pairing.
- Adds per-pairing pass/fail bars and last-launch deltas; first launch has no deltas.
- Recovers previous-run delta context and announces each pairing result once.
- Simplifies the matrix to test cases plus search, status, client, and model filters.
- Moves Compare next to Run again and removes the duplicate chrome and eyebrow labels.
- Fixes pairing key generation so previous-run deltas still match when the view is filtered by client or model.

**Suite and run tables**
- Moves Client/Server filters from pills into column headers on the Suites tab.
- Reorders run history to Date first, then Run, and inlines pairings with a hoverable +N count.
- Shares the same empty hero across Runs and Suites; "Eval my server" cards open the create suite form with the server and name prefilled.
- Prefills new suite names as the next unused "Suite N" (e.g., Suite 3 after Suite 2), preserving any name already typed.
- Removes failed-iteration and percentage-point chips from history metric strips.

<sup>Written for commit 97098dcc4444f07377d9f017d941bfc45fcf1282. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

