### PR TITLE
One switch, every tool that acts

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -1875,18 +1875,17 @@ export function ChatInput({
                               around it would open over the control the user is
                               reaching for, and a non-focusable trigger div
                               would never open for a keyboard user at all.
-                              Both halves of the rule are surprising — the
-                              switch RAISES a floor and never lowers it, so
-                              some things pause without it and some never
-                              pause with it — and neither should be behind a
-                              hover. */}
+                              The switch now decides for every tool that acts,
+                              so the only thing left to say is which calls it
+                              does not cover, and that belongs in front of
+                              someone rather than behind a hover. */}
                           <p
                             id="tool-approval-floor-note"
                             className="mt-1 pl-6 text-[11px] leading-snug text-muted-foreground"
                           >
-                            Pause before tool calls. Browser, page,
-                            local-machine and destructive UI actions always
-                            pause; read-only lookups never do.
+                            Pause before every tool call: MCP servers, the
+                            browser, a page's own tools, the shell. Read-only
+                            lookups never pause.
                           </p>
                         </div>
                       )}

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -1875,17 +1875,19 @@ export function ChatInput({
                               around it would open over the control the user is
                               reaching for, and a non-focusable trigger div
                               would never open for a keyboard user at all.
-                              The switch now decides for every tool that acts,
-                              so the only thing left to say is which calls it
-                              does not cover, and that belongs in front of
-                              someone rather than behind a hover. */}
+                              The switch decides for every tool that acts, so
+                              the only thing left to say is which calls it does
+                              not cover — reads, and an app's own tools, which
+                              belong to the iframe the user opened rather than
+                              to this setting. That belongs in front of someone
+                              rather than behind a hover. */}
                           <p
                             id="tool-approval-floor-note"
                             className="mt-1 pl-6 text-[11px] leading-snug text-muted-foreground"
                           >
-                            Pause before every tool call: MCP servers, the
-                            browser, a page's own tools, the shell. Read-only
-                            lookups never pause.
+                            Pause before tool calls: MCP servers, the browser,
+                            a page's own tools, the shell. Read-only lookups
+                            and an open app's own actions never pause.
                           </p>
                         </div>
                       )}

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.local-engine.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.local-engine.test.tsx
@@ -450,4 +450,91 @@ describe("useChatSession — local computer engine transmission", () => {
       }),
     );
   });
