### PR TITLE
Add bounded network diagnostics to GitHub check sandboxes

### DIFF
--- a/.changeset/tidy-egress-diagnostics.md
+++ b/.changeset/tidy-egress-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Apply shared sandbox egress overrides consistently and collect bounded network diagnostics for GitHub checks.

--- a/mcpjam-inspector/docs/github-checks-network-smoke-2026-09-09.json
+++ b/mcpjam-inspector/docs/github-checks-network-smoke-2026-09-09.json
@@ -1,0 +1,23 @@
+{
+  "startedAt": "2026-09-09T19:41:30.031Z",
+  "sandboxId": "i9x3h83o1pnxhp0wvrzoy",
+  "buildDependencies": true,
+  "started": true,
+  "attempt": true,
+  "reply": true,
+  "identity": true,
+  "redaction": true,
+  "monitorHealthy": true,
+  "cleanup": "verified_stopped",
+  "finishedAt": "2026-09-09T19:41:45.559Z",
+  "connectionRecords": 38,
+  "observedOutcomes": ["attempted", "syn_ack_observed"],
+  "policy": {
+    "triggerId": "synthetic-network-smoke",
+    "repoFullName": "synthetic/network-probe",
+    "prNumber": 0,
+    "policyVersion": "private-networks-v1",
+    "denyOut": ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"],
+    "policySource": "default"
+  }
+}

--- a/mcpjam-inspector/docs/github-checks-network.md
+++ b/mcpjam-inspector/docs/github-checks-network.md
@@ -1,0 +1,97 @@
+# GitHub-check network diagnostics
+
+New GitHub-check sandboxes use the mirrored `egress-policy.ts` defaults and
+override parser. `E2B_EGRESS_DENY_CIDRS` replaces the full list: unset uses RFC1918
+defaults, empty disables denies with a warning, malformed values fail provisioning.
+E2B rejection fails provisioning; there is no unrestricted retry. Keep the value
+aligned with the Convex backend. Compare actual `denyOut` and `policySource` in
+logs; `policyVersion` alone does not distinguish different overrides.
+
+The backend manifest pins `convex/lib/egressPolicy.ts` against this module. Keep
+both copies synchronized, including parser changes. Its trailing-comma style
+matches the backend so the textual mirror check can compare the whole module.
+
+## What is recorded
+
+`provisionCheckSandbox` starts a Python 3 Linux packet-header observer before
+returning the sandbox for clone/build. The dedicated template needs Python 3,
+`sudo -n`, and permission to create an AF_PACKET socket. No pip package, agent
+download, firewall change, credential environment, or checkout file is needed.
+
+The observer uses a bounded packet prefix in memory. It emits only IP/transport
+fields; it never writes packet files or sends payloads, DNS names, URL paths,
+headers, credentials, or raw stderr to the logger. Server parsing copies an
+allowlist of validated fields and discards everything else from guest JSON.
+
+`[github-checks] network connection` fields:
+
+| Field                                                    | Meaning                                                                                       |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `destinationIp`, `destinationPort`, `protocol`, `family` | Observed peer; TCP/UDP, IPv4/IPv6                                                             |
+| `outcome`                                                | `attempted`, `syn_ack_observed`, `reset_observed`, `unreachable_observed`, `timeout_inferred` |
+| `guestTimestamp`                                         | Guest wall clock, not trusted                                                                 |
+| `observedAt`                                             | Server receipt time                                                                           |
+| `sandboxId`, `triggerId`, `repoFullName`, `prNumber`     | Attached by the server, never accepted from guest JSON                                        |
+| `policyVersion`, `policySource`, `denyOut`               | Policy supplied at creation, including any override                                           |
+| `evidence`                                               | Always `guest_observed`                                                                       |
+
+`triggerId` identifies the PR check before an eval-run row exists. Filter logs by
+that ID or by repo/PR/sandbox when handling a user complaint. The effective policy
+is also logged before provisioning and after creation.
+
+`logger.info` / `logger.warn` use the existing Axiom dataset and its retention.
+Records already shipped survive sandbox deletion. No new storage or retention
+job is introduced. Shipping requires `AXIOM_TOKEN` and `AXIOM_DATASET` and respects
+`DO_NOT_TRACK`; console messages alone do not preserve structured context. Verify
+the worker's existing log destination during final deployment validation.
+
+## Limits and failures
+
+- Packet processing is capped at 2,000 packets/second to limit CPU use.
+- Guest and server each allow 120 connection records/minute and 2,000/run.
+- Pending TCP handshakes and recently established connections each have a
+  512-entry cap. Inferred handshake timeout is 10 seconds; established tracking
+  expires after five minutes. UDP records are attempts, not delivery receipts.
+- Each line is at most 1,024 characters. Server parsing accepts at most 128 KiB
+  per minute; it disconnects the command at 2 MiB total stdout or 4 KiB stderr
+  because the E2B SDK also buffers output. One transport chunk may overshoot.
+- Every 10 seconds, drop summaries include guest limits, kernel socket overflow,
+  and server discards. Missing heartbeats, process/stream failures, startup
+  timeout, and cleanup errors produce generic warnings without raw guest text.
+- Startup waits at most five seconds; process kill waits at most two seconds.
+  Monitor failure does not stop the check or modify its network policy.
+  Sandbox cleanup still runs even when monitor cleanup fails.
+
+These records are **diagnostics, not proof of a provider block**. E2B may reject
+traffic outside the VM after a SYN-ACK; timeouts have several causes. Guest root
+can disable or spoof the observer. Loopback is excluded; fragmented/truncated
+headers and unsupported protocols may be missed. The monitor cannot see every
+application error (for example, a TLS error or HTTP 500 after a successful TCP
+connection). No outcome is named `blocked`.
+
+## Live validation
+
+Provide only the E2B key and deployed GitHub-check template ID, then run from
+`mcpjam-inspector`:
+
+```sh
+NETWORK_SMOKE_REPORT=/tmp/network-smoke.json node --import tsx scripts/verify-network-diagnostics.ts
+```
+
+The smoke uses the real provisioning/monitor/cleanup path with synthetic HTTP
+traffic. It captures logs locally, checks connection/reply records, host identity,
+sentinel-header exclusion, monitor health, and provider-confirmed sandbox shutdown. It never contacts GitHub's write
+APIs or runs customer code. The paired backend probe tests denial classification
+and normal command/Git/package/API/MCP workloads under candidate policies.
+
+Saved [live smoke result](./github-checks-network-smoke-2026-09-09.json).
+
+On 2026-09-09 the real `mcpjam-github-checks` template started the monitor,
+reported TCP/UDP attempts and SYN-ACK observations, and excluded the sentinel
+header. The kernel-drop heartbeat remained healthy. Public IPv6 connectivity was
+unverified; no IPv6 block is claimed. The backend probe also found that
+`169.254.169.254` still answers HTTP 401 with a link-local deny, so that candidate
+was not added to defaults. Responsive private/CGNAT fixtures remain outstanding.
+
+Only new sandboxes receive this change. No UI, database migration, backfill, or
+fork credential change. Final staging fork tests and production rollout are deferred.

