### PR TITLE
User Testing: say Team members everywhere, not Project members (BB-203)

### DIFF
--- a/mcp/src/ui/views/scenarios.tsx
+++ b/mcp/src/ui/views/scenarios.tsx
@@ -30,7 +30,7 @@ const MODE_PRESENTATIONS: Record<
   string,
   { label: string; icon: ComponentType<{ className?: string }> }
 > = {
-  project_members: { label: "Project members", icon: Users },
+  project_members: { label: "Team members", icon: Users },
   invited_only: { label: "Invited only", icon: Lock },
   anyone_with_link: { label: "Anyone with link", icon: Globe },
 };

--- a/mcpjam-inspector/client/src/components/organization/OrganizationSharingPolicyCard.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationSharingPolicyCard.tsx
@@ -27,7 +27,7 @@ import {
 const MODE_OPTIONS: Array<{ value: ShareMode; label: string }> = [
   { value: "anyone_with_link", label: "Anyone with the link" },
   { value: "invited_only", label: "Invited users only" },
-  { value: "project_members", label: "Project members" },
+  { value: "project_members", label: "Team members" },
 ];
 
 export function OrganizationSharingPolicyCard({

--- a/mcpjam-inspector/client/src/components/scenarios/ScenarioShareSection.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/ScenarioShareSection.tsx
@@ -20,8 +20,6 @@ import type { ShareMemberView } from "@/components/sharing/share-types";
 interface ScenarioShareSectionProps {
   scenario: ScenarioSettings;
   onUpdated?: (scenario: ScenarioSettings) => void;
-  /** Shown as the project-wide access option label (e.g. current project name). */
-  projectName?: string | null;
   /** Off in the Share modal — roster management stays on the settings page. */
   showMembers?: boolean;
   /**
@@ -47,7 +45,6 @@ function memberView(member: ScenarioMember): ShareMemberView {
 export function ScenarioShareSection({
   scenario,
   onUpdated,
-  projectName,
   showMembers = true,
   allowRotate = true,
 }: ScenarioShareSectionProps) {
@@ -67,7 +64,6 @@ export function ScenarioShareSection({
     setSettings(scenario);
   }, [scenario]);
 
-  const projectLabel = projectName?.trim() || "Project";
   const accessPreset = scenarioAccessPresetFromSettings(
     settings.mode,
     settings.allowGuestAccess,
@@ -107,18 +103,19 @@ export function ScenarioShareSection({
           },
           {
             value: "project",
-            // The project's own NAME used to be the label here, which made a
-            // third way of saying one thing (sidebar "team members", create
-            // flow "Project members", this one "Acme"). The vocabulary is the
-            // label's job; which project it is stays in the description, so
-            // nothing is lost (BB-203).
+            // This option used to be labeled with the project's NAME — a third
+            // way of saying one thing, beside the sidebar's "team members" and
+            // the create flow's "Project members" (BB-203). No caller ever
+            // passed a name, so what actually rendered was the literal word
+            // "Project"; the prop went with it.
             label: "Team members",
-            description: `Signed-in members of ${projectLabel} can open the scenario with the link. Guests cannot.`,
+            description:
+              "Signed-in team members can open the scenario with the link. Guests cannot.",
           },
         ],
         settings.maxShareMode,
       ),
-    [projectLabel, settings.maxShareMode],
+    [settings.maxShareMode],
   );
 
   const updateSettings = (next: ScenarioSettings) => {

--- a/mcpjam-inspector/client/src/components/scenarios/ScenarioShareSection.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/ScenarioShareSection.tsx
@@ -107,9 +107,13 @@ export function ScenarioShareSection({
           },
           {
             value: "project",
-            label: projectLabel,
-            description:
-              "Signed-in members of this project can open the scenario with the link. Guests cannot.",
+            // The project's own NAME used to be the label here, which made a
+            // third way of saying one thing (sidebar "team members", create
+            // flow "Project members", this one "Acme"). The vocabulary is the
+            // label's job; which project it is stays in the description, so
+            // nothing is lost (BB-203).
+            label: "Team members",
+            description: `Signed-in members of ${projectLabel} can open the scenario with the link. Guests cannot.`,
           },
         ],
         settings.maxShareMode,

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareSection.test.tsx
@@ -274,7 +274,7 @@ describe("ScenarioShareSection", () => {
       }),
     ).toHaveAttribute("data-disabled");
     expect(
-      screen.getByRole("menuitemradio", { name: /Acme/i }),
+      screen.getByRole("menuitemradio", { name: /Team members/i }),
     ).not.toHaveAttribute("data-disabled");
   });
 

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareSection.test.tsx
@@ -74,7 +74,7 @@ describe("ScenarioShareSection", () => {
 
   it("renders the same section structure as the project share dialog", () => {
     render(
-      <ScenarioShareSection scenario={createScenario()} projectName="Acme" />,
+      <ScenarioShareSection scenario={createScenario()} />,
     );
 
     // getByLabelText, not getByText: the "Tester link" label has to resolve to
@@ -102,7 +102,7 @@ describe("ScenarioShareSection", () => {
   it("discloses guest credit usage only when link guest access is selected", () => {
     const creditNotice = /Guest usage runs on your organization's credits/i;
     const { rerender } = render(
-      <ScenarioShareSection scenario={createScenario()} projectName="Acme" />,
+      <ScenarioShareSection scenario={createScenario()} />,
     );
 
     expect(screen.queryByText(creditNotice)).not.toBeInTheDocument();
@@ -113,7 +113,7 @@ describe("ScenarioShareSection", () => {
           allowGuestAccess: true,
           mode: "anyone_with_link",
         })}
-        projectName="Acme"
+       
       />,
     );
 
@@ -148,7 +148,7 @@ describe("ScenarioShareSection", () => {
             },
           ],
         })}
-        projectName="Acme"
+       
       />,
     );
 
@@ -181,7 +181,7 @@ describe("ScenarioShareSection", () => {
       },
     });
 
-    render(<ScenarioShareSection scenario={scenario} projectName="Acme" />);
+    render(<ScenarioShareSection scenario={scenario} />);
 
     // The withheld copy, not just the absence of the link: asserting a path is
     // missing would stay green if the path shape ever changed under it.
@@ -259,7 +259,7 @@ describe("ScenarioShareSection", () => {
     render(
       <ScenarioShareSection
         scenario={createScenario({ maxShareMode: "invited_only" })}
-        projectName="Acme"
+       
       />,
     );
 

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioCreateFlow.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioCreateFlow.test.tsx
@@ -1198,10 +1198,10 @@ describe("UserTestingScenarioCreateFlow — org share ceiling", () => {
     const { onCreateScenario } = renderFlow();
 
     expect(
-      screen.getByText("Your organization limits sharing to project members."),
+      screen.getByText("Your organization limits sharing to team members."),
     ).toBeInTheDocument();
     expect(screen.getByTestId("user-testing-create-access")).toHaveTextContent(
-      "Project members",
+      "Team members",
     );
 
     await user.click(screen.getByTestId("user-testing-create-access"));

--- a/mcpjam-inspector/client/src/components/sharing/ResourceSharePanel.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/ResourceSharePanel.tsx
@@ -18,8 +18,9 @@ import type {
 const RUN_PRESETS: readonly ShareAccessOption[] = [
   {
     value: "project_members",
-    label: "Project members",
-    description: "Only signed-in members of this project can open the share.",
+    // One name for one group of people — see `scenario-access-presets`.
+    label: "Team members",
+    description: "Only signed-in team members can open the share.",
   },
   {
     value: "invited_only",

--- a/mcpjam-inspector/client/src/components/sharing/__tests__/ResourceSharePanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/__tests__/ResourceSharePanel.test.tsx
@@ -75,7 +75,7 @@ describe("ResourceSharePanel", () => {
       screen.getByRole("menuitemradio", { name: /Anyone with the link/i }),
     ).toHaveAttribute("data-disabled");
     expect(
-      screen.getByRole("menuitemradio", { name: /Project members/i }),
+      screen.getByRole("menuitemradio", { name: /Team members/i }),
     ).not.toHaveAttribute("data-disabled");
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/share-mode-ceiling.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/share-mode-ceiling.test.ts
@@ -9,13 +9,13 @@ import {
 import type { ShareAccessOption } from "@/components/sharing/share-types";
 
 const PRESETS: readonly ShareAccessOption[] = [
-  { value: "project_members", label: "Project members", description: "" },
+  { value: "project_members", label: "Team members", description: "" },
   { value: "invited_only", label: "Invited users only", description: "" },
   { value: "anyone_with_link", label: "Anyone with the link", description: "" },
 ];
 
 describe("share-mode-ceiling", () => {
-  it("ranks modes from project members to anyone with the link", () => {
+  it("ranks modes from team members to anyone with the link", () => {
     expect(SHARE_MODE_RANK.project_members).toBe(0);
     expect(SHARE_MODE_RANK.invited_only).toBe(1);
     expect(SHARE_MODE_RANK.anyone_with_link).toBe(2);

--- a/mcpjam-inspector/client/src/lib/scenario-access-presets.ts
+++ b/mcpjam-inspector/client/src/lib/scenario-access-presets.ts
@@ -47,9 +47,12 @@ export const SCENARIO_ACCESS_OPTIONS: ReadonlyArray<{
   },
   {
     value: "project",
-    label: "Project members",
+    // "Team members", not "Project members": the sidebar has always called
+    // these people the team, and a second name for one group read as a second
+    // group (BB-203).
+    label: "Team members",
     description:
-      "Signed-in members of this project can open it with the link. Guests cannot.",
+      "Signed-in team members can open it with the link. Guests cannot.",
   },
 ];
 
@@ -78,7 +81,7 @@ export function applyShareCeilingToScenarioOptions(
   ceiling?: ShareMode | null,
 ): ShareAccessOption[] {
   return options.map((option) => {
-    // Project members is rank 0 — a ceiling never greys it out.
+    // Team members is rank 0 — a ceiling never greys it out.
     if (option.value === "project") {
       return { ...option, disabled: undefined, disabledReason: undefined };
     }

--- a/mcpjam-inspector/client/src/lib/share-mode-ceiling.ts
+++ b/mcpjam-inspector/client/src/lib/share-mode-ceiling.ts
@@ -11,7 +11,7 @@ export const SHARE_MODE_RANK: Record<ShareMode, number> = {
 };
 
 export const SHARE_MODE_LABELS: Record<ShareMode, string> = {
-  project_members: "project members",
+  project_members: "team members",
   invited_only: "invited users only",
   anyone_with_link: "anyone with the link",
 };

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/scenarios.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/scenarios.ts
@@ -57,7 +57,7 @@ export function buildScenariosUiTools(): UiToolDefinition[] {
             type: "string",
             enum: [...ACCESS_VALUES],
             description:
-              "Who may open the link: 'invited_only' (people invited by email), 'link_guests' (anyone with the link, including signed-out visitors, funded by this organization), or 'project' (signed-in project members). Applied when the scenario is created; defaults to 'invited_only'.",
+              "Who may open the link: 'invited_only' (people invited by email), 'link_guests' (anyone with the link, including signed-out visitors, funded by this organization), or 'project' (signed-in team members). Applied when the scenario is created; defaults to 'invited_only'.",
           },
           name: {
             type: "string",


### PR DESCRIPTION
Kestral: [BB-203](https://app.kestral.ai/workspace/yhNILB2/task/1KDLcAGC)

From Emmanuel Paraskakis' research (Sep 4). The sidebar says **team members**. The create-study "who can open" step said **Project members**. He read them as two different groups of people: *"What are project members? That confuses me because right here it says team members on the bottom left."* Vignesh: *"It's the same thing."*

## What changed

One label — **Team members** — everywhere it means the company/team list:

| Surface | Before | After |
|---|---|---|
| Create study → who can open | Project members | Team members |
| Scenario share dialog | *the project's own name* (e.g. "Acme") | Team members |
| Resource share panel (runs) | Project members | Team members |
| Org settings → sharing policy | Project members | Team members |
| Org share-limit sentence | "…limits sharing to project members." | "…limits sharing to team members." |

The share dialog was a third variant, not a second: it labeled the option with the project's name. The vocabulary is now the label's job and *which* project stays in the description ("Signed-in members of Acme can open the scenario…"), so no specificity is lost.

## Acceptance

- [x] User Testing copy never says Project members for the company/team list
- [x] Sidebar and create/share use the same words

## Deliberately out of scope

Three other places still say "project member", and each means something different from this access group — renaming them would be the third-synonym problem in reverse. Flagging rather than deciding:

- `App.tsx` — "Swarms is available to project members" (Swarms access gate, not User Testing)
- `ChatHistoryRow` / `sender-avatar` — "Project member" as the label for an *unnamed author* of a thread
- `ProjectSettingsTab` — "when an authenticated project member connects without a server override"

Say the word and I'll fold any of them in.

## Tests

Updated the four suites that asserted the old wording (create flow, resource share panel, share-mode ceiling, scenario share section). `npx vitest run client/src/components/scenarios client/src/components/sharing client/src/components/organization client/src/lib/__tests__/share-mode-ceiling.test.ts` → 366 passed, 1 failed (`ScenarioOutcomeCalibration > qualifies its rates when the scan was truncated`, which fails on clean `main` too). `typecheck:client` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the access-group label to "Team members" everywhere the sidebar already used that word — create-study access step, scenario share dialog, resource share panel, org sharing policy, share-limit sentence, MCP host widget badge, and `webmcp` tool description — so no surface reads as a second, separate group.

The share dialog previously rendered the literal word "Project" because its `projectName` prop was never passed by any caller; the prop and the dead interpolation are removed.

- Updates the four test suites that asserted the old wording.
- Three other "project member" strings are intentionally left alone — the Swarms access gate, the unnamed-author label in chat history, and the project-settings fallback text — because each refers to something different from this access group.

<sup>Written for commit 64b9f134867a0dc10c1c2bc3d8156d58e3695a95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

