### PR TITLE
Session detail: name the client and model, label the share control (BB-197)

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { AlertTriangle, Copy, Loader2 } from "lucide-react";
+import { AlertTriangle, Loader2, Share2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@mcpjam/design-system/button";
 import { copyToClipboard } from "@/lib/clipboard";
@@ -39,6 +39,7 @@ import {
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { SessionScoredTranscript } from "@/components/connection/share-usage/session-scored-transcript";
 import { SessionFeedbackMark } from "@/components/connection/share-usage/session-feedback-mark";
+import { SessionClientModelChip } from "@/components/connection/share-usage/session-client-model";
 import { ConvertPromotableSessionDialog } from "@/components/chat-v2/history/convert-promotable-session-dialog";
 import { navigateToPromotedTestCase } from "@/components/chat-v2/shared/promote-to-eval-navigation";
 import { useAction } from "convex/react";
@@ -631,6 +632,12 @@ export function ShareUsageThreadDetail({
           <p className="truncate text-sm font-semibold text-card-foreground">
             {thread.visitorDisplayName}
           </p>
+          {/* Which client and model ran this session — beside the name on both
+              products, so nobody has to open Raw or the trace to find out. */}
+          <SessionClientModelChip
+            sessionId={thread._id}
+            modelId={thread.modelId}
+          />
           <SessionFeedbackMark thread={thread} variant="header" />
         </div>
         <div className="flex shrink-0 items-center gap-2">
@@ -646,15 +653,24 @@ export function ShareUsageThreadDetail({
               Promote to test case
             </Button>
           ) : null}
+          {/* Labeled, never icon-only: readers who wanted to send a session to
+              a teammate did not recognize the copy icon as the way to do it.
+              Same label on Swarm and User Testing. */}
           <Button
             type="button"
             variant="outline"
             size="sm"
-            className="h-8 w-8 rounded-lg px-0"
-            aria-label={sessionLink ? "Copy session link" : "Copy session ID"}
+            className="h-8 rounded-lg px-2.5 text-xs"
+            data-testid="share-usage-share-session"
+            title={
+              sessionLink
+                ? "Copy a link to this session"
+                : "Copy this session's reference"
+            }
             onClick={() => void handleCopySessionRef()}
           >
-            <Copy className="size-3.5" />
+            <Share2 className="mr-1.5 size-3.5" />
+            Share this session
           </Button>
         </div>
       </div>

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadDetail.test.tsx
@@ -15,6 +15,8 @@ const {
   mockHydrateTurnTraceSpans,
   mockTraceViewer,
   mockTurnTracesState,
+  mockHostConfigState,
+  mockCopyToClipboard,
 } = vi.hoisted(() => ({
   mockMessageView: vi.fn(),
   mockReadOnlyTranscript: vi.fn(),
@@ -37,6 +39,13 @@ const {
   mockTraceViewer: vi.fn(),
   mockTurnTracesState: {
     traces: [] as unknown[],
+  },
+  // The session's pinned historical host config — what the header's
+  // client/model chip reads the CLIENT from. `null` is the ordinary answer for
+  // a session written before the pin existed.
+  mockCopyToClipboard: vi.fn().mockResolvedValue(true),
+  mockHostConfigState: {
+    config: null as { hostStyle?: string; currentHostName?: string | null; modelId?: string } | null,
   },
 }));
 
@@ -77,6 +86,30 @@ vi.mock("@/hooks/useSharedChatThreads", () => ({
   }),
   useSessionBrowserArtifacts: () => ({
     artifacts: mockBrowserArtifactsState.artifacts,
+  }),
+  useSessionHistoricalHostConfig: () => ({
+    config: mockHostConfigState.config,
+  }),
+}));
+
+// The header chip resolves model NAMES through the hosted catalog. Pinned to
+// the static fallback here so the label under test is the component's
+// resolution order and not a live fetch.
+vi.mock("@/lib/clipboard", () => ({
+  copyToClipboard: (...args: unknown[]) => mockCopyToClipboard(...args),
+}));
+
+vi.mock("@/hooks/use-hosted-model-catalog", () => ({
+  useHostedModelCatalog: () => ({
+    hostedCatalog: [
+      {
+        id: "openai/gpt-oss-120b",
+        name: "GPT-OSS 120B",
+        provider: "openai",
+        hosted: true,
+      },
+    ],
+    status: "live",
   }),
 }));
 
@@ -176,6 +209,7 @@ describe("ShareUsageThreadDetail", () => {
     mockThreadState.readiness = undefined;
     mockThreadState.goalScore = undefined;
     mockBrowserArtifactsState.artifacts = undefined;
+    mockHostConfigState.config = null;
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => [{ role: "assistant", content: [] }],
@@ -684,6 +718,87 @@ describe("ShareUsageThreadDetail — span load failure", () => {
         traceStartedAtMs: 1_000_000,
         traceEndedAtMs: 1_012_000,
       }),
+    );
+  });
+});
+
+/**
+ * BB-197 — session identity in the header.
+ *
+ * Research (Sep 4): a reader with the transcript open forgot which model
+ * produced it, and share was an icon they did not read as "send this to
+ * someone". Both answers now live in the header of the ONE detail component
+ * Swarm and User Testing share.
+ */
+describe("ShareUsageThreadDetail — session identity header", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockThreadState.sourceType = "scenario";
+    mockThreadState.synthetic = false;
+    mockThreadState.readiness = undefined;
+    mockThreadState.goalScore = undefined;
+    mockBrowserArtifactsState.artifacts = undefined;
+    mockHostConfigState.config = null;
+    mockCopyToClipboard.mockResolvedValue(true);
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ role: "assistant", content: [] }],
+    } as Response);
+    mockAdaptTraceToUiMessages.mockReturnValue({
+      messages: [{ id: "assistant-1", role: "assistant", parts: [] }],
+      toolRenderOverrides: {},
+    });
+  });
+
+  it("names the client and the model in the session header", async () => {
+    // The whole point of the chip: the reader learns which model produced the
+    // transcript without opening Raw or the trace tabs.
+    mockHostConfigState.config = {
+      hostStyle: "chatgpt",
+      currentHostName: "Emmanuel's staging bot",
+      modelId: "openai/gpt-oss-120b",
+    };
+    render(<ShareUsageThreadDetail threadId="thread-1" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("session-client-model")).toHaveTextContent(
+        "ChatGPT · GPT-OSS 120B",
+      ),
+    );
+  });
+
+  it("still names the model when the session pinned no client", async () => {
+    // No pinned host config is the ordinary state for older sessions. The
+    // model is still known, and half an answer beats none.
+    mockHostConfigState.config = null;
+    render(<ShareUsageThreadDetail threadId="thread-1" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("session-client-model")).toHaveTextContent(
+        "GPT-OSS 120B",
+      ),
+    );
+  });
+
+  it("copies the session link from a labeled share control", async () => {
+    // Labeled, not an icon: readers did not recognize the copy icon as the way
+    // to send a session to a teammate.
+    render(
+      <ShareUsageThreadDetail
+        threadId="thread-1"
+        sessionLink="https://app.test/swarms/session-doc-1"
+      />,
+    );
+
+    const share = await screen.findByRole("button", {
+      name: /share this session/i,
+    });
+    await userEvent.click(share);
+
+    await waitFor(() =>
+      expect(mockCopyToClipboard).toHaveBeenCalledWith(
+        "https://app.test/swarms/session-doc-1",
+      ),
     );
   });
 });

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/session-client-model.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/session-client-model.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  clientLabelForSession,
+  modelLabelForSession,
+  sessionClientModelLabel,
+} from "../session-client-model";
+
+/**
+ * The words a session detail uses to say what ran. Both products print the
+ * same string, so the composition rules live here rather than in either
+ * surface.
+ */
+describe("clientLabelForSession", () => {
+  it("prefers the client's brand word over the host's nickname", () => {
+    // A nickname is what the workspace called its host row; the brand word is
+    // what the reader is actually asking about.
+    expect(
+      clientLabelForSession({
+        hostStyle: "chatgpt",
+        hostName: "Emmanuel's staging bot",
+      }),
+    ).toBe("ChatGPT");
+  });
+
+  it("falls back to the nickname for a style no preset claims", () => {
+    expect(
+      clientLabelForSession({ hostStyle: "byo-host-42", hostName: "Acme Bot" }),
+    ).toBe("Acme Bot");
+  });
+
+  it("is null when the session names neither", () => {
+    expect(clientLabelForSession({})).toBeNull();
+    expect(clientLabelForSession({ hostName: "   " })).toBeNull();
+  });
+});
+
+describe("modelLabelForSession", () => {
+  const catalog = [
+    { id: "openai/gpt-5", name: "GPT-5", provider: "openai" as const },
+  ];
+
+  it("uses the catalog's curated name", () => {
+    expect(modelLabelForSession("openai/gpt-5", catalog)).toBe("GPT-5");
+  });
+
+  it("resolves a BYOK model id from the static list", () => {
+    expect(modelLabelForSession("claude-opus-5")).toBe("Claude Opus 5");
+  });
+
+  it("falls back to the id tail for a model no catalog knows", () => {
+    // Better the string the Raw tab would have shown than nothing at all.
+    expect(modelLabelForSession("acme/experimental-7b")).toBe(
+      "experimental-7b",
+    );
+  });
+
+  it("is null when the session recorded no model", () => {
+    expect(modelLabelForSession(undefined)).toBeNull();
+    expect(modelLabelForSession("  ")).toBeNull();
+  });
+});
+
+describe("sessionClientModelLabel", () => {
+  it("joins client and model", () => {
+    expect(sessionClientModelLabel("ChatGPT", "GPT-5")).toBe("ChatGPT · GPT-5");
+  });
+
+  it("prints whichever half is known, never a placeholder", () => {
+    expect(sessionClientModelLabel(null, "Claude Haiku 4.5")).toBe(
+      "Claude Haiku 4.5",
+    );
+    expect(sessionClientModelLabel("Claude", null)).toBe("Claude");
+    expect(sessionClientModelLabel(null, null)).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/session-client-model.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/session-client-model.test.ts
@@ -47,6 +47,33 @@ describe("modelLabelForSession", () => {
     expect(modelLabelForSession("claude-opus-5")).toBe("Claude Opus 5");
   });
 
+  it("resolves a bare hosted id to the catalog's curated name", () => {
+    // Sessions persist both shapes, and the bare one carries no provider for
+    // `getCanonicalModelId` to look under — without the suffix match this read
+    // back as the raw id on 148 of the 173 hosted models.
+    expect(
+      modelLabelForSession("gpt-oss-120b", [
+        {
+          id: "openai/gpt-oss-120b",
+          name: "GPT-OSS 120B",
+          provider: "openai" as const,
+        },
+      ]),
+    ).toBe("GPT-OSS 120B");
+    // Real snapshot entry, no injected catalog — the example from the task.
+    expect(modelLabelForSession("claude-haiku-4.5")).toBe("Claude Haiku 4.5");
+  });
+
+  it("refuses to guess when two vendors claim the same bare name", () => {
+    // A plain id beats a confidently wrong vendor label.
+    expect(
+      modelLabelForSession("mystery-7b", [
+        { id: "openai/mystery-7b", name: "OpenAI Mystery", provider: "openai" as const },
+        { id: "acme/mystery-7b", name: "Acme Mystery", provider: "acme" as const },
+      ]),
+    ).toBe("mystery-7b");
+  });
+
   it("falls back to the id tail for a model no catalog knows", () => {
     // Better the string the Raw tab would have shown than nothing at all.
     expect(modelLabelForSession("acme/experimental-7b")).toBe(

--- a/mcpjam-inspector/client/src/components/connection/share-usage/session-client-model.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/session-client-model.tsx
@@ -11,7 +11,6 @@
  * called "staging bot" still reads `Claude · Claude Haiku 4.5`.
  */
 import {
-  getModelById,
   getCanonicalModelId,
   hostedModelDefinitionsFromSnapshot,
   SUPPORTED_MODELS,
@@ -45,14 +44,49 @@ export function clientLabelForSession(args: {
 }
 
 /**
+ * The catalog entry a BARE hosted id belongs to, e.g. `claude-haiku-4.5` →
+ * `anthropic/claude-haiku-4.5`.
+ *
+ * `getCanonicalModelId` cannot do this for us: it only tries the prefixed form
+ * when it is TOLD which provider to look under, and a session row carries an
+ * id with no provider beside it. Without this, 148 of the 173 hosted ids read
+ * back as their raw id whenever a session stored the bare shape — including
+ * `claude-haiku-4.5`, one of the two examples this label exists to print.
+ *
+ * Only a UNIQUE match counts. Two vendors shipping the same model name is not
+ * hypothetical, and guessing between them would put one vendor's curated label
+ * on the other's session — a wrong answer, where the id tail is merely a plain
+ * one. Ties therefore fall through to the tail.
+ */
+function uniqueBareIdMatch(
+  candidates: readonly ModelDefinition[],
+  id: string,
+): ModelDefinition | undefined {
+  if (id.includes("/")) return undefined;
+  const suffix = `/${id}`;
+  // Keyed by id, because the same model arrives from both the live catalog and
+  // the snapshot — two entries for one model are one candidate, not a tie. The
+  // first writer wins, and `candidates` is ordered so that is the live
+  // catalog's curated name.
+  const byId = new Map<string, ModelDefinition>();
+  for (const model of candidates) {
+    if (!model.id.endsWith(suffix) || byId.has(model.id)) continue;
+    byId.set(model.id, model);
+  }
+  if (byId.size !== 1) return undefined;
+  return byId.values().next().value;
+}
+
+/**
  * The model a session ran on, as the catalog names it.
  *
  * Resolution order is widest-first: the live hosted catalog (curated names such
  * as "GPT-5"), then the BYOK statics, then the checked-in hosted snapshot — and
- * each is tried against the id as stored AND against its canonical form, since
- * sessions persist both the bare (`claude-haiku-4.5`) and prefixed
- * (`anthropic/claude-haiku-4.5`) shapes. An id no catalog knows still gets an
- * answer: its tail, which is what the reader would have read off the Raw tab.
+ * each is tried against the id as stored, against its canonical form, and
+ * against its bare form, since sessions persist both the bare
+ * (`claude-haiku-4.5`) and prefixed (`anthropic/claude-haiku-4.5`) shapes. An
+ * id no catalog knows still gets an answer: its tail, which is what the reader
+ * would have read off the Raw tab.
  */
 export function modelLabelForSession(
   modelId: string | undefined | null,
@@ -69,8 +103,8 @@ export function modelLabelForSession(
   const canonical = getCanonicalModelId(id, undefined, candidates);
   const named =
     candidates.find((model) => model.id === id) ??
-    getModelById(id) ??
-    candidates.find((model) => model.id === canonical);
+    candidates.find((model) => model.id === canonical) ??
+    uniqueBareIdMatch(candidates, id);
 
   return compactModelLabel(named?.name) || compactModelIdTail(id);
 }

--- a/mcpjam-inspector/client/src/components/connection/share-usage/session-client-model.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/session-client-model.tsx
@@ -1,0 +1,135 @@
+/**
+ * "Which client and which model ran this session?" — the one line that answers
+ * it, in the session-detail header of BOTH products. Swarm and User Testing
+ * render the same {@link ShareUsageThreadDetail}, so the treatment is shared by
+ * construction rather than by two components agreeing to look alike.
+ *
+ * From user research (Sep 4): a reader with a transcript in front of them
+ * forgot which model produced it, and the answer was only reachable through the
+ * Raw / trace tabs. So this is session IDENTITY, not a detail — it sits beside
+ * the session name, and it never hides behind the host's nickname: a host
+ * called "staging bot" still reads `Claude · Claude Haiku 4.5`.
+ */
+import {
+  getModelById,
+  getCanonicalModelId,
+  hostedModelDefinitionsFromSnapshot,
+  SUPPORTED_MODELS,
+  type ModelDefinition,
+} from "@/shared/types";
+import { compactModelLabel } from "@/components/chat-v2/shared/model-helpers";
+import { compactModelIdTail } from "@/lib/environment-label";
+import { findHostStyle } from "@/lib/client-styles";
+import type { HostStyleId } from "@/lib/client-styles";
+import { useHostedModelCatalog } from "@/hooks/use-hosted-model-catalog";
+import { useSessionHistoricalHostConfig } from "@/hooks/useSharedChatThreads";
+import { cn } from "@/lib/utils";
+
+/**
+ * The client a session ran on, in the product's own brand words ("Claude",
+ * "ChatGPT") rather than the host row's nickname.
+ *
+ * A BYO host style that no preset claims is not nameless — it just has no brand
+ * word, so the nickname is all we have and it is better than silence. `null`
+ * when we know neither.
+ */
+export function clientLabelForSession(args: {
+  hostStyle?: string | null;
+  hostName?: string | null;
+}): string | null {
+  const brand = findHostStyle(args.hostStyle as HostStyleId | null | undefined)
+    ?.chatUi.label;
+  if (brand) return brand;
+  const nickname = args.hostName?.trim();
+  return nickname ? nickname : null;
+}
+
+/**
+ * The model a session ran on, as the catalog names it.
+ *
+ * Resolution order is widest-first: the live hosted catalog (curated names such
+ * as "GPT-5"), then the BYOK statics, then the checked-in hosted snapshot — and
+ * each is tried against the id as stored AND against its canonical form, since
+ * sessions persist both the bare (`claude-haiku-4.5`) and prefixed
+ * (`anthropic/claude-haiku-4.5`) shapes. An id no catalog knows still gets an
+ * answer: its tail, which is what the reader would have read off the Raw tab.
+ */
+export function modelLabelForSession(
+  modelId: string | undefined | null,
+  hostedCatalog: readonly ModelDefinition[] = [],
+): string | null {
+  const id = modelId?.trim();
+  if (!id) return null;
+
+  const candidates: ModelDefinition[] = [
+    ...hostedCatalog,
+    ...SUPPORTED_MODELS,
+    ...hostedModelDefinitionsFromSnapshot(),
+  ];
+  const canonical = getCanonicalModelId(id, undefined, candidates);
+  const named =
+    candidates.find((model) => model.id === id) ??
+    getModelById(id) ??
+    candidates.find((model) => model.id === canonical);
+
+  return compactModelLabel(named?.name) || compactModelIdTail(id);
+}
+
+/**
+ * The single string both products print. `Client · Model` when both are known;
+ * whichever one is known otherwise. Never a placeholder — an invented "Unknown
+ * model" would be a claim about the session, and the point of this label is
+ * that it only ever states what actually ran.
+ */
+export function sessionClientModelLabel(
+  client: string | null,
+  model: string | null,
+): string | null {
+  if (client && model) return `${client} · ${model}`;
+  return model ?? client;
+}
+
+/**
+ * The header chip. Reads the session's pinned historical host config for the
+ * client; the model comes from the session row itself (the pin is the fallback
+ * for rows written before sessions carried their own model attribution).
+ *
+ * Renders nothing when the session names neither — the same silence the header
+ * had before, rather than an empty chip.
+ */
+export function SessionClientModelChip({
+  sessionId,
+  modelId,
+  className,
+}: {
+  sessionId: string;
+  modelId?: string | null;
+  className?: string;
+}) {
+  const { config } = useSessionHistoricalHostConfig({ sessionId });
+  const { hostedCatalog } = useHostedModelCatalog();
+
+  const client = clientLabelForSession({
+    hostStyle: config?.hostStyle,
+    hostName: config?.currentHostName,
+  });
+  const resolvedModelId = modelId ?? config?.modelId ?? null;
+  const model = modelLabelForSession(resolvedModelId, hostedCatalog);
+  const label = sessionClientModelLabel(client, model);
+  if (!label) return null;
+
+  return (
+    <span
+      data-testid="session-client-model"
+      className={cn(
+        "inline-flex min-w-0 shrink items-center gap-1.5 rounded-md border border-border/60 px-2 py-0.5 text-[11px] text-foreground",
+        className,
+      )}
+      // The exact id, for the reader who needs the version string and not the
+      // brand words.
+      title={resolvedModelId ? `${label} · ${resolvedModelId}` : label}
+    >
+      <span className="truncate">{label}</span>
+    </span>
+  );
+}


### PR DESCRIPTION
Kestral: [BB-197](https://app.kestral.ai/workspace/yhNILB2/task/1KDBhB1U)

From Emmanuel Paraskakis' research session (Sep 4): with a transcript open he could not remember which model had produced it, and the share affordance was an icon he did not read as "send this to someone" ("That copy button is an unclear version of that").

Swarm and User Testing render the same `ShareUsageThreadDetail`, so both surfaces were missing the same two things — and both get the same treatment here, by construction rather than by two components agreeing to look alike.

## What changed

- **`client · model` chip** beside the session name in the detail header. The client comes from the session's pinned historical host config as a brand word ("Claude", "ChatGPT") — never the host row's nickname, which is what the research called out. The model comes from the session's own `modelId`, resolved through the hosted catalog → BYOK statics → snapshot → id tail, so it reads `GPT-5`, not `openai/gpt-5`. Renders nothing (not a placeholder) when the session names neither.
- **`Share this session`** replaces the icon-only copy button. Same label on both products; it copies the same deep link it always did, and the tooltip says which reference it copied.

## Acceptance

- [x] Swarm session detail shows the model without opening raw/trace
- [x] User Testing session detail shows the model the same way
- [x] The control reads "Share this session", not an icon-only copy button

## Tests

- `session-client-model.test.ts` — new, covers the label composition rules (brand word over nickname, catalog resolution order, id-tail fallback, no placeholders).
- `ShareUsageThreadDetail.test.tsx` — new "session identity header" block: names client and model, still names the model when the session pinned no client, and the labeled control copies the session link.

`npx vitest run client/src/components/connection/share-usage client/src/components/scenarios client/src/components/swarms` → 878 passed, 1 failed (`ScenarioOutcomeCalibration > qualifies its rates when the scan was truncated`, which fails on clean `main` too). `typecheck:client` clean.

Not verified against a live workspace — the chip needs real sessions with a pinned host config to see on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a client·model chip to the session detail header and replaces the icon-only copy button with a labeled "Share this session" control.

- The chip shows the client's brand word from the pinned host config and the model name from the catalog (including bare hosted ids via suffix match, falling back to the id tail when unknown or ambiguous), and never shows a placeholder.
- The share button copies the same session link as before, now with a label and tooltip describing the copied reference.
- Swarm and User Testing share the same detail component, so both surfaces get the same change.

<sup>Written for commit 0b64a10c58f9276b67454e599679234fab1d5963. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