--- a/mcpjam-inspector/scripts/verify-network-diagnostics.ts
+++ b/mcpjam-inspector/scripts/verify-network-diagnostics.ts
@@ -1,0 +1,97 @@
+/**
+ * Live, synthetic smoke: node --import tsx scripts/verify-network-diagnostics.ts
+ * Requires only E2B_API_KEY and GITHUB_CHECKS_E2B_TEMPLATE_ID. No app env loader.
+ * Uses the real provisioning/monitor/cleanup path; never clones customer code.
+ */
+import { writeFile } from "node:fs/promises";
+import { Sandbox } from "e2b";
+import { logger } from "../server/utils/logger.js";
+import {
+  provisionCheckSandbox,
+  killCheckSandbox,
+  type CheckSandbox,
+} from "../server/services/github-checks/sandbox.js";
+
+const rows: { message: string; context?: Record<string, unknown> }[] = [];
+// Keep synthetic logs local: exercise the production call sites without
+// sending smoke records into an operator's configured telemetry sink.
+logger.info = (message, context) => {
+  rows.push({ message, context });
+};
+logger.warn = (message, context) => {
+  rows.push({ message, context });
+};
+const report: Record<string, unknown> = { startedAt: new Date().toISOString() };
+let sandbox: CheckSandbox | undefined;
+try {
+  sandbox = await provisionCheckSandbox({
+    triggerId: "synthetic-network-smoke",
+    repoFullName: "synthetic/network-probe",
+    prNumber: 0,
+  });
+  report.sandboxId = sandbox.sandboxId;
+  await sandbox.commands.run(
+    "git -c credential.helper= clone --depth 1 --no-checkout https://github.com/octocat/Hello-World.git /tmp/network-smoke-clone >/dev/null 2>&1",
+    { timeoutMs: 40_000 },
+  );
+  await sandbox.commands.run(
+    "npm install --prefix /tmp/network-smoke-package --cache /tmp/network-smoke-package/cache --ignore-scripts --package-lock=false --no-audit --no-fund is-number@7.0.0 >/dev/null 2>&1",
+    { timeoutMs: 40_000 },
+  );
+  report.buildDependencies = true;
+  // The sentinel is request text. It must never appear in network diagnostics.
+  await sandbox.commands.run(
+    "curl --noproxy '*' -fsS -o /dev/null --max-time 10 -H 'X-Probe: NETWORK-SECRET-SENTINEL' https://example.com/",
+    { timeoutMs: 15_000 },
+  );
+  // At least one heartbeat also exercises kernel packet-loss accounting.
+  await new Promise((resolve) => setTimeout(resolve, 11_000));
+  report.started = rows.some((r) =>
+    r.message.endsWith("network monitor started"),
+  );
+  report.attempt = rows.some((r) => r.context?.outcome === "attempted");
+  report.reply = rows.some((r) => r.context?.outcome === "syn_ack_observed");
+  report.identity = rows
+    .filter((r) => r.context?.outcome)
+    .every(
+      (r) =>
+        r.context?.sandboxId === sandbox!.sandboxId &&
+        r.context?.triggerId === "synthetic-network-smoke",
+    );
+  report.redaction = !JSON.stringify(rows).includes("NETWORK-SECRET-SENTINEL");
+  report.monitorHealthy = !rows.some((r) => r.context?.reason);
+} catch {
+  report.error = "smoke_failed";
+} finally {
+  await killCheckSandbox(sandbox ?? null);
+  try {
+    report.cleanup =
+      sandbox && !(await (sandbox as unknown as Sandbox).isRunning())
+        ? "verified_stopped"
+        : "failed";
+  } catch {
+    report.cleanup = "inconclusive";
+  }
+  report.rows = rows;
+  report.finishedAt = new Date().toISOString();
+  if (process.env.NETWORK_SMOKE_REPORT)
+    await writeFile(
+      process.env.NETWORK_SMOKE_REPORT,
+      JSON.stringify(report, null, 2) + "\n",
+    );
+  process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+  process.exitCode =
+    [
+      report.buildDependencies,
+      report.started,
+      report.attempt,
+      report.reply,
+      report.identity,
+      report.redaction,
+      report.monitorHealthy,
+    ].every((v) => v === true) &&
+    report.cleanup === "verified_stopped" &&
+    !report.error
+      ? 0
+      : 1;
+}

--- a/mcpjam-inspector/server/services/github-checks/__tests__/egress-policy.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/egress-policy.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_EGRESS_DENY_CIDRS,
+  resolveEgressPolicy,
+} from "../egress-policy";
+
+describe("shared sandbox network policy", () => {
+  it("keeps public access and the three private network blocks by default", () => {
+    expect(resolveEgressPolicy(undefined)).toMatchObject({
+      denyOut: [...DEFAULT_EGRESS_DENY_CIDRS],
+      source: "default",
+      weakensDefaults: false,
+    });
+  });
+  it("reads a full replacement, including the existing explicit empty override", () => {
+    expect(resolveEgressPolicy("169.254.0.0/16, 100.64.0.0/10")).toMatchObject({
+      denyOut: ["169.254.0.0/16", "100.64.0.0/10"],
+      source: "override",
+      weakensDefaults: true,
+    });
+    expect(resolveEgressPolicy("")).toMatchObject({
+      denyOut: [],
+      weakensDefaults: true,
+    });
+  });
+  it.each([
+    "10.0.0.0/8,",
+    "300.0.0.0/8",
+    "10.0.0.0/33",
+    "10.0.0.0/1e1",
+    "010.0.0.0/8",
+    "::/0",
+    "secret-canary",
+  ])("refuses malformed input without echoing it: %s", (raw) => {
+    expect(() => resolveEgressPolicy(raw)).toThrow("E2B_EGRESS_DENY_CIDRS");
+    try {
+      resolveEgressPolicy(raw);
+    } catch (error) {
+      expect(String(error)).not.toContain(raw);
+    }
+  });
+  it("does not share mutable arrays across callers", () => {
+    resolveEgressPolicy(undefined).denyOut.length = 0;
+    expect(resolveEgressPolicy(undefined).denyOut).toHaveLength(3);
+  });
+});

