### PR TITLE
Bump next to 15.5.25 to close the SSRF in soundcheck

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8114,15 +8114,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
-      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
+      "version": "15.5.25",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.25.tgz",
+      "integrity": "sha512-42h1lLr07vl4gawALP1hsgRZjHB1xYa58JfUfHwr0f7jG/zhPakh5GHkADHXOC9ZxUvlQFOPIrp7s6qX4DezPQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.15.tgz",
-      "integrity": "sha512-ExQoBfyKMjAUQ2nuF39ryQsG26H374ZfH13dlOZqf6TaE9ycRbIm+qUbUFCliU4BtQhiqtS7cnGA1yWfPMQ+jA==",
+      "version": "15.5.25",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.25.tgz",
+      "integrity": "sha512-dAzOqZQCAOgIq5yQpsuMBZcwxK0AtzGqHMQpxNWYLQlvf79rsP3SDwdGPNQC4ySaMSihOQXMO/VXubQ3JWW+3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8160,9 +8160,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
-      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
+      "version": "15.5.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.25.tgz",
+      "integrity": "sha512-w+RR0v/QuApnWEjRGm1z6gcObKwGMb5YPA7V3bzBEVSBpMFUXprer0tS27UxjUcEnqbhL7Zuzohej79B6rYmBg==",
       "cpu": [
         "arm64"
       ],
@@ -8176,9 +8176,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
-      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
+      "version": "15.5.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.25.tgz",
+      "integrity": "sha512-QiGGBUSakt8S1H4Lt9Ehsh6Ja87axiBnQQgysOObvCbI7iUfJnRGntF1P64S4/ijuHFnSB8KLsEddkY3nN26uw==",
       "cpu": [
         "x64"
       ],
@@ -8192,11 +8192,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
-      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
+      "version": "15.5.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.25.tgz",
+      "integrity": "sha512-ehLos/66zo0d/mJCU5u96a/VDcr01aaUrX0o/i16UdInxz8qPTCDSxGtjk/Lps1sIr1RJFdiX3hxc0fxJo+cPA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -8208,11 +8211,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
-      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
+      "version": "15.5.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.25.tgz",
+      "integrity": "sha512-ZVMrqLiJ7DiChgmbkQwFtdhAnUkSH/4p7tB29QY+giATb0Q/XGHNRSKAb/B8XGDHRUaA67NepOW5W8u3ZRJBAA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8224,11 +8230,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
-      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
+      "version": "15.5.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.25.tgz",
+      "integrity": "sha512-UOewtDGkTMJTiODrEdeLZ50yGb59xCZSriNpXkfPMxRRgwDkGc7i8mLWqV5076wEdb+Ca/XN7MhJyM3CupyNyQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -8240,11 +8249,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
-      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
+      "version": "15.5.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.25.tgz",
+      "integrity": "sha512-UBHwA8AhkCZgtRfU1aJpunuAJe/6gZv6jDESQe4p5MjTb5V0YEeJBWCdNqx15Vj3x+5jmauRfeMJSjfQj9HGFQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8256,9 +8268,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
-      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
+      "version": "15.5.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.25.tgz",
+      "integrity": "sha512-QcFcPRr16djk5IqK5+e8O80eZfgWzIvVBXfitIq0tQ/uc+eyfdoZ0NmKc0cnbIJyfVwREapKuG97YcxWA9gcpA==",
       "cpu": [
         "arm64"
       ],
@@ -8272,9 +8284,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
-      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
+      "version": "15.5.25",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.25.tgz",
+      "integrity": "sha512-zREeykps3ndWr9egJgvJKqVkkDuaw6Zrrg23cYBos0ygydFkAWYU4+PaPVwXzP1eAYQJe53ShSK45iDM529BOg==",
       "cpu": [
         "x64"
       ],
