### PR TITLE
Name the wrong OAuth error code in the refresh-declined toast

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-oauth-failure.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-oauth-failure.test.ts
@@ -147,6 +147,59 @@ describe("describeHostedOAuthFailure structured backend shapes", () => {
       "Hosted OAuth refresh token is invalid. Please reconnect.",
     ]);
   });
+
+  it("shows the spec note instead of the generic message when one is sent", () => {
+    // The authorization server declined a dead refresh token under
+    // invalid_request. The reconnect is unchanged; the note is the part the
+    // user can act on, and it replaces a generic line that only repeats the
+    // title.
+    const specNote =
+      "Your server answered invalid_request. RFC 6749 expects invalid_grant when a refresh token is unknown or expired.";
+    const copy = describeHostedOAuthFailure(
+      Object.assign(
+        new Error("Hosted OAuth refresh token is invalid. Please reconnect."),
+        {
+          code: "UNAUTHORIZED",
+          details: {
+            oauthRequired: true,
+            refreshTokenInvalid: true,
+            serverId: "srv_1",
+            serverName: "Linear",
+            specNote,
+          },
+        }
+      ),
+      "Linear"
+    );
+
+    expect(copy?.kind).toBe("declined");
+    expect(copy?.action).toBe("reconnect");
+    expect(copy?.detail).toEqual([specNote]);
+  });
+
+  it("falls back to the generic message when no spec note is sent", () => {
+    // A conforming invalid_grant decline carries no note; nothing changes.
+    const copy = describeHostedOAuthFailure(
+      Object.assign(
+        new Error("Hosted OAuth refresh token is invalid. Please reconnect."),
+        {
+          code: "UNAUTHORIZED",
+          details: {
+            oauthRequired: true,
+            refreshTokenInvalid: true,
+            serverId: "srv_1",
+            serverName: "Linear",
+            specNote: null,
+          },
+        }
+      ),
+      "Linear"
+    );
+
+    expect(copy?.detail).toEqual([
+      "Hosted OAuth refresh token is invalid. Please reconnect.",
+    ]);
+  });
 });
 
 describe("describeHostedOAuthFailure invalid_client messages", () => {

--- a/mcpjam-inspector/client/src/lib/hosted-oauth-failure.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-oauth-failure.ts
@@ -181,10 +181,17 @@ export function describeHostedOAuthFailure(
     code === "refresh_token_invalid" ||
     details?.refreshTokenInvalid === true
   ) {
+    // The backend's own message here is generic ("...is invalid. Please
+    // reconnect."), which only restates the title. When the authorization
+    // server declined under the wrong RFC 6749 code, the note naming that
+    // violation is the one line worth the space — it is what the user can
+    // take back to their own server.
+    const specNote =
+      typeof details?.specNote === "string" ? details.specNote.trim() : "";
     return {
       kind: "declined",
       title: `Refresh token declined for ${serverName}`,
-      detail: [message],
+      detail: [specNote || message],
       action: "reconnect",
     };
   }

--- a/mcpjam-inspector/server/utils/hosted-oauth-refresh.ts
+++ b/mcpjam-inspector/server/utils/hosted-oauth-refresh.ts
@@ -263,6 +263,11 @@ export async function forceRefreshHostedOAuthAccessToken(
             refreshTokenInvalid: true,
             serverId,
             serverName: options?.serverName ?? null,
+            // Present only when the authorization server declined under a code
+            // that does not mean "dead refresh token". Forwarded verbatim: it
+            // is the one part of this failure the user can fix on their side.
+            specNote:
+              typeof body?.specNote === "string" ? body.specNote : null,
           }
         : isAuthServerUnreachable
         ? {


### PR DESCRIPTION
- When a server rejects a dead refresh token using the wrong OAuth error code, the toast now says so instead of showing a generic line that just repeated its own title.
- The copy reads: "Your server answered invalid_request. RFC 6749 expects invalid_grant when a refresh token is unknown or expired." That is the part the user can take back and fix on their own server.
- Nothing else changes. The Reconnect button behaves exactly as before, and servers that reject correctly show the same message they always did.
- Needs the backend change in MCPJam/mcpjam-backend#1303 to send the note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
When a server rejects a dead refresh token with the wrong OAuth error code, the refresh-declined toast now names the exact violation instead of showing a generic line that repeated its title.

- The note comes from the backend's `specNote` field and replaces the generic detail line only when present.
- Reconnect behavior and messages for conforming `invalid_grant` declines are unchanged.
- Requires the backend to send `specNote`, tracked in `MCPJam/mcpjam-backend#1303`.

<sup>Written for commit e3ea120cc87a816b065b58ee59ec244387ad40b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