--- a/mcpjam-inspector/server/services/github-checks/__tests__/network-monitor.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/network-monitor.test.ts
@@ -1,0 +1,297 @@
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../../../utils/logger";
+import {
+  parseConnectionRecord,
+  startNetworkMonitor,
+  stopNetworkMonitor,
+} from "../network-monitor";
+import { NETWORK_MONITOR_SCRIPT } from "../network-monitor-script";
+import type { CheckSandbox } from "../sandbox";
+
+vi.mock("../../../utils/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn() },
+}));
+
+const context = {
+  triggerId: "trusted-trigger",
+  repoFullName: "acme/repo",
+  prNumber: 1,
+  policyVersion: "private-networks-v1",
+  policySource: "default" as const,
+  denyOut: ["10.0.0.0/8"],
+};
+const connection = {
+  kind: "connection",
+  destinationIp: "10.0.0.1",
+  destinationPort: 443,
+  family: 4,
+  protocol: "tcp",
+  outcome: "attempted",
+  timestamp: 1,
+};
+const stops: CheckSandbox[] = [];
+afterEach(async () => {
+  for (const sandbox of stops.splice(0)) await stopNetworkMonitor(sandbox);
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+function fake() {
+  let stdout!: (s: string) => void;
+  let rejectWait!: (error: Error) => void;
+  const handle = {
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn().mockResolvedValue(true),
+    wait: () =>
+      new Promise((_, reject) => {
+        rejectWait = reject;
+      }),
+  };
+  const sandbox = {
+    sandboxId: "trusted-sandbox",
+    commands: {
+      run: vi.fn(async (_cmd, opts) => {
+        stdout = opts.onStdout;
+        stdout('{"kind":"ready"}\n');
+        return handle;
+      }),
+    },
+  } as unknown as CheckSandbox;
+  stops.push(sandbox);
+  return {
+    sandbox,
+    handle,
+    stdout: (s: string) => stdout(s),
+    fail: () => rejectWait(new Error("SECRET_STDERR")),
+  };
+}
+
+describe("network diagnostics boundary", () => {
+  it("copies only valid network fields, excluding guest-provided context and secrets", () => {
+    const row = parseConnectionRecord(
+      JSON.stringify({ ...connection, headers: "SECRET", triggerId: "spoof" }),
+    );
+    expect(row).toMatchObject({
+      destinationIp: "10.0.0.1",
+      outcome: "attempted",
+    });
+    expect(JSON.stringify(row)).not.toMatch(/SECRET|spoof|headers/);
+    for (const bad of [
+      { destinationIp: "https://user:SECRET@host" },
+      { destinationPort: 0 },
+      { outcome: "blocked" },
+      { family: 6 },
+      { destinationIp: "fe80::1%SECRET", family: 6 },
+    ]) {
+      expect(
+        parseConnectionRecord(JSON.stringify({ ...connection, ...bad })),
+      ).toBeNull();
+    }
+  });
+  it("starts before returning, streams split records with trusted IDs, and stops once", async () => {
+    const f = fake();
+    await startNetworkMonitor(f.sandbox, context);
+    const row = JSON.stringify({
+      ...connection,
+      sandboxId: "spoof",
+      triggerId: "spoof",
+      body: "SECRET",
+    });
+    f.stdout(row.slice(0, 20));
+    f.stdout(row.slice(20) + "\n");
+    expect(logger.info).toHaveBeenCalledWith(
+      "[github-checks] network connection",
+      expect.objectContaining({
+        sandboxId: "trusted-sandbox",
+        triggerId: "trusted-trigger",
+        outcome: "attempted",
+      }),
+    );
+    expect(JSON.stringify(vi.mocked(logger.info).mock.calls)).not.toMatch(
+      /SECRET|spoof/,
+    );
+    expect(f.sandbox.commands.run).toHaveBeenCalledWith(
+      expect.stringContaining("sudo -n python3"),
+      expect.objectContaining({ background: true, timeoutMs: 0 }),
+    );
+    await stopNetworkMonitor(f.sandbox);
+    await stopNetworkMonitor(f.sandbox);
+    expect(f.handle.kill).toHaveBeenCalledTimes(1);
+  });
+  it("bounds hostile output and reports dropped records", async () => {
+    vi.useFakeTimers();
+    const f = fake();
+    await startNetworkMonitor(f.sandbox, context);
+    f.stdout("x".repeat(2000) + "\n");
+    for (let i = 0; i < 200; i++) f.stdout(JSON.stringify(connection) + "\n");
+    expect(
+      vi
+        .mocked(logger.info)
+        .mock.calls.filter((c) => c[0].endsWith("network connection")),
+    ).toHaveLength(120);
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[github-checks] network monitor dropped records",
+      expect.objectContaining({ dropped: 81 }),
+    );
+  });
+  it("disconnects excessive transport output so the SDK cannot keep buffering it", async () => {
+    vi.useFakeTimers();
+    const f = fake();
+    await startNetworkMonitor(f.sandbox, context);
+    for (let i = 0; i < 34; i++) f.stdout("x".repeat(65536));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(f.handle.disconnect).toHaveBeenCalledOnce();
+    expect(f.handle.kill).toHaveBeenCalledOnce();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[github-checks] network monitor",
+      expect.objectContaining({ reason: "transport_limit" }),
+    );
+  });
+  it("reports a silent monitor and bounds cleanup when the provider stops responding", async () => {
+    vi.useFakeTimers();
+    const f = fake();
+    await startNetworkMonitor(f.sandbox, context);
+    await vi.advanceTimersByTimeAsync(40000);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[github-checks] network monitor",
+      expect.objectContaining({ reason: "heartbeat_missing" }),
+    );
+    f.handle.kill.mockImplementationOnce(() => new Promise(() => {}));
+    const stop = stopNetworkMonitor(f.sandbox);
+    await vi.advanceTimersByTimeAsync(2000);
+    await stop;
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[github-checks] network monitor",
+      expect.objectContaining({ reason: "stop_failed" }),
+    );
+  });
+  it("caps the complete run even when each minute is below its limit", async () => {
+    vi.useFakeTimers();
+    const f = fake();
+    await startNetworkMonitor(f.sandbox, context);
+    for (let minute = 0; minute < 21; minute++) {
+      f.stdout('{"kind":"heartbeat"}\n');
+      for (let i = 0; i < 100; i++) f.stdout(JSON.stringify(connection) + "\n");
+      await vi.advanceTimersByTimeAsync(60000);
+    }
+    expect(
+      vi
+        .mocked(logger.info)
+        .mock.calls.filter((c) => c[0].endsWith("network connection")),
+    ).toHaveLength(2000);
+  });
+  it("reports stream failures without leaking errors or changing the check", async () => {
+    const f = fake();
+    await startNetworkMonitor(f.sandbox, context);
+    f.fail();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[github-checks] network monitor",
+      expect.objectContaining({ reason: "stream_failed" }),
+    );
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain(
+      "SECRET",
+    );
+  });
+  it("times out startup without blocking the check and kills a late handle", async () => {
+    vi.useFakeTimers();
+    let resolve!: (v: unknown) => void;
+    const sandbox = {
+      sandboxId: "sb",
+      commands: {
+        run: () =>
+          new Promise((r) => {
+            resolve = r;
+          }),
+      },
+    } as unknown as CheckSandbox;
+    const start = startNetworkMonitor(sandbox, context);
+    await vi.advanceTimersByTimeAsync(5000);
+    await start;
+    const kill = vi.fn().mockResolvedValue(true);
+    resolve({
+      kill,
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      wait: () => new Promise(() => {}),
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(kill).toHaveBeenCalledOnce();
+  });
+  it("does not block a run when dependencies or privileges are missing", async () => {
+    const sandbox = {
+      sandboxId: "sb",
+      commands: { run: vi.fn().mockRejectedValue(new Error("SECRET")) },
+    } as unknown as CheckSandbox;
+    await expect(
+      startNetworkMonitor(sandbox, context),
+    ).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[github-checks] network monitor",
+      expect.objectContaining({ reason: "start_failed" }),
+    );
+  });
+});
+
+describe("passive packet observer", () => {
+  it("observes TCP resets and inferred timeouts, UDP and IPv6 without emitting packet payloads", () => {
+    const test = String.raw`
+rows=[]
+o=Observer(rows.append)
+def tcp(src,dst,sport,dport,flags):
+    ip=bytes([69,0,0,40,0,0,0,0,64,6,0,0])+socket.inet_aton(src)+socket.inet_aton(dst)
+    transport=struct.pack('!HH',sport,dport)+bytes(8)+bytes([80,flags])+bytes(6)
+    return ip+transport+b'SECRET-BODY'
+o.observe(tcp('192.0.2.2','10.0.0.1',12345,443,2),True,0)
+o.observe(tcp('10.0.0.1','192.0.2.2',443,12345,20),False,1)
+o.observe(tcp('192.0.2.2','10.0.0.2',12346,443,2),True,2)
+o.expire(13)
+v6=bytes([96,0,0,0,0,8,17,64])+socket.inet_pton(socket.AF_INET6,'2001:db8::1')+socket.inet_pton(socket.AF_INET6,'2001:db8::2')+struct.pack('!HHHH',1234,53,8,0)
+o.observe(v6,True,14)
+# Standard ICMP quotes contain only eight TCP bytes, not a full TCP header.
+original=tcp('192.0.2.2','10.0.0.3',12347,443,2)
+o.observe(original,True,15)
+ip=bytes([69,0,0,56,0,0,0,0,64,1,0,0])+socket.inet_aton('10.0.0.3')+socket.inet_aton('192.0.2.2')
+o.observe(ip+bytes([3,1,0,0,0,0,0,0])+original[:28],False,16)
+o.expire(30)
+# A provider can accept SYN then reset the connection after seeing traffic.
+o.observe(tcp('192.0.2.2','10.0.0.4',12348,443,2),True,31)
+o.observe(tcp('10.0.0.4','192.0.2.2',443,12348,18),False,32)
+o.observe(tcp('10.0.0.4','192.0.2.2',443,12348,20),False,33)
+print(json.dumps(rows))
+`;
+    const result = spawnSync(
+      "python3",
+      [
+        "-c",
+        NETWORK_MONITOR_SCRIPT.replace(
+          "if __name__ == '__main__':",
+          "if False:",
+        ) + test,
+      ],
+      { encoding: "utf8" },
+    );
+    expect(result.status, result.stderr).toBe(0);
+    const rows = JSON.parse(result.stdout);
+    expect(rows.map((r: { outcome: string }) => r.outcome)).toEqual([
+      "attempted",
+      "reset_observed",
+      "attempted",
+      "timeout_inferred",
+      "attempted",
+      "attempted",
+      "unreachable_observed",
+      "attempted",
+      "syn_ack_observed",
+      "reset_observed",
+    ]);
+    expect(rows[4]).toMatchObject({
+      family: 6,
+      protocol: "udp",
+      destinationIp: "2001:db8::2",
+    });
+    expect(result.stdout).not.toContain("SECRET");
+  });
+});