@@ -21899,13 +21911,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.15.tgz",
-      "integrity": "sha512-mI5KIONOIosjF3jK2z9a8fY2LePNeW5C4lRJ+XZoJHAKkwx2MQjMPQ2/kL7tsMRPcQPZc/UBtCfqxElluL1CBg==",
+      "version": "15.5.25",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.25.tgz",
+      "integrity": "sha512-hB1oClZzRO3vMAeMmBMch0FHNJ4irH74LvQWDEMHkJtG/Us9+SAsg1f5Pvcw9jz4tc8wSGnvbmF050BRAAIbBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.5.15",
+        "@next/eslint-plugin-next": "15.5.25",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -29997,12 +30009,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
-      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
+      "version": "15.5.25",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.25.tgz",
+      "integrity": "sha512-OMWNulIIqKM2ykvC2qMjIt0IoavB4UB2SCs4iXJ6z6847FvyH8jBmBWcvrF5iuhTu8Przh20Fo/aoszIdqx4PA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.15",
+        "@next/env": "15.5.25",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -30015,15 +30027,15 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.15",
-        "@next/swc-darwin-x64": "15.5.15",
-        "@next/swc-linux-arm64-gnu": "15.5.15",
-        "@next/swc-linux-arm64-musl": "15.5.15",
-        "@next/swc-linux-x64-gnu": "15.5.15",
-        "@next/swc-linux-x64-musl": "15.5.15",
-        "@next/swc-win32-arm64-msvc": "15.5.15",
-        "@next/swc-win32-x64-msvc": "15.5.15",
-        "sharp": "^0.34.3"
+        "@next/swc-darwin-arm64": "15.5.25",
+        "@next/swc-darwin-x64": "15.5.25",
+        "@next/swc-linux-arm64-gnu": "15.5.25",
+        "@next/swc-linux-arm64-musl": "15.5.25",
+        "@next/swc-linux-x64-gnu": "15.5.25",
+        "@next/swc-linux-x64-musl": "15.5.25",
+        "@next/swc-win32-arm64-msvc": "15.5.25",
+        "@next/swc-win32-x64-msvc": "15.5.25",
+        "sharp": "^0.34.3 || ^0.35.4"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -39821,7 +39833,7 @@
       "dependencies": {
         "@mcpjam/design-system": "*",
         "@workos-inc/authkit-nextjs": "^0.14.0",
-        "next": "^15.5.9",
+        "next": "^15.5.25",
         "react": "19.1.0",
         "react-dom": "19.1.0"
       },
@@ -39831,7 +39843,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^8.57.0",
-        "eslint-config-next": "^15.5.9",
+        "eslint-config-next": "^15.5.25",
         "postcss": "^8.4.38",
         "tailwindcss": "^4.1.11",
         "tw-animate-css": "^1.3.5",

--- a/soundcheck/package.json
+++ b/soundcheck/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@mcpjam/design-system": "*",
     "@workos-inc/authkit-nextjs": "^0.14.0",
-    "next": "^15.5.9",
+    "next": "^15.5.25",
     "react": "19.1.0",
     "react-dom": "19.1.0"
   },
@@ -23,7 +23,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^8.57.0",
-    "eslint-config-next": "^15.5.9",
+    "eslint-config-next": "^15.5.25",
     "postcss": "^8.4.38",
     "tailwindcss": "^4.1.11",
     "tw-animate-css": "^1.3.5",


### PR DESCRIPTION
## The vulnerability

