### PR TITLE
Put local browser activity in the playground Logs list

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/logger-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/logger-view.test.tsx
@@ -28,6 +28,29 @@ vi.mock("@/stores/traffic-log-store", async () => {
   };
 });
 
+const browserActivityState = vi.hoisted(() => ({
+  entries: [] as Array<{
+    kind: "command";
+    seq: number;
+    commandId: string;
+    ts: number;
+    durationMs: number;
+    source: string;
+    actor: { kind: string; id: string };
+    command: { kind: string };
+    outcome: "executed";
+    ok: boolean;
+  }>,
+  warning: null as string | null,
+}));
+
+vi.mock("@/components/browser/useLocalBrowserActivity", () => ({
+  useLocalBrowserActivity: () => ({
+    entries: browserActivityState.entries,
+    warning: browserActivityState.warning,
+  }),
+}));
+
 // Real dropdown menu is a Radix popover; swap it for plain markup so the
 // source-filter radio items are directly clickable in jsdom.
 vi.mock("@mcpjam/design-system/dropdown-menu", () => ({
@@ -78,6 +101,8 @@ import { subscribeToOAuthDebuggerRequests } from "@/lib/oauth/oauth-debugger-nav
 describe("LoggerView hosted rpc logs", () => {
   beforeEach(() => {
     useTrafficLogStore.getState().clear();
+    browserActivityState.entries = [];
+    browserActivityState.warning = null;
   });
 
   it("renders hosted server names and filters by server name prop", () => {
@@ -517,5 +542,74 @@ describe("LoggerView truncated payloads", () => {
     await expandRow("notifications/initialized");
 
     expect(screen.queryByText(/Payload not recorded/)).not.toBeInTheDocument();
+  });
+});
+
+describe("LoggerView browser activity", () => {
+  beforeEach(() => {
+    useTrafficLogStore.getState().clear();
+    browserActivityState.entries = [];
+    browserActivityState.warning = null;
+  });
+
+  it("keeps MCP traffic and browser commands in one list", () => {
+    useTrafficLogStore.getState().addMcpServerLog({
+      serverId: "srv-1",
+      serverName: "Notion",
+      direction: "SEND",
+      method: "tools/list",
+      timestamp: "2026-04-10T12:00:00.000Z",
+      payload: { jsonrpc: "2.0", id: 1, method: "tools/list" },
+    });
+    browserActivityState.entries = [
+      {
+        kind: "command",
+        seq: 1,
+        commandId: "c1",
+        ts: Date.parse("2026-04-10T12:00:02.000Z"),
+        durationMs: 12,
+        source: "agent",
+        actor: { kind: "agent", id: "cli" },
+        command: { kind: "reload" },
+        outcome: "executed",
+        ok: true,
+      },
+    ];
+
+    render(
+      <LoggerView
+        browserActivity={{
+          projectId: "proj-1",
+          consentToken: "tok",
+          active: true,
+        }}
+      />,
+    );
+
+    expect(screen.getAllByPlaceholderText("Search logs")).toHaveLength(1);
+    expect(screen.getByText("tools/list")).toBeInTheDocument();
+    expect(screen.getByText("reload")).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitemradio", { name: "Browser" }),
+    ).toBeInTheDocument();
+  });
+
+  it("uses one empty state when the browser source is attached", () => {
+    render(
+      <LoggerView
+        browserActivity={{
+          projectId: "proj-1",
+          consentToken: "tok",
+          active: true,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("No logs yet")).toBeInTheDocument();
+    expect(
+      screen.getByText(/MCP traffic and browser commands show up here/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Nothing has driven/)).not.toBeInTheDocument();
+    expect(screen.getAllByPlaceholderText("Search logs")).toHaveLength(1);
   });
 });

--- a/mcpjam-inspector/client/src/components/browser/BrowserActivityList.tsx
+++ b/mcpjam-inspector/client/src/components/browser/BrowserActivityList.tsx
@@ -1,59 +1,21 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { AlertTriangle, HelpCircle, ShieldOff } from "lucide-react";
 import { cn } from "@/lib/utils";
-import {
-  listLocalBrowserSessions,
-  readLocalBrowserTrace,
-  type LocalBrowserTraceEntry,
-  type LocalBrowserTraceRow,
+import { copyToClipboard } from "@/lib/clipboard";
+import { toast } from "@/lib/toast";
+import { LogRow } from "@/components/ui/log-row";
+import { LogToolbar } from "@/components/ui/log-toolbar";
+import { useLocalBrowserActivity } from "@/components/browser/useLocalBrowserActivity";
+import type {
+  LocalBrowserTraceEntry,
+  LocalBrowserTraceRow,
 } from "@/lib/local-browser/client";
 
 /**
- * What the rail has been missing: what the browser was ASKED to do.
- *
- * "The panel PERSISTS NOTHING" was true of the Browser tab until now — frames,
- * a tab strip and a take-control bar, with no record of what the agent or the
- * model did to produce them. A person watching a browser drive itself can see
- * the picture move and cannot see who moved it, which is the difference
- * between watching and understanding.
- *
- * It reads the SESSION LEDGER rather than keeping its own list, which is what
- * makes it survive a reload — and what makes a command the model issued show
- * up here too, since every source writes the same rows through the same daemon
- * handler.
- *
- * POLLED, not streamed. The frames socket carries pixels and would have to grow
- * a second record kind to carry these; polling with the last `seq` seen is one
- * small request per tick, costs nothing while nothing is happening, and cannot
- * lag a slow client out of a broadcast the way the frame stream can.
+ * Browser commands as log rows. The playground Logs tab feeds these into
+ * `LoggerView` so MCP traffic and the ledger share one search; this component
+ * is the isolated list used by tests of the ledger itself.
  */
-const POLL_INTERVAL_MS = 2_000;
-/**
- * How many quiet ticks before the pane asks which session it should be reading.
- *
- * It resolves a session once and then follows it, which is right while that
- * session is the live one and wrong the moment it ends: a closed session's
- * trace still reads perfectly, so an agent that closed one and opened another
- * left the pane showing a history that had stopped moving, with nothing on
- * screen to say it was watching the wrong browser. Asking again is one small
- * request, and only when nothing is arriving — a session that is producing
- * rows is self-evidently the one to read.
- */
-const REDISCOVER_AFTER_QUIET_TICKS = 15;
-/**
- * The session this pane may follow: an OPEN, PERSISTENT one.
- *
- * The frames above this list come from the project's persistent browser, so
- * that is the browser a reader is watching. Taking the newest open session of
- * any profile let a throwaway agent run steal the list — the history on screen
- * then belonged to a browser nobody could see, and the model's and the
- * person's own commands vanished from the rail.
- */
-const watchable = (session: { closedAt?: number; profile?: string }) =>
-  !session.closedAt && session.profile !== "ephemeral";
-/** How many rows the pane keeps. Older ones stay in the trace on disk. */
-const MAX_ROWS = 200;
-
 export function BrowserActivityList({
   projectId,
   consentToken,
@@ -66,270 +28,120 @@ export function BrowserActivityList({
   active: boolean;
   className?: string;
 }) {
-  const [entries, setEntries] = useState<LocalBrowserTraceEntry[]>([]);
-  /**
-   * The session being read, WITH the project it belongs to.
-   *
-   * Stored as one value rather than two pieces of state so a stale pairing is
-   * impossible by construction: holding a bare `sessionId` meant a project
-   * switch left the previous project's session in place for at least one poll,
-   * which asked the new project for the old project's history. Two fields that
-   * must agree are two fields that eventually will not.
-   */
-  const [reading, setReading] = useState<
-    { projectId: string; sessionId: string } | null
-  >(null);
-  const sessionId = reading?.projectId === projectId ? reading.sessionId : null;
-  const [warning, setWarning] = useState<string | null>(null);
-  const cursor = useRef(0);
-  /**
-   * One poll at a time, and only the current generation's answer is applied.
-   *
-   * A slow trace request that overlaps the next tick would otherwise have both
-   * polls read the same cursor and append the same rows, so one click appears
-   * in the list twice — the same duplication the server-side mirror lock
-   * prevents, arriving from the other end.
-   */
-  const inFlight = useRef(false);
-  const generation = useRef(0);
-  /** Consecutive polls that brought nothing. @see REDISCOVER_AFTER_QUIET_TICKS */
-  const quietTicks = useRef(0);
-  const listRef = useRef<HTMLDivElement | null>(null);
-  // Whether the reader is at the bottom. A list that auto-scrolled while
-  // somebody was reading three rows up would be a list they cannot read.
-  const pinned = useRef(true);
+  const { entries, warning } = useLocalBrowserActivity({
+    projectId,
+    consentToken,
+    active,
+  });
+  const [searchQuery, setSearchQuery] = useState("");
 
-  /**
-   * Start a fresh list whenever the thing being read changes.
-   *
-   * Keyed on the pair, so it covers both a project switch and an agent opening
-   * a new session in the same project. The FIRST resolution — null to a
-   * session — is deliberately not a reset: that is this pane learning what it
-   * was already reading, and resetting there would wipe the page the same poll
-   * had just appended while leaving the cursor past it.
-   */
-  const readingKey = sessionId ? `${projectId}:${sessionId}` : null;
-  const lastKey = useRef<string | null>(null);
-  useEffect(() => {
-    const previous = lastKey.current;
-    lastKey.current = readingKey;
-    if (previous === null || previous === readingKey) return;
-    // An in-flight poll belongs to what we just left, so its answer is already
-    // discarded by the generation check; releasing the latch lets the new one
-    // start at once rather than waiting out a worthless request.
-    generation.current += 1;
-    inFlight.current = false;
-    cursor.current = 0;
-    quietTicks.current = 0;
-    setEntries([]);
-    setWarning(null);
-  }, [readingKey]);
-
-  const poll = useCallback(async () => {
-    if (!projectId || inFlight.current) return;
-    inFlight.current = true;
-    const mine = generation.current;
-    try {
-      let currentSession = sessionId;
-      // A session that has gone quiet may have ended. Ask before assuming it is
-      // simply idle; switching resets the list through `readingKey`.
-      //
-      // ONLY WHEN THIS ONE HAS CLOSED, though — not merely because a newer one
-      // exists. A project can have a person's persistent session and several
-      // ephemeral runs open at once, so "switch to the newest" handed the pane
-      // to whichever run started last and wiped the history somebody was
-      // reading, for a session that had never closed.
-      if (currentSession && quietTicks.current >= REDISCOVER_AFTER_QUIET_TICKS) {
-        quietTicks.current = 0;
-        const sessions = await listLocalBrowserSessions(projectId, consentToken)
-          .then((r) => r.sessions)
-          .catch(() => null);
-        if (generation.current !== mine) return;
-        const mineStillOpen = sessions?.some(
-          (s) => s.sessionId === currentSession && !s.closedAt,
-        );
-        // A lookup that failed says nothing about whether this session closed,
-        // so it is not a reason to leave it.
-        if (sessions && !mineStillOpen) {
-          const next = sessions.find(watchable)?.sessionId ?? null;
-          if (next) {
-            setReading({ projectId, sessionId: next });
-            return;
-          }
-        }
-      }
-      if (!currentSession) {
-        let lookupFailed = false;
-        const found = await listLocalBrowserSessions(projectId, consentToken)
-          .then((r) => r.sessions.find(watchable)?.sessionId ?? null)
-          .catch(() => {
-            // A failure to LOOK is not an absence of history, and a pane that
-            // showed "nothing has driven this browser" either way would be
-            // telling a reader something it does not know.
-            lookupFailed = true;
-            return null;
-          });
-        // Applied only if we are still the current reader — this is the same
-        // late answer the rows below are dropped for, and a warning is no more
-        // this pane's to show for a project it has left than a row is.
-        if (generation.current !== mine) return;
-        if (!found) {
-          // A LOOK THAT SUCCEEDED AND FOUND NOTHING CLEARS THE WARNING. Only
-          // setting it on failure left "history unavailable" on screen for as
-          // long as the project had no open session, long after the lookup had
-          // started working again.
-          setWarning(
-            lookupFailed
-              ? "this session's history could not be read just now; retrying"
-              : null,
-          );
-          return;
-        }
-        currentSession = found;
-        setReading({ projectId, sessionId: found });
-      }
-      const page = await readLocalBrowserTrace(
-        {
-          projectId,
-          sessionId: currentSession,
-          afterSeq: cursor.current,
-          limit: 100,
-        },
-        consentToken,
-      ).catch(() => null);
-      // A late answer from a session or project we have since left is dropped:
-      // applying it would file one project's rows under another's name.
-      if (generation.current !== mine) return;
-      if (!page) {
-        setWarning("this session's history could not be read just now; retrying");
-        return;
-      }
-      // Never silent: a hole in the history is the pane's to report, not
-      // something a reader should have to notice for themselves.
-      setWarning(page.historyWarning ?? null);
-      if (page.entries.length === 0) {
-        quietTicks.current += 1;
-        return;
-      }
-      quietTicks.current = 0;
-      cursor.current = Math.max(
-        cursor.current,
-        ...page.entries.map((entry) => entry.seq),
-      );
-      setEntries((previous) => [...previous, ...page.entries].slice(-MAX_ROWS));
-    } finally {
-      // ONLY THIS GENERATION'S LATCH. A poll left over from a project we have
-      // since switched away from would otherwise clear the latch that the
-      // CURRENT poll is holding, and the next tick would start a second poll
-      // beside it — both reading the same cursor and appending the same rows,
-      // which is precisely the duplication this latch exists to prevent.
-      if (generation.current === mine) inFlight.current = false;
-    }
-  }, [projectId, sessionId, consentToken]);
-
-  useEffect(() => {
-    if (!active || !projectId) return;
-    let cancelled = false;
-    const tick = () => {
-      if (cancelled) return;
-      void poll();
-    };
-    tick();
-    const timer = window.setInterval(tick, POLL_INTERVAL_MS);
-    return () => {
-      cancelled = true;
-      window.clearInterval(timer);
-    };
-  }, [active, projectId, poll]);
-
-  useEffect(() => {
-    if (!pinned.current) return;
-    const node = listRef.current;
-    if (node) node.scrollTop = node.scrollHeight;
-  }, [entries]);
-
-  const onScroll = useCallback(() => {
-    const node = listRef.current;
-    if (!node) return;
-    // A small slack so a rounding difference does not unpin a list that is, to
-    // a reader, plainly at the bottom.
-    pinned.current =
-      node.scrollHeight - node.scrollTop - node.clientHeight < 24;
-  }, []);
-
-  const body = useMemo(() => {
-    if (entries.length === 0) {
-      return (
-        <p className="px-3 py-2 text-xs text-muted-foreground">
-          Nothing has driven this browser yet.
-        </p>
-      );
-    }
-    return entries.map((entry) =>
-      entry.kind === "gap" ? (
-        <GapRow key={`gap-${entry.seq}`} entry={entry} />
-      ) : (
-        <CommandRow key={`row-${entry.seq}`} row={entry} />
-      ),
+  const newestFirst = useMemo(() => [...entries].reverse(), [entries]);
+  const filtered = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return newestFirst;
+    return newestFirst.filter((entry) =>
+      entryHaystack(entry).includes(query),
     );
-  }, [entries]);
+  }, [entries, newestFirst, searchQuery]);
+
+  const copyLogs = useCallback(async () => {
+    const copied = await copyToClipboard(JSON.stringify(filtered, null, 2));
+    if (copied) toast.success("Logs copied to clipboard");
+    else toast.error("Could not copy logs to your clipboard");
+  }, [filtered]);
 
   return (
-    <div className={cn("flex min-h-0 flex-col", className)}>
-      <div className="flex shrink-0 items-center justify-between border-b px-3 py-1.5">
-        <span className="text-xs font-medium text-foreground">Activity</span>
-        {warning ? (
-          <span
-            className="flex items-center gap-1 text-[11px] text-destructive"
-            title={warning}
-          >
-            <AlertTriangle className="h-3 w-3" />
-            {warning.includes("could not be read")
-              ? "history unavailable"
-              : "history incomplete"}
-          </span>
-        ) : null}
-      </div>
+    <div className={cn("flex h-full min-h-0 flex-col", className)}>
+      <LogToolbar
+        searchQuery={searchQuery}
+        onSearchQueryChange={setSearchQuery}
+        filteredCount={filtered.length}
+        totalCount={entries.length}
+        onCopy={entries.length > 0 ? copyLogs : undefined}
+        copyDisabled={filtered.length === 0}
+        leading={
+          warning ? (
+            <span
+              className="flex items-center gap-1 text-[11px] text-destructive"
+              title={warning}
+            >
+              <AlertTriangle className="h-3 w-3" />
+              {warning.includes("could not be read")
+                ? "history unavailable"
+                : "history incomplete"}
+            </span>
+          ) : null
+        }
+      />
       <div
-        ref={listRef}
-        onScroll={onScroll}
         data-testid="rail-browser-activity"
         className="min-h-0 flex-1 overflow-y-auto"
       >
-        {body}
+        {filtered.length === 0 ? (
+          <div className="py-8 text-center">
+            <div className="text-xs text-muted-foreground">
+              {entries.length === 0
+                ? "Nothing has driven this browser yet."
+                : "No matches in this view"}
+            </div>
+            <div className="mt-1 text-[10px] text-muted-foreground">
+              {entries.length === 0
+                ? "Commands the agent, the model, or you issue show up here."
+                : "Try a different search term"}
+            </div>
+          </div>
+        ) : (
+          filtered.map((entry) =>
+            entry.kind === "gap" ? (
+              <GapRow key={`gap-${entry.seq}`} entry={entry} />
+            ) : (
+              <CommandRow key={`row-${entry.seq}`} row={entry} />
+            ),
+          )
+        )}
       </div>
     </div>
   );
 }
 
 /**
- * One command.
+ * One command, as a log row.
  *
  * The three outcomes are shown as three different things rather than as a
  * colour on one thing: `refused` means nothing ran, `unknown` means we cannot
  * say, and a reader who cannot tell those apart cannot tell whether to retry.
  */
-function CommandRow({ row }: { row: LocalBrowserTraceRow }) {
+export function CommandRow({ row }: { row: LocalBrowserTraceRow }) {
+  const [open, setOpen] = useState(false);
   const failed = row.outcome === "executed" && row.ok === false;
+  const isError = row.outcome === "refused" || row.outcome === "unknown" || failed;
+  const summary = summarizeCommand(row);
   return (
-    <div className="border-b px-3 py-1.5 text-xs last:border-b-0">
-      <div className="flex items-baseline gap-2">
-        <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
-          {row.seq}
-        </span>
-        <span className="min-w-0 flex-1 truncate font-medium text-foreground">
-          {describe(row)}
-        </span>
-        <Outcome row={row} failed={failed} />
-      </div>
-      <div className="mt-0.5 flex items-baseline gap-2 text-[11px] text-muted-foreground">
-        <span className="shrink-0" title={row.actor.label ?? undefined}>
-          {actorLabel(row)}
-        </span>
-        {row.url ? <span className="min-w-0 truncate">{row.url}</span> : null}
-        <span className="ml-auto shrink-0 tabular-nums">{row.durationMs}ms</span>
-      </div>
-    </div>
+    <LogRow
+      expanded={open}
+      onToggle={() => setOpen((value) => !value)}
+      isError={isError}
+      borderClass={isError ? "border-l-destructive" : "border-l-transparent"}
+      badge={<KindBadge label={summary.badge} tone={summary.tone} />}
+      title={summary.detail}
+      titleTooltip={summary.detail}
+      meta={
+        <>
+          <span
+            className="shrink-0 text-[11px] text-muted-foreground"
+            title={row.actor.label ?? undefined}
+          >
+            {actorLabel(row)}
+          </span>
+          <Outcome row={row} failed={failed} />
+        </>
+      }
+      timestamp={timeOf(row.ts)}
+    >
+      <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-words rounded border bg-muted/40 p-2 text-[11px]">
+        {JSON.stringify(row, null, 2)}
+      </pre>
+    </LogRow>
   );
 }
 
@@ -379,23 +191,103 @@ function Outcome({
 }
 
 /** A stretch of history that is missing, said out loud. */
-function GapRow({
+export function GapRow({
   entry,
 }: {
   entry: Extract<LocalBrowserTraceEntry, { kind: "gap" }>;
 }) {
+  const [open, setOpen] = useState(false);
+  const detail = gapMessage(entry);
   return (
-    <div className="flex items-center gap-2 border-b bg-muted/40 px-3 py-1 text-[11px] text-muted-foreground last:border-b-0">
-      <AlertTriangle className="h-3 w-3 shrink-0" />
-      <span>
-        {entry.reason === "daemon_restart"
-          ? "the browser restarted here"
-          : entry.reason === "ring_overflow"
-            ? `${entry.toSeq - entry.fromSeq + 1} earlier commands are no longer kept`
-            : "some history could not be recorded"}
-      </span>
-    </div>
+    <LogRow
+      expanded={open}
+      onToggle={() => setOpen((value) => !value)}
+      borderClass="border-l-transparent"
+      badge={<KindBadge label="gap" tone="warn" />}
+      title={detail}
+      titleTooltip={detail}
+      timestamp={timeOf(entry.ts)}
+    >
+      <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-words rounded border bg-muted/40 p-2 text-[11px]">
+        {JSON.stringify(entry, null, 2)}
+      </pre>
+    </LogRow>
   );
+}
+
+function gapMessage(
+  entry: Extract<LocalBrowserTraceEntry, { kind: "gap" }>,
+): string {
+  if (entry.reason === "daemon_restart") return "the browser restarted here";
+  if (entry.reason === "ring_overflow") {
+    return `${entry.toSeq - entry.fromSeq + 1} earlier commands are no longer kept`;
+  }
+  return "some history could not be recorded";
+}
+
+function timeOf(ts: number): string {
+  return new Date(ts).toLocaleTimeString();
+}
+
+function KindBadge({
+  label,
+  tone,
+}: {
+  label: string;
+  tone?: "error" | "warn" | "call" | "res" | "nav";
+}) {
+  return (
+    <span
+      className={cn(
+        "flex-shrink-0 font-mono text-[10px] leading-none",
+        tone === "error" && "text-destructive",
+        tone === "warn" && "text-amber-600 dark:text-amber-400",
+        tone === "call" && "text-green-600 dark:text-green-400",
+        tone === "res" && "text-blue-600 dark:text-blue-400",
+        tone === "nav" && "text-blue-600 dark:text-blue-400",
+        !tone && "text-muted-foreground",
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function summarizeCommand(row: LocalBrowserTraceRow): {
+  badge: string;
+  detail: string;
+  tone?: "error" | "warn" | "call" | "res" | "nav";
+} {
+  const detail = describe(row);
+  const kind = row.command.kind;
+  if (kind === "navigate" || kind === "back" || kind === "reload") {
+    return { badge: "nav", detail, tone: "nav" };
+  }
+  if (kind === "observe") return { badge: "obs", detail, tone: "res" };
+  if (kind === "note") return { badge: "note", detail };
+  if (kind === "webmcp_invoke") return { badge: "call", detail, tone: "call" };
+  if (kind === "webmcp_cancel") return { badge: "call", detail };
+  if (kind === "act") {
+    return { badge: row.command.verb ?? "act", detail, tone: "call" };
+  }
+  return { badge: kind, detail };
+}
+
+function entryHaystack(entry: LocalBrowserTraceEntry): string {
+  if (entry.kind === "gap") {
+    return [gapMessage(entry), entry.reason, String(entry.seq)].join(" ").toLowerCase();
+  }
+  return [
+    describe(entry),
+    actorLabel(entry),
+    entry.url ?? "",
+    entry.outcome,
+    entry.errorCode ?? "",
+    entry.command.kind,
+    String(entry.seq),
+  ]
+    .join(" ")
+    .toLowerCase();
 }
 
 /**

--- a/mcpjam-inspector/client/src/components/browser/LocalBrowserBody.tsx
+++ b/mcpjam-inspector/client/src/components/browser/LocalBrowserBody.tsx
@@ -12,7 +12,6 @@ import {
   type PaneControl,
 } from "@/components/browser/BrowserPaneSurface";
 import { ElectronNativeBody } from "@/components/browser/ElectronNativeBody";
-import { BrowserActivityList } from "@/components/browser/BrowserActivityList";
 import type { BrowserInputEvent, PaneFrame } from "@/lib/browser-pane/input";
 import { paneFrameStats } from "@/lib/browser-pane/frame-stats";
 import { createFrameWireReader } from "@/lib/browser-pane/frame-wire";
@@ -870,58 +869,23 @@ export function LocalBrowserBody({
   // decode. Everything above is unchanged and still applies: the same status,
   // the same lease, the same holder identity, the same take-control bar. What
   // differs is only that there is no picture to draw.
+  //
+  // `flex flex-col` and not merely `flex-1`: both pane bodies render a
+  // control bar above a `min-h-0 flex-1` viewport and so expect a flex
+  // COLUMN parent. A plain block wrapper leaves that `flex-1` with no
+  // flex container to grow in, and the picture collapses to nothing.
+  //
+  // Activity used to sit under the picture here. It now lives on the Logs
+  // tab, so this pane is only the browser.
   if (native) {
     return (
       <div className="flex h-full min-h-0 flex-col">
-        {/* `flex flex-col` and not merely `flex-1`: both pane bodies render a
-            control bar above a `min-h-0 flex-1` viewport and so expect a flex
-            COLUMN parent. A plain block wrapper leaves that `flex-1` with no
-            flex container to grow in, and the picture collapses to nothing. */}
-        <div className="flex min-h-0 flex-1 flex-col">
-          <ElectronNativeBody
-            session={session}
-            holder={holder}
-            control={control}
-            holding={holding}
-            consentGranted={consentGranted}
-            onTakeControl={
-              session && !holding && lease.state === "free"
-                ? () => void setLeaseAction("acquire")
-                : undefined
-            }
-            onHandBack={
-              session && holding
-                ? () => void setLeaseAction("resume")
-                : undefined
-            }
-            placeholder={placeholder}
-            error={error}
-            active={active}
-            engine="local-native"
-          />
-        </div>
-        <Activity
-          projectId={projectId}
-          consentToken={consentToken}
-          consentGranted={consentGranted}
-          active={active}
-        />
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex h-full min-h-0 flex-col">
-      <div className="flex min-h-0 flex-1 flex-col">
-        <BrowserPaneSurface
-          // Gated as well as cleared: a frame that lands in the same tick as
-          // the revocation must not be the one that gets painted.
-          frame={consentGranted ? frame : null}
-          holding={holding}
+        <ElectronNativeBody
+          session={session}
+          holder={holder}
           control={control}
-          // Offered only when there is a browser to take and nobody has it. A
-          // lease held by somebody else is not something this pane may step
-          // over.
+          holding={holding}
+          consentGranted={consentGranted}
           onTakeControl={
             session && !holding && lease.state === "free"
               ? () => void setLeaseAction("acquire")
@@ -932,49 +896,42 @@ export function LocalBrowserBody({
               ? () => void setLeaseAction("resume")
               : undefined
           }
-          onInput={send}
           placeholder={placeholder}
           error={error}
           active={active}
-          engine={status?.runtime ?? "local"}
+          engine="local-native"
         />
       </div>
-      <Activity
-        projectId={projectId}
-        consentToken={consentToken}
-        consentGranted={consentGranted}
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <BrowserPaneSurface
+        // Gated as well as cleared: a frame that lands in the same tick as
+        // the revocation must not be the one that gets painted.
+        frame={consentGranted ? frame : null}
+        holding={holding}
+        control={control}
+        // Offered only when there is a browser to take and nobody has it. A
+        // lease held by somebody else is not something this pane may step
+        // over.
+        onTakeControl={
+          session && !holding && lease.state === "free"
+            ? () => void setLeaseAction("acquire")
+            : undefined
+        }
+        onHandBack={
+          session && holding
+            ? () => void setLeaseAction("resume")
+            : undefined
+        }
+        onInput={send}
+        placeholder={placeholder}
+        error={error}
         active={active}
+        engine={status?.runtime ?? "local"}
       />
     </div>
-  );
-}
-
-/**
- * The Activity list, mounted only once consent is granted.
- *
- * Gated on consent for the same reason every other route here is: the rows
- * carry a browsing history, and the consent capability is what authorizes
- * reading it. Capped at a third of the pane so the picture — which is what a
- * person came to the tab for — stays the larger half.
- */
-function Activity({
-  projectId,
-  consentToken,
-  consentGranted,
-  active,
-}: {
-  projectId: string | null;
-  consentToken: string | null;
-  consentGranted: boolean;
-  active: boolean;
-}) {
-  if (!consentGranted || !projectId) return null;
-  return (
-    <BrowserActivityList
-      projectId={projectId}
-      consentToken={consentToken}
-      active={active}
-      className="max-h-[33%] shrink-0 border-t"
-    />
   );
 }

--- a/mcpjam-inspector/client/src/components/browser/__tests__/BrowserActivityList.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/BrowserActivityList.test.tsx
@@ -1,5 +1,5 @@
 /**
- * The rail's record of what drove the browser.
+ * What drove the browser, as logs on the Logs tab.
  *
  * What is asserted here is mostly about HONESTY rather than layout: the three
  * outcomes stay three different things, a gap in the history is shown rather
@@ -7,7 +7,7 @@
  * never carried one.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 const listSessions = vi.fn();
 const readTrace = vi.fn();
@@ -70,6 +70,17 @@ describe("BrowserActivityList", () => {
     expect(
       await screen.findByText(/Nothing has driven this browser yet/i),
     ).toBeTruthy();
+    expect(screen.getByPlaceholderText("Search logs")).toBeTruthy();
+  });
+
+  it("expands a command row like the other log rails", async () => {
+    readTrace.mockResolvedValueOnce({
+      entries: [row({ seq: 1, command: { kind: "reload" } })],
+      headSeq: 1,
+    });
+    mount();
+    fireEvent.click(await screen.findByText("reload"));
+    expect(screen.getByText(/"kind": "reload"/)).toBeTruthy();
   });
 
   it("polls nothing while the tab is hidden", async () => {
@@ -251,7 +262,7 @@ describe("BrowserActivityList", () => {
   });
 
   it("follows the PERSISTENT session, not a throwaway agent run", async () => {
-    // The frames above this list come from the project's persistent browser.
+    // The Browser tab's frames come from the project's persistent browser.
     // Following the newest open session of any profile let an ephemeral run
     // steal the rail, so the history on screen belonged to a browser nobody
     // could see — and the person's own clicks vanished from it.

--- a/mcpjam-inspector/client/src/components/browser/useLocalBrowserActivity.ts
+++ b/mcpjam-inspector/client/src/components/browser/useLocalBrowserActivity.ts
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  listLocalBrowserSessions,
+  readLocalBrowserTrace,
+  type LocalBrowserTraceEntry,
+} from "@/lib/local-browser/client";
+
+/**
+ * What drove the browser, as a log source.
+ *
+ * POLLED, not streamed. The frames socket carries pixels and would have to grow
+ * a second record kind to carry these; polling with the last `seq` seen is one
+ * small request per tick, costs nothing while nothing is happening, and cannot
+ * lag a slow client out of a broadcast the way the frame stream can.
+ */
+const POLL_INTERVAL_MS = 2_000;
+/**
+ * How many quiet ticks before the pane asks which session it should be reading.
+ *
+ * It resolves a session once and then follows it, which is right while that
+ * session is the live one and wrong the moment it ends: a closed session's
+ * trace still reads perfectly, so an agent that closed one and opened another
+ * left the pane showing a history that had stopped moving, with nothing on
+ * screen to say it was watching the wrong browser. Asking again is one small
+ * request, and only when nothing is arriving — a session that is producing
+ * rows is self-evidently the one to read.
+ */
+const REDISCOVER_AFTER_QUIET_TICKS = 15;
+/**
+ * The session this pane may follow: an OPEN, PERSISTENT one.
+ *
+ * The Browser tab's frames come from the project's persistent browser, so that
+ * is the browser a reader is watching. Taking the newest open session of any
+ * profile let a throwaway agent run steal the list — the history on screen
+ * then belonged to a browser nobody could see, and the model's and the
+ * person's own commands vanished from the rail.
+ */
+const watchable = (session: { closedAt?: number; profile?: string }) =>
+  !session.closedAt && session.profile !== "ephemeral";
+/** How many rows the pane keeps. Older ones stay in the trace on disk. */
+const MAX_ROWS = 200;
+
+export function useLocalBrowserActivity({
+  projectId,
+  consentToken,
+  active,
+}: {
+  projectId: string | null;
+  consentToken: string | null;
+  /** False while the tab is hidden: a pane nobody is looking at polls nothing. */
+  active: boolean;
+}): {
+  entries: LocalBrowserTraceEntry[];
+  warning: string | null;
+} {
+  const [entries, setEntries] = useState<LocalBrowserTraceEntry[]>([]);
+  /**
+   * The session being read, WITH the project it belongs to.
+   *
+   * Stored as one value rather than two pieces of state so a stale pairing is
+   * impossible by construction: holding a bare `sessionId` meant a project
+   * switch left the previous project's session in place for at least one poll,
+   * which asked the new project for the old project's history. Two fields that
+   * must agree are two fields that eventually will not.
+   */
+  const [reading, setReading] = useState<
+    { projectId: string; sessionId: string } | null
+  >(null);
+  const sessionId = reading?.projectId === projectId ? reading.sessionId : null;
+  const [warning, setWarning] = useState<string | null>(null);
+  const cursor = useRef(0);
+  /**
+   * One poll at a time, and only the current generation's answer is applied.
+   *
+   * A slow trace request that overlaps the next tick would otherwise have both
+   * polls read the same cursor and append the same rows, so one click appears
+   * in the list twice — the same duplication the server-side mirror lock
+   * prevents, arriving from the other end.
+   */
+  const inFlight = useRef(false);
+  const generation = useRef(0);
+  /** Consecutive polls that brought nothing. @see REDISCOVER_AFTER_QUIET_TICKS */
+  const quietTicks = useRef(0);
+
+  /**
+   * Start a fresh list whenever the thing being read changes.
+   *
+   * Keyed on the pair, so it covers both a project switch and an agent opening
+   * a new session in the same project. The FIRST resolution — null to a
+   * session — is deliberately not a reset: that is this pane learning what it
+   * was already reading, and resetting there would wipe the page the same poll
+   * had just appended while leaving the cursor past it.
+   */
+  const readingKey = sessionId ? `${projectId}:${sessionId}` : null;
+  const lastKey = useRef<string | null>(null);
+  useEffect(() => {
+    const previous = lastKey.current;
+    lastKey.current = readingKey;
+    if (previous === null || previous === readingKey) return;
+    // An in-flight poll belongs to what we just left, so its answer is already
+    // discarded by the generation check; releasing the latch lets the new one
+    // start at once rather than waiting out a worthless request.
+    generation.current += 1;
+    inFlight.current = false;
+    cursor.current = 0;
+    quietTicks.current = 0;
+    setEntries([]);
+    setWarning(null);
+  }, [readingKey]);
+
+  const poll = useCallback(async () => {
+    if (!projectId || inFlight.current) return;
+    inFlight.current = true;
+    const mine = generation.current;
+    try {
+      let currentSession = sessionId;
+      // A session that has gone quiet may have ended. Ask before assuming it is
+      // simply idle; switching resets the list through `readingKey`.
+      //
+      // ONLY WHEN THIS ONE HAS CLOSED, though — not merely because a newer one
+      // exists. A project can have a person's persistent session and several
+      // ephemeral runs open at once, so "switch to the newest" handed the pane
+      // to whichever run started last and wiped the history somebody was
+      // reading, for a session that had never closed.
+      if (currentSession && quietTicks.current >= REDISCOVER_AFTER_QUIET_TICKS) {
+        quietTicks.current = 0;
+        const sessions = await listLocalBrowserSessions(projectId, consentToken)
+          .then((r) => r.sessions)
+          .catch(() => null);
+        if (generation.current !== mine) return;
+        const mineStillOpen = sessions?.some(
+          (s) => s.sessionId === currentSession && !s.closedAt,
+        );
+        // A lookup that failed says nothing about whether this session closed,
+        // so it is not a reason to leave it.
+        if (sessions && !mineStillOpen) {
+          const next = sessions.find(watchable)?.sessionId ?? null;
+          if (next) {
+            setReading({ projectId, sessionId: next });
+            return;
+          }
+        }
+      }
+      if (!currentSession) {
+        let lookupFailed = false;
+        const found = await listLocalBrowserSessions(projectId, consentToken)
+          .then((r) => r.sessions.find(watchable)?.sessionId ?? null)
+          .catch(() => {
+            // A failure to LOOK is not an absence of history, and a pane that
+            // showed "nothing has driven this browser" either way would be
+            // telling a reader something it does not know.
+            lookupFailed = true;
+            return null;
+          });
+        // Applied only if we are still the current reader — this is the same
+        // late answer the rows below are dropped for, and a warning is no more
+        // this pane's to show for a project it has left than a row is.
+        if (generation.current !== mine) return;
+        if (!found) {
+          // A LOOK THAT SUCCEEDED AND FOUND NOTHING CLEARS THE WARNING. Only
+          // setting it on failure left "history unavailable" on screen for as
+          // long as the project had no open session, long after the lookup had
+          // started working again.
+          setWarning(
+            lookupFailed
+              ? "this session's history could not be read just now; retrying"
+              : null,
+          );
+          return;
+        }
+        currentSession = found;
+        setReading({ projectId, sessionId: found });
+      }
+      const page = await readLocalBrowserTrace(
+        {
+          projectId,
+          sessionId: currentSession,
+          afterSeq: cursor.current,
+          limit: 100,
+        },
+        consentToken,
+      ).catch(() => null);
+      // A late answer from a session or project we have since left is dropped:
+      // applying it would file one project's rows under another's name.
+      if (generation.current !== mine) return;
+      if (!page) {
+        setWarning("this session's history could not be read just now; retrying");
+        return;
+      }
+      // Never silent: a hole in the history is the pane's to report, not
+      // something a reader should have to notice for themselves.
+      setWarning(page.historyWarning ?? null);
+      if (page.entries.length === 0) {
+        quietTicks.current += 1;
+        return;
+      }
+      quietTicks.current = 0;
+      cursor.current = Math.max(
+        cursor.current,
+        ...page.entries.map((entry) => entry.seq),
+      );
+      setEntries((previous) => [...previous, ...page.entries].slice(-MAX_ROWS));
+    } finally {
+      // ONLY THIS GENERATION'S LATCH. A poll left over from a project we have
+      // since switched away from would otherwise clear the latch that the
+      // CURRENT poll is holding, and the next tick would start a second poll
+      // beside it — both reading the same cursor and appending the same rows,
+      // which is precisely the duplication this latch exists to prevent.
+      if (generation.current === mine) inFlight.current = false;
+    }
+  }, [projectId, sessionId, consentToken]);
+
+  useEffect(() => {
+    if (!active || !projectId) return;
+    let cancelled = false;
+    const tick = () => {
+      if (cancelled) return;
+      void poll();
+    };
+    tick();
+    const timer = window.setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [active, projectId, poll]);
+
+  return { entries, warning };
+}

--- a/mcpjam-inspector/client/src/components/logger-view.tsx
+++ b/mcpjam-inspector/client/src/components/logger-view.tsx
@@ -3,6 +3,7 @@ import { track } from "@/lib/analytics";
 import type { ClientAnalyticsEventName } from "@/shared/analytics-events";
 import {
   AlertCircle,
+  AlertTriangle,
   Trash2,
   Download,
 } from "lucide-react";
@@ -59,8 +60,14 @@ import { cn } from "@/lib/utils";
 import { HttpExchangeDetails } from "@/components/tracing/HttpExchangeDetails";
 import { InlineFrameHeaders } from "@/components/tracing/InlineFrameHeaders";
 import type { HttpExchangeLogEvent } from "@mcpjam/sdk/browser";
+import { useLocalBrowserActivity } from "@/components/browser/useLocalBrowserActivity";
+import {
+  CommandRow,
+  GapRow,
+} from "@/components/browser/BrowserActivityList";
+import type { LocalBrowserTraceEntry } from "@/lib/local-browser/client";
 
-type TrafficSource = "mcp-server" | "mcp-apps" | "oauth" | "http";
+type TrafficSource = "mcp-server" | "mcp-apps" | "oauth" | "http" | "browser";
 
 interface RenderableRpcItem {
   id: string;
@@ -84,6 +91,16 @@ interface LoggerViewProps {
   isLogLevelVisible?: boolean;
   isCollapsable?: boolean;
   isSearchVisible?: boolean;
+  /**
+   * When set, the local browser ledger is a source in this same list — not a
+   * second log rail. Gated by the caller (consent, local engine) because the
+   * rows are a browsing history.
+   */
+  browserActivity?: {
+    projectId: string;
+    consentToken: string | null;
+    active: boolean;
+  } | null;
 }
 
 const LOGGING_LEVELS: LoggingLevel[] = [
@@ -303,6 +320,7 @@ export function LoggerView({
   isLogLevelVisible = true,
   isCollapsable = true,
   isSearchVisible = true,
+  browserActivity = null,
 }: LoggerViewProps = {}) {
   const appState = useSharedAppState();
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -322,6 +340,15 @@ export function LoggerView({
     "all"
   );
   const lastIngestedOAuthTraceKeysRef = useRef<Map<string, string>>(new Map());
+  const browser = useLocalBrowserActivity({
+    projectId: browserActivity?.projectId ?? null,
+    consentToken: browserActivity?.consentToken ?? null,
+    active: Boolean(browserActivity?.active),
+  });
+
+  useEffect(() => {
+    if (!browserActivity && sourceFilter === "browser") setSourceFilter("all");
+  }, [browserActivity, sourceFilter]);
 
   // Subscribe to UI log store (includes both MCP Apps and MCP Server RPC traffic)
   const uiLogItems = useTrafficLogStore((s) => s.items);
@@ -390,6 +417,20 @@ export function LoggerView({
       oauthRecovered: item.oauthRecovered,
     }));
   }, [mcpServerRpcItems]);
+
+  const browserItems = useMemo<RenderableRpcItem[]>(() => {
+    if (!browserActivity) return [];
+    return browser.entries.map((entry) => ({
+      id: `browser-${entry.seq}`,
+      serverId: "browser",
+      serverName: "browser",
+      direction: "browser",
+      method: entry.kind === "gap" ? "gap" : entry.command.kind,
+      timestamp: new Date(entry.ts).toISOString(),
+      payload: entry,
+      source: "browser" as TrafficSource,
+    }));
+  }, [browserActivity, browser.entries]);
 
   const connectedServers = useMemo<
     Array<{ id: string; server: ServerWithName }>
@@ -491,12 +532,12 @@ export function LoggerView({
 
   // Combine and sort all items by timestamp (newest first)
   const allItems = useMemo(() => {
-    const combined = [...mcpServerItems, ...mcpAppsItems];
+    const combined = [...mcpServerItems, ...mcpAppsItems, ...browserItems];
     return combined.sort(
       (a, b) =>
         new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
     );
-  }, [mcpServerItems, mcpAppsItems]);
+  }, [mcpServerItems, mcpAppsItems, browserItems]);
 
   // Precomputed, lowercased search text per item — the same four fields the
   // search used to concatenate inline (server label, method, direction, and
@@ -538,6 +579,7 @@ export function LoggerView({
       const serverIdSet = new Set(serverIds);
       result = result.filter(
         (item) =>
+          item.source === "browser" ||
           serverIdSet.has(item.serverId) ||
           (!!item.serverName && serverIdSet.has(item.serverName))
       );
@@ -602,6 +644,17 @@ export function LoggerView({
         leading={
             /* Source filter + log levels — hide on narrow panels; search + copy/clear stay */
             <div className="hidden items-center gap-1.5 @min-[340px]/logger-toolbar:flex">
+              {browserActivity && browser.warning ? (
+                <span
+                  className="flex items-center gap-1 text-[11px] text-destructive"
+                  title={browser.warning}
+                >
+                  <AlertTriangle className="h-3 w-3" />
+                  {browser.warning.includes("could not be read")
+                    ? "history unavailable"
+                    : "history incomplete"}
+                </span>
+              ) : null}
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
@@ -653,6 +706,11 @@ export function LoggerView({
                     <DropdownMenuRadioItem value="mcp-apps" className="text-xs">
                       Apps
                     </DropdownMenuRadioItem>
+                    {browserActivity ? (
+                      <DropdownMenuRadioItem value="browser" className="text-xs">
+                        Browser
+                      </DropdownMenuRadioItem>
+                    ) : null}
                   </DropdownMenuRadioGroup>
                 </DropdownMenuContent>
               </DropdownMenu>
@@ -898,7 +956,9 @@ export function LoggerView({
                   {"No logs yet"}
                 </div>
                 <div className="text-[10px] text-muted-foreground mt-1">
-                  {"Logs will appear here"}
+                  {browserActivity
+                    ? "MCP traffic and browser commands show up here"
+                    : "Logs will appear here"}
                 </div>
               </>
             )}
@@ -906,6 +966,14 @@ export function LoggerView({
         ) : (
           <>
             {filteredItems.map((it) => {
+              if (it.source === "browser") {
+                const entry = it.payload as LocalBrowserTraceEntry;
+                return entry.kind === "gap" ? (
+                  <GapRow key={it.id} entry={entry} />
+                ) : (
+                  <CommandRow key={it.id} row={entry} />
+                );
+              }
               const isExpanded = expanded.has(it.id);
               const isAppsTraffic = it.source === "mcp-apps";
               const isOAuthTraffic = it.source === "oauth";

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
@@ -234,7 +234,18 @@ function RightRailTabbed({
           activeTab === "logs" ? "flex flex-col" : "hidden",
         )}
       >
-        <LoggerView isCollapsable={false} />
+        <LoggerView
+          isCollapsable={false}
+          browserActivity={
+            hasBrowser && isLocalBrowser && engine.consent.granted && projectId
+              ? {
+                  projectId,
+                  consentToken: engine.consent.token,
+                  active: activeTab === "logs",
+                }
+              : null
+          }
+        />
       </div>
       {hasBrowser ? (
         <div

--- a/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundRightRail.test.tsx
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundRightRail.test.tsx
@@ -63,7 +63,15 @@ vi.mock("@/hooks/useComputersEnabled", () => ({
 }));
 
 vi.mock("@/components/logger-view", () => ({
-  LoggerView: () => <div data-testid="logger-view" />,
+  LoggerView: (props: {
+    browserActivity?: { active?: boolean } | null;
+  }) => (
+    <div
+      data-testid="logger-view"
+      data-has-browser={String(Boolean(props.browserActivity))}
+      data-browser-active={String(Boolean(props.browserActivity?.active))}
+    />
+  ),
 }));
 
 vi.mock("@/components/computer/ComputerStatusChip", () => ({
@@ -445,5 +453,67 @@ describe("PlaygroundRightRail — the Browser tab", () => {
     expect(screen.getByTestId("browser-pane").dataset.active).toBe("false");
     fireEvent.click(screen.getByRole("button", { name: /browser/i }));
     expect(screen.getByTestId("browser-pane").dataset.active).toBe("true");
+  });
+});
+
+describe("PlaygroundRightRail — browser activity on the Logs tab", () => {
+  const browserHost = {
+    computer: { workdir: "/home/user" },
+    builtInToolIds: ["browser"],
+  } as any;
+
+  it("feeds local browser activity into the same Logs list", () => {
+    engineState.engine = "local";
+    engineState.selectedEngine = "local";
+    engineState.granted = true;
+    render(
+      <PlaygroundRightRail
+        onClose={() => {}}
+        hostConfig={browserHost}
+        hostId="host-1"
+        projectId="proj-1"
+        isAuthenticated
+      />,
+    );
+
+    const logs = screen.getByTestId("logger-view");
+    expect(logs.dataset.hasBrowser).toBe("true");
+    expect(logs.dataset.browserActive).toBe("true");
+    fireEvent.click(screen.getByRole("button", { name: /browser/i }));
+    expect(logs.dataset.browserActive).toBe("false");
+    fireEvent.click(screen.getByRole("button", { name: /logs/i }));
+    expect(logs.dataset.browserActive).toBe("true");
+  });
+
+  it("does not read the ledger before this machine is authorized", () => {
+    engineState.engine = "local";
+    engineState.selectedEngine = "local";
+    engineState.granted = false;
+    render(
+      <PlaygroundRightRail
+        onClose={() => {}}
+        hostConfig={browserHost}
+        hostId="host-1"
+        projectId="proj-1"
+        isAuthenticated
+      />,
+    );
+    expect(screen.getByTestId("logger-view").dataset.hasBrowser).toBe("false");
+  });
+
+  it("does not mount a local ledger on the hosted engine", () => {
+    engineState.engine = "cloud";
+    engineState.selectedEngine = "cloud";
+    engineState.granted = true;
+    render(
+      <PlaygroundRightRail
+        onClose={() => {}}
+        hostConfig={browserHost}
+        hostId="host-1"
+        projectId="proj-1"
+        isAuthenticated
+      />,
+    );
+    expect(screen.getByTestId("logger-view").dataset.hasBrowser).toBe("false");
   });
 });

--- a/mcpjam-inspector/docs/local-browser-engine.md
+++ b/mcpjam-inspector/docs/local-browser-engine.md
@@ -146,7 +146,7 @@ the idempotent queue apply exactly as they do to a model's tool call.
 | Logical session + durable ledger     | `server/services/browserd/local/agent-session-store.ts`       |
 | The ledger itself                    | `server/services/browserd/daemon/command-ledger.ts`          |
 | CLI                                  | `../cli/src/commands/browser.ts`                             |
-| The rail's Activity list             | `client/src/components/browser/BrowserActivityList.tsx`      |
+| The rail's Logs tab (browser source) | `client/src/components/logger-view.tsx`, `client/src/components/browser/useLocalBrowserActivity.ts` |
 
 Four things about it are load-bearing.
 


### PR DESCRIPTION
## Summary
- Move local browser activity off the Browser pane (no more footer under the screenshot) and into the playground Logs tab.
- Feed the local browser ledger into `LoggerView` as a `"browser"` source so MCP traffic and browser commands share one list, one search, and one empty state.
- Browser tab stays the picture / take-control surface; consent still gates ledger reads.

## Test plan
- [ ] Open playground with a local browser project, grant consent, drive the browser, then open Logs — browser commands appear in the same list as MCP traffic.
- [ ] Confirm the Browser tab has no activity footer or second “Search logs” rail.
- [ ] Filter Logs by source **Browser**; search should match command rows.
- [ ] History warning still appears in the Logs toolbar when browsing history is in play.
- [ ] Hosted engine playground: Logs behaves as before (no Browser source attached).
- [ ] Leave Logs: ledger polling should stop (`active` only while Logs is selected).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves local browser activity out of the Browser tab footer and into the playground Logs list, so MCP traffic and browser commands share one search, one source filter, and one empty state.

- Browser commands appear in `LoggerView` under a new "Browser" source; the Browser tab is now just the picture and take-control surface.
- Ledger reads stay gated on consent, and polling runs only while the Logs tab is selected.
- Hosted-engine playgrounds see no change — the Browser source is attached only for local browser projects.

<sup>Written for commit c9fdc94ae1453308cf6eb60a59b64808f2790c06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