--- a/mcpjam-inspector/server/services/github-checks/__tests__/network-monitor.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/network-monitor.test.ts
@@ -262,6 +262,18 @@ o.observe(tcp('10.0.0.4','192.0.2.2',443,12348,18),False,32)
 o.observe(tcp('10.0.0.4','192.0.2.2',443,12348,20),False,33)
 print(json.dumps(rows))
 `;
+    const availability = spawnSync("python3", ["--version"], {
+      encoding: "utf8",
+    });
+    expect(
+      availability.error,
+      `python3 is required for the network monitor tests: ${availability.error?.message ?? "failed to start"}`,
+    ).toBeUndefined();
+    expect(
+      availability.status,
+      `python3 is required for the network monitor tests: ${availability.stderr || availability.stdout}`,
+    ).toBe(0);
+
     const result = spawnSync(
       "python3",
       [
@@ -273,7 +285,11 @@ print(json.dumps(rows))
       ],
       { encoding: "utf8" },
     );
-    expect(result.status, result.stderr).toBe(0);
+    expect(
+      result.error,
+      `python3 failed to start the network monitor test: ${result.error?.message ?? "unknown startup error"}`,
+    ).toBeUndefined();
+    expect(result.status, result.error?.message ?? result.stderr).toBe(0);
     const rows = JSON.parse(result.stdout);
     expect(rows.map((r: { outcome: string }) => r.outcome)).toEqual([
       "attempted",

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox-provision.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox-provision.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Sandbox } from "e2b";
+import { startNetworkMonitor, stopNetworkMonitor } from "../network-monitor";
+import { logger } from "../../../utils/logger";
+vi.mock("../network-monitor", () => ({
+  startNetworkMonitor: vi.fn(),
+  stopNetworkMonitor: vi.fn(),
+}));
+vi.mock("../../../utils/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn() },
+}));
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
 import {
   CHECK_SANDBOX_TIMEOUT_MS,
   GITHUB_CHECKS_EGRESS_DENY_CIDRS,
@@ -14,6 +27,7 @@ vi.mock("e2b", async () => {
 
 /** The env every test here provisions against. */
 function stubProvisionEnv(): void {
+  vi.stubEnv("E2B_EGRESS_DENY_CIDRS", undefined);
   vi.stubEnv("E2B_API_KEY", "e2b_test_key");
   vi.stubEnv("GITHUB_CHECKS_E2B_TEMPLATE_ID", "template-test");
 }
@@ -25,6 +39,75 @@ const ARGS = {
 } as const;
 
 describe("provisionCheckSandbox", () => {
+  it("applies the shared override and starts monitoring before handing back the box", async () => {
+    stubProvisionEnv();
+    vi.stubEnv("E2B_EGRESS_DENY_CIDRS", "10.0.0.0/8,169.254.0.0/16");
+    const sandbox = { sandboxId: "sb_override" } as never;
+    vi.mocked(Sandbox.create).mockResolvedValueOnce(sandbox);
+    let started = false;
+    vi.mocked(startNetworkMonitor).mockImplementationOnce(async () => {
+      await Promise.resolve();
+      started = true;
+    });
+    expect(await provisionCheckSandbox(ARGS)).toBe(sandbox);
+    expect(started).toBe(true);
+    expect(Sandbox.create).toHaveBeenCalledWith(
+      "template-test",
+      expect.objectContaining({
+        network: {
+          allowPublicTraffic: true,
+          denyOut: ["10.0.0.0/8", "169.254.0.0/16"],
+        },
+      }),
+    );
+    expect(startNetworkMonitor).toHaveBeenCalledWith(
+      sandbox,
+      expect.objectContaining({
+        ...ARGS,
+        policyVersion: "private-networks-v1",
+        policySource: "override",
+        denyOut: ["10.0.0.0/8", "169.254.0.0/16"],
+      }),
+    );
+  });
+
+  it("rejects invalid overrides before contacting E2B without exposing the value", async () => {
+    stubProvisionEnv();
+    vi.stubEnv("E2B_EGRESS_DENY_CIDRS", "SECRET");
+    await expect(provisionCheckSandbox(ARGS)).rejects.toMatchObject({
+      outcome: "infra_error",
+    });
+    expect(Sandbox.create).not.toHaveBeenCalled();
+    expect(startNetworkMonitor).not.toHaveBeenCalled();
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain(
+      "SECRET",
+    );
+  });
+
+  it("does not retry a rejected provider policy with unrestricted networking", async () => {
+    stubProvisionEnv();
+    vi.mocked(Sandbox.create).mockRejectedValueOnce(
+      new Error("SECRET provider response"),
+    );
+    await expect(provisionCheckSandbox(ARGS)).rejects.toMatchObject({
+      outcome: "infra_error",
+    });
+    expect(Sandbox.create).toHaveBeenCalledTimes(1);
+    expect(startNetworkMonitor).not.toHaveBeenCalled();
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain(
+      "SECRET",
+    );
+  });
+
+  it("continues with the provisioned policy if monitoring fails", async () => {
+    stubProvisionEnv();
+    const sandbox = { sandboxId: "sb_monitor_failure" } as never;
+    vi.mocked(Sandbox.create).mockResolvedValueOnce(sandbox);
+    vi.mocked(startNetworkMonitor).mockRejectedValueOnce(new Error("SECRET"));
+    await expect(provisionCheckSandbox(ARGS)).resolves.toBe(sandbox);
+    expect(Sandbox.create).toHaveBeenCalledTimes(1);
+  });
+
   it("creates a public box with the backend's non-guest egress baseline", async () => {
     const create = vi.mocked(Sandbox.create);
     const sandbox = { sandboxId: "sb_test" } as never;
@@ -41,7 +124,7 @@ describe("provisionCheckSandbox", () => {
             allowPublicTraffic: true,
             denyOut: [...GITHUB_CHECKS_EGRESS_DENY_CIDRS],
           },
-        })
+        }),
       );
     } finally {
       create.mockReset();
@@ -94,7 +177,7 @@ describe("provisionCheckSandbox", () => {
       await provisionCheckSandbox({ ...ARGS });
       const [, options] = create.mock.calls[0] as [
         string,
-        Record<string, unknown>
+        Record<string, unknown>,
       ];
       const { apiKey, ...rest } = options;
       expect(apiKey).toBe("e2b_test_key");
@@ -137,6 +220,16 @@ describe("provisionCheckSandbox", () => {
 });
 
 describe("killCheckSandbox", () => {
+  it("still destroys the sandbox after a monitor cleanup failure", async () => {
+    vi.mocked(stopNetworkMonitor).mockRejectedValueOnce(new Error("SECRET"));
+    const kill = vi.fn().mockResolvedValue(undefined);
+    await killCheckSandbox({ sandboxId: "sb_cleanup", kill } as never);
+    expect(kill).toHaveBeenCalledOnce();
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain(
+      "SECRET",
+    );
+  });
+
   it("kills the box it is given", async () => {
     const kill = vi.fn().mockResolvedValue(undefined);
     await killCheckSandbox({ sandboxId: "sb_1", kill } as never);
@@ -150,7 +243,7 @@ describe("killCheckSandbox", () => {
     // rather than merely convenient.
     const kill = vi.fn().mockRejectedValue(new Error("e2b unreachable"));
     await expect(
-      killCheckSandbox({ sandboxId: "sb_2", kill } as never)
+      killCheckSandbox({ sandboxId: "sb_2", kill } as never),
     ).resolves.toBeUndefined();
     expect(kill).toHaveBeenCalledTimes(1);
   });

--- a/mcpjam-inspector/server/services/github-checks/egress-policy.ts
+++ b/mcpjam-inspector/server/services/github-checks/egress-policy.ts
@@ -1,0 +1,47 @@
+/** Mirrored into Inspector; keep parsing and defaults identical in both runtimes. */
+export const EGRESS_POLICY_VERSION = "private-networks-v1";
+export const DEFAULT_EGRESS_DENY_CIDRS = [
+  "10.0.0.0/8",
+  "172.16.0.0/12",
+  "192.168.0.0/16",
+] as const;
+
+export function isValidIpv4Cidr(entry: string): boolean {
+  const [address, prefix, extra] = entry.split("/");
+  if (!address || !prefix || extra !== undefined || !/^\d{1,2}$/.test(prefix)) {
+    return false;
+  }
+  if (Number(prefix) > 32) return false;
+  const octets = address.split(".");
+  return (
+    octets.length === 4 &&
+    octets.every(
+      (octet) => /^(0|[1-9]\d{0,2})$/.test(octet) && Number(octet) <= 255
+    )
+  );
+}
+
+/** Preserve the existing operator override: it replaces the complete list. */
+export function resolveEgressPolicy(raw: string | undefined) {
+  let denyOut: string[] = [...DEFAULT_EGRESS_DENY_CIDRS];
+  if (raw !== undefined) {
+    denyOut =
+      raw.trim() === "" ? [] : raw.split(",").map((entry) => entry.trim());
+  }
+  if (denyOut.length > 64 || denyOut.some((entry) => !isValidIpv4Cidr(entry))) {
+    // Do not echo a malformed env value: it can be a secret pasted into the wrong key.
+    throw new Error("E2B_EGRESS_DENY_CIDRS must contain at most 64 IPv4 CIDRs");
+  }
+  return {
+    version: EGRESS_POLICY_VERSION,
+    source: raw === undefined ? ("default" as const) : ("override" as const),
+    denyOut: [...new Set(denyOut)],
+    weakensDefaults: egressOverrideWeakensDefaults(denyOut),
+  };
+}
+
+export function egressOverrideWeakensDefaults(
+  override: readonly string[]
+): boolean {
+  return DEFAULT_EGRESS_DENY_CIDRS.some((cidr) => !override.includes(cidr));
+}

--- a/mcpjam-inspector/server/services/github-checks/network-monitor-script.ts
+++ b/mcpjam-inspector/server/services/github-checks/network-monitor-script.ts
@@ -1,0 +1,195 @@
+/**
+ * Passive Linux packet-header observer. No pcap files, payload decoding, DNS
+ * names, or request text. Runs outside the checkout, before any repository code.
+ * Guest root can disable or spoof it: these are diagnostics, not firewall audit.
+ */
+export const NETWORK_MONITOR_SCRIPT = String.raw`
+import collections
+import json
+import signal
+import socket
+import struct
+import time
+
+MAX_PENDING = 512
+WINDOW_LIMIT = 120
+TOTAL_LIMIT = 2000
+TIMEOUT = 10
+
+def decode(packet, quoted=False):
+    if not packet:
+        return None
+    version = packet[0] >> 4
+    if version == 4:
+        if len(packet) < 20:
+            return None
+        offset = (packet[0] & 15) * 4
+        if offset < 20 or len(packet) < offset or struct.unpack('!H', packet[6:8])[0] & 8191:
+            return None
+        proto = packet[9]
+        src = socket.inet_ntop(socket.AF_INET, packet[12:16])
+        dst = socket.inet_ntop(socket.AF_INET, packet[16:20])
+    elif version == 6:
+        if len(packet) < 40:
+            return None
+        src = socket.inet_ntop(socket.AF_INET6, packet[8:24])
+        dst = socket.inet_ntop(socket.AF_INET6, packet[24:40])
+        proto, offset = packet[6], 40
+        for _ in range(6):
+            if proto not in (0, 43, 44, 51, 60):
+                break
+            if len(packet) < offset + 8:
+                return None
+            if proto == 44:
+                if struct.unpack('!H', packet[offset+2:offset+4])[0] & 65528:
+                    return None
+                size = 8
+            else:
+                size = (packet[offset+1] + (2 if proto == 51 else 1)) * (4 if proto == 51 else 8)
+            proto, offset = packet[offset], offset + size
+    else:
+        return None
+    if proto in (6, 17):
+        needed = 4 if quoted else (20 if proto == 6 else 8)
+        if len(packet) < offset + needed:
+            return None
+        sport, dport = struct.unpack('!HH', packet[offset:offset+4])
+        flags = packet[offset+13] if proto == 6 and not quoted else 0
+        return (version, proto, src, dst, sport, dport, flags, None)
+    if proto in (1, 58) and len(packet) >= offset + 8:
+        # Only ICMP unreachable responses; decode the quoted IP + transport
+        # headers, never their body. Short/truncated quotes are ignored.
+        if packet[offset] == (3 if proto == 1 else 1):
+            return (version, proto, src, dst, 0, 0, 0, packet[offset+8:])
+    return None
+
+class Observer:
+    def __init__(self, emit):
+        self.emit = emit
+        self.pending = collections.OrderedDict()
+        self.established = collections.OrderedDict()
+
+    def event(self, p, outcome, reverse=False):
+        version, proto, src, dst, sport, dport, flags, quote = p
+        self.emit({'kind': 'connection', 'family': version,
+                   'protocol': 'tcp' if proto == 6 else 'udp',
+                   'destinationIp': src if reverse else dst,
+                   'destinationPort': sport if reverse else dport,
+                   'outcome': outcome, 'timestamp': int(time.time() * 1000)})
+
+    def observe(self, packet, outgoing, now):
+        p = decode(packet)
+        if p is None:
+            return
+        version, proto, src, dst, sport, dport, flags, quote = p
+        if quote is not None:
+            original = decode(quote, quoted=True)
+            if not outgoing and original and original[1] in (6, 17):
+                self.pending.pop((original[2], original[4], original[3], original[5]), None)
+                self.event(original, 'unreachable_observed')
+            return
+        key = (src, sport, dst, dport)
+        if outgoing and proto == 17:
+            self.event(p, 'attempted')
+        elif outgoing and proto == 6 and flags & 2 and not flags & 16:
+            if key not in self.pending:
+                if len(self.pending) >= MAX_PENDING:
+                    self.pending.popitem(last=False)
+                    self.emit({'kind': 'dropped', 'count': 1})
+                self.pending[key] = (now, p)
+                self.event(p, 'attempted')
+        elif not outgoing and proto == 6:
+            reverse = (dst, dport, src, sport)
+            if reverse in self.pending and (flags & 4 or flags & 18 == 18):
+                self.pending.pop(reverse)
+                self.event(p, 'reset_observed' if flags & 4 else 'syn_ack_observed', True)
+                if not flags & 4:
+                    if len(self.established) >= MAX_PENDING:
+                        self.established.popitem(last=False)
+                        self.emit({'kind': 'dropped', 'count': 1})
+                    self.established[reverse] = now
+            elif reverse in self.established and flags & 4:
+                self.established.pop(reverse)
+                self.event(p, 'reset_observed', True)
+            if flags & 1:
+                self.established.pop(reverse, None)
+
+    def expire(self, now):
+        for key, started in list(self.established.items()):
+            if now - started >= 300:
+                self.established.pop(key)
+        for key, (started, packet) in list(self.pending.items()):
+            if now - started >= TIMEOUT:
+                self.pending.pop(key)
+                self.event(packet, 'timeout_inferred')
+
+def main():
+    running = True
+    def stop(*_):
+        nonlocal running
+        running = False
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    def output(row):
+        print(json.dumps(row, separators=(',', ':')), flush=True)
+    window_start = time.monotonic()
+    window_count = total = dropped = 0
+    def emit(row):
+        nonlocal window_start, window_count, total, dropped
+        if row['kind'] == 'dropped':
+            dropped += row['count']
+            return
+        now = time.monotonic()
+        if now - window_start >= 60:
+            window_start, window_count = now, 0
+        if window_count >= WINDOW_LIMIT or total >= TOTAL_LIMIT:
+            dropped += 1
+            return
+        window_count += 1
+        total += 1
+        output(row)
+    # SOCK_DGRAM excludes Ethernet headers. Capture only a bounded prefix in
+    # memory, and emit only the typed network fields above.
+    sock = socket.socket(socket.AF_PACKET, socket.SOCK_DGRAM, socket.htons(3))
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 65536)
+    sock.settimeout(0.5)
+    observer = Observer(emit)
+    output({'kind': 'ready'})
+    last_tick = last_expiry = time.monotonic()
+    deadline = last_tick + 45 * 60
+    packet_window, packet_count = last_tick, 0
+    try:
+        while running and time.monotonic() < deadline:
+            now = time.monotonic()
+            if now - packet_window >= 1:
+                packet_window, packet_count = now, 0
+            if packet_count >= 2000:
+                # Bound CPU work during a packet flood; socket-overflow losses
+                # are reported at the next heartbeat.
+                time.sleep(max(0, 1 - (now - packet_window)))
+                continue
+            try:
+                packet, address = sock.recvfrom(128)
+                packet_count += 1
+                if address[0] != 'lo':
+                    observer.observe(packet, address[2] == 4, time.monotonic())
+            except socket.timeout:
+                pass
+            now = time.monotonic()
+            if now - last_expiry >= 1:
+                observer.expire(now)
+                last_expiry = now
+            if now - last_tick >= 10:
+                # Linux resets this counter on read. Include socket-overflow
+                # losses, not just the monitor's own rate-limit drops.
+                _, kernel_drops = struct.unpack('II', sock.getsockopt(263, 6, 8))
+                output({'kind': 'heartbeat', 'dropped': dropped + kernel_drops})
+                dropped = 0
+                last_tick = now
+    finally:
+        sock.close()
+        output({'kind': 'stopped', 'dropped': dropped})
+
+if __name__ == '__main__':
+    main()
+`;

--- a/mcpjam-inspector/server/services/github-checks/network-monitor.ts
+++ b/mcpjam-inspector/server/services/github-checks/network-monitor.ts
@@ -1,0 +1,285 @@
+import { isIP } from "node:net";
+import { logger } from "../../utils/logger.js";
+import type { CheckSandbox } from "./sandbox.js";
+import { NETWORK_MONITOR_SCRIPT } from "./network-monitor-script.js";
+
+const LINE_LIMIT = 1024;
+const BYTE_LIMIT_PER_MINUTE = 128 * 1024;
+const RECORD_LIMIT_PER_MINUTE = 120;
+const TOTAL_RECORD_LIMIT = 2000;
+const START_TIMEOUT_MS = 5000;
+const outcomes = new Set([
+  "attempted",
+  "syn_ack_observed",
+  "reset_observed",
+  "unreachable_observed",
+  "timeout_inferred",
+]);
+
+/** Guest text is untrusted. Copy only validated fields, never spread its JSON. */
+export function parseConnectionRecord(line: string) {
+  if (line.length > LINE_LIMIT) return null;
+  try {
+    const row = JSON.parse(line);
+    if (
+      !row ||
+      row.kind !== "connection" ||
+      !outcomes.has(row.outcome) ||
+      !["tcp", "udp"].includes(row.protocol) ||
+      typeof row.destinationIp !== "string" ||
+      isIP(row.destinationIp) === 0 ||
+      row.destinationIp.includes("%") ||
+      isIP(row.destinationIp) !== row.family ||
+      !Number.isInteger(row.destinationPort) ||
+      row.destinationPort < 1 ||
+      row.destinationPort > 65535 ||
+      !Number.isSafeInteger(row.timestamp) ||
+      row.timestamp < 0
+    )
+      return null;
+    return {
+      destinationIp: row.destinationIp as string,
+      destinationPort: row.destinationPort as number,
+      protocol: row.protocol as string,
+      family: row.family as number,
+      outcome: row.outcome as string,
+      guestTimestamp: row.timestamp as number,
+    };
+  } catch {
+    return null;
+  }
+}
+
+type Handle = {
+  kill(): Promise<unknown>;
+  wait(): Promise<unknown>;
+  disconnect(): Promise<void>;
+};
+type MonitorContext = {
+  triggerId: string;
+  repoFullName: string;
+  prNumber: number;
+  policyVersion: string;
+  policySource: "default" | "override";
+  denyOut: string[];
+};
+const monitors = new WeakMap<CheckSandbox, () => Promise<void>>();
+
+/** Best-effort diagnostics, started before clone/build. Never carries auth env. */
+export async function startNetworkMonitor(
+  sandbox: CheckSandbox,
+  context: MonitorContext,
+): Promise<void> {
+  const base = {
+    ...context,
+    sandboxId: sandbox.sandboxId,
+    evidence: "guest_observed",
+  };
+  let stopped = false;
+  let handle: Handle | undefined;
+  let buffer = "";
+  let discardLine = false;
+  let lastSeen = Date.now();
+  let windowStart = Date.now();
+  let bytes = 0,
+    records = 0,
+    total = 0,
+    dropped = 0;
+  let transportBytes = 0,
+    stderrBytes = 0;
+  let reportedMissing = false;
+  let ready!: () => void;
+  const readiness = new Promise<void>((resolve) => {
+    ready = resolve;
+  });
+  const warn = (reason: string) =>
+    logger.warn("[github-checks] network monitor", { ...base, reason });
+  const onStdout = (chunk: string) => {
+    if (stopped) return;
+    const now = Date.now();
+    if (now - windowStart >= 60_000) {
+      windowStart = now;
+      bytes = records = 0;
+    }
+    const size = Buffer.byteLength(chunk);
+    transportBytes += size;
+    // The SDK also buffers command output. Disconnect, rather than merely
+    // discarding records, when a tampered monitor exceeds the transport budget.
+    if (transportBytes > 2 * 1024 * 1024) {
+      warn("transport_limit");
+      void stop();
+      return;
+    }
+    bytes += size;
+    if (bytes > BYTE_LIMIT_PER_MINUTE || chunk.length > 16_384) {
+      dropped++;
+      buffer = "";
+      discardLine = !chunk.endsWith("\n");
+      return;
+    }
+    for (const char of chunk) {
+      if (char !== "\n") {
+        if (!discardLine) buffer += char;
+        if (buffer.length > LINE_LIMIT) {
+          buffer = "";
+          discardLine = true;
+          dropped++;
+        }
+        continue;
+      }
+      const line = buffer;
+      buffer = "";
+      if (discardLine) {
+        discardLine = false;
+        continue;
+      }
+      let control: { kind?: unknown; dropped?: unknown };
+      try {
+        control = JSON.parse(line);
+      } catch {
+        dropped++;
+        continue;
+      }
+      if (
+        control &&
+        ["ready", "heartbeat", "stopped"].includes(String(control.kind))
+      ) {
+        lastSeen = now;
+        if (control.kind === "ready") ready();
+        if (
+          typeof control.dropped === "number" &&
+          Number.isSafeInteger(control.dropped) &&
+          control.dropped > 0
+        ) {
+          dropped += Math.min(control.dropped, 1_000_000);
+        }
+        continue;
+      }
+      const record = parseConnectionRecord(line);
+      if (
+        !record ||
+        records >= RECORD_LIMIT_PER_MINUTE ||
+        total >= TOTAL_RECORD_LIMIT
+      ) {
+        dropped++;
+        continue;
+      }
+      lastSeen = now;
+      records++;
+      total++;
+      logger.info("[github-checks] network connection", {
+        ...record,
+        ...base,
+        observedAt: now,
+      });
+    }
+  };
+  const flushDropped = () => {
+    if (dropped) {
+      logger.warn("[github-checks] network monitor dropped records", {
+        ...base,
+        dropped,
+      });
+      dropped = 0;
+    }
+  };
+  const heartbeat = setInterval(() => {
+    flushDropped();
+    if (!reportedMissing && Date.now() - lastSeen > 30_000) {
+      reportedMissing = true;
+      warn("heartbeat_missing");
+    }
+  }, 10_000);
+  heartbeat.unref?.();
+  const stop = async () => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(heartbeat);
+    flushDropped();
+    monitors.delete(sandbox);
+    if (handle) {
+      await handle.disconnect().catch(() => {
+        warn("disconnect_failed");
+      });
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          handle.kill(),
+          new Promise((_, reject) => {
+            timer = setTimeout(() => reject(new Error()), 2000);
+          }),
+        ]);
+      } catch {
+        warn("stop_failed");
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+  };
+  monitors.set(sandbox, stop);
+  let startupTimer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const quoted = `'${NETWORK_MONITOR_SCRIPT.replace(/'/g, `'\\''`)}'`;
+    const spawned = sandbox.commands
+      .run(`sudo -n python3 -u -c ${quoted}`, {
+        background: true,
+        timeoutMs: 0,
+        onStdout,
+        // Never log stderr: interpreter/guest failures can contain arbitrary text.
+        onStderr: (chunk) => {
+          if (stopped) return;
+          stderrBytes += Buffer.byteLength(chunk);
+          if (stderrBytes > 4096) {
+            warn("stderr_limit");
+            void stop();
+          }
+        },
+      })
+      .then(async (value) => {
+        const candidate = value as Handle;
+        if (
+          !candidate ||
+          typeof candidate.kill !== "function" ||
+          typeof candidate.wait !== "function" ||
+          typeof candidate.disconnect !== "function"
+        )
+          throw new Error();
+        handle = candidate;
+        if (stopped) {
+          await candidate.disconnect().catch(() => {});
+          await candidate.kill().catch(() => {});
+          return;
+        }
+        void candidate.wait().then(
+          () => {
+            if (!stopped) {
+              warn("exited");
+              void stop();
+            }
+          },
+          () => {
+            if (!stopped) {
+              warn("stream_failed");
+              void stop();
+            }
+          },
+        );
+      });
+    await Promise.race([
+      Promise.all([spawned, readiness]),
+      new Promise((_, reject) => {
+        startupTimer = setTimeout(() => reject(new Error()), START_TIMEOUT_MS);
+      }),
+    ]);
+    if (!stopped) logger.info("[github-checks] network monitor started", base);
+  } catch {
+    warn("start_failed");
+    await stop();
+  } finally {
+    clearTimeout(startupTimer);
+  }
+}
+
+export async function stopNetworkMonitor(sandbox: CheckSandbox): Promise<void> {
+  await monitors.get(sandbox)?.();
+}

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -32,6 +32,11 @@
  */
 
 import { Sandbox } from "e2b";