**CVE-2026-44578** / [GHSA-c4j6-fc7j-m34r](https://github.com/advisories/GHSA-c4j6-fc7j-m34r) — server-side request forgery in applications using WebSocket upgrades. CWE-918, CVSS 3.1 **8.6**. Affected range `>=13.4.13 <15.5.16`.

Oneleet has had this past its SLA since **2026-07-14** (alerting since 2026-07-07). It is the **only unresolved finding in the tenant rated `riskLevel: CRITICAL`** — every other one of the 501 open findings is LOW or INFO. Monitor `3fa94307-caae-4af9-b233-17b56d51c008` ("Dependency scanning findings are resolved") rolls up to `vulnerabilitiesRemediated_v1`, SOC 2 CC6.8 / CC7.3.

## Where the package came from

`next` is a **direct dependency of the `soundcheck` workspace** — not transitive, and not an example.

```
mcpjam-workspace
└─┬ @mcpjam/soundcheck@0.0.0 -> .\soundcheck
  ├─┬ @workos-inc/authkit-nextjs@0.14.0
  │ ├─┬ @workos-inc/node@7.82.0
  │ │ └─┬ iron-session@6.3.1
  │ │   └── next@15.5.25 deduped
  │ └── next@15.5.25 deduped
  └── next@15.5.25
```

`soundcheck` is MCPJam's internal deployment dashboard. It is **not** published to npm and **not** bundled into `@mcpjam/inspector`, but it is deployed as its own Railway service at `soundcheck.mcpjam.com` — `output: "standalone"`, served by `next start`. So this is a live, network-reachable Next.js server, not an unshipped example. `next` is reachable only through `soundcheck`, so no other workspace's dependency tree changes.

## Version before and after

| | Before | After |
|---|---|---|
| `soundcheck` manifest range | `^15.5.9` | `^15.5.25` |
| Resolved `next` | 15.5.15 | 15.5.25 |
| `eslint-config-next` | `^15.5.9` → 15.5.15 | `^15.5.25` → 15.5.25 |

The manifest **floor** moves rather than only the lockfile, so a fresh install cannot resolve back onto an affected version. `eslint-config-next` moves with it because Next keeps the two in lockstep. Both stay on the 15.5.x backport line — patch-level, no major upgrade, no API surface change.

### Why 15.5.25 and not 15.5.16

15.5.16 is the minimum that closes this CVE. But `npm audit` reports **23 advisories** against 15.5.15, including two **CRITICAL unauthenticated RCEs** fixed in 15.5.24:

- Unauthenticated Remote Code Execution on windows-hosted servers
- Unauthenticated Remote Code Execution in the Image Optimization API when AVIF files are used

15.5.25 is the head of the 15.5.x line and closes all 23 in the same in-range bump.

## How this was verified

**`next` no longer resolves to an affected version**

```
$ npm ls next
mcpjam-workspace@ D:\orca\worktrees\soc2-deps-critical-next
└─┬ @mcpjam/soundcheck@0.0.0 -> .\soundcheck
  ├─┬ @workos-inc/authkit-nextjs@0.14.0
  │ ├─┬ @workos-inc/node@7.82.0
  │ │ └─┬ iron-session@6.3.1
  │ │   └── next@15.5.25 deduped
  │ └── next@15.5.25 deduped
  └── next@15.5.25
```

**Advisory count went to zero for `next`**

| | Before | After |
|---|---|---|
| `npm audit` critical total | 1 | **0** |
| advisories against `next` | 23 | 0 (only `via postcss`, a pin inside `next` itself) |

All **21** `next` findings Oneleet currently has open are a subset of those 23 advisories, so this bump closes all 21 — not just the breaching one. Verified by cross-referencing the GHSA IDs from `SoftwarePackageVulnerabilityList` against the pre-bump `npm audit` set; zero Oneleet GHSAs fell outside it.

**Build and typecheck**

```
$ npm run typecheck -w @mcpjam/soundcheck
> tsc --noEmit
EXIT=0

$ npm run build -w @mcpjam/soundcheck
   ▲ Next.js 15.5.25
 ✓ Compiled successfully in 8.7s
 ✓ Generating static pages (4/4)
EXIT=0
```

(The build needs `WORKOS_*` set. Railway supplies these on the service; locally it fails on `NoApiKeyProvidedException` before and after the bump alike.)

**Lockfile diff is scoped**

Regenerated via `npm install --package-lock-only --legacy-peer-deps` — not hand-edited. The diff against `main` is exactly 12 entries: `next`, `eslint-config-next`, and the ten `@next/*` platform binaries. Zero entries added, zero removed, zero dependency-flag changes. `npm ci --dry-run --legacy-peer-deps` resolves all 2425 packages and exits 0.

## Preflight

Rebased onto `main` at `31a383a9` (previously based on `8330b092`, 22 commits back). The branch is now a single commit on top of `main` and merges as a fast-forward.

Verification on the rebased tree:

| Check | Result |
|---|---|
| `npm ci --dry-run --legacy-peer-deps` | exit 0, 2425 packages |
| Lockfile delta vs `main` | 12 entries, all `next`-family |
| Entries added / removed | 0 / 0 |
| Peer ranges (`authkit-nextjs`, `iron-session`) | satisfied by 15.5.25 |

Full typecheck/build/test gates were not re-run locally after the rebase; CI covers them. The previous run’s evidence predated the rebase and no longer described the merge result.

## Test suite

Non-Windows-bound workspaces are green: `@mcpjam/vitest`, `@mcpjam/design-system`, `@mcpjam/chat-ui`, `@mcpjam/widget-react`, `@mcpjam/slack-app` (195 pass / 0 fail), `@mcpjam/surface-core` (96 pass / 0 fail). Repo guard checks (`test:checks`) pass.

Remaining local failures in `sdk`, `cli`, `discord-app`, and `inspector` are Windows-environment-bound and **reproduce on clean `main`** — verified by running the same suites in a separate worktree at `origin/main` (8330b09). The baseline actually fails harder than this branch (sdk 3 failed files vs 1; cli 148 failures vs 6), which shows how load-sensitive they are. The failure modes are `EBUSY` on temp-dir teardown after the assertion already passed, `chmod`/POSIX-mode assertions that cannot hold on Windows, and `cancelledByParent` event-loop flakes. None touch `next`, which is not in any of those workspaces' trees.

## Not done here

Marking the Oneleet finding resolved. Nothing in Oneleet was modified — the monitor should flip on its own once the dependency scan reruns against merged `main`. Formal closure evidence (deploy date, environment, approver) is the CTO's to record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `next` in `soundcheck` from 15.5.15 to 15.5.25, closing the critical SSRF (CVE-2026-44578) and 22 other advisories.

- The manifest floor moves to `^15.5.25`, so fresh installs cannot resolve back to affected versions.
- `eslint-config-next` bumps in lockstep.
- Two unauthenticated RCEs fixed in 15.5.24 are covered by this bump.
- This is the only critical-risk finding in the Oneleet tenant; no other workspace is affected.
- Lockfile regeneration also picks up dev/devOptional/peer flag churn on 95 untouched entries; that's pre-existing drift, not from this bump.

<sup>Written for commit 63794ea06a0151d33e5f1347677fcae83cf9d812. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

