### PR TITLE
User Testing analyzes itself, and stops asking to be asked (BB-196)

### DIFF
--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/scenario-goal-chain.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/scenario-goal-chain.test.tsx
@@ -26,20 +26,28 @@ import type { ChatSessionStageFunnel } from "@/components/shared/user-value-chai
 import { ScenarioGoalChain } from "@/components/scenarios/findings/scenario-goal-chain";
 import { ScenarioFindingsTab } from "@/components/scenarios/findings/scenario-findings-tab";
 
-const { mockUseQuery, mockUseGoalOutcomeDrilldown, mockReportBoundaryError } =
-  vi.hoisted(() => ({
-    mockUseQuery: vi.fn(),
-    mockUseGoalOutcomeDrilldown: vi.fn(),
-    mockReportBoundaryError: vi.fn(),
-  }));
+const {
+  mockUseQuery,
+  mockUseGoalOutcomeDrilldown,
+  mockUseUsageInsights,
+  mockReportBoundaryError,
+} = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+  mockUseGoalOutcomeDrilldown: vi.fn(),
+  mockUseUsageInsights: vi.fn(),
+  mockReportBoundaryError: vi.fn(),
+}));
 
 vi.mock("convex/react", () => ({
   useQuery: (...args: unknown[]) => mockUseQuery(...args),
 }));
 