+import {
+  DEFAULT_EGRESS_DENY_CIDRS,
+  resolveEgressPolicy,
+} from "./egress-policy.js";
+import { startNetworkMonitor, stopNetworkMonitor } from "./network-monitor.js";
 import { logger } from "../../utils/logger.js";
 import type { CheckRecipe } from "./recipes.js";
 
@@ -93,18 +98,8 @@ export const CLONE_TIMEOUT_MS = 5 * 60_000;
 export const HEALTH_TIMEOUT_MS = 2 * 60_000;
 export const HEALTH_INTERVAL_MS = 2_000;
 
-/**
- * The GitHub-checks box is non-guest, so its baseline must match the backend's
- * `resolveEgressBaseline(false)` exactly. Keep this hand-mirrored list in sync
- * with `convex/lib/computerProviders/e2b.ts`; omitting it here would silently
- * fall back to E2B's allow-all default. Link-local is intentionally not part of
- * this list because E2B uses that range for its own metadata service.
- */
-export const GITHUB_CHECKS_EGRESS_DENY_CIDRS = [
-  "10.0.0.0/8",
-  "172.16.0.0/12",
-  "192.168.0.0/16",
-] as const;
+/** Shared defaults; a deployment override replaces the effective list. */
+export const GITHUB_CHECKS_EGRESS_DENY_CIDRS = DEFAULT_EGRESS_DENY_CIDRS;
 
 /**
  * Per-attempt cap on the health probe, clamped to the remaining deadline. A
@@ -364,11 +359,25 @@ export async function provisionCheckSandbox(args: {
   if (!apiKey || !templateId) {
     throw new CheckStepError(
       "infra_error",
-      "github-checks sandbox requires E2B_API_KEY and GITHUB_CHECKS_E2B_TEMPLATE_ID"
+      "github-checks sandbox requires E2B_API_KEY and GITHUB_CHECKS_E2B_TEMPLATE_ID",
     );
   }
 
   try {
+    const policy = resolveEgressPolicy(process.env.E2B_EGRESS_DENY_CIDRS);
+    const policyContext = {
+      ...args,
+      policyVersion: policy.version,
+      denyOut: policy.denyOut,
+      policySource: policy.source,
+    };
+    if (policy.weakensDefaults) {
+      logger.warn(
+        "[github-checks] network override weakens defaults",
+        policyContext,
+      );
+    }
+    logger.info("[github-checks] network policy requested", policyContext);
     const sandbox = await Sandbox.create(templateId, {
       apiKey,
       timeoutMs: CHECK_SANDBOX_TIMEOUT_MS,
@@ -380,7 +389,7 @@ export async function provisionCheckSandbox(args: {
       // The network is never modified afterwards — see the module docblock.
       network: {
         allowPublicTraffic: true,
-        denyOut: [...GITHUB_CHECKS_EGRESS_DENY_CIDRS],
+        denyOut: policy.denyOut,
       },
       metadata: {
         purpose: "github-checks",
@@ -390,14 +399,30 @@ export async function provisionCheckSandbox(args: {
       },
     });
     logger.info("[github-checks] sandbox provisioned", {
+      ...policyContext,
       sandboxId: sandbox.sandboxId,
-      triggerId: args.triggerId,
     });
+    try {
+      await startNetworkMonitor(
+        sandbox as unknown as CheckSandbox,
+        policyContext,
+      );
+    } catch {
+      logger.warn("[github-checks] network monitor", {
+        ...policyContext,
+        sandboxId: sandbox.sandboxId,
+        reason: "start_failed",
+      });
+    }
     return sandbox as unknown as CheckSandbox;
-  } catch (error) {
+  } catch {
+    logger.warn("[github-checks] sandbox provisioning failed", {
+      ...args,
+      reason: "policy_or_provider_rejected",
+    });
     throw new CheckStepError(
       "infra_error",
-      `sandbox provision failed: ${errorMessage(error)}`
+      "sandbox provisioning failed; verify the network policy and provider configuration",
     );
   }
 }
@@ -1861,9 +1886,16 @@ function isServerIdentity(value: unknown): boolean {
 
 /** Best-effort teardown. E2B's TTL + `onTimeout: "kill"` is the real backstop. */
 export async function killCheckSandbox(
-  sandbox: CheckSandbox | null
+  sandbox: CheckSandbox | null,
 ): Promise<void> {
   if (!sandbox) return;
+  try {
+    await stopNetworkMonitor(sandbox);
+  } catch {
+    logger.warn("[github-checks] monitor cleanup failed", {
+      sandboxId: sandbox.sandboxId,
+    });
+  }
   try {
     await sandbox.kill();
   } catch (error) {


### PR DESCRIPTION
GitHub checks now apply the same validated egress override as the backend and start a bounded network observer before clone/build. Connection failures previously left no retained network evidence to investigate user complaints. The observer streams only validated IP/port/protocol/outcome records to the existing server logger, with run identity and effective policy attached by the server.

The Python observer records attempts, SYN-ACKs, resets, ICMP unreachables, and separately labeled inferred timeouts. Both guest and server cap records; packet processing and SDK output buffering are bounded. Startup/stream/heartbeat/drop/cleanup failures emit generic warnings and do not stop the check or modify its policy. Guest text, headers, credentials, paths, payloads, and raw stderr are excluded. These observations are tamperable diagnostics, not provider-denial audit events.

Companion backend PR: https://github.com/MCPJam/mcpjam-backend/pull/1302. It pins the shared module and provides the policy probe. Defaults remain RFC1918-only because live testing found link-local metadata still reachable with its deny rule, while private/CGNAT denial requires responsive fixtures. No modes, UI, migration, backfill, rollout, or fork credential change.

Validation:
- All 492 GitHub-check tests pass; final focused policy/monitor/provision suite passes 32 tests, including packet decoding, redaction, flooding, late startup, and cleanup failures.
- SDK and Inspector server builds pass; repository runtime/import/bundle checks pass.
- Backend mirror pins pass and the new pair matches exactly after normalization; five unrelated existing cross-repo drifts remain.
- Inspector full server typecheck has 271 diagnostics, exactly matching an untouched base checkout using the same installed dependencies (zero added/removed). Repository ESLint does not configure these server files; a targeted TypeScript-parser/core-rule lint pass is clean.
- Live dedicated-template smoke: real monitor starts, public Git clone and uncached npm installation succeed, TCP/UDP records arrive with host identity, sentinel header stays out of logs, heartbeat stays healthy, and E2B confirms sandbox shutdown. Saved result and runbook are in mcpjam-inspector/docs/github-checks-network.md.

Final staging fork testing, deployment override/log-sink verification, and production promotion remain deferred.