+
+  // The switch is a live control and the response is a stream, so a user can
+  // move it while a turn is in flight. The SERVER decided each tool's
+  // `needsApproval` from the value in that turn's request and cannot be told
+  // otherwise, so the client has to answer the same question the server
+  // answered — the value the turn was SENT with, not the one showing now.
+  // Reading it live breaks in both directions, and each break is silent.
+  describe.each([
+    {
+      name: "OFF at send, flipped ON mid-turn: still runs, no stall",
+      sentWith: false,
+      flippedTo: true,
+      // The server declared it ungated and will never emit a pill. Deferring
+      // on the new value waits for a decision nobody will be asked for.
+      expectRun: true,
+    },
+    {
+      name: "ON at send, flipped OFF mid-turn: still defers, no bypass",
+      sentWith: true,
+      flippedTo: false,
+      // The server declared it gated and its pill is already on the way.
+      // Running on the new value executes a page tool the user was meant to
+      // see first, and then the pill arrives for a call already spent.
+      expectRun: false,
+    },
+  ])("approval flipped mid-turn — $name", ({ sentWith, flippedTo, expectRun }) => {
+    it("honours the value the turn was sent with", async () => {
+      const pageTool = {
+        alias: pageToolAlias("session-1", "https://shop.test::add_to_cart"),
+        sessionId: "session-1",
+        toolKey: "https://shop.test::add_to_cart",
+        rawName: "add_to_cart",
+        origin: "https://shop.test",
+      };
+      useWebmcpInspectorStore.setState({
+        session: { sessionId: pageTool.sessionId, status: "ready" } as never,
+        tools: [
+          {
+            toolKey: pageTool.toolKey,
+            name: pageTool.rawName,
+            origin: pageTool.origin,
+            fromSubframe: false,
+            registrationKind: "imperative",
+          } as never,
+        ],
+        chatEnabled: true,
+      });
+      const invoke = vi.fn(async () => ({
+        state: "succeeded",
+        output: "added",
+      }));
+      const initialStore = useWebmcpInspectorStore.getState();
+      vi.spyOn(useWebmcpInspectorStore, "getState").mockReturnValue({
+        ...initialStore,
+        session: { sessionId: pageTool.sessionId, status: "ready" } as never,
+        invokeToolForResult: invoke as never,
+      });
+
+      const rendered = await renderWithEngine(undefined, undefined, {
+        usePageTools: true,
+        requireToolApproval: sentWith,
+      });
+      // Sending the turn is what stamps the value; the body closure runs here.
+      const advertised = lastTransport().body.pageTools as Array<{
+        alias: string;
+      }>;
+      setAdvertisedPageTools(advertised as never);
+
+      // The user moves the switch while the response is still streaming.
+      act(() => rendered.result.current.setRequireToolApproval(flippedTo));
+
+      await mockState.chatOnToolCall!({
+        toolCall: {
+          toolName: advertised[0]!.alias,
+          toolCallId: `page-call-flip-${String(sentWith)}`,
+          input: { sku: "ABC-123" },
+        },
+      });
+
+      if (expectRun) {
+        await waitFor(() => expect(invoke).toHaveBeenCalled());
+      } else {
+        expect(invoke).not.toHaveBeenCalled();
+        expect(mockState.addToolOutput).not.toHaveBeenCalled();
+      }
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.local-engine.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.local-engine.test.tsx
@@ -170,14 +170,20 @@ type EnginePref = { engine: "local" | "cloud"; consentToken: string | null };
 async function renderWithEngine(
   personalComputerEngine?: EnginePref,
   hostedContext?: Record<string, unknown>,
-  extra?: { usePageTools?: boolean },
+  extra?: { usePageTools?: boolean; requireToolApproval?: boolean },
 ) {
+  // The switch is STATE seeded from `executionConfig`, not a prop of its own —
+  // so a case that needs it on has to seed it the way the app does.
+  const { requireToolApproval, ...rest } = extra ?? {};
   const rendered = renderHook(() =>
     useChatSession({
       selectedServers: ["server-1"],
       ...(personalComputerEngine ? { personalComputerEngine } : {}),
       ...(hostedContext ? { hostedContext } : {}),
-      ...(extra ?? {}),
+      ...(requireToolApproval !== undefined
+        ? { executionConfig: { requireToolApproval } }
+        : {}),
+      ...rest,
     } as never),
   );
   await waitFor(() => expect(mockState.chatOnData).not.toBeNull());
@@ -340,8 +346,12 @@ describe("useChatSession — local computer engine transmission", () => {
       invokeToolForResult: invoke as never,
     });
 
+    // Switch ON, which is what makes the server emit the pill this test waits
+    // for. With it off there is no pill coming and the call runs immediately
+    // — see the case below.
     const rendered = await renderWithEngine(undefined, undefined, {
       usePageTools: true,
+      requireToolApproval: true,
     });
     const advertised = lastTransport().body.pageTools as Array<{
       alias: string;
@@ -374,6 +384,69 @@ describe("useChatSession — local computer engine transmission", () => {
         output: expect.objectContaining({
           content: [{ type: "text", text: "added" }],
         }),
+      }),
+    );
+  });
+
+  it("runs a page call immediately when approval is off, instead of stalling", async () => {
+    // The client claims every owned `page_*` call so it can hold it until the
+    // user decides. With the switch off the server declares no approval and
+    // sends no pill, so a claim with nothing to release it waits forever: the
+    // model's call never resolves and the turn stops with no error and no
+    // result. It has to run the call itself.
+    const pageTool = {
+      alias: pageToolAlias("session-1", "https://shop.test::add_to_cart"),
+      sessionId: "session-1",
+      toolKey: "https://shop.test::add_to_cart",
+      rawName: "add_to_cart",
+      origin: "https://shop.test",
+    };
+    useWebmcpInspectorStore.setState({
+      session: { sessionId: pageTool.sessionId, status: "ready" } as never,
+      tools: [
+        {
+          toolKey: pageTool.toolKey,
+          name: pageTool.rawName,
+          origin: pageTool.origin,
+          fromSubframe: false,
+          registrationKind: "imperative",
+        } as never,
+      ],
+      chatEnabled: true,
+    });
+    const invoke = vi.fn(async () => ({ state: "succeeded", output: "added" }));
+    const initialStore = useWebmcpInspectorStore.getState();
+    vi.spyOn(useWebmcpInspectorStore, "getState").mockReturnValue({
+      ...initialStore,
+      session: { sessionId: pageTool.sessionId, status: "ready" } as never,
+      invokeToolForResult: invoke as never,
+    });
+
+    await renderWithEngine(undefined, undefined, {
+      usePageTools: true,
+      requireToolApproval: false,
+    });
+    const advertised = lastTransport().body.pageTools as Array<{
+      alias: string;
+    }>;
+    setAdvertisedPageTools(advertised as never);
+
+    await mockState.chatOnToolCall!({
+      toolCall: {
+        toolName: advertised[0]!.alias,
+        toolCallId: "page-call-ungated",
+        input: { sku: "ABC-123" },
+      },
+    });
+
+    // No pill was requested and none is coming, so the result has to arrive
+    // from here.
+    await waitFor(() => expect(mockState.addToolOutput).toHaveBeenCalled());
+    expect(invoke).toHaveBeenCalledWith(pageTool.toolKey, { sku: "ABC-123" });
+    expect(mockState.addToolOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool: advertised[0]!.alias,
+        toolCallId: "page-call-ungated",
       }),
     );
   });

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -1976,6 +1976,16 @@ export function useChatSession(
   );
   const requireToolApprovalRef = useRef(requireToolApproval);
   requireToolApprovalRef.current = requireToolApproval;
+  /**
+   * The approval value the IN-FLIGHT turn was sent with.
+   *
+   * Stamped once per send, in the transport's `body` closure, beside
+   * `turnTaskScopeRef`. Everything that has to agree with the SERVER's view of
+   * this turn reads this rather than the live setting: the server declared
+   * every tool's `needsApproval` from the value in that request, and a user is
+   * free to flip the switch while the response streams.
+   */
+  const turnRequireToolApprovalRef = useRef(requireToolApproval);
 
   // Host-level progressive tool discovery toggle. The value comes from the
   // caller — each useChatSession site knows which host config row applies
@@ -3027,6 +3037,14 @@ export function useChatSession(
         turnTaskScopeRef.current = shouldUseOrgAwareChatApi
           ? hostedProjectId ?? undefined
           : getTrackedTaskScope();
+        // And the approval value this turn is SENT with, for the same reason.
+        // The server declares each tool's `needsApproval` from the value in
+        // THIS request; a client that later read the live setting would answer
+        // a different question than the one the server answered. Flipping the
+        // switch mid-stream then either runs a page tool the server is about
+        // to request approval for, or defers one nothing will ever ask about
+        // — and that second one stalls the turn.
+        turnRequireToolApprovalRef.current = requireToolApprovalRef.current;
         const widgetModelContext = pendingWidgetModelContextRef.current;
         pendingWidgetModelContextRef.current = undefined;
         const rewind =
@@ -3333,10 +3351,12 @@ export function useChatSession(
         // waits for a decision nobody will make — the turn stalls on a tool
         // that was never gated in the first place.
         //
-        // The SAME predicate the server built the tool from, so the two cannot
-        // drift: a client that guessed differently either strands the turn or
-        // runs something the user was meant to see first.
-        if (!pageToolCallNeedsApproval(requireToolApprovalRef.current)) {
+        // The SAME predicate the server built the tool from, AND the same
+        // value: `turnRequireToolApprovalRef` is what this turn was sent with,
+        // not what the switch says now. A client that guessed differently
+        // either strands the turn or runs something the user was meant to see
+        // first, and flipping the switch mid-stream is enough to cause it.
+        if (!pageToolCallNeedsApproval(turnRequireToolApprovalRef.current)) {
           void fulfillApprovedPageToolCall({
             toolCallId: pageToolCallId,
             alias: toolName,

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -174,8 +174,10 @@ import {
 import {} from "@/state/oauth-orchestrator";
 import {
   deferPageToolCallForApproval,
+  fulfillApprovedPageToolCall,
   snapshotPageToolsForTurn,
 } from "@/lib/webmcp-inspector/chat-dispatch";
+import { pageToolCallNeedsApproval } from "@/shared/client-fulfilled-tools";
 import { createUiAwareApprovalResponseHandler } from "@/lib/webmcp/ui-tool-approval";
 import { respondToChatElicitation } from "@/lib/apis/elicitation-api";
 import {
@@ -3313,16 +3315,35 @@ export function useChatSession(
 
       // WebMCP page tools: the model asked for a tool a real web page
       // registered, and the browser session that owns that page lives in this
-      // app. Claim it synchronously and wait for the approval pill to fulfill
-      // it. AI SDK delivers tool-input-available before tool-approval-request,
-      // so invoking here would bypass the user's decision.
+      // app. Claim it synchronously — the AI SDK delivers
+      // tool-input-available before tool-approval-request, so a claim is the
+      // only way to hold the call until the user's decision arrives.
+      const pageToolCallId = (toolCall as { toolCallId: string }).toolCallId;
+      const pageToolInput = (toolCall as { input: unknown }).input;
       if (
         deferPageToolCallForApproval({
           toolName,
-          toolCallId: (toolCall as { toolCallId: string }).toolCallId,
-          input: (toolCall as { input: unknown }).input,
+          toolCallId: pageToolCallId,
+          input: pageToolInput,
         })
       ) {
+        // AND RUN IT, when nothing is going to ask. The server emits an
+        // approval request only when the tool it built declared one, so with
+        // the switch off there is no pill coming and a call left deferred
+        // waits for a decision nobody will make — the turn stalls on a tool
+        // that was never gated in the first place.
+        //
+        // The SAME predicate the server built the tool from, so the two cannot
+        // drift: a client that guessed differently either strands the turn or
+        // runs something the user was meant to see first.
+        if (!pageToolCallNeedsApproval(requireToolApprovalRef.current)) {
+          void fulfillApprovedPageToolCall({
+            toolCallId: pageToolCallId,
+            alias: toolName,
+            input: pageToolInput,
+            addToolOutput,
+          });
+        }
         return;
       }
 

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/agent-chat-instances.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/agent-chat-instances.test.ts
@@ -264,6 +264,10 @@ describe("agent-chat-instances", () => {
       const def = registerTool();
       const entry = getOrCreateAgentChat("s1");
       entry.config.requireToolApproval = true;
+      // SEND the turn. `onToolCall` only ever fires while a response is
+      // streaming, which is always after a POST — and the POST is what stamps
+      // the approval value this turn's tools were built from.
+      mockState.lastTransportOptions.body();
 
       await entry.chat.init.onToolCall({
         toolCall: {
@@ -277,6 +281,54 @@ describe("agent-chat-instances", () => {
       expect((entry.chat as any).addToolOutput).not.toHaveBeenCalled();
       // Deferral must also not hand off — nothing navigated yet.
       expect(useAgentPanelStore.getState().isOpen).toBe(false);
+    });
+
+    it("honours the turn's approval value when the switch flips mid-stream", async () => {
+      // The switch is a live control and the response is a stream. The server
+      // built this turn's `ui_*` tools with `needsApproval: true` and its pill
+      // is already on the way; the tool-input event arrives first. Reading the
+      // mutable config here would execute a destructive action — a computer
+      // deletion, a billed swarm launch — straight past that pill.
+      const def = registerTool();
+      const entry = getOrCreateAgentChat("s1");
+      entry.config.requireToolApproval = true;
+      mockState.lastTransportOptions.body();
+
+      // The user turns it off while the response streams.
+      entry.config.requireToolApproval = false;
+
+      await entry.chat.init.onToolCall({
+        toolCall: {
+          toolName: "ui_navigate",
+          toolCallId: "tc-flip-off",
+          input: { target: "servers" },
+        },
+      });
+
+      expect(def.execute).not.toHaveBeenCalled();
+      expect((entry.chat as any).addToolOutput).not.toHaveBeenCalled();
+    });
+
+    it("does not wait for a pill the turn never asked for", async () => {
+      // The other direction: sent with the switch off, so the server declared
+      // the tool ungated and emits nothing. Deferring on the newer value would
+      // wait for a decision nobody will be asked for.
+      const def = registerTool();
+      const entry = getOrCreateAgentChat("s1");
+      entry.config.requireToolApproval = false;
+      mockState.lastTransportOptions.body();
+
+      entry.config.requireToolApproval = true;
+
+      await entry.chat.init.onToolCall({
+        toolCall: {
+          toolName: "ui_navigate",
+          toolCallId: "tc-flip-on",
+          input: { target: "servers" },
+        },
+      });
+
+      expect(def.execute).toHaveBeenCalled();
     });
 
     it("handleToolApprovalResponse: approve executes + ships result; deny sends the response", async () => {

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
@@ -273,6 +273,23 @@ export function getOrCreateAgentChat(chatSessionId: string): AgentChatEntry {
     requireToolApproval: false,
   };
 
+  /**
+   * The approval value the IN-FLIGHT turn was sent with.
+   *
+   * `config.requireToolApproval` is mutable and the switch is a live control,
+   * so reading it in `onToolCall` answers a different question than the server
+   * answered: the server declared every tool's `needsApproval` from the value
+   * in THAT request. Flipping the switch off while the response streams would
+   * otherwise let `handleUiToolCall` run a destructive `ui_*` action — a
+   * computer deletion, a billed swarm launch — immediately, past the pill the
+   * server is already emitting, because the tool-input event arrives before
+   * the approval request.
+   *
+   * Stamped once per send, in the `body` closure below. Mirrors
+   * `turnRequireToolApprovalRef` in `use-chat-session`.
+   */
+  let turnRequireToolApproval = config.requireToolApproval;
+
   const chat: Chat<UIMessage> = new Chat<UIMessage>({
     id: chatSessionId,
     transport: new DefaultChatTransport({
@@ -293,7 +310,10 @@ export function getOrCreateAgentChat(chatSessionId: string): AgentChatEntry {
         model: config.model,
         projectId: config.projectId,
         chatSessionId,
-        requireToolApproval: config.requireToolApproval,
+        // Stamped here, where the turn is actually sent, so `onToolCall`
+        // decides with the value the SERVER built this turn's tools from.
+        requireToolApproval: (turnRequireToolApproval =
+          config.requireToolApproval),
         // WebMCP UI tools snapshot, drained fresh at POST time (same
         // contract as `useChatSession`). The server validates again in
         // `validateUiToolEntries`.
@@ -324,7 +344,8 @@ export function getOrCreateAgentChat(chatSessionId: string): AgentChatEntry {
         onNavigationToolCall: (toolName) => {
           maybeHandoffToPanel(config, toolName);
         },
-        requireToolApproval: config.requireToolApproval,
+        // The turn's value, not the live one — see `turnRequireToolApproval`.
+        requireToolApproval: turnRequireToolApproval,
         // Duplicate detection is per chat session — this instance's key.
         telemetryScope: chatSessionId,
       });

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.telemetry.test.ts
@@ -382,11 +382,14 @@ describe("ui-tool-executor outcome telemetry", () => {
       );
       const addToolOutput = vi.fn();
 
+      // The switch is what defers now, so this case has to turn it on to have
+      // a deferred call to re-emit at all.
       await handleUiToolCall({
         toolName: "ui_navigate",
         toolCallId: "tc-defer-re",
         input: { target: "servers" },
         addToolOutput,
+        requireToolApproval: true,
       });
       expect(eventCalls("ui_tool_call_started")).toHaveLength(1);
 
@@ -396,6 +399,7 @@ describe("ui-tool-executor outcome telemetry", () => {
         toolCallId: "tc-defer-re",
         input: { target: "servers" },
         addToolOutput,
+        requireToolApproval: true,
       });
       expect(claimed).toBe(true);
       expect(eventCalls("ui_tool_call_started")).toHaveLength(1);

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.test.ts
@@ -102,10 +102,11 @@ describe("handleUiToolCall", () => {
     ]);
   });
 
-  it("defers a DESTRUCTIVE tool even when requireToolApproval is off", async () => {
-    // The default mode. The client decides "defer" before the server's
-    // approval-request chunk arrives, so this must match the server's
-    // classification exactly or the turn strands.
+  it("defers a DESTRUCTIVE tool when the switch is ON", async () => {
+    // The client decides "defer" before the server's approval-request chunk
+    // arrives, so this must match the server's classification exactly or the
+    // turn strands. Both sides call the same `uiToolCallNeedsApproval`, which
+    // is what keeps them from drifting.
     const def = makeTool({
       name: "ui_execute_tool",
       readOnly: false,
@@ -119,7 +120,7 @@ describe("handleUiToolCall", () => {
       toolCallId: "tc-destructive",
       input: {},
       addToolOutput,
-      requireToolApproval: false,
+      requireToolApproval: true,
     });
 
     expect(handled).toBe(true);
@@ -128,6 +129,31 @@ describe("handleUiToolCall", () => {
     expect(listDeferredUiToolCalls()).toEqual([
       { toolCallId: "tc-destructive", toolName: "ui_execute_tool", input: {} },
     ]);
+  });
+
+  it("runs a DESTRUCTIVE tool without asking when the switch is OFF", async () => {
+    // The switch governs every family now. A client that kept deferring here
+    // would wait for an approval the server never requests, which strands the
+    // turn — the mirror image of the drift the test above guards.
+    const def = makeTool({
+      name: "ui_execute_tool",
+      readOnly: false,
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    });
+    useUiToolsRegistry.getState().registerUiTool(def);
+    const addToolOutput = vi.fn();
+
+    const handled = await handleUiToolCall({
+      toolName: "ui_execute_tool",
+      toolCallId: "tc-destructive-off",
+      input: {},
+      addToolOutput,
+      requireToolApproval: false,
+    });
+
+    expect(handled).toBe(true);
+    expect(def.execute).toHaveBeenCalled();
+    expect(listDeferredUiToolCalls()).toEqual([]);
   });
 
   it("executes an ADDITIVE tool immediately when requireToolApproval is off", async () => {

--- a/mcpjam-inspector/docs/webmcp-inspector.md
+++ b/mcpjam-inspector/docs/webmcp-inspector.md
@@ -624,12 +624,18 @@ names are arbitrary while a model-facing name must satisfy
 Manual invocation from the tab is **not** gated. A person clicking Invoke on a
 tool they can see, on a page they opened, has already made the decision.
 
-Every model-driven page call **is** gated, unconditionally — not via
-`requireToolApproval`. A page tool runs code on a third-party site, the only
-claims about what it does come from that site, and Chromium does not carry those
-claims through anyway. The sanctioned way to relax this later is an explicit,
-per-session "trust this page's read-only claims" choice, never a flag that
-quietly turns every page tool into an auto-run.
+Every model-driven page call follows **Tool Approval**, the host's one approval
+switch, exactly like an MCP server's tool or a browser verb. It used to gate
+unconditionally, on the reasoning that a page tool runs code on a third-party
+site and the only claims about what it does come from that site. That reasoning
+still holds and still decides one thing: the page's own annotations are **never**
+read, so nothing the site says can lower the gate. What it no longer decides is
+whether to overrule the person who set the switch — a family that answers "not
+you" teaches people the setting is decorative, which costs more than the pill
+was worth.
+
+So: switch on, every page call pauses; switch off, none do. The page never gets
+a vote either way.
 
 Page tools are a third client-fulfilled namespace beside `app_` and `ui_`.
 Adding the alias to `isClientFulfilledToolName` is what wires the server's pause

--- a/mcpjam-inspector/server/utils/__tests__/built-in-tools-registry.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/built-in-tools-registry.test.ts
@@ -219,9 +219,17 @@ describe("resolveHostTools — local engine actor coercion (structural)", () => 
   }
 
   it("honors local for a signed-in member's direct turn", () => {
+    // `bashTool` threads `requireToolApproval: false`, and local bash follows
+    // the switch like every other family now. What "local" still decides is
+    // WHICH machine the description names, which is the coercion under test.
     const bash = bashTool({});
-    expect(bash?.needsApproval).toBe(true);
+    expect(bash?.needsApproval).toBe(false);
     expect(bash?.description).toMatch(/user's own machine/);
+  });
+
+  it("gates local bash when the switch is on", () => {
+    const bash = bashTool({ requireToolApproval: true });
+    expect(bash?.needsApproval).toBe(true);
   });
 
   it("downgrades local for a scenario session", () => {
@@ -602,16 +610,26 @@ describe("resolveHostTools — browser", () => {
 
   it("hands back tools that carry their own approval declaration", () => {
     // Nothing is threaded back any more. The registry's whole job here is to
-    // pass the built tools through unchanged, declarations included — a
-    // caller that forgets a step cannot un-gate a browser tool.
+    // pass the built tools through unchanged, declarations included — and to
+    // hand the builder the host's switch, which is what the declaration is
+    // computed from. A registry that dropped it would silently un-gate every
+    // browser tool on a host that asked for approval.
     withFlag("1", () => {
-      const tools = resolveHostTools(
+      const gated = resolveHostTools(
         { builtInToolIds: ["browser"], computer },
-        browserCtx,
+        { ...browserCtx, requireToolApproval: true },
       );
       expect(
-        (tools?.browser_act as { needsApproval?: unknown })?.needsApproval,
+        (gated?.browser_act as { needsApproval?: unknown })?.needsApproval,
       ).toBe(true);
+
+      const free = resolveHostTools(
+        { builtInToolIds: ["browser"], computer },
+        { ...browserCtx, requireToolApproval: false },
+      );
+      expect(
+        (free?.browser_act as { needsApproval?: unknown })?.needsApproval,
+      ).toBe(false);
     });
   });
 

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -1491,7 +1491,7 @@ describe("prepareChatV2 — WebMCP UI tools", () => {
     ).toBeFalsy();
   });
 
-  it("promises a destructive gate in default mode ONLY when the snapshot is annotation-aware", () => {
+  it("describes the switch's actual state, and never promises a pause it cannot deliver", () => {
     const annotated: UiToolEntry[] = [
       {
         name: "ui_navigate",
@@ -1507,41 +1507,41 @@ describe("prepareChatV2 — WebMCP UI tools", () => {
       },
     ];
 
-    // The families that pause whatever the settings say are stated in every
-    // mode — they are the ones the model should know about before it commits
-    // to a plan, and none of them depends on the ui snapshot.
+    // NOTHING pauses whatever the settings say any more, so nothing may claim
+    // to. A model told a browser action will be checked by a human plans as if
+    // someone is reading along — the expensive direction of this mistake.
     for (const prompt of [
-      buildUiToolsSystemPrompt(annotated, { requireToolApproval: true }),
       buildUiToolsSystemPrompt(annotated),
       buildUiToolsSystemPrompt(uiTools),
+      buildUiToolsSystemPrompt(annotated, { requireToolApproval: false }),
     ]) {
-      expect(prompt).toContain("always pause");
+      expect(prompt).not.toContain("always pause");
+      expect(prompt).not.toContain("whatever the settings say");
+      expect(prompt).toContain("Tool approval is OFF");
+      expect(prompt).toContain("apply immediately");
+      // The families it names as running unchecked are the ones a model is
+      // most likely to assume are gated.
       expect(prompt).toContain("driving a browser");
       expect(prompt).toContain("on the user's own machine");
-      expect(prompt).toContain("A denial is final");
     }
 
-    // Strict mode: most other calls pause too, and the model is told which
-    // families the switch does NOT cover — promising it covers everything
-    // would have the model narrate a pause that never comes.
+    // Switch ON: every family that acts pauses, named so the model can plan
+    // around the checkpoint rather than guess at it.
     const strict = buildUiToolsSystemPrompt(annotated, {
       requireToolApproval: true,
     });
-    expect(strict).toContain("most other tool calls pause too");
-    expect(strict).toContain("still run without asking");
+    expect(strict).toContain("Tool approval is ON");
+    expect(strict).toContain("every tool call that ACTS pauses");
+    expect(strict).toContain("driving a browser");
+    expect(strict).toContain("A denial is final");
 
-    // Default mode, annotation-aware: the destructive-`ui_*` promise holds.
-    const annotatedDefault = buildUiToolsSystemPrompt(annotated);
-    expect(annotatedDefault).toContain("destructive `ui_*` actions");
-    expect(annotatedDefault).toContain("Everything else applies immediately");
-
-    // Default mode, LEGACY snapshot (the fixture has no annotations): a bare
-    // `readOnly` entry sits at the `setting` floor, so with the switch off
-    // NOTHING in that namespace pauses. The prompt must not promise a
-    // destructive gate that isn't enforced.
-    const legacyDefault = buildUiToolsSystemPrompt(uiTools);
-    expect(legacyDefault).not.toContain("destructive `ui_*` actions");
-    expect(legacyDefault).toContain("applies immediately");
+    // What never pauses is stated in BOTH modes: it does not change with the
+    // switch, and it is the half a model most often gets wrong.
+    for (const prompt of [strict, buildUiToolsSystemPrompt(annotated)]) {
+      expect(prompt).toContain("never pause");
+      expect(prompt).toContain("`app_*`");
+      expect(prompt).toContain("discovery meta-tools");
+    }
   });
 });
 

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -1542,6 +1542,18 @@ describe("prepareChatV2 — WebMCP UI tools", () => {
       expect(prompt).toContain("`app_*`");
       expect(prompt).toContain("discovery meta-tools");
     }
+
+    // And so is the ONE thing that still asks whatever the switch says. This
+    // is the opposite mistake and the worse one: a server-origin skill ref
+    // pauses in either setting, so an approval-off prompt that claimed nothing
+    // would stop the model has it plan straight past a real checkpoint.
+    for (const prompt of [strict, buildUiToolsSystemPrompt(annotated)]) {
+      expect(prompt).toContain("skill that a connected MCP server provides");
+      expect(prompt).toContain("always asks");
+    }
+    expect(buildUiToolsSystemPrompt(annotated)).not.toContain(
+      "Nothing will stop you",
+    );
   });
 });
 

--- a/mcpjam-inspector/server/utils/__tests__/computers-bash-tool.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-bash-tool.test.ts
@@ -235,7 +235,7 @@ describe(`${BASH_TOOL_NAME} tool`, () => {
     expect(result.error).toMatch(/local computer engine/i);
   });
 
-  it("approval: cloud honors the host policy; local is ALWAYS on", () => {
+  it("approval: both engines honor the host policy", () => {
     const cloudOff = buildBashTool(
       { ...toolOpts, engine: "e2b", requireToolApproval: false },
       vi.fn()
@@ -248,10 +248,16 @@ describe(`${BASH_TOOL_NAME} tool`, () => {
       { ...toolOpts, engine: "local", requireToolApproval: false },
       vi.fn()
     ) as any;
+    const localOn = buildBashTool(
+      { ...toolOpts, engine: "local", requireToolApproval: true },
+      vi.fn()
+    ) as any;
     expect(cloudOff.needsApproval).toBe(false);
     expect(cloudOn.needsApproval).toBe(true);
-    // v1: no auto-approve for a model-driven shell on the user's machine.
-    expect(localOff.needsApproval).toBe(true);
+    // Local used to ask unconditionally. It is the sharpest tool here and the
+    // weakest case for overruling the person whose machine it is.
+    expect(localOff.needsApproval).toBe(false);
+    expect(localOn.needsApproval).toBe(true);
   });
 
   it("surfaces reserve denials (e.g. non-member) as tool errors", async () => {

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -1973,6 +1973,11 @@ describe("mcpjam-stream-handler", () => {
       // that waits forever. There is nothing to thread now: the tool
       // `buildPageTools` produces carries the answer, and this drives the
       // engine with exactly that tool and nothing else.
+      //
+      // The switch is ON here so the built tool's answer is `true` and the
+      // pill below is a real assertion. What it pins is that the ENGINE reads
+      // the tool's own declaration — the OFF direction is pinned in the
+      // approval matrix, which drives every family through both settings.
       global.fetch = vi.fn().mockResolvedValue(
         createSseResponse([
           {
@@ -1998,11 +2003,11 @@ describe("mcpjam-stream-handler", () => {
             origin: "https://shop.test",
             description: "Check out",
           },
-        ] as never) as any,
+        ] as never, true) as any,
         mcpClientManager: {
           getAllToolsMetadata: vi.fn().mockReturnValue({}),
         } as any,
-        requireToolApproval: false,
+        requireToolApproval: true,
       });
 
       await lastExecution;

--- a/mcpjam-inspector/server/utils/__tests__/page-tools.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/page-tools.test.ts
@@ -101,14 +101,23 @@ describe("validatePageToolEntries", () => {
 });
 
 describe("buildPageTools", () => {
-  it("keys tools by alias and gates every one for approval", () => {
-    const tools = buildPageTools(validatePageToolEntries([entry()]));
-    expect(Object.keys(tools)).toEqual(["page_1a2b3c4d"]);
-    // Unconditional: a page tool runs code on a third-party site, and nothing
-    // the page says about it is evidence.
+  it("keys tools by alias and takes approval from the switch", () => {
+    const gated = buildPageTools(validatePageToolEntries([entry()]), true);
+    expect(Object.keys(gated)).toEqual(["page_1a2b3c4d"]);
+    // A page tool runs code on a third-party site and nothing the page says
+    // about it is evidence — which is why its annotations are never read. The
+    // user's switch is what decides, here as everywhere else.
     expect(
-      (tools.page_1a2b3c4d as { needsApproval?: boolean }).needsApproval,
+      (gated.page_1a2b3c4d as { needsApproval?: boolean }).needsApproval,
     ).toBe(true);
+
+    // ABSENT rather than `false`: `toNoExecuteAiSdkTool` spells a free tool by
+    // omission, so a no-execute turn built before floors existed stays
+    // byte-identical. The AI SDK reads the two the same way.
+    const free = buildPageTools(validatePageToolEntries([entry()]), false);
+    expect(
+      (free.page_1a2b3c4d as { needsApproval?: boolean }).needsApproval,
+    ).toBeUndefined();
   });
 
   it("has no execute, so the browser fulfills the call", () => {

--- a/mcpjam-inspector/server/utils/__tests__/tool-approval-matrix.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/tool-approval-matrix.test.ts
@@ -25,6 +25,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ToolSet } from "ai";
 import { hasUnresolvedToolCalls } from "@/shared/http-tool-calls";
+
+// The stream handler imports one function from the harness runner, and that
+// module loads `@ai-sdk/harness/agent` at import time. Nothing here runs a
+// harness turn, and without this the file that pins the WHOLE approval matrix
+// fails to LOAD wherever that optional package is not installed.
+vi.mock("../harness/run-harness-turn", () => ({
+  runHarnessTurn: vi.fn(),
+}));
+
 import {
   createApprovalDecisionCache,
   handleMCPJamFreeChatModel,
@@ -355,8 +364,8 @@ const MATRIX: MatrixRow[] = [
     },
   },
   {
-    // Floor: always — a model-driven shell on the user's own machine has no
-    // auto-approve in v1, "whatever the host config says" (bash.ts).
+    // Floor: setting. The sharpest tool here, and still the user's call — a
+    // switch some families ignore is a switch people stop believing.
     family: "local bash",
     name: "bash",
     input: { command: "ls" },
@@ -372,8 +381,8 @@ const MATRIX: MatrixRow[] = [
       ),
     }),
     expected: {
-      mcpjam: { on: "gate", off: "gate" },
-      byok: { on: "gate", off: "gate" },
+      mcpjam: { on: "gate", off: "free" },
+      byok: { on: "gate", off: "free" },
     },
   },
   {
@@ -411,7 +420,8 @@ const MATRIX: MatrixRow[] = [
     },
   },
   {
-    // Floor: always. Destructive wins over the switch in both directions.
+    // Floor: setting. `destructiveHint` still decides whether this entry is a
+    // READ or an ACTION; it no longer decides for the user.
     family: "ui_* destructive",
     name: UI_DESTRUCTIVE.name,
     tools: (flag) =>
@@ -419,8 +429,8 @@ const MATRIX: MatrixRow[] = [
         requireToolApproval: flag,
       }),
     expected: {
-      mcpjam: { on: "gate", off: "gate" },
-      byok: { on: "gate", off: "gate" },
+      mcpjam: { on: "gate", off: "free" },
+      byok: { on: "gate", off: "free" },
     },
   },
   {
@@ -450,40 +460,46 @@ const MATRIX: MatrixRow[] = [
     },
   },
   {
-    // Floor: always. Third-party code in a browser that is signed into things,
-    // and the page's own annotations are claims by the party whose code runs.
+    // Floor: setting. The page's annotations are still never read — they are
+    // claims by the party whose code runs — but the person who turned the
+    // switch off has said what they want from this host.
     family: "page_*",
     name: "page_ab12cd34",
-    tools: () =>
-      buildPageTools([
-        {
-          alias: "page_ab12cd34",
-          sessionId: "sess_1",
-          toolKey: "https://shop.test::checkout",
-          rawName: "checkout",
-          origin: "https://shop.test",
-          description: "Check out",
-        },
-      ] as never),
+    tools: (flag) =>
+      buildPageTools(
+        [
+          {
+            alias: "page_ab12cd34",
+            sessionId: "sess_1",
+            toolKey: "https://shop.test::checkout",
+            rawName: "checkout",
+            origin: "https://shop.test",
+            description: "Check out",
+          },
+        ] as never,
+        flag,
+      ),
     expected: {
-      mcpjam: { on: "gate", off: "gate" },
-      byok: { on: "gate", off: "gate" },
+      mcpjam: { on: "gate", off: "free" },
+      byok: { on: "gate", off: "free" },
     },
   },
   {
-    // Floor: always.
+    // Floor: setting. This is the one the bug report was about: "Tool
+    // Approval: off" and a pill on `browser_navigate` anyway.
     family: "browser_* attested",
     name: "browser_act",
-    tools: () =>
+    tools: (flag) =>
       buildBrowserTools({
         authHeader: "Bearer u",
         projectId: "proj_1",
         approvalDelivery: { kind: "attested" },
+        requireToolApproval: flag,
         ensureSession: fakeBrowserSession() as never,
       })!.tools,
     expected: {
-      mcpjam: { on: "gate", off: "gate" },
-      byok: { on: "gate", off: "gate" },
+      mcpjam: { on: "gate", off: "free" },
+      byok: { on: "gate", off: "free" },
     },
   },
   {
@@ -492,12 +508,16 @@ const MATRIX: MatrixRow[] = [
     // there is nobody to ask.
     family: "browser_* unattended read-only observation",
     name: "browser_observe",
-    tools: () =>
+    // THE FLAG IS THREADED AND STILL LOSES. An unattended run has nobody to
+    // ask, so a switch left on by whoever saved the host config must not turn
+    // every eval iteration into a hang.
+    tools: (flag) =>
       buildBrowserTools({
         authHeader: "Bearer u",
         projectId: "proj_1",
         engine: "local",
         runKey: "run-1",
+        requireToolApproval: flag,
         approvalDelivery: {
           kind: "unattended",
           policy: { mode: "read_only" },
@@ -510,20 +530,21 @@ const MATRIX: MatrixRow[] = [
     },
   },
   {
-    // Floor: always. Same rule as local bash, same reason.
+    // Floor: setting. Same rule as local bash, same reason.
     family: "browser_* local",
     name: "browser_act",
-    tools: () =>
+    tools: (flag) =>
       buildBrowserTools({
         authHeader: "Bearer u",
         projectId: "proj_1",
         engine: "local",
         approvalDelivery: { kind: "attested" },
+        requireToolApproval: flag,
         ensureSession: fakeBrowserSession() as never,
       })!.tools,
     expected: {
-      mcpjam: { on: "gate", off: "gate" },
-      byok: { on: "gate", off: "gate" },
+      mcpjam: { on: "gate", off: "free" },
+      byok: { on: "gate", off: "free" },
     },
   },
   {

--- a/mcpjam-inspector/server/utils/__tests__/tool-approval-matrix.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/tool-approval-matrix.test.ts
@@ -503,6 +503,33 @@ const MATRIX: MatrixRow[] = [
     },
   },
   {
+    // Floor: never, and the row that matters most for it. An unattended run
+    // uses the LOCAL engine, so a floor keyed on the engine rather than on the
+    // DELIVERY would put this back on the switch — and a host config with
+    // approval on would then hang every eval iteration on a pill nobody can
+    // click. `allow_all` so the interactive verbs are actually built: the
+    // read-only row below proves the policy filter, this one proves the floor.
+    family: "browser_* unattended (allow_all) — nobody to ask",
+    name: "browser_act",
+    tools: (flag) =>
+      buildBrowserTools({
+        authHeader: "Bearer u",
+        projectId: "proj_1",
+        engine: "local",
+        runKey: "run-1",
+        requireToolApproval: flag,
+        approvalDelivery: {
+          kind: "unattended",
+          policy: { mode: "allow_all" },
+        },
+        ensureSession: fakeBrowserSession() as never,
+      })!.tools,
+    expected: {
+      mcpjam: { on: "free", off: "free" },
+      byok: { on: "free", off: "free" },
+    },
+  },
+  {
     // Floor: never. An unattended read-only run builds ONLY the tools that
     // look — refusing to build the rest is stronger than gating them, since
     // there is nobody to ask.

--- a/mcpjam-inspector/server/utils/built-in-tools/__tests__/browser-tools.test.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/__tests__/browser-tools.test.ts
@@ -174,8 +174,19 @@ describe("buildBrowserTools — fail-closed advertisement", () => {
       "browser_webmcp_invoke",
       "browser_webmcp_tools",
     ]);
-    // Everything gates by default: a page is third-party code and the browser
-    // is signed into things, so there is nothing trustworthy to relax on.
+    // The switch decides, and this build did not set it. A page is still
+    // third-party code in a browser that may be signed into things — what
+    // changed is that the person, not this builder, says whether to pause.
+    for (const [name, definition] of Object.entries(result!.tools)) {
+      expect(
+        (definition as { needsApproval?: unknown }).needsApproval,
+        name,
+      ).toBe(false);
+    }
+  });
+
+  it("gates every verb when the switch is on", () => {
+    const { result } = build({ requireToolApproval: true });
     for (const [name, definition] of Object.entries(result!.tools)) {
       expect(
         (definition as { needsApproval?: unknown }).needsApproval,
@@ -226,14 +237,14 @@ describe("buildBrowserTools — unattended policy", () => {
     expect(Object.keys(result!.tools)).toHaveLength(
       FIRST_CLASS_TOOL_NAMES.length,
     );
-    // The `build` helper runs unattended cases on the LOCAL engine, where the
-    // floor is `always` whoever is watching — a browser on someone's own
-    // machine is not something a policy can wave through.
+    // An UNATTENDED run declares none of them, whatever the switch says:
+    // there is nobody to ask, so a gate here would hang the run rather than
+    // protect it, and the declared `toolPolicy` is the answer instead.
     for (const [name, definition] of Object.entries(result!.tools)) {
       expect(
         (definition as { needsApproval?: unknown }).needsApproval,
         name,
-      ).toBe(true);
+      ).toBe(false);
     }
   });
 
@@ -1644,13 +1655,26 @@ describe("buildBrowserTools — engines and profile mode", () => {
     expect(seen[1]).toMatchObject({ contextMode: "persistent" });
   });
 
-  it("always asks before acting on the user's own machine", async () => {
-    const { result } = build({ engine: "local" });
+  it("asks before acting on the user's own machine when the switch is on", async () => {
+    const { result } = build({ engine: "local", requireToolApproval: true });
     for (const name of Object.keys(result!.tools)) {
       expect(
         (result!.tools as any)[name].needsApproval,
         `${name} must ask on the local engine`,
       ).toBe(true);
+    }
+  });
+
+  it("honours the switch being OFF on the local engine too", async () => {
+    // The local browser used to ask unconditionally. It is the sharpest case
+    // for asking and the weakest case for overruling: the machine is theirs,
+    // and so is the setting.
+    const { result } = build({ engine: "local" });
+    for (const name of Object.keys(result!.tools)) {
+      expect(
+        (result!.tools as any)[name].needsApproval,
+        `${name} must follow the switch`,
+      ).toBe(false);
     }
   });
 
@@ -2169,6 +2193,7 @@ describe("buildBrowserTools — first-class page tools", () => {
         approvalDelivery: { kind: "attested" },
         ensureSession,
         pageTools: PAGE_TOOLS,
+        requireToolApproval: true,
       }),
     )!;
     expect(Object.keys(built.tools)).toContain("webmcp_add_topping");
@@ -2180,6 +2205,25 @@ describe("buildBrowserTools — first-class page tools", () => {
       (built.tools.webmcp_add_topping as { needsApproval?: unknown })
         .needsApproval,
     ).toBe(true);
+  });
+
+  it("FLAG ON: a page tool follows the switch like everything else", () => {
+    // It used to gate whatever the switch said. The page's own annotations are
+    // still never consulted — the switch is what answers now.
+    const { ensureSession } = fakeSession(async () => OK);
+    const built = withFlag("first_class", () =>
+      buildBrowserTools({
+        authHeader: "Bearer t",
+        projectId: "p1",
+        approvalDelivery: { kind: "attested" },
+        ensureSession,
+        pageTools: PAGE_TOOLS,
+      }),
+    )!;
+    expect(
+      (built.tools.webmcp_add_topping as { needsApproval?: unknown })
+        .needsApproval,
+    ).toBe(false);
   });
 
   it("retires the generic verbs only on an engine that can grow mid-turn", () => {
@@ -2569,7 +2613,10 @@ describe("buildBrowserTools — the mid-turn refresh", () => {
     return { state, seen, commands, send };
   }
 
-  function build(fake: ReturnType<typeof daemon>) {
+  function build(
+    fake: ReturnType<typeof daemon>,
+    requireToolApproval = false,
+  ) {
     const { ensureSession } = fakeSession(fake.send);
     return withFlagOn(() =>
       buildBrowserTools({
@@ -2578,6 +2625,7 @@ describe("buildBrowserTools — the mid-turn refresh", () => {
         approvalDelivery: { kind: "attested" },
         ensureSession,
         dynamicPageTools: true,
+        requireToolApproval,
         pageTools: {
           tools: [PAGE],
           bootId: "boot-1",
@@ -2839,7 +2887,9 @@ describe("buildBrowserTools — the mid-turn refresh", () => {
 
   it("advertises a tool the page registered with no model action in between", async () => {
     const fake = daemon({ revision: 5, hash: "h1", tools: [PAGE] });
-    const built = build(fake);
+    // Switch ON, so the gate below is a real assertion rather than the
+    // default answer.
+    const built = build(fake, true);
     // The page registers a second tool two seconds after load. Nothing the
     // model did caused it, so nothing but this refresh could ever see it.
     fake.state.revision = 6;
@@ -2850,9 +2900,9 @@ describe("buildBrowserTools — the mid-turn refresh", () => {
     expect(Object.keys(refresh?.add ?? {})).toEqual(
       expect.arrayContaining(["webmcp_remove_topping"]),
     );
-    // It arrives WITH its gate, on the tool object. A tool that appeared
-    // mid-turn without one would be free — which on this engine executes
-    // with no pill at all.
+    // It arrives WITH the same gate a turn-start tool would have carried. A
+    // tool that appeared mid-turn and skipped the turn's approval policy would
+    // execute with no pill on an engine where every sibling has one.
     expect(
       (refresh?.add?.webmcp_remove_topping as { needsApproval?: unknown })
         ?.needsApproval,

--- a/mcpjam-inspector/server/utils/built-in-tools/bash.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/bash.ts
@@ -125,12 +125,14 @@ export function buildBashTool(
           `Command timeout in seconds (default ${DEFAULT_COMMAND_TIMEOUT_S})`
         ),
     }),
-    // A root shell on a personal machine must honor the host's approval
-    // policy exactly like MCP/skill tools do. The LOCAL engine goes further:
-    // approval is ALWAYS on — a model-driven shell on the user's real machine
-    // has no auto-approve in v1, whatever the host config says.
+    // A root shell honors the host's approval policy exactly like MCP tools
+    // do, on both engines. The local engine used to go further and ask
+    // unconditionally — a model-driven shell on someone's real machine is the
+    // sharpest tool here — but a switch that some families ignore is a switch
+    // people stop believing, and the person who turned it off is the same
+    // person whose machine this is.
     needsApproval: needsApprovalFor(
-      isLocal ? "always" : "setting",
+      "setting",
       opts.requireToolApproval === true,
     ),
     execute: async (

--- a/mcpjam-inspector/server/utils/built-in-tools/browser.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/browser.ts
@@ -115,6 +115,16 @@ export interface BrowserToolsOptions {
   projectId: string;
   executionScope?: ExecutionScope;
   /**
+   * The host's Tool Approval switch.
+   *
+   * Threaded like `bash` threads it, and read for the same reason: this family
+   * follows the user's setting rather than overruling it. Absent counts as
+   * off, so a caller that never had a switch to thread gets the same answer it
+   * did before this option existed — and an UNATTENDED run ignores it either
+   * way, because its floor is `never` (nobody to ask).
+   */
+  requireToolApproval?: boolean;
+  /**
    * Where L3 tokens live BETWEEN requests, so an act that paused for approval
    * is still pinned when it resumes. Defaults to the process-wide one;
    * injected by tests, which otherwise inherit each other's tokens through it.
@@ -941,24 +951,33 @@ export function buildBrowserTools(
     return undefined;
   }
 
-  // Floors, one per shape of run. Local is forced to ask, exactly as `bash` is
-  // — the browser is driving a real, signed-in Chromium on someone's own
-  // machine, where the blast radius of an unreviewed click is their accounts
-  // rather than a disposable box. An attested (interactive) run has someone to
-  // ask, so it always does. What is left is an unattended run on a disposable
-  // box: nobody to ask, so the declared policy is the answer, and the
-  // interactive tools it might have freed were never built (see `names`).
+  // Floors, one per shape of run.
   //
-  // NOT the switch, on any branch: `requireToolApproval` cannot lower a floor,
-  // and there is no reading of this family where it should.
+  // A run with SOMEBODY TO ASK — an attested interactive turn, or the local
+  // engine driving a real signed-in Chromium on someone's own machine — asks
+  // when the user's switch says to. It used to ask unconditionally, and that
+  // made "Tool Approval: off" untrue for the most common thing anyone does
+  // here: opening a page. The blast radius argument was real, but it is an
+  // argument for what to DEFAULT to, not for overruling a person who has just
+  // told this host what they want.
+  //
+  // An UNATTENDED run on a disposable box keeps `never`, and that is not the
+  // switch being ignored — there is nobody to ask, so a gate would hang the
+  // run rather than protect it. The declared `toolPolicy` is the answer
+  // instead, and the interactive tools it might have freed were never built
+  // (see `names`).
   const interactiveFloor: ApprovalFloor =
-    delivery.kind === "attested" || engine === "local" ? "always" : "never";
+    delivery.kind === "attested" || engine === "local" ? "setting" : "never";
   // Observation is the one thing a read-only policy may free, and only there:
   // a policy cannot make clicking a button on a live logged-in page safe, but
   // it can say this run only looks.
   const observationFloor: ApprovalFloor = readOnly ? "never" : interactiveFloor;
-  const needsApproval = needsApprovalFor(interactiveFloor, false);
-  const observationNeedsApproval = needsApprovalFor(observationFloor, false);
+  const requireToolApproval = opts.requireToolApproval === true;
+  const needsApproval = needsApprovalFor(interactiveFloor, requireToolApproval);
+  const observationNeedsApproval = needsApprovalFor(
+    observationFloor,
+    requireToolApproval,
+  );
 
   /**
    * The tab the model is actually working in.

--- a/mcpjam-inspector/server/utils/built-in-tools/browser.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/browser.ts
@@ -961,13 +961,19 @@ export function buildBrowserTools(
   // argument for what to DEFAULT to, not for overruling a person who has just
   // told this host what they want.
   //
-  // An UNATTENDED run on a disposable box keeps `never`, and that is not the
-  // switch being ignored — there is nobody to ask, so a gate would hang the
-  // run rather than protect it. The declared `toolPolicy` is the answer
-  // instead, and the interactive tools it might have freed were never built
-  // (see `names`).
+  // An UNATTENDED run keeps `never`, and that is not the switch being ignored
+  // — there is nobody to ask, so a gate would hang the run rather than protect
+  // it. The declared `toolPolicy` is the answer instead, and the interactive
+  // tools it might have freed were never built (see `names`).
+  //
+  // ON DELIVERY ALONE, not on the engine. An unattended run uses the LOCAL
+  // engine (a throwaway Chromium keyed per run), so an `|| engine === "local"`
+  // here would put every unattended local run back on the switch — and a host
+  // config with approval on would then hang each eval iteration against a pill
+  // nobody can click. The engine says whose machine it is; only the delivery
+  // says whether anyone is there to ask.
   const interactiveFloor: ApprovalFloor =
-    delivery.kind === "attested" || engine === "local" ? "setting" : "never";
+    delivery.kind === "attested" ? "setting" : "never";
   // Observation is the one thing a read-only policy may free, and only there:
   // a policy cannot make clicking a button on a live logged-in page safe, but
   // it can say this run only looks.

--- a/mcpjam-inspector/server/utils/built-in-tools/page-tools.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/page-tools.ts
@@ -32,17 +32,18 @@
  *      off the tool object itself (`shared/tool-approval.ts`), and an absent
  *      declaration is FREE — so a `webmcp_*` tool built without one would run
  *      third-party code on a signed-in browser with no pill at all. The value
- *      is the browser capability's interactive floor for this turn: `always`
- *      wherever a person can be asked, and the declared policy where nobody
- *      can (an unattended run, gated at execute time by the tool policy).
- *      `mcpjam-stream-handler.test.ts` pins the ungated behaviour that makes
- *      the declaration mandatory.
+ *      is the browser capability's interactive floor for this turn: the user's
+ *      Tool Approval switch wherever a person can be asked, and the declared
+ *      policy where nobody can (an unattended run, gated at execute time by
+ *      the tool policy). `mcpjam-stream-handler.test.ts` pins the ungated
+ *      behaviour that makes the declaration mandatory.
  *
  *   2. PAGE ANNOTATIONS ARE NEVER READ. A page's `readOnly` is a claim by the
  *      party whose code would run, and Chromium does not carry annotations
  *      through for imperative registrations at all — so `readOnly: false` on
- *      one of those is the absence of a signal, not a claim. Everything gates.
- *      See `pageToolCallNeedsApproval`.
+ *      one of those is the absence of a signal, not a claim. The switch is the
+ *      only input; the page never gets a vote. See
+ *      `pageToolCallNeedsApproval`.
  */
 import { jsonSchema, tool, type ToolSet } from "ai";
 import { type BrowserUnattendedPolicy } from "@/shared/client-fulfilled-tools";

--- a/mcpjam-inspector/server/utils/built-in-tools/registry.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/registry.ts
@@ -762,6 +762,9 @@ export function resolveHostTools(
         authHeader,
         projectId: ctx.projectId,
         engine: isLocalBrowser ? "local" : "hosted",
+        // The host's switch, exactly as bash gets it. This family follows it
+        // rather than overruling it.
+        requireToolApproval: ctx.requireToolApproval,
         ...(ctx.executionScope ? { executionScope: ctx.executionScope } : {}),
         // The run's own identity, falling back to the chat session when a
         // surface has one — both name a single run, which is all the ephemeral

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -1162,43 +1162,31 @@ export function buildUiToolsSystemPrompt(
 /**
  * The approval sentence for the turn.
  *
- * States the FLOOR RULE once, for every family, rather than only for `ui_*`.
- * The model is choosing between a browser tool, a shell and a UI action in the
- * same breath; a sentence about one namespace leaves it guessing about the
- * others — including the ones that pause whatever the settings say, which are
- * exactly the ones worth knowing about before it commits to a plan.
+ * States the rule once, for every family, rather than only for `ui_*`. The
+ * model is choosing between a browser tool, a shell and a UI action in the same
+ * breath, and a sentence about one namespace leaves it guessing about the rest.
  *
- * Told honestly for the snapshot that was actually sent. The destructive-`ui_*`
- * half of the promise only holds when EVERY entry is annotation-aware: a legacy
- * client sends bare `readOnly`, whose floor with the switch off is `setting`,
- * i.e. nothing pauses. The families above it do not depend on the snapshot and
- * are stated either way.
+ * It used to name the families that paused WHATEVER the settings said. There
+ * are none now: one switch decides for every tool that acts, so the honest
+ * sentence is about this conversation's setting rather than about a floor the
+ * model cannot see. Describing a checkpoint the turn does not have is the worse
+ * failure of the two — a model that expects to be stopped plans as if someone
+ * is reading along.
  */
 function approvalGuidance(
-  uiTools: UiToolEntry[],
+  _uiTools: UiToolEntry[],
   requireToolApproval: boolean,
 ): string {
-  const annotationAware = uiTools.every((t) => t.annotations !== undefined);
-  // Only families that pause on EVERY path belong here. Loading a skill an
-  // MCP server provided does not: the live SEP-2640 wrapper delegates to the
-  // base skill tool (`hostWantsApproval`), so with the switch off it can load
-  // without a prompt — what it always does is TAG the origin and bind the
-  // digest, which is not a pause. Promising one here would advertise a gate
-  // the turn may not have.
-  const alwaysPause = [
-    "anything driving a browser or a third-party web page",
-    "anything running on the user's own machine",
-    ...(annotationAware ? ["destructive `ui_*` actions"] : []),
-  ];
-  const always =
-    "Some actions always pause for the user's explicit approval before they " +
-    `run, whatever the settings say: ${alwaysPause
-      .slice(0, -1)
-      .join(", ")}, and ${alwaysPause[alwaysPause.length - 1]}.`;
-  const rest = requireToolApproval
-    ? "Tool approval is ON for this conversation, so most other tool calls pause too. Read-only lookups of the user's own project, the discovery meta-tools and read-only `ui_*` actions still run without asking — they are not covered by the switch in either direction."
-    : "Everything else applies immediately, so be deliberate about mutating actions — describe what you're about to do when it isn't obviously what the user asked for.";
-  return `${always} ${rest} A denial is final — explain what you wanted to do instead of retrying the call.`;
+  // Named either way, because "what never pauses" does not change with the
+  // switch and is the half the model most often gets wrong: it is why a read
+  // it expected to be gated simply happened.
+  const free =
+    "Read-only lookups of the user's own project, the discovery meta-tools, " +
+    "read-only `ui_*` actions and an open app's own `app_*` tools never pause, " +
+    "in either setting.";
+  return requireToolApproval
+    ? `Tool approval is ON for this conversation: every tool call that ACTS pauses for the user's explicit approval before it runs — MCP server tools, anything driving a browser or a third-party web page, anything running on the user's own machine, and mutating \`ui_*\` actions. ${free} A denial is final — explain what you wanted to do instead of retrying the call.`
+    : `Tool approval is OFF for this conversation: tool calls apply immediately, including anything driving a browser or a third-party web page and anything running on the user's own machine. Nothing will stop you, so be deliberate about mutating actions — describe what you're about to do when it isn't obviously what the user asked for. ${free}`;
 }
 
 /**

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -1177,16 +1177,27 @@ function approvalGuidance(
   _uiTools: UiToolEntry[],
   requireToolApproval: boolean,
 ): string {
-  // Named either way, because "what never pauses" does not change with the
-  // switch and is the half the model most often gets wrong: it is why a read
-  // it expected to be gated simply happened.
+  // Named either way, because neither of these changes with the switch, and
+  // both are halves the model gets wrong in the expensive direction.
+  //
+  // `free` is why a read it expected to be gated simply happened. `alwaysAsks`
+  // is the opposite mistake and the worse one: loading a skill a connected MCP
+  // server provides pauses whatever this setting says (`effective-skill-tools`
+  // binds the digest and asks), so a model told "nothing will stop you" plans
+  // straight past a checkpoint that will stop it. Stated conditionally — "a
+  // skill a connected MCP server provides" — so a turn with no such skill is
+  // not promised a gate it will never meet.
   const free =
     "Read-only lookups of the user's own project, the discovery meta-tools, " +
     "read-only `ui_*` actions and an open app's own `app_*` tools never pause, " +
     "in either setting.";
+  const alwaysAsks =
+    "Loading a skill that a connected MCP server provides always asks for " +
+    "confirmation, in either setting — it brings that server's instructions " +
+    "into this conversation.";
   return requireToolApproval
-    ? `Tool approval is ON for this conversation: every tool call that ACTS pauses for the user's explicit approval before it runs — MCP server tools, anything driving a browser or a third-party web page, anything running on the user's own machine, and mutating \`ui_*\` actions. ${free} A denial is final — explain what you wanted to do instead of retrying the call.`
-    : `Tool approval is OFF for this conversation: tool calls apply immediately, including anything driving a browser or a third-party web page and anything running on the user's own machine. Nothing will stop you, so be deliberate about mutating actions — describe what you're about to do when it isn't obviously what the user asked for. ${free}`;
+    ? `Tool approval is ON for this conversation: every tool call that ACTS pauses for the user's explicit approval before it runs — MCP server tools, anything driving a browser or a third-party web page, anything running on the user's own machine, and mutating \`ui_*\` actions. ${free} ${alwaysAsks} A denial is final — explain what you wanted to do instead of retrying the call.`
+    : `Tool approval is OFF for this conversation: tool calls apply immediately, including anything driving a browser or a third-party web page and anything running on the user's own machine. Be deliberate about mutating actions — describe what you're about to do when it isn't obviously what the user asked for. ${free} ${alwaysAsks}`;
 }
 
 /**

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -1058,12 +1058,13 @@ export function validatePageToolEntries(input: unknown): PageToolEntry[] {
  * the approval handshake, so routing execution back through the server would
  * add a round trip and a second approval path for no gain.
  *
- * `needsApproval` is unconditional — see `pageToolCallNeedsApproval`. The
- * description carries the origin because a model choosing between tools should
- * be able to see whose page each one belongs to.
+ * `needsApproval` follows the user's switch — see `pageToolCallNeedsApproval`.
+ * The description carries the origin because a model choosing between tools
+ * should be able to see whose page each one belongs to.
  */
 export function buildPageTools(
   pageTools: PageToolEntry[] | undefined,
+  requireToolApproval = false,
 ): ToolSet {
   if (!pageTools || pageTools.length === 0) return {};
   const out: ToolSet = {};
@@ -1073,8 +1074,8 @@ export function buildPageTools(
         entry.description ?? entry.rawName
       }`,
       inputSchema: entry.inputSchema,
-      // Floor: always.
-      needsApproval: pageToolCallNeedsApproval(),
+      // Floor: the switch.
+      needsApproval: pageToolCallNeedsApproval(requireToolApproval),
     });
   }
   return out;
@@ -1579,7 +1580,10 @@ export async function prepareChatV2(
   // way, so `page_<8hex>` cannot collide with a server tool, a UI tool or an
   // app alias. A collision here would mean two sessions minted the same alias,
   // which is a bug rather than a conflict to resolve, so it throws below.
-  const pageToolEntries = buildPageTools(pageTools);
+  const pageToolEntries = buildPageTools(
+    pageTools,
+    requireToolApproval === true,
+  );
   // COPIED, because the page-tool policy below removes entries from it and the
   // caller's object is the resolver's own return value.
   const builtInToolEntries: ToolSet = { ...(builtInTools ?? {}) };

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -2521,10 +2521,10 @@ async function handlePendingApprovals(
   //     so a result for that sibling is written whether or not anyone approved
   //     anything.
   //
-  // The mixed step is now the ordinary case rather than a corner. A page tool
-  // always pauses while the `browser_*` verbs follow their own floor, so one
-  // "add pepperoni" emits a `webmcp_*` call and a `browser_observe` in a
-  // single step, approves one, and resumes into exactly this.
+  // A MIXED STEP IS ORDINARY, and does not need two families on two floors to
+  // happen: the model emits several calls in one assistant message all the
+  // time, an `app_*` or read-only `ui_*` among them never pauses, and one
+  // gated call is enough to park every sibling here.
   //
   // Idempotent by construction: the helper skips any call that already has a
   // result, so a second pass over the same history emits nothing.

--- a/mcpjam-inspector/shared/__tests__/client-fulfilled-tools.test.ts
+++ b/mcpjam-inspector/shared/__tests__/client-fulfilled-tools.test.ts
@@ -63,16 +63,24 @@ describe("client-fulfilled tool names", () => {
     const destructive = { readOnlyHint: false, destructiveHint: true };
     const readOnly = { readOnlyHint: true, destructiveHint: false };
 
-    it("gates destructive tools even when the flag is OFF", () => {
-      // The whole point of the annotation work: `requireToolApproval` is off
-      // by default, and a destructive action must still confirm.
+    it("leaves a destructive tool to the switch, in both directions", () => {
+      // `destructiveHint` decides whether this entry is a READ or an ACTION.
+      // It used to decide FOR the user as well, which made "Tool Approval:
+      // off" untrue.
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: false,
+          annotations: destructive,
+          requireToolApproval: true,
+        })
+      ).toBe(true);
       expect(
         uiToolCallNeedsApproval({
           readOnly: false,
           annotations: destructive,
           requireToolApproval: false,
         })
-      ).toBe(true);
+      ).toBe(false);
     });
 
     it("does not gate additive tools when the flag is OFF", () => {
@@ -109,38 +117,48 @@ describe("client-fulfilled tool names", () => {
       }
     });
 
-    it("treats an absent destructiveHint as destructive (protocol default)", () => {
-      // A tool added without annotating destructiveHint must fail SAFE.
-      expect(
-        uiToolCallNeedsApproval({
-          readOnly: false,
-          annotations: { readOnlyHint: false },
-          requireToolApproval: false,
-        })
-      ).toBe(true);
-      expect(
-        uiToolCallNeedsApproval({
-          readOnly: false,
-          annotations: {},
-          requireToolApproval: false,
-        })
-      ).toBe(true);
-    });
-
-    it("fails CLOSED on a contradictory read-only + destructive entry", () => {
-      // The validator rejects `readOnlyHint` disagreeing with `readOnly`, but
-      // nothing stops "read-only AND destructive". Resolving that in favor of
-      // "don't ask" is the one reading that can silently delete something, so
-      // destructive wins.
-      for (const requireToolApproval of [true, false]) {
+    it("treats an absent destructiveHint as an ACTION, not a read", () => {
+      // The protocol default still applies where it decides something: an
+      // unannotated entry is an action, so it follows the switch rather than
+      // joining the reads that never ask.
+      for (const annotations of [{ readOnlyHint: false }, {}]) {
         expect(
           uiToolCallNeedsApproval({
-            readOnly: true,
-            annotations: { readOnlyHint: true, destructiveHint: true },
-            requireToolApproval,
-          }),
+            readOnly: false,
+            annotations,
+            requireToolApproval: true,
+          })
         ).toBe(true);
+        expect(
+          uiToolCallNeedsApproval({
+            readOnly: false,
+            annotations,
+            requireToolApproval: false,
+          })
+        ).toBe(false);
       }
+    });
+
+    it("reads a contradictory read-only + destructive entry as an ACTION", () => {
+      // The validator rejects `readOnlyHint` disagreeing with `readOnly`, but
+      // nothing stops "read-only AND destructive". Resolving that in favor of
+      // "this is a read" is the one reading that can silently delete
+      // something, so destructive still wins the READ-or-ACTION question —
+      // and the switch then answers the only question left.
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: true,
+          annotations: { readOnlyHint: true, destructiveHint: true },
+          requireToolApproval: true,
+        }),
+      ).toBe(true);
+      expect(
+        uiToolCallNeedsApproval({
+          readOnly: true,
+          annotations: { readOnlyHint: true, destructiveHint: true },
+          requireToolApproval: false,
+        }),
+      ).toBe(false);
     });
 
     it("does not gate a read-only tool whose annotations omit readOnlyHint", () => {
@@ -202,13 +220,13 @@ describe("browser tool names", () => {
  * the one the entry alone decides, which is what a future setting will vary.
  */
 describe("uiToolApprovalFloor", () => {
-  it("reads destructive as `always` and read-only as `never`", () => {
+  it("reads destructive as `setting` and read-only as `never`", () => {
     expect(
       uiToolApprovalFloor({
         readOnly: false,
         annotations: { destructiveHint: true },
       }),
-    ).toBe("always");
+    ).toBe("setting");
     expect(
       uiToolApprovalFloor({
         readOnly: true,
@@ -229,15 +247,23 @@ describe("uiToolApprovalFloor", () => {
     expect(uiToolApprovalFloor({ readOnly: false })).toBe("setting");
   });
 
-  it("reads an ABSENT destructiveHint as `always` (protocol default)", () => {
+  it("reads an ABSENT destructiveHint as an action, not a read", () => {
+    // The protocol default is "assume destructive". That still keeps an
+    // unannotated entry out of the `never` bucket; it no longer promotes it
+    // above the user's switch.
     expect(uiToolApprovalFloor({ readOnly: false, annotations: {} })).toBe(
-      "always",
+      "setting",
     );
   });
 });
 
 describe("pageToolCallNeedsApproval", () => {
-  it("is `always`, and says so without consulting anything", () => {
-    expect(pageToolCallNeedsApproval()).toBe(true);
+  it("follows the user's switch, in both directions", () => {
+    // It was unconditional, and the page's annotations are still never read —
+    // they are claims by the party whose code would run. What the switch buys
+    // is that "off" means off: a family answering "not you" is a setting that
+    // does not work, which costs more trust than the pill bought safety.
+    expect(pageToolCallNeedsApproval(true)).toBe(true);
+    expect(pageToolCallNeedsApproval(false)).toBe(false);
   });
 });

--- a/mcpjam-inspector/shared/__tests__/page-tool-namespace.test.ts
+++ b/mcpjam-inspector/shared/__tests__/page-tool-namespace.test.ts
@@ -46,10 +46,11 @@ describe("page tool namespace", () => {
     expect(PAGE_TOOL_ALIAS_REGEX.source).toContain("page_");
   });
 
-  it("always requires approval for a model-driven call", () => {
-    // Not a flag, and not derived from annotations: page annotations are claims
-    // by the party whose code would run, and Chromium does not carry their
-    // values through for imperative registrations anyway.
-    expect(pageToolCallNeedsApproval()).toBe(true);
+  it("takes approval from the user's switch, never from the page", () => {
+    // Page annotations are claims by the party whose code would run, and
+    // Chromium does not carry their values through for imperative
+    // registrations anyway — so they are still not consulted. The switch is.
+    expect(pageToolCallNeedsApproval(true)).toBe(true);
+    expect(pageToolCallNeedsApproval(false)).toBe(false);
   });
 });

--- a/mcpjam-inspector/shared/client-fulfilled-tools.ts
+++ b/mcpjam-inspector/shared/client-fulfilled-tools.ts
@@ -70,33 +70,37 @@ export function isPageToolAlias(name: string): boolean {
   return PAGE_TOOL_ALIAS_REGEX.test(name);
 }
 
-/** Floor: always. The switch is not consulted, which is the point. */
-const PAGE_TOOL_APPROVAL_FLOOR: ApprovalFloor = "always";
+/** Floor: the user's switch, like every other tool that acts. */
+const PAGE_TOOL_APPROVAL_FLOOR: ApprovalFloor = "setting";
 
 /**
  * Whether a model-requested WebMCP page-tool call must pause for approval.
  *
- * ALWAYS, in V1, and not because of the `requireToolApproval` flag.
+ * THE USER'S SWITCH, like every other tool that acts.
  *
- * A page tool is code on a third-party site, invoked in a live browser that may
- * be signed into things. The only signal about what it does is the page's own
- * annotations, and those fail as a basis for policy twice over: they are claims
- * by the very party whose code would run, and Chromium 151 does not carry their
- * values through for imperative registrations at all — a tool registered
- * `readOnly: true` is reported as `false` (see `webmcp-cdp.spike.test.ts`). So
- * "the page says this is read-only" is not evidence, and there is nothing else
- * to go on.
+ * It used to be unconditional, and the reasoning was sound as far as it went: a
+ * page tool is code on a third-party site, invoked in a live browser that may
+ * be signed into things, and the only signal about what it does is the page's
+ * own annotations — claims by the very party whose code would run, which
+ * Chromium 151 does not even carry through for imperative registrations (a tool
+ * registered `readOnly: true` is reported as `false`; see
+ * `webmcp-cdp.spike.test.ts`). None of that changed.
+ *
+ * What changed is who decides. A person who turns Tool Approval off has said
+ * what they want from THIS host, and a family that answers "not you" is a
+ * setting that does not work — which is worse for trust than the pill was good
+ * for safety, because it teaches people the switch is decorative. The page's
+ * annotations are still not evidence and are still never read: the floor is the
+ * switch, not the page's word.
  *
  * A person clicking Invoke in the WebMCP tab is a different case entirely and
  * is not gated: they chose the tool, on a page they opened, and the click IS
  * the decision.
- *
- * The sanctioned way to relax this later is an explicit, per-session, opt-in
- * "trust this page's read-only claims" choice — not a flag that quietly turns
- * every page tool into an auto-run.
  */
-export function pageToolCallNeedsApproval(): boolean {
-  return needsApprovalFor(PAGE_TOOL_APPROVAL_FLOOR, false);
+export function pageToolCallNeedsApproval(
+  requireToolApproval: boolean,
+): boolean {
+  return needsApprovalFor(PAGE_TOOL_APPROVAL_FLOOR, requireToolApproval);
 }
 
 /**
@@ -181,15 +185,17 @@ export function uiToolApprovalFloor(opts: {
   // `readOnlyHint: true`. The validator rejects `readOnlyHint` disagreeing
   // with `readOnly`, but nothing stops "read-only AND destructive" — and
   // resolving that contradiction in favor of "don't ask" is the one reading
-  // that can silently delete something.
-  if (annotations.destructiveHint === true) return "always";
+  // that can silently delete something. It decides whether this entry is a
+  // READ (never asks) or an ACTION (the switch decides); it no longer
+  // overrides the switch, which is the user's to set.
+  if (annotations.destructiveHint === true) return "setting";
   // Read-only never gates. Honor BOTH signals: a partial annotation object
   // (e.g. `{destructiveHint: false}`) leaves `readOnlyHint` undefined, and
   // ignoring the legacy flag there would gate a snapshot for no reason.
   if (opts.readOnly || annotations.readOnlyHint === true) return "never";
   // Protocol default: absent destructiveHint means destructive, so an
-  // unannotated future tool asks in both modes rather than in neither.
-  return annotations.destructiveHint === false ? "setting" : "always";
+  // unannotated future tool is treated as an action rather than a read.
+  return "setting";
 }
 
 /**

--- a/mcpjam-inspector/shared/client-fulfilled-tools.ts
+++ b/mcpjam-inspector/shared/client-fulfilled-tools.ts
@@ -21,8 +21,10 @@
  * WebMCP-*shaped* but deliberately never exposed to browser-native agents
  * (`document.modelContext` / `navigator.modelContext`). Tools that ARE
  * browser-native WebMCP live under `page_` instead, and the two must not be
- * confused: `ui_` is first-party and curated, `page_` is third-party and
- * always gated. The prefixes are load bearing precisely because they are this
+ * confused: `ui_` is first-party and curated, `page_` is third-party — and
+ * never trusted to describe itself, whatever its annotations claim, though
+ * whether a call pauses is the user's Tool Approval switch to decide (see
+ * `pageToolCallNeedsApproval`). The prefixes are load bearing because they are this
  * narrow: they are the token the server's skip gate and pause predicate key
  * on, so a browser-fulfilled tool named anything else would either be executed
  * server-side or leave the stream waiting on a result nobody will send.

--- a/mcpjam-inspector/shared/tool-approval.ts
+++ b/mcpjam-inspector/shared/tool-approval.ts
@@ -5,14 +5,27 @@
  * module is where the value comes from. There is exactly one input besides the
  * tool's own nature: the host's `requireToolApproval` switch.
  *
- * THE SWITCH RAISES. It can never lower. That is the whole semantics, and it
- * is what makes the two facts a user needs to hold in their head small enough
- * to hold: some actions always ask, and the switch makes everything else ask
- * too. A family that must ask (a shell on your own machine, a click on a live
- * signed-in page, a third party's instructions entering the turn) asks whether
- * the switch is on or off. A family that never needs to (looking at something,
- * listing your own projects, the discovery meta-tools) never asks, because
- * pausing an observation buys no safety and costs a click.
+ * THE SWITCH DECIDES, for every tool the model calls to ACT. One setting, one
+ * answer, and a user who turns it off sees no approval pill — on an MCP
+ * server's tool, on a page's `webmcp_*` tool, on a browser verb, on a shell.
+ *
+ * It used to raise only. Several families sat at `always` and ignored it, so
+ * "Tool Approval: off" still paused on the most common thing anyone does with
+ * this product — open a page and click something. A switch that does not
+ * govern the tools a person actually watches is not a switch, and the rule
+ * "off means off" is worth more than a per-family judgement they cannot see.
+ *
+ * What is left at `never` is not a carve-out from that rule so much as the
+ * absence of anything to decide: looking at something, listing your own
+ * projects, the discovery meta-tools. Pausing an observation buys no safety
+ * and costs a click, and it is what the setting's own copy promises.
+ *
+ * `always` survives for a family that must ask whatever the switch says.
+ * Nothing sits there today as a FLOOR; the one thing that still asks
+ * unconditionally declares it as a function, because the answer depends on
+ * which value the model named — a third party's instructions entering the turn
+ * (`computers/effective-skill-tools.ts`), which is a trust boundary rather
+ * than a preference.
  *
  * WHY A FLOOR RATHER THAN A BOOLEAN AT EACH BUILDER. Before this, each builder
  * wrote its own expression — `isLocal ? true : opts.requireToolApproval ===
@@ -27,9 +40,10 @@
  * What a tool family needs from the user, before the switch is consulted.
  *
  *  - `never`   — asking buys nothing. Reads, observations, discovery.
- *  - `setting` — the ordinary case: the user's switch decides.
- *  - `always`  — asks whatever the switch says. Reserved for actions whose
- *                blast radius is outside anything the turn can undo.
+ *  - `setting` — every tool that acts: the user's switch decides.
+ *  - `always`  — asks whatever the switch says. See the header: no family
+ *                declares this as a floor today, and one that wants it should
+ *                have to argue why the user's own switch does not apply.
  */
 export type ApprovalFloor = "never" | "setting" | "always";
 


### PR DESCRIPTION
Tool Approval was off and `browser_navigate` still asked. So did page tools, local bash, and destructive `ui_*` entries. Five families sat at the `always` floor and ignored the setting.

This makes the switch the single authority for every tool the model calls to act.

## The floors that move

| Family | Was | Now |
|---|---|---|
| `page_*` and `webmcp_*` page tools | `always` | `setting` |
| `browser_*` attested / local | `always` | `setting` |
| local bash | `always` | `setting` |
| `ui_*` destructive | `always` | `setting` |
| `ui_*` unannotated (protocol default) | `always` | `setting` |

Each of those floors had a real argument behind it. A page tool runs a third party's code in a browser that may be signed into things, and its annotations are claims by the party whose code would run. Local bash is a model-driven shell on someone's own machine. Those are arguments about what to **default** to. None of them is an argument for overruling a person who has just told this host what they want, and a switch that some families ignore is a switch people stop believing — which costs more trust than any single pill bought in safety.

The page's annotations are still never consulted for page tools. What decides is the switch, not the page's word.

## What deliberately does not move

- **`never` stays `never`.** Reads, observations and the discovery meta-tools ask nothing, which is what the caption under the switch already promises. `destructiveHint` still decides whether a `ui_*` entry is a READ or an ACTION; it just no longer decides for the user.
- **Unattended runs keep `never` on the browser verbs.** Not the switch being ignored: there is nobody to ask, so a gate would hang an eval iteration rather than protect it, and the declared `toolPolicy` is the answer instead. The matrix now threads the flag through that row so this is pinned rather than assumed.
- **Server-origin skill refs still ask unconditionally.** A third party's instructions entering the turn, declared as a function because the answer depends on which skill the model named. That is a trust boundary rather than a preference, so I left it alone rather than quietly folding it in. **Say the word if you want it to follow the switch too** — it is one line.

## Plumbing

`buildBrowserTools` now takes `requireToolApproval` the way `bash` does, and the registry threads it. `pageToolCallNeedsApproval` and `buildPageTools` take it too, instead of hardcoding `false` into a helper whose whole job was to ignore the switch.

The client's `ui_*` executor needed no change: it already calls the shared `uiToolCallNeedsApproval`, which is what keeps its defer decision from drifting from the server's pill. Its tests moved, its code did not.

The caption under the switch said browser, page, local-machine and destructive UI actions always pause. It now says what is true.

## Verification

- Full `server` + `shared` run: **11122 pass**, 6 failures, all pre-existing environment ones (`@ai-sdk/harness` is declared in `package.json` but absent from a plain install here, and an `@ai-sdk/anthropic` provider-tool version drift). None involve a file in this diff.
- Client: 1460 pass across the `webmcp` and `chat-v2` suites. `npm run typecheck:client` clean.
- The approval matrix drives every family through **both** settings, so each row in the table above is pinned in both directions rather than asserted once.
- Also mocked the harness runner in the matrix suite. It imports the stream handler, which loads `@ai-sdk/harness/agent`, so the file that pins the whole matrix failed to **load** wherever that optional package is not installed — the one test you would most want to run before merging this.

## Reviewer's attention

The security posture genuinely loosens by default, because the default is off. If you would rather ship this with the switch defaulting **on**, that is a separate one-line change to the setting's default and I would not object to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes who must confirm before browser, shell, page, and destructive UI actions run when approval is off (default), with broad server/client coordination; mistakes could auto-run sensitive tools or hang turns on approval mismatch.
> 
> **Overview**
> **Tool Approval** becomes the single gate for every acting tool: when the switch is off, families that used to pause anyway (page/`webmcp_*`, attested/local **browser_***, local **bash**, destructive/unannotated **ui_***) now honor `requireToolApproval` instead of sitting on an `always` floor. Read-only/discovery paths stay `never`; unattended browser runs still never ask; MCP server skill loads still always ask.
> 
> Server builders thread the flag (`buildPageTools`, `buildBrowserTools` + registry, bash floor → `setting`) and model guidance/`approvalGuidance` text is rewritten so prompts match ON vs OFF rather than promising invisible “always pause” rules. Shared helpers (`pageToolCallNeedsApproval`, `uiToolApprovalFloor` for destructive) and `tool-approval.ts` semantics shift from “switch raises only” to “switch decides for actions.”
> 
> On the client, each send stamps **`turnRequireToolApproval`** (chat session + agent instances) so mid-stream toggles cannot bypass pills or stall ungated page calls; deferred **`page_*`** calls call **`fulfillApprovedPageToolCall`** when approval is off. The composer caption under the switch is updated to match.
> 
> Tests/docs/matrix rows are expanded for both switch positions and mid-turn flips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cda92db935f59a8d81f9b6de4609edff1a4c6f58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Tool Approval switch the single authority for every tool the model calls to act, so off means off. Page tools, browser verbs, local bash, and destructive or unannotated `ui_*` entries used to ask even with the switch off; they now follow it, which loosens the security posture because the switch defaults off.

**What deliberately does not move**
- Read-only lookups and discovery meta-tools keep `never` and never ask.
- Unattended browser runs keep `never` — nobody is there to ask, so the declared `toolPolicy` is the answer. The floor is keyed on delivery alone, so an approval-on host config cannot hang an eval on a pill nobody can click.
- Server-origin skill refs still ask unconditionally, as a trust boundary rather than a preference, and the guidance names that checkpoint in both modes.

**Plumbing and verification**
- `buildBrowserTools`, `buildPageTools`, and `pageToolCallNeedsApproval` now take `requireToolApproval`, threaded through the registry.
- The client runs ungated page calls itself, using the same predicate as the server, so a claim is never left waiting for a pill that won't come.
- The approval value is stamped once per turn send and read from that stamp on both client paths — the page-tool branch and the MCPJam Agent's `ui_*` handler — so flipping the switch mid-stream can neither strand a call nor bypass a pill.
- The model-facing guidance, switch caption, and security docs now describe the actual setting and contract instead of promising pauses the turn won't have.
- The approval matrix drives every family through both settings.

<sup>Written for commit cda92db935f59a8d81f9b6de4609edff1a4c6f58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

