### PR TITLE
Client header: make the verification date read as a verdict

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusPanel.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusPanel.tsx
@@ -115,8 +115,10 @@ export function HostFocusPanel({
           logoSrc={logoSrc}
           action={
             // The stamp sits left of the button on purpose: it says how old the
-            // profile is, the button is what fixes that.
-            <div className="flex items-center gap-2">
+            // profile is, the button is what fixes that. No wrapper here —
+            // `HostIdentityRow` lays the action out so it can restyle the group
+            // when it wraps to its own line.
+            <>
               <HostVerifiedAtStamp hostStyle={draft.hostStyle} />
               <UpdateHostToLatestButton
                 hostId={hostId}
@@ -131,7 +133,7 @@ export function HostFocusPanel({
                 hostLoaded={hostLoaded}
                 saveInFlight={saveInFlight}
               />
-            </div>
+            </>
           }
         />
       </div>

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostIdentityRow.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostIdentityRow.tsx
@@ -20,6 +20,9 @@ export function HostIdentityRow({
   className,
 }: HostIdentityRowProps) {
   return (
+    // Wrapping, not shrinking: the name field keeps a readable width and the
+    // action group drops to its own line once the header gets narrow, rather
+    // than squeezing the name down to a couple of letters.
     <div className={cn("flex flex-wrap items-center gap-3", className)}>
       {logoSrc ? (
         <img
@@ -34,11 +37,18 @@ export function HostIdentityRow({
         placeholder="Client name"
         aria-label="Client name"
         className={cn(
-          "h-8 min-w-0 flex-1 text-[13px]",
+          "h-8 min-w-40 flex-1 basis-40 text-[13px]",
           hasNameIssue && "border-amber-500"
         )}
       />
-      {action ? <div className="shrink-0">{action}</div> : null}
+      {action ? (
+        // `ml-auto` keeps the group on the right edge of whichever line it
+        // lands on, so a wrapped action still ends under the name field rather
+        // than restarting at the left margin.
+        <div className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-2">
+          {action}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostVerifiedAtStamp.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostVerifiedAtStamp.tsx
@@ -1,4 +1,4 @@
-import { TriangleAlert } from "lucide-react";
+import { Check, TriangleAlert } from "lucide-react";
 import { getCatalogHost } from "@mcpjam/sdk/host-compat";
 import { useHostCatalog } from "@/lib/host-compat/use-host-catalog";
 import { MCPJAM_WEB_DEPLOYED_AT } from "@/generated/mcpjam-web-deployed-at";
@@ -16,13 +16,18 @@ interface HostVerifiedAtStampProps {
   className?: string;
 }
 
+const stampPillClass =
+  "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border px-2.5 py-1 text-[11.5px] font-medium leading-tight";
+
 /**
  * When we last checked this client profile against the real app, shown beside
  * "Update to latest" — the date is what makes that button worth pressing.
  *
- * Same date, same 30-day staleness wording as the Host Compare matrix (both
- * read `../../verified-at`). Renders nothing for a client whose catalog row we
- * have never verified, rather than printing an empty placeholder.
+ * Reads as a pill so the header carries a verdict, not a footnote: green while
+ * the check still holds, amber once it has aged out. Same date, same 30-day
+ * staleness wording as the Host Compare matrix (both read `../../verified-at`).
+ * Renders nothing for a client whose catalog row we have never verified,
+ * rather than printing an empty placeholder.
  */
 export function HostVerifiedAtStamp({
   hostStyle,
@@ -55,7 +60,8 @@ export function HostVerifiedAtStamp({
         data-testid="host-verified-at-stamp"
         title={`Last checked ${formatted}`}
         className={cn(
-          "inline-flex items-center gap-1 whitespace-nowrap text-[11.5px] leading-tight text-muted-foreground",
+          stampPillClass,
+          "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400",
           className,
         )}
       >
@@ -68,12 +74,15 @@ export function HostVerifiedAtStamp({
   return (
     <span
       data-testid="host-verified-at-stamp"
+      title={`Last checked ${formatted}`}
       className={cn(
-        "whitespace-nowrap text-[11.5px] leading-tight tabular-nums text-muted-foreground",
+        stampPillClass,
+        "tabular-nums border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
         className,
       )}
     >
-      Last checked {formatted}
+      <Check className="size-3.5 shrink-0" aria-hidden />
+      Verified {formatted}
     </span>
   );
 }

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/HostVerifiedAtStamp.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/HostVerifiedAtStamp.test.tsx
@@ -65,7 +65,7 @@ describe("HostVerifiedAtStamp", () => {
   it("prints the verification date while it is fresh", () => {
     renderAt(CATALOG_VERIFIED_AT + 5 * 24 * 60 * 60 * 1000);
     expect(screen.getByTestId("host-verified-at-stamp")).toHaveTextContent(
-      "Last checked 2026-09-02",
+      "Verified 2026-09-02",
     );
   });
 
@@ -98,7 +98,7 @@ describe("HostVerifiedAtStamp", () => {
     };
     renderAt(CATALOG_VERIFIED_AT + 5 * 24 * 60 * 60 * 1000);
     expect(screen.getByTestId("host-verified-at-stamp")).toHaveTextContent(
-      "Last checked 2026-09-02",
+      "Verified 2026-09-02",
     );
   });
 


### PR DESCRIPTION
- The "Last checked 2026-09-02" text next to **Update to latest** is now a green pill with a checkmark that says "Verified 2026-09-02", so you can tell at a glance that the client profile is current.
- If the check is more than 30 days old the pill turns amber and keeps the old "over 30 days ago" wording, with the exact date on hover.
- In a narrow panel the client name box no longer shrinks to a few letters. It keeps a readable width and the pill plus button drop to their own line underneath, aligned right.
- No behaviour change: same date, same staleness rule, same button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns the verification date in the client header into a visual verdict: the "Last checked <date>" footnote is now a green pill reading "Verified <date>", or amber with the existing "over 30 days ago" wording once the check is older than 30 days (the exact date stays on hover). Same date and staleness rule as the Host Compare matrix—presentation only, no behavior change. Also stops the client name field from shrinking in narrow panels; it keeps a readable minimum width and the pill plus "Update to latest" button wrap to their own right-aligned line underneath.

<sup>Written for commit 5b6d7ee592a085593b79fe117c392df6dd1905d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