+// The tab reads the breakdown too, for the one signal the drill-down cannot
+// give it: whether an analysis has ever run (BB-196).
 vi.mock("@/hooks/useUsageInsights", () => ({
   useGoalOutcomeDrilldown: (...args: unknown[]) =>
     mockUseGoalOutcomeDrilldown(...args),
+  useUsageInsights: (...args: unknown[]) => mockUseUsageInsights(...args),
 }));
 
 vi.mock("@/lib/error-reporting", () => ({
@@ -141,7 +149,22 @@ function twoGoalDrilldown() {
 beforeEach(() => {
   mockUseQuery.mockReset();
   mockUseGoalOutcomeDrilldown.mockReset();
+  mockUseUsageInsights.mockReset();
   mockReportBoundaryError.mockReset();
+  // A study already analyzed: these tests are about the chain, not about the
+  // first-analysis start, so `latestRun` keeps that path out of them.
+  mockUseUsageInsights.mockReturnValue({
+    threads: undefined,
+    breakdown: {
+      totalSessions: 4,
+      latestRun: { status: "done" },
+    },
+    rebuild: vi.fn().mockResolvedValue({
+      runId: "run-1",
+      status: "queued",
+      alreadyRunning: false,
+    }),
+  });
   mockUseGoalOutcomeDrilldown.mockReturnValue({
     drilldown: drilldownFixture(),
     isLoading: false,
@@ -241,6 +264,106 @@ describe("ScenarioGoalChain", () => {
 });
 
 // ── the tab ─────────────────────────────────────────────────────────────────
+
+describe("the Findings tab starts its own analysis (BB-196)", () => {
+  /** Sessions exist but none is analyzed — the state a tester lands on. */
+  function unanalyzed() {
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        sessions: [
+          { _id: "s-1", threadId: "t-1", lastActivityAt: 1 },
+          { _id: "s-2", threadId: "t-2", lastActivityAt: 2 },
+        ],
+        nextBefore: null,
+        total: 2,
+        totalTruncated: false,
+      },
+      isLoading: false,
+    });
+  }
+
+  it("queues the analysis and says it is working, not waiting", async () => {
+    // This is the LANDING tab, so it is the surface the ticket is really
+    // about. Before this it read "No session has been analyzed yet" with
+    // nothing queued and no affordance — less than the old button offered.
+    unanalyzed();
+    const rebuild = vi.fn().mockResolvedValue({
+      runId: "run-1",
+      status: "queued",
+      alreadyRunning: false,
+    });
+    mockUseUsageInsights.mockReturnValue({
+      threads: undefined,
+      breakdown: { totalSessions: 2, latestRun: null },
+      rebuild,
+    });
+
+    render(<ScenarioFindingsTab scenarioId="scn-1" />);
+
+    await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId("scenario-findings-empty")).toHaveTextContent(
+      /Analyzing sessions/,
+    );
+  });
+
+  it("keeps the honest dead end when the start is refused", async () => {
+    // A signed-out guest: the rebuild mutation authenticates, so nothing is
+    // ever coming and a spinner would be a lie.
+    unanalyzed();
+    mockUseUsageInsights.mockReturnValue({
+      threads: undefined,
+      breakdown: { totalSessions: 2, latestRun: null },
+      rebuild: vi.fn().mockRejectedValue(new Error("Not authenticated")),
+    });
+
+    render(<ScenarioFindingsTab scenarioId="scn-1" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("scenario-findings-empty")).toHaveTextContent(
+        "No session has been analyzed yet.",
+      ),
+    );
+  });
+
+  it("does not start one for a study with no sessions", () => {
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        sessions: [],
+        nextBefore: null,
+        total: 0,
+        totalTruncated: false,
+      },
+      isLoading: false,
+    });
+    const rebuild = vi.fn();
+    mockUseUsageInsights.mockReturnValue({
+      threads: undefined,
+      breakdown: { totalSessions: 0, latestRun: null },
+      rebuild,
+    });
+
+    render(<ScenarioFindingsTab scenarioId="scn-1" />);
+
+    expect(rebuild).not.toHaveBeenCalled();
+    expect(screen.getByTestId("scenario-findings-empty")).toHaveTextContent(
+      "No sessions in this study yet.",
+    );
+  });
+
+  it("leaves an already-analyzed study alone", () => {
+    unanalyzed();
+    const rebuild = vi.fn();
+    mockUseUsageInsights.mockReturnValue({
+      threads: undefined,
+      breakdown: { totalSessions: 2, latestRun: { status: "done" } },
+      rebuild,
+    });
+
+    render(<ScenarioFindingsTab scenarioId="scn-1" />);
+
+    expect(rebuild).not.toHaveBeenCalled();
+  });
+});
 
 describe("the Findings tab, once a goal is open", () => {
   it("paints the measured chain and opens on the break", async () => {

--- a/mcpjam-inspector/client/src/components/scenarios/findings/scenario-findings-tab.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/findings/scenario-findings-tab.tsx
@@ -24,7 +24,11 @@ import {
   EMPTY_USAGE_FILTER,
   type UsageFilterState,
 } from "@/hooks/scenario-usage-filters";
-import { useGoalOutcomeDrilldown } from "@/hooks/useUsageInsights";
+import {
+  useGoalOutcomeDrilldown,
+  useUsageInsights,
+} from "@/hooks/useUsageInsights";
+import { useEnsureFirstAnalysis } from "@/hooks/useInsightsFlowController";
 import { withHideSynthetic } from "@/components/scenarios/user-testing-traffic";
 import { FindingsSummaryCard } from "@/components/swarms/findings/findings-summary-card";
 import { FindingsPersonaTabs } from "@/components/swarms/findings/findings-persona-tabs";
@@ -60,6 +64,42 @@ export function ScenarioFindingsTab({
     filters,
     limit: GRID_PAGE_SIZE,
   });
+
+  /**
+   * This tab analyzes itself too (BB-196).
+   *
+   * It is the LANDING tab, so it is the surface most people see first — and
+   * the drill-down alone cannot tell "never analyzed" from "analyzed and
+   * empty", which is why the breakdown is read here as well: `latestRun` is
+   * the only honest signal for the former. Same hook and same one-attempt
+   * discipline as the Insights workbench.
+   */
+  const { breakdown, rebuild } = useUsageInsights({
+    scope: { kind: "scenario", scenarioId },
+    filters,
+    threadsEnabled: false,
+    breakdownEnabled: true,
+  });
+  const { failed: firstAnalysisRefused } = useEnsureFirstAnalysis({
+    enabled: true,
+    cohortKey: scenarioId,
+    breakdown,
+    rebuild,
+  });
+  /**
+   * Is an analysis on its way? Same rule the session-flow diagram applies: on
+   * a surface that starts its own, a MISSING run means one is being arranged
+   * rather than waiting to be asked for — until a refusal withdraws that.
+   *
+   * Gated on the breakdown having loaded, so the first subscription cannot
+   * flash "analyzing" at a study that has simply never been analyzed and never
+   * will be.
+   */
+  const latestRun = breakdown?.latestRun ?? null;
+  const analysisInFlight =
+    latestRun?.status === "queued" ||
+    latestRun?.status === "running" ||
+    (!firstAnalysisRefused && Boolean(breakdown) && latestRun === null);
 
   const model = useMemo(
     () =>
@@ -224,9 +264,16 @@ export function ScenarioFindingsTab({
         className="flex h-full items-center justify-center text-sm text-muted-foreground"
         data-testid="scenario-findings-empty"
       >
-        {model.unanalyzedCount > 0
-          ? "No session has been analyzed yet."
-          : "No sessions in this study yet."}
+        {/* An analysis on its way is working, not waiting for a click — the
+            whole of BB-196, and it matters most here because this is the tab
+            people land on. "No session has been analyzed yet" stays for the
+            cases where that is the end of the story: a refused start, or a run
+            that failed. */}
+        {model.unanalyzedCount === 0
+          ? "No sessions in this study yet."
+          : analysisInFlight
+            ? "Analyzing sessions — grouping goals, behaviors, outcomes, and sentiment. This can take a few minutes."
+            : "No session has been analyzed yet."}
       </div>
     );
   }

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/InsightsWorkbench.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/InsightsWorkbench.tsx
@@ -229,13 +229,23 @@ export function InsightsWorkbench({
    * benchmark flow is the one PAID analysis here — an action, not a mutation —
    * whose whole design is to wait to be asked.
    */
-  const analysisIsAutomatic = scope?.kind === "scenario";
-  useEnsureFirstAnalysis({
-    enabled: analysisIsAutomatic,
+  const scopeAnalyzesItself = scope?.kind === "scenario";
+  const { failed: firstAnalysisRefused } = useEnsureFirstAnalysis({
+    enabled: scopeAnalyzesItself,
     cohortKey,
     breakdown,
     rebuild,
   });
+  /**
+   * A refused start WITHDRAWS the promise, handing the manual affordance back.
+   *
+   * `analysisIsAutomatic` makes the diagram read a missing run as work in
+   * progress and hide the rebuild button. If the start was refused there will
+   * never be a run, so keeping the promise would leave the viewer watching a
+   * spinner with the one control that could fix it hidden behind it — worst of
+   * all for the signed-out guest the rebuild mutation always refuses.
+   */
+  const analysisIsAutomatic = scopeAnalyzesItself && !firstAnalysisRefused;
 
   const { setView } = flow;
   const handleViewChange = useCallback(

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/InsightsWorkbench.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/InsightsWorkbench.tsx
@@ -15,6 +15,7 @@ import {
   type UsageFilterState,
 } from "@/hooks/scenario-usage-filters";
 import {
+  useEnsureFirstAnalysis,
   useInsightsFlowController,
   useInsightsRebuild,
   type InsightsView,
@@ -211,6 +212,30 @@ export function InsightsWorkbench({
     rebuild,
     cohortKey,
   );
+
+  /**
+   * User Testing analyzes itself (BB-196): a scenario with sessions and no
+   * analysis starts one on open, so the surface never asks for a click it
+   * could make itself.
+   *
+   * Keyed on the scope rather than taken as a prop because the client rule
+   * MIRRORS a backend one — `scenarioWindowFreshness`'s first-analysis fast
+   * path — and the scope is the same fact both are keyed on. Two ways to say
+   * it would let a caller turn off half of a guarantee.
+   *
+   * The other two scopes are deliberately excluded. Swarms already auto-queue
+   * when a run settles (`journeyRuns.recomputeRunSummaries`), so a swarm with
+   * no run has a different story than an unanalyzed scenario. And the
+   * benchmark flow is the one PAID analysis here — an action, not a mutation —
+   * whose whole design is to wait to be asked.
+   */
+  const analysisIsAutomatic = scope?.kind === "scenario";
+  useEnsureFirstAnalysis({
+    enabled: analysisIsAutomatic,
+    cohortKey,
+    breakdown,
+    rebuild,
+  });
 
   const { setView } = flow;
   const handleViewChange = useCallback(
@@ -409,6 +434,7 @@ export function InsightsWorkbench({
           onRebuild={handleRebuild}
           rebuildBusy={rebuildBusy}
           onApplyTuning={handleApplyTuning}
+          analysisIsAutomatic={analysisIsAutomatic}
           showLinkThreshold
           fillHeight={fillBody}
           scrollLayout={!fillBody}

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/InsightsWorkbench.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/InsightsWorkbench.tsx
@@ -214,20 +214,14 @@ export function InsightsWorkbench({
   );
 
   /**
-   * User Testing analyzes itself (BB-196): a scenario with sessions and no
-   * analysis starts one on open, so the surface never asks for a click it
-   * could make itself.
+   * User Testing analyzes itself (BB-196).
    *
-   * Keyed on the scope rather than taken as a prop because the client rule
-   * MIRRORS a backend one — `scenarioWindowFreshness`'s first-analysis fast
-   * path — and the scope is the same fact both are keyed on. Two ways to say
-   * it would let a caller turn off half of a guarantee.
-   *
-   * The other two scopes are deliberately excluded. Swarms already auto-queue
-   * when a run settles (`journeyRuns.recomputeRunSummaries`), so a swarm with
-   * no run has a different story than an unanalyzed scenario. And the
-   * benchmark flow is the one PAID analysis here — an action, not a mutation —
-   * whose whole design is to wait to be asked.
+   * Keyed on the scope, not a prop: this mirrors a backend rule keyed on the
+   * same fact (`scenarioWindowFreshness`'s first-analysis fast path), and two
+   * ways to say it would let a caller turn off half of a guarantee. Swarms are
+   * excluded because a settling run already queues theirs (journeyRuns.ts);
+   * the benchmark flow because it is the one paid analysis and waits to be
+   * asked.
    */
   const scopeAnalyzesItself = scope?.kind === "scenario";
   const { failed: firstAnalysisRefused } = useEnsureFirstAnalysis({
@@ -236,15 +230,9 @@ export function InsightsWorkbench({
     breakdown,
     rebuild,
   });
-  /**
-   * A refused start WITHDRAWS the promise, handing the manual affordance back.
-   *
-   * `analysisIsAutomatic` makes the diagram read a missing run as work in
-   * progress and hide the rebuild button. If the start was refused there will
-   * never be a run, so keeping the promise would leave the viewer watching a
-   * spinner with the one control that could fix it hidden behind it — worst of
-   * all for the signed-out guest the rebuild mutation always refuses.
-   */
+  // A refused start withdraws the promise: with no run ever coming, keeping it
+  // would leave the viewer watching a spinner with the only control that could
+  // fix it hidden behind it.
   const analysisIsAutomatic = scopeAnalyzesItself && !firstAnalysisRefused;
 
   const { setView } = flow;

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/SessionFlowSankey.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/SessionFlowSankey.tsx
@@ -39,6 +39,17 @@ interface SessionFlowSankeyProps {
     tuning: ClusterTuning,
     opts?: { force?: boolean },
   ) => void;
+  /**
+   * This surface starts its own analysis, so the ABSENCE of a run is a run
+   * being arranged rather than a request waiting to be made (BB-196). It
+   * changes what "no analysis yet" is allowed to say: a working state, never
+   * an "Analyze sessions" button the user has to find.
+   *
+   * Off by default, because it is a promise the OWNER has to keep — the
+   * benchmark diagram deliberately waits to be asked, and a surface that
+   * claimed this without queueing anything would show a spinner forever.
+   */
+  analysisIsAutomatic?: boolean;
   /** False for scopes with no topic map, where link distance means nothing. */
   showLinkThreshold?: boolean;
   /**
@@ -117,6 +128,7 @@ export function SessionFlowSankey({
   onRebuild,
   rebuildBusy,
   onApplyTuning,
+  analysisIsAutomatic = false,
   showLinkThreshold,
   stageTitles,
   headerActions,
@@ -127,6 +139,20 @@ export function SessionFlowSankey({
   const scan = breakdown?.scan;
   const signalsVersion = breakdown?.latestRun?.signalsVersion ?? null;
   const latestRun = breakdown?.latestRun ?? null;
+
+  /**
+   * Hoisted above the early returns: the empty-flow branch below needs it too.
+   * Offering "Rebuild clusters" while a rebuild is already running was always
+   * wrong there, and on a self-analyzing surface it is the whole bug.
+   */
+  const analysisInFlight =
+    latestRun?.status === "queued" ||
+    latestRun?.status === "running" ||
+    // No run at all, on a surface that starts its own: one is being arranged.
+    (analysisIsAutomatic && latestRun === null);
+  // What the first column is called on this surface, for banner copy —
+  // "journeys" on the swarm panel, "goals" on the scenario one.
+  const goalNoun = (stageTitles?.goal ?? STAGE_TITLES.goal).toLowerCase();
 
   const titles = useMemo(
     () => ({ ...STAGE_TITLES, ...stageTitles }),
@@ -185,20 +211,34 @@ export function SessionFlowSankey({
               : "px-5 py-10",
         )}
       >
-        <Target className="h-6 w-6 text-muted-foreground/60" />
-        <p className="text-sm font-medium">No session flow yet</p>
+        {analysisInFlight ? (
+          <RefreshCw className="h-6 w-6 animate-spin text-muted-foreground/60" />
+        ) : (
+          <Target className="h-6 w-6 text-muted-foreground/60" />
+        )}
+        <p className="text-sm font-medium">
+          {analysisInFlight ? "Analyzing sessions…" : "No session flow yet"}
+        </p>
         <p className="max-w-md text-xs text-muted-foreground">
-          {signalsVersion === null
-            ? "The last rebuild ran before session signals existed. Rebuild clusters to extract and group goals, behaviors, outcomes, and sentiment."
-            : "Rebuild clusters once there are enough sessions to cluster."}
+          {analysisInFlight
+            ? `Grouping ${goalNoun}s, behaviors, outcomes, and sentiment. This can take a few minutes.`
+            : signalsVersion === null
+              ? "The last rebuild ran before session signals existed. Rebuild clusters to extract and group goals, behaviors, outcomes, and sentiment."
+              : "Rebuild clusters once there are enough sessions to cluster."}
         </p>
         <div className="flex items-center gap-2">
           {headerActions}
-          <RebuildButton
-            onRebuild={onRebuild}
-            busy={rebuildBusy}
-            label="Rebuild clusters"
-          />
+          {/* An analysis already on its way needs no button to start it — and
+              on a self-analyzing surface there is never a resting state where
+              one is required. The tuning control stays: choosing HOW to
+              cluster is still a thing to ask for. */}
+          {analysisInFlight ? null : (
+            <RebuildButton
+              onRebuild={onRebuild}
+              busy={rebuildBusy}
+              label="Rebuild clusters"
+            />
+          )}
           {tuningControl}
         </div>
       </div>
@@ -207,11 +247,6 @@ export function SessionFlowSankey({
 
   const needsThemeRebuild =
     signalsVersion !== null && signalsVersion < SIGNALS_VERSION_WITH_THEMES;
-  const analysisInFlight =
-    latestRun?.status === "queued" || latestRun?.status === "running";
-  // What the first column is called on this surface, for banner copy —
-  // "journeys" on the swarm panel, "goals" on the scenario one.
-  const goalNoun = (stageTitles?.goal ?? STAGE_TITLES.goal).toLowerCase();
   const selectedKeys = new Set(
     (selection?.themes ?? []).map(
       (theme) => `${theme.dimension}:${theme.clusterId}`,
@@ -291,7 +326,11 @@ export function SessionFlowSankey({
       {/* One analysis banner at a time, most-live state first: a rebuild in
           flight beats advertising the button that starts one, and
           never-analyzed beats the old-signals nudge (which requires a run to
-          exist at all). */}
+          exist at all).
+          On a self-analyzing surface the never-analyzed branch below is
+          unreachable — `analysisInFlight` absorbs a missing run — which is
+          how the Analyze sessions button stops being a required first step
+          without being deleted from the surfaces that still need it. */}
       {analysisInFlight ? (
         <div
           role="status"

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/SessionFlowSankey.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/SessionFlowSankey.tsx
@@ -40,14 +40,12 @@ interface SessionFlowSankeyProps {
     opts?: { force?: boolean },
   ) => void;
   /**
-   * This surface starts its own analysis, so the ABSENCE of a run is a run
-   * being arranged rather than a request waiting to be made (BB-196). It
-   * changes what "no analysis yet" is allowed to say: a working state, never
-   * an "Analyze sessions" button the user has to find.
+   * This surface starts its own analysis, so a MISSING run means one is being
+   * arranged rather than waiting to be asked for (BB-196) — a working state,
+   * not an "Analyze sessions" button.
    *
-   * Off by default, because it is a promise the OWNER has to keep — the
-   * benchmark diagram deliberately waits to be asked, and a surface that
-   * claimed this without queueing anything would show a spinner forever.
+   * Off by default: it is a promise the owner has to keep, and a surface that
+   * claimed it without queueing anything would spin forever.
    */
   analysisIsAutomatic?: boolean;
   /** False for scopes with no topic map, where link distance means nothing. */
@@ -326,11 +324,9 @@ export function SessionFlowSankey({
       {/* One analysis banner at a time, most-live state first: a rebuild in
           flight beats advertising the button that starts one, and
           never-analyzed beats the old-signals nudge (which requires a run to
-          exist at all).
-          On a self-analyzing surface the never-analyzed branch below is
-          unreachable — `analysisInFlight` absorbs a missing run — which is
-          how the Analyze sessions button stops being a required first step
-          without being deleted from the surfaces that still need it. */}
+          exist at all). On a self-analyzing surface `analysisInFlight` absorbs
+          a missing run, so the never-analyzed branch below is unreachable
+          there but still serves the surfaces that wait to be asked. */}
       {analysisInFlight ? (
         <div
           role="status"

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/InsightsWorkbench.auto-analysis.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/InsightsWorkbench.auto-analysis.test.tsx
@@ -147,6 +147,22 @@ describe("InsightsWorkbench automatic analysis", () => {
     );
   });
 
+  it("withdraws the promise when the start is refused", async () => {
+    // The refusal a signed-out guest gets: `rebuildScenarioInsights`
+    // authenticates. There will never be a run, so continuing to promise that
+    // this surface analyzes itself would leave the guest watching a spinner
+    // with the rebuild button hidden behind it.
+    rebuild.mockRejectedValue(new Error("Not authenticated"));
+    renderWorkbench({ kind: "scenario", scenarioId: "sc-1" });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("analysis-is-automatic")).toHaveTextContent(
+        "false",
+      ),
+    );
+    expect(rebuild).toHaveBeenCalledTimes(1);
+  });
+
   it("does not buy a benchmark flow analysis on open", () => {
     renderWorkbench({ kind: "benchmark", benchmarkRunId: "run-9" });
     expect(rebuild).not.toHaveBeenCalled();

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/InsightsWorkbench.auto-analysis.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/InsightsWorkbench.auto-analysis.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * BB-196: User Testing analyzes itself.
+ *
+ * The workbench is shared by three scopes, and only one of them makes this
+ * promise — so what these pin is mostly the BOUNDARY:
+ *
+ *   - SCENARIO scope starts the first analysis on open, and tells the diagram
+ *     that a missing run means work in progress rather than a button to find.
+ *   - SWARM scope does not. It already auto-queues when a run settles
+ *     (`journeyRuns.recomputeRunSummaries`), so a swarm with no run is a
+ *     different story from an unanalyzed scenario.
+ *   - BENCHMARK scope does not. Its flow analysis is the one PAID call here,
+ *     an action rather than a mutation, designed to wait to be asked.
+ *   - The automatic start is SILENT. Nobody asked for it, so a toast would
+ *     report an outcome for an action the user did not take.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { InsightsWorkbench } from "../InsightsWorkbench";
+import type { InsightsScope, UsageBreakdown } from "@/hooks/useUsageInsights";
+
+const { mockUseUsageInsights, mockUseGoalOutcomeDrilldown, toastMock } =
+  vi.hoisted(() => ({
+    mockUseUsageInsights: vi.fn(),
+    mockUseGoalOutcomeDrilldown: vi.fn(),
+    toastMock: {
+      success: vi.fn(),
+      info: vi.fn(),
+      warning: vi.fn(),
+      error: vi.fn(),
+    },
+  }));
+
+vi.mock("@/lib/toast", () => ({ toast: toastMock }));
+
+vi.mock("convex/react", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useQuery: () => undefined,
+    useMutation: () => async () => undefined,
+  };
+});
+
+vi.mock("@/hooks/useUsageInsights", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useUsageInsights: (...args: unknown[]) => mockUseUsageInsights(...args),
+    useGoalOutcomeDrilldown: (...args: unknown[]) =>
+      mockUseGoalOutcomeDrilldown(...args),
+  };
+});
+
+vi.mock("@/components/shared/usage-insights/TopicMapPanel", () => ({
+  TopicMapPanel: () => <div data-testid="topic-map-panel" />,
+}));
+
+// Stubbed to the one prop under test: this file exercises what the workbench
+// TELLS the diagram, not what the diagram does with it (that has its own).
+vi.mock("@/components/shared/usage-insights/SessionFlowSankey", () => ({
+  SessionFlowSankey: ({
+    analysisIsAutomatic,
+  }: {
+    analysisIsAutomatic?: boolean;
+  }) => (
+    <span data-testid="analysis-is-automatic">
+      {String(analysisIsAutomatic)}
+    </span>
+  ),
+}));
+
+let rebuild: ReturnType<typeof vi.fn>;
+
+/** A cohort with sessions and no analysis — the state BB-196 is about. */
+function breakdown(
+  overrides: Partial<Pick<UsageBreakdown, "totalSessions" | "latestRun">> = {},
+): UsageBreakdown {
+  return {
+    totalSessions: 4,
+    latestRun: null,
+    ...overrides,
+  } as unknown as UsageBreakdown;
+}
+
+function renderWorkbench(
+  scope: InsightsScope | null,
+  breakdownValue: UsageBreakdown | null | undefined = breakdown(),
+) {
+  mockUseUsageInsights.mockReturnValue({
+    threads: undefined,
+    breakdown: breakdownValue,
+    rebuild,
+  });
+  return render(
+    <InsightsWorkbench
+      scope={scope}
+      cohortKey="cohort-1"
+      testIdPrefix="insights"
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rebuild = vi.fn().mockResolvedValue({
+    runId: "run-1",
+    status: "queued",
+    alreadyRunning: false,
+  });
+  mockUseGoalOutcomeDrilldown
+    .mockReset()
+    .mockReturnValue({ drilldown: undefined, isLoading: false });
+});
+
+describe("InsightsWorkbench automatic analysis", () => {
+  it("starts the first analysis of a User Testing scenario on open", async () => {
+    renderWorkbench({ kind: "scenario", scenarioId: "sc-1" });
+    await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId("analysis-is-automatic")).toHaveTextContent(
+      "true",
+    );
+  });
+
+  it("says nothing about it — the user did not ask", async () => {
+    renderWorkbench({ kind: "scenario", scenarioId: "sc-1" });
+    await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(1));
+    expect(toastMock.success).not.toHaveBeenCalled();
+    expect(toastMock.info).not.toHaveBeenCalled();
+  });
+
+  it("leaves a scenario that has already been analyzed alone", () => {
+    renderWorkbench(
+      { kind: "scenario", scenarioId: "sc-1" },
+      breakdown({
+        latestRun: { status: "done" } as UsageBreakdown["latestRun"],
+      }),
+    );
+    expect(rebuild).not.toHaveBeenCalled();
+  });
+
+  it("does not analyze a swarm on open — a settling run already does", () => {
+    renderWorkbench({ kind: "swarm", projectId: "proj-1" });
+    expect(rebuild).not.toHaveBeenCalled();
+    expect(screen.getByTestId("analysis-is-automatic")).toHaveTextContent(
+      "false",
+    );
+  });
+
+  it("does not buy a benchmark flow analysis on open", () => {
+    renderWorkbench({ kind: "benchmark", benchmarkRunId: "run-9" });
+    expect(rebuild).not.toHaveBeenCalled();
+    expect(screen.getByTestId("analysis-is-automatic")).toHaveTextContent(
+      "false",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/InsightsWorkbench.auto-analysis.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/InsightsWorkbench.auto-analysis.test.tsx
@@ -7,7 +7,7 @@
  *   - SCENARIO scope starts the first analysis on open, and tells the diagram
  *     that a missing run means work in progress rather than a button to find.
  *   - SWARM scope does not. It already auto-queues when a run settles
- *     (`journeyRuns.recomputeRunSummaries`), so a swarm with no run is a
+ *     (journeyRuns.ts, on first settle), so a swarm with no run is a
  *     different story from an unanalyzed scenario.
  *   - BENCHMARK scope does not. Its flow analysis is the one PAID call here,
  *     an action rather than a mutation, designed to wait to be asked.

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/InsightsWorkbench.flow-selection.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/InsightsWorkbench.flow-selection.test.tsx
@@ -238,7 +238,14 @@ beforeEach(() => {
   mockUseUsageInsights.mockReturnValue({
     threads: undefined,
     breakdown: breakdown(),
-    rebuild: vi.fn(),
+    // Resolves, because the real one is an async function and this scope now
+    // starts its own first analysis on mount (BB-196) — a bare `vi.fn()`
+    // hands that effect `undefined` to await.
+    rebuild: vi.fn().mockResolvedValue({
+      runId: "run-1",
+      status: "queued",
+      alreadyRunning: false,
+    }),
   });
   mockUseGoalOutcomeDrilldown.mockReturnValue({
     drilldown: {

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/SessionFlowSankey.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/SessionFlowSankey.test.tsx
@@ -330,6 +330,86 @@ describe("SessionFlowSankey", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("treats a missing run as work in progress on a self-analyzing surface", () => {
+    // BB-196: User Testing starts its own analysis, so "no run yet" is a run
+    // being arranged. Offering a button here is offering to do the thing that
+    // is already happening.
+    renderSankey({
+      breakdown: breakdown({ latestRun: null }),
+      analysisIsAutomatic: true,
+    });
+
+    expect(screen.getByText(/Analyzing sessions/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Analyze sessions/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/haven.t been analyzed yet/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps offering to analyze on a surface that waits to be asked", () => {
+    // The same state WITHOUT the promise. The benchmark diagram is the paid
+    // one and deliberately waits, so the default must not change.
+    renderSankey({ breakdown: breakdown({ latestRun: null }) });
+    expect(
+      screen.getByRole("button", { name: /Analyze sessions/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("reads an empty flow as building rather than as a prompt to build it", () => {
+    renderSankey({
+      breakdown: breakdown({
+        sankey: { nodes: [], links: [], foldedGoalCount: 0, foldedByStage: {} },
+        latestRun: null,
+      }),
+      analysisIsAutomatic: true,
+      onApplyTuning: vi.fn(),
+    });
+
+    expect(screen.getByText(/Analyzing sessions/)).toBeInTheDocument();
+    expect(screen.queryByText("No session flow yet")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Rebuild clusters/ }),
+    ).not.toBeInTheDocument();
+    // The button goes; choosing HOW to cluster is still a thing to ask for.
+    expect(screen.getByTestId("cluster-tuning-trigger")).toBeInTheDocument();
+  });
+
+  it("stops advertising a rebuild while one is already running", () => {
+    // True on every surface, not just the self-analyzing ones: this branch
+    // used to offer "Rebuild clusters" during a rebuild.
+    renderSankey({
+      breakdown: breakdown({
+        sankey: { nodes: [], links: [], foldedGoalCount: 0, foldedByStage: {} },
+        latestRun: run({ status: "running" }),
+      }),
+    });
+
+    expect(screen.getByText(/Analyzing sessions/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Rebuild clusters/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("still offers a rebuild on an empty flow a completed analysis produced", async () => {
+    // A finished run that clustered nothing IS a dead end a rebuild can move,
+    // so the affordance has to survive. Removing it as "required" must not
+    // remove it as available.
+    const user = userEvent.setup();
+    const { onRebuild } = renderSankey({
+      breakdown: breakdown({
+        sankey: { nodes: [], links: [], foldedGoalCount: 0, foldedByStage: {} },
+        latestRun: run(),
+      }),
+      analysisIsAutomatic: true,
+    });
+
+    expect(screen.getByText("No session flow yet")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Rebuild clusters/ }));
+    expect(onRebuild).toHaveBeenCalledTimes(1);
+  });
+
   it("draws each column header at its own column's x", () => {
     // Guards the misalignment that shipped: headers laid out by CSS across the
     // full panel while the columns lived in a fixed-width SVG.

--- a/mcpjam-inspector/client/src/hooks/__tests__/useEnsureFirstAnalysis.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useEnsureFirstAnalysis.test.ts
@@ -1,0 +1,136 @@
+/**
+ * BB-196: analysis and clustering run on their own.
+ *
+ * What these pin is the discipline around that, not the queueing itself — the
+ * mutation is one line. A hook that starts paid work on mount is one bad
+ * dependency away from starting it on every keystroke, so:
+ *
+ *   - ONE START PER COHORT, however many times the breakdown updates. A
+ *     clustering pass costs embeddings plus an LLM pass; two of them over
+ *     nearly the same window is money for nothing.
+ *   - FROM A STANDING START ONLY. An analysis that exists is never refreshed
+ *     here. Staleness is the backend's to judge, on a clock that knows when a
+ *     session's outcome became assertable; a mount knows nothing about that.
+ *   - LOADING IS NOT AN ANSWER. Acting on the first, undefined subscription
+ *     would analyze every cohort the user merely passes through.
+ *   - ABSENT IS NOT ZERO. A backend that does not report a session count is
+ *     not a cohort with no sessions.
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useEnsureFirstAnalysis } from "../useInsightsFlowController";
+import type { UsageBreakdown } from "../useUsageInsights";
+
+/** Only the three fields the hook reads; the rest never reaches it. */
+function breakdown(
+  overrides: Partial<Pick<UsageBreakdown, "totalSessions" | "latestRun">> = {},
+): UsageBreakdown {
+  return {
+    totalSessions: 4,
+    latestRun: null,
+    ...overrides,
+  } as unknown as UsageBreakdown;
+}
+
+const queued = { runId: "run-1", status: "queued", alreadyRunning: false };
+
+function setup(
+  initial: {
+    enabled?: boolean;
+    cohortKey?: string;
+    breakdown?: UsageBreakdown | null | undefined;
+  } = {},
+) {
+  const rebuild = vi.fn().mockResolvedValue(queued);
+  const props = {
+    enabled: initial.enabled ?? true,
+    cohortKey: initial.cohortKey ?? "scenario-1",
+    breakdown: "breakdown" in initial ? initial.breakdown : breakdown(),
+    rebuild,
+  };
+  const view = renderHook((p: typeof props) => useEnsureFirstAnalysis(p), {
+    initialProps: props,
+  });
+  return { rebuild, view, props };
+}
+
+describe("useEnsureFirstAnalysis", () => {
+  it("starts the analysis a cohort with sessions has never had", async () => {
+    const { rebuild } = setup();
+    await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(1));
+    // No arguments: the surface is not choosing tuning on the user's behalf.
+    expect(rebuild.mock.calls[0]).toEqual([]);
+  });
+
+  it("starts it once however many times the breakdown updates", async () => {
+    const { rebuild, view, props } = setup();
+    await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(1));
+
+    // A fresh object identity each time, as a Convex subscription delivers.
+    view.rerender({ ...props, breakdown: breakdown() });
+    view.rerender({ ...props, breakdown: breakdown({ totalSessions: 5 }) });
+    expect(rebuild).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves an analysis that already exists alone", () => {
+    const { rebuild } = setup({
+      breakdown: breakdown({
+        latestRun: { status: "done" } as UsageBreakdown["latestRun"],
+      }),
+    });
+    expect(rebuild).not.toHaveBeenCalled();
+  });
+
+  it("waits for the breakdown rather than acting on a loading subscription", async () => {
+    const { rebuild, view, props } = setup({ breakdown: undefined });
+    expect(rebuild).not.toHaveBeenCalled();
+
+    view.rerender({ ...props, breakdown: breakdown() });
+    await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(1));
+  });
+
+  it("does nothing for a cohort with no sessions", () => {
+    const { rebuild } = setup({ breakdown: breakdown({ totalSessions: 0 }) });
+    expect(rebuild).not.toHaveBeenCalled();
+  });
+
+  it("treats a missing session count as unknown rather than empty", async () => {
+    const { rebuild } = setup({
+      breakdown: breakdown({ totalSessions: undefined }),
+    });
+    await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(1));
+  });
+
+  it("stays out of the way on a surface that waits to be asked", () => {
+    const { rebuild } = setup({ enabled: false });
+    expect(rebuild).not.toHaveBeenCalled();
+  });
+
+  it("arms again for a different cohort", async () => {
+    const { rebuild, view, props } = setup();
+    await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(1));
+
+    view.rerender({ ...props, cohortKey: "scenario-2" });
+    await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(2));
+  });
+
+  it("releases the latch when the start fails, so a later update retries", async () => {
+    const rebuild = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValue(queued);
+    const props = {
+      enabled: true,
+      cohortKey: "scenario-1",
+      breakdown: breakdown(),
+      rebuild,
+    };
+    const view = renderHook((p: typeof props) => useEnsureFirstAnalysis(p), {
+      initialProps: props,
+    });
+    await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(1));
+
+    view.rerender({ ...props, breakdown: breakdown() });
+    await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(2));
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/useEnsureFirstAnalysis.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useEnsureFirstAnalysis.test.ts
@@ -160,6 +160,31 @@ describe("useEnsureFirstAnalysis", () => {
     expect(view.result.current.failed).toBe(true);
   });
 
+  it("does not re-attempt a refused cohort when the user returns to it", async () => {
+    // The single-key latch could only remember the LAST cohort. Go to a
+    // refused scenario, leave, come back, and the guard passed again — so the
+    // hook re-queued in the background while `failed` was still presenting the
+    // manual button that says it will not.
+    const rebuild = vi.fn().mockRejectedValue(REFUSED);
+    const props = {
+      enabled: true,
+      cohortKey: "scenario-1",
+      breakdown: breakdown(),
+      rebuild,
+    };
+    const view = renderHook((p: typeof props) => useEnsureFirstAnalysis(p), {
+      initialProps: props,
+    });
+    await waitFor(() => expect(view.result.current.failed).toBe(true));
+
+    view.rerender({ ...props, cohortKey: "scenario-2" });
+    await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(2));
+
+    view.rerender({ ...props, cohortKey: "scenario-1" });
+    expect(rebuild).toHaveBeenCalledTimes(2);
+    expect(view.result.current.failed).toBe(true);
+  });
+
   it("does not carry one cohort's refusal over to the next", async () => {
     const rebuild = vi
       .fn()

--- a/mcpjam-inspector/client/src/hooks/__tests__/useEnsureFirstAnalysis.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useEnsureFirstAnalysis.test.ts
@@ -54,6 +54,9 @@ function setup(
   return { rebuild, view, props };
 }
 
+/** The failure the signed-out-guest path produces: a refused mutation. */
+const REFUSED = new Error("Not authenticated");
+
 describe("useEnsureFirstAnalysis", () => {
   it("starts the analysis a cohort with sessions has never had", async () => {
     const { rebuild } = setup();
@@ -114,10 +117,53 @@ describe("useEnsureFirstAnalysis", () => {
     await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(2));
   });
 
-  it("releases the latch when the start fails, so a later update retries", async () => {
+  it("reports a refused start, with no further subscription update needed", async () => {
+    // The regression this pins: a rejection used to only clear a ref, which
+    // re-runs nothing. The caller was left promising an analysis that was
+    // never coming, and the diagram hides its rebuild button while it thinks
+    // one is on the way.
+    const rebuild = vi.fn().mockRejectedValue(REFUSED);
+    const props = {
+      enabled: true,
+      cohortKey: "scenario-1",
+      breakdown: breakdown(),
+      rebuild,
+    };
+    const view = renderHook((p: typeof props) => useEnsureFirstAnalysis(p), {
+      initialProps: props,
+    });
+
+    await waitFor(() => expect(view.result.current.failed).toBe(true));
+    // Nothing about the inputs changed — the failure surfaced on its own.
+    expect(rebuild).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not keep retrying a start that was refused", async () => {
+    // `rebuildScenarioInsights` authenticates, so a signed-out guest is
+    // refused every time. Re-attempting on each breakdown push would spend
+    // attempts to arrive at the same place; the recovery is the button.
+    const rebuild = vi.fn().mockRejectedValue(REFUSED);
+    const props = {
+      enabled: true,
+      cohortKey: "scenario-1",
+      breakdown: breakdown(),
+      rebuild,
+    };
+    const view = renderHook((p: typeof props) => useEnsureFirstAnalysis(p), {
+      initialProps: props,
+    });
+    await waitFor(() => expect(view.result.current.failed).toBe(true));
+
+    view.rerender({ ...props, breakdown: breakdown() });
+    view.rerender({ ...props, breakdown: breakdown({ totalSessions: 9 }) });
+    expect(rebuild).toHaveBeenCalledTimes(1);
+    expect(view.result.current.failed).toBe(true);
+  });
+
+  it("does not carry one cohort's refusal over to the next", async () => {
     const rebuild = vi
       .fn()
-      .mockRejectedValueOnce(new Error("offline"))
+      .mockRejectedValueOnce(REFUSED)
       .mockResolvedValue(queued);
     const props = {
       enabled: true,
@@ -128,9 +174,17 @@ describe("useEnsureFirstAnalysis", () => {
     const view = renderHook((p: typeof props) => useEnsureFirstAnalysis(p), {
       initialProps: props,
     });
-    await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(view.result.current.failed).toBe(true));
 
-    view.rerender({ ...props, breakdown: breakdown() });
+    // A different scenario is a clean slate: its analysis has not been refused.
+    view.rerender({ ...props, cohortKey: "scenario-2" });
     await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(2));
+    expect(view.result.current.failed).toBe(false);
+  });
+
+  it("reports no failure on a start that succeeded", async () => {
+    const { rebuild, view } = setup();
+    await waitFor(() => expect(rebuild).toHaveBeenCalledTimes(1));
+    expect(view.result.current.failed).toBe(false);
   });
 });

--- a/mcpjam-inspector/client/src/hooks/useInsightsFlowController.ts
+++ b/mcpjam-inspector/client/src/hooks/useInsightsFlowController.ts
@@ -272,9 +272,23 @@ export function useInsightsRebuild(rebuild: RebuildFn, cohortKey: string) {
  *
  * Deliberately NOT routed through {@link useInsightsRebuild}: that hook toasts
  * the result, and nobody asked for this one — a toast would report an outcome
- * for an action the user did not take. Failures release the ref so a later
- * breakdown update can try again, and the panel's own copy is what tells the
- * user where the analysis stands.
+ * for an action the user did not take.
+ *
+ * Returns `failed` when the start was REFUSED, which the caller must use to
+ * stop promising that this surface analyzes itself. Without that, a rejection
+ * strands the viewer: `latestRun` stays null forever, the diagram keeps saying
+ * "Analyzing sessions", and the state that hides the manual rebuild is the
+ * state that can no longer recover on its own.
+ *
+ * That is not a rare path. `rebuildScenarioInsights` authenticates, so a
+ * SIGNED-OUT GUEST on a shared scenario link is refused every time — and
+ * guests can read window signals, so they do reach this surface.
+ *
+ * The latch is kept SET on failure rather than released. Releasing it would
+ * re-attempt on the next breakdown push, and the refusal above is precisely
+ * the kind that will refuse again; a bounded retry would spend attempts to
+ * arrive at the same place. Handing the button back is the recovery, and it
+ * reports its own outcome because the manual path toasts.
  *
  * Shared rather than inlined in the workbench so a second User Testing surface
  * — the Findings tab — can adopt the same rule with one call.
@@ -291,8 +305,10 @@ export function useEnsureFirstAnalysis({
   cohortKey: string;
   breakdown: UsageBreakdown | null | undefined;
   rebuild: RebuildFn;
-}) {
+}): { failed: boolean } {
   const startedKeyRef = useRef<string | null>(null);
+  // State, not a ref: the caller has to re-render to withdraw the promise.
+  const [failedKey, setFailedKey] = useState<string | null>(null);
 
   useEffect(() => {
     if (!enabled) return;
@@ -307,7 +323,11 @@ export function useEnsureFirstAnalysis({
     if (startedKeyRef.current === cohortKey) return;
     startedKeyRef.current = cohortKey;
     void rebuild().catch(() => {
-      startedKeyRef.current = null;
+      setFailedKey(cohortKey);
     });
   }, [enabled, breakdown, cohortKey, rebuild]);
+
+  // Keyed on the cohort rather than reset by an effect, so switching scenarios
+  // cannot show one scenario's refusal against another's data for a frame.
+  return { failed: failedKey === cohortKey };
 }

--- a/mcpjam-inspector/client/src/hooks/useInsightsFlowController.ts
+++ b/mcpjam-inspector/client/src/hooks/useInsightsFlowController.ts
@@ -258,40 +258,31 @@ export function useInsightsRebuild(rebuild: RebuildFn, cohortKey: string) {
  * analyzed, so no surface presents "analyze this" as a required first step
  * (BB-196).
  *
- * ONE SHOT PER COHORT, and only from a standing start: it fires when there is
- * NO analysis at all and never to refresh one that exists. Staleness is the
- * backend's to judge — its idle rebuild runs on a clock that knows when a
- * session's outcome became assertable, which a mount cannot know. Same
- * discipline as the workbench's topic-map backfill.
+ * One attempt per cohort, and only from a standing start — never to refresh an
+ * analysis that exists. Staleness is the backend's to judge, on a clock that
+ * knows when a session's outcome became assertable; a mount knows nothing
+ * about that.
  *
- * Racing is fine and expected. The scenario's own backend fast path queues the
- * same analysis minutes after its testers stop, and two tabs may mount at
- * once; the rebuild mutation's in-flight guard coalesces all of them into a
- * single job. The ref is hygiene for the window before Convex reflects the
- * queued run.
- *
- * Deliberately NOT routed through {@link useInsightsRebuild}: that hook toasts
- * the result, and nobody asked for this one — a toast would report an outcome
- * for an action the user did not take.
+ * Racing is fine: the backend fast path queues the same analysis minutes after
+ * the testers stop, and the rebuild mutation's in-flight guard coalesces that,
+ * this, and any other tab into a single job.
  *
  * Returns `failed` when the start was REFUSED, which the caller must use to
- * stop promising that this surface analyzes itself. Without that, a rejection
- * strands the viewer: `latestRun` stays null forever, the diagram keeps saying
- * "Analyzing sessions", and the state that hides the manual rebuild is the
- * state that can no longer recover on its own.
+ * stop promising that the surface analyzes itself — otherwise `latestRun`
+ * stays null forever while the diagram says "Analyzing sessions" and hides the
+ * manual rebuild. Not a rare path: `rebuildScenarioInsights` authenticates, so
+ * a signed-out guest on a shared scenario link is refused every time, and
+ * guests do reach this surface.
  *
- * That is not a rare path. `rebuildScenarioInsights` authenticates, so a
- * SIGNED-OUT GUEST on a shared scenario link is refused every time — and
- * guests can read window signals, so they do reach this surface.
+ * A refused cohort is therefore never retried — handing the button back is the
+ * recovery, and it reports its own outcome because the manual path toasts. Note
+ * this is the OPPOSITE policy to the topic-map backfill in `InsightsWorkbench`,
+ * which releases its latch and is gated on an opt-in prop. That one retries a
+ * cheap map rebuild on a run that already succeeded; this one starts a paid
+ * analysis whose refusals are systemic. Do not align them by reflex.
  *
- * The latch is kept SET on failure rather than released. Releasing it would
- * re-attempt on the next breakdown push, and the refusal above is precisely
- * the kind that will refuse again; a bounded retry would spend attempts to
- * arrive at the same place. Handing the button back is the recovery, and it
- * reports its own outcome because the manual path toasts.
- *
- * Shared rather than inlined in the workbench so a second User Testing surface
- * — the Findings tab — can adopt the same rule with one call.
+ * Not routed through {@link useInsightsRebuild}: that hook toasts, and nobody
+ * asked for this one.
  */
 export function useEnsureFirstAnalysis({
   enabled,
@@ -301,33 +292,49 @@ export function useEnsureFirstAnalysis({
 }: {
   /** False on surfaces whose analysis must stay explicitly requested. */
   enabled: boolean;
-  /** Identity of the cohort; the one-shot latch is per cohort. */
+  /** Identity of the cohort; attempts and refusals are tracked per cohort. */
   cohortKey: string;
   breakdown: UsageBreakdown | null | undefined;
   rebuild: RebuildFn;
 }): { failed: boolean } {
-  const startedKeyRef = useRef<string | null>(null);
+  /**
+   * Every cohort attempted, not just the last one. A single key could only
+   * remember the most recent cohort, so leaving a refused scenario and coming
+   * back passed the guard and re-queued it — silently, while `failed` was
+   * still presenting the manual button that says it will not.
+   */
+  const attemptedKeysRef = useRef<Set<string>>(new Set());
   // State, not a ref: the caller has to re-render to withdraw the promise.
-  const [failedKey, setFailedKey] = useState<string | null>(null);
+  const [failedKeys, setFailedKeys] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
 
   useEffect(() => {
     if (!enabled) return;
     // `undefined` is the first subscription, not an answer. Acting on it would
     // queue an analysis for every cohort the user merely passes through.
     if (!breakdown) return;
-    // Absent is not zero — a backend that does not report the count is not a
-    // cohort with no sessions. Only an explicit zero means there is nothing
-    // here to analyze.
+    // Typed `number`, but it crosses an `as any` Convex boundary, so an absent
+    // count is reachable at runtime — and absent means unknown, not empty.
+    // Only an explicit zero says there is nothing here to analyze.
     if (breakdown.totalSessions === 0) return;
     if (breakdown.latestRun) return;
-    if (startedKeyRef.current === cohortKey) return;
-    startedKeyRef.current = cohortKey;
-    void rebuild().catch(() => {
-      setFailedKey(cohortKey);
+    if (attemptedKeysRef.current.has(cohortKey)) return;
+    attemptedKeysRef.current.add(cohortKey);
+    void rebuild().catch((error: unknown) => {
+      // Logged, unlike the neighbouring backfill: this starts a paid pass
+      // nobody asked for, so a systemic refusal (quota, backend down) must
+      // leave a trace somewhere rather than only turning a spinner into a
+      // button.
+      console.warn(
+        `[insights] automatic first analysis refused for ${cohortKey}`,
+        error,
+      );
+      setFailedKeys((prev) => new Set(prev).add(cohortKey));
     });
   }, [enabled, breakdown, cohortKey, rebuild]);
 
   // Keyed on the cohort rather than reset by an effect, so switching scenarios
   // cannot show one scenario's refusal against another's data for a frame.
-  return { failed: failedKey === cohortKey };
+  return { failed: failedKeys.has(cohortKey) };
 }

--- a/mcpjam-inspector/client/src/hooks/useInsightsFlowController.ts
+++ b/mcpjam-inspector/client/src/hooks/useInsightsFlowController.ts
@@ -19,7 +19,7 @@ import {
   type UsageFilterChip,
   type UsageFilterState,
 } from "@/hooks/scenario-usage-filters";
-import type { RebuildResult } from "@/hooks/useUsageInsights";
+import type { RebuildResult, UsageBreakdown } from "@/hooks/useUsageInsights";
 import { rebuildFeedback } from "@/components/shared/usage-insights/rebuild-feedback";
 import type { ClusterTuning } from "@/lib/cluster-tuning";
 
@@ -251,4 +251,63 @@ export function useInsightsRebuild(rebuild: RebuildFn, cohortKey: string) {
   );
 
   return { rebuildBusy, handleRebuild, handleApplyTuning };
+}
+
+/**
+ * Start the first analysis of a cohort that has sessions and has never been
+ * analyzed, so no surface presents "analyze this" as a required first step
+ * (BB-196).
+ *
+ * ONE SHOT PER COHORT, and only from a standing start: it fires when there is
+ * NO analysis at all and never to refresh one that exists. Staleness is the
+ * backend's to judge — its idle rebuild runs on a clock that knows when a
+ * session's outcome became assertable, which a mount cannot know. Same
+ * discipline as the workbench's topic-map backfill.
+ *
+ * Racing is fine and expected. The scenario's own backend fast path queues the
+ * same analysis minutes after its testers stop, and two tabs may mount at
+ * once; the rebuild mutation's in-flight guard coalesces all of them into a
+ * single job. The ref is hygiene for the window before Convex reflects the
+ * queued run.
+ *
+ * Deliberately NOT routed through {@link useInsightsRebuild}: that hook toasts
+ * the result, and nobody asked for this one — a toast would report an outcome
+ * for an action the user did not take. Failures release the ref so a later
+ * breakdown update can try again, and the panel's own copy is what tells the
+ * user where the analysis stands.
+ *
+ * Shared rather than inlined in the workbench so a second User Testing surface
+ * — the Findings tab — can adopt the same rule with one call.
+ */
+export function useEnsureFirstAnalysis({
+  enabled,
+  cohortKey,
+  breakdown,
+  rebuild,
+}: {
+  /** False on surfaces whose analysis must stay explicitly requested. */
+  enabled: boolean;
+  /** Identity of the cohort; the one-shot latch is per cohort. */
+  cohortKey: string;
+  breakdown: UsageBreakdown | null | undefined;
+  rebuild: RebuildFn;
+}) {
+  const startedKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    // `undefined` is the first subscription, not an answer. Acting on it would
+    // queue an analysis for every cohort the user merely passes through.
+    if (!breakdown) return;
+    // Absent is not zero — a backend that does not report the count is not a
+    // cohort with no sessions. Only an explicit zero means there is nothing
+    // here to analyze.
+    if (breakdown.totalSessions === 0) return;
+    if (breakdown.latestRun) return;
+    if (startedKeyRef.current === cohortKey) return;
+    startedKeyRef.current = cohortKey;
+    void rebuild().catch(() => {
+      startedKeyRef.current = null;
+    });
+  }, [enabled, breakdown, cohortKey, rebuild]);
 }


### PR DESCRIPTION
Client half of [BB-196](https://app.kestral.ai/workspace/yhNILB2/task/1KDB1XoG). Pairs with MCPJam/mcpjam-backend#1300, which is where the analysis actually gets queued without anyone looking.

From Emmanuel Paraskakis research (Sep 4): "I would definitely expect these sessions to be already analyzed and not need to have to analyze them."

## The state this removes

Open a User Testing scenario's Insights with sessions but no analysis and you got "These sessions haven't been analyzed yet" plus an **Analyze sessions** button. Nothing about that state needed a human: the surface knows there are sessions, knows there is no analysis, and can already queue one.

## What changed

**`useEnsureFirstAnalysis`** (`hooks/useInsightsFlowController.ts`) starts it. One shot per cohort, and only from a standing start — never to refresh an analysis that exists, because staleness is the backend's to judge on a clock that knows when a session's outcome became assertable, and a mount knows nothing about that. Same discipline as the topic-map backfill next to it.

Deliberately *not* routed through `useInsightsRebuild`: that hook toasts the result, and reporting an outcome for an action the user did not take is worse than saying nothing.

Shared rather than inlined so the User Testing Findings tab can adopt the same rule with one call — see Scope below.

**`SessionFlowSankey`** learns one prop, `analysisIsAutomatic`: on a surface that starts its own analysis, a **missing** run is a run being arranged rather than a request waiting to be made, so it takes the working banner the in-flight path already had. Off by default, because it is a promise the *owner* has to keep — a surface claiming it without queueing anything would spin forever.

## Only the scenario scope opts in

The workbench is shared by three, and the other two are excluded on purpose:

- **Swarm** already auto-queues when a run settles (`journeyRuns.recomputeRunSummaries`), so a swarm with no run is a different story from an unanalyzed scenario.
- **Benchmark** flow analysis is the one PAID call here — an action, not a mutation — whose whole design is to wait to be asked.

Keyed on `scope.kind` rather than taken as a prop because the client rule mirrors a backend one (`scenarioWindowFreshness`'s first-analysis fast path) and the scope is the same fact both are keyed on. Two ways to say it would let a caller turn off half of a guarantee.

## Buttons are removed as required, not as available

Per the ticket's "as required buttons". The freshness chip and the cluster tuning control still force a run — choosing *how* to cluster is still a thing to ask for, and the tuning control has no other way to apply a setting. A completed run that clustered nothing still offers Rebuild clusters, because that is a real dead end a rebuild can move; there is a test for it.

## Drive-by fix

The empty-flow branch offered "Rebuild clusters" while a rebuild was already running, and said "once there are enough sessions to cluster" during one. True on every surface, not just the self-analyzing ones.

## Scope — no overlap with BB-145 / BB-146

Nothing here touches `components/scenarios/findings/**`, `components/swarms/findings/**`, `UserTestingScenarioDetail.tsx`, or `lib/app-navigation.ts`.

**The Findings tab IS wired** (updated). It was not, originally, because User Testing had no Findings tab on `main`; merging BB-146 in brought one, and it is the LANDING tab. Leaving it unwired would have meant the surface everyone sees first said "No session has been analyzed yet" with nothing queued and no affordance — less than the old button offered. It now calls `useEnsureFirstAnalysis` with the same one-attempt discipline, and its empty state separates "an analysis is on its way" from the honest dead end.

## Testing

- `SessionFlowSankey.test.tsx`: 22 passed (5 new) — the working banner on a missing run, the unchanged default for surfaces that wait to be asked, the empty flow reading as building, no rebuild button mid-rebuild, and the affordance surviving on a completed-but-empty run.
- `useEnsureFirstAnalysis.test.ts`: 13 new — one start per cohort however many times the breakdown updates, no refresh of an existing analysis, loading is not an answer, absent is not zero, disabled stays out of the way, a fresh cohort is a clean slate, a refused start is reported and never retried, and a refused cohort stays un-retried when the user navigates away and back.
- `InsightsWorkbench.auto-analysis.test.tsx`: 5 new — the scenario/swarm/benchmark boundary, and that the automatic start is silent.
- `usage-insights/` suite: 219 passed. `typecheck:client` clean.

`InsightsWorkbench.flow-selection.test.tsx` needed its `rebuild` fixture to resolve: the real one is an async function, and this scope now starts an analysis on mount, so a bare `vi.fn()` handed that effect `undefined` to await.

Not caused by this branch, verified against a stashed tree: `ClusterTuningControl` "puts the expensive re-analysis behind a confirmation that names the cost", `GoalOutcomeDrilldown` "warns when the selection total hit the scan limit", and `ScenarioOutcomeCalibration` "qualifies its rates when the scan was truncated" all fail on a clean `main`.

## Known gap, left alone deliberately

A cluster run whose status is `failed` matches no branch in the banner chain, and the empty-flow copy blames a lack of sessions. Pre-existing, but more reachable now that runs start unprompted. Kept out of this PR to hold its scope to the auto-run rule.

## How to see it

1. Open a User Testing scenario that has sessions and has never been analyzed, on the Insights tab.
2. Before: "These sessions haven't been analyzed yet" and an Analyze sessions button. After: the analyzing banner, and the flow fills in on its own.
3. Check the tuning control is still reachable in that state, and that a swarm's Insights still shows its own button.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
User Testing scenario insights now start their first analysis automatically on open, replacing the "These sessions haven't been analyzed yet" state and its "Analyze sessions" button — and if that automatic start is refused (the signed-out guest path is refused every time), the promise is withdrawn and the manual button comes back. This pairs with backend change `mcpjam-backend#1300` that queues the analysis.

**What changed**
- `useEnsureFirstAnalysis` starts the first analysis: one attempt per cohort, tracked per cohort so navigating away and back never re-queues a refused scenario, standing start only, never refreshes an existing analysis, and silent.
- On refusal it returns `failed`; the workbench then turns off the automatic promise so the diagram falls back to "not analyzed yet" and the manual affordance returns. No retry attempted — the latch stays set, and the button is the recovery.
- `SessionFlowSankey` gains `analysisIsAutomatic` (off by default): a missing run reads as work being arranged (working banner) rather than a request waiting to be made.
- The Findings tab — the landing tab since BB-146 merged — now uses the same hook, reading `latestRun` because the drill-down alone cannot tell "never analyzed" from "analyzed and empty". Its empty state distinguishes "no sessions", "analysis in flight", and the honest dead end.
- Only the scenario scope opts in — swarm already auto-queues, and benchmark flow analysis stays explicitly requested.
- Drive-by fix: the empty-flow branch no longer offers "Rebuild clusters" while a rebuild is already running.

**Scope**
- Buttons are removed as required, not as available — the freshness chip and cluster tuning still force a run, and a completed run that clustered nothing still offers "Rebuild clusters."
- Known gap left alone: a `failed` run matches no banner branch, and the empty-flow copy still blames session count.

<sup>Written for commit 8632f65da63bb5d6fb69071ec2535e3d9bd8cc81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

