### PR TITLE
Record eval execution timing and parallelism

### DIFF
--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -101,6 +101,7 @@
     "test:watch": "cross-env NODE_OPTIONS=--max-old-space-size=6144 vitest",
     "test:coverage": "cross-env NODE_OPTIONS=--max-old-space-size=6144 vitest run --coverage",
     "test:e2e": "playwright test",
+    "test:github-checks-cleanup:e2b": "cross-env RUN_GITHUB_CHECKS_E2B_CLEANUP=1 vitest run server/services/github-checks/__tests__/cleanup.e2b.integration.test.ts",
     "test:e2e:oauth-debugger": "npm run sdk:build && playwright test -c playwright.oauth-debugger.config.ts",
     "ship": "bash scripts/ship.sh"
   },

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -99,6 +99,9 @@ type Harness = {
   completions: Completion[];
   events: string[];
   heartbeats: string[];
+  liveSandboxes: Set<string>;
+  liveServers: Set<string>;
+  savedEvalResults: Set<string>;
   /**
    * The box `resolveAndStart` hands back. Exposed so a test can wrap its
    * command channel — the post-failure liveness diagnostic is the one thing the
@@ -126,6 +129,9 @@ function harness(
   const completions: Completion[] = [];
   const events: string[] = [];
   const heartbeats: string[] = [];
+  const liveSandboxes = new Set(["sb_1", "sb_unrelated"]);
+  const liveServers = new Set(["server_unrelated"]);
+  const savedEvalResults = new Set(["run_unrelated"]);
   const resolveArgs: Array<{ cloneToken?: string }> = [];
   const {
     runEvalSuite: runEvalSuiteOverride,
@@ -208,7 +214,8 @@ function harness(
         },
       };
     },
-    killSandbox: async () => {
+    killSandbox: async (box) => {
+      if (box) liveSandboxes.delete(box.sandboxId);
       events.push("killSandbox");
     },
     reportCredentialBlocked: async () => {
@@ -222,10 +229,12 @@ function harness(
     },
     createEphemeralServer: async (args) => {
       events.push(`createServer:${args.name}:${args.url}`);
+      liveServers.add("server-1");
       return "server-1";
     },
     deleteEphemeralServer: async (args) => {
       events.push(`deleteServer:${args.serverId}`);
+      liveServers.delete(args.serverId);
     },
     recordServer: async (triggerId, serverId) => {
       events.push(`recordServer:${triggerId}:${serverId}`);
@@ -254,6 +263,7 @@ function harness(
       heartbeats.push(triggerId);
     },
     heartbeatIntervalMs: 1_000,
+    cleanupTimeoutMs: 15_000,
     ...restOverrides,
   };
 
@@ -265,8 +275,19 @@ function harness(
     completions,
     events,
     heartbeats,
+    liveSandboxes,
+    liveServers,
+    savedEvalResults,
     sandbox,
   };
+}
+
+function expectOnlyCheckResourcesRemoved(h: Harness): void {
+  expect(h.liveSandboxes.has("sb_1")).toBe(false);
+  expect(h.liveServers.has("server-1")).toBe(false);
+  expect(h.liveSandboxes).toEqual(new Set(["sb_unrelated"]));
+  expect(h.liveServers).toEqual(new Set(["server_unrelated"]));
+  expect(h.savedEvalResults).toEqual(new Set(["run_unrelated"]));
 }
 
 describe("executeClaimedCheck — happy path", () => {
@@ -666,6 +687,7 @@ describe("executeClaimedCheck — the plan owns the verdict", () => {
     expect(h.completions).toHaveLength(0);
     expect(h.reports).toHaveLength(0);
     expect(h.events).toContain("killSandbox");
+    expectOnlyCheckResourcesRemoved(h);
   });
 
   it("abandons the check when the lease is lost during the liveness diagnostic", async () => {
@@ -702,6 +724,7 @@ describe("executeClaimedCheck — the plan owns the verdict", () => {
     // Abandoned, not completed — and the box is still torn down.
     expect(h.completions).toHaveLength(0);
     expect(h.events).toContain("killSandbox");
+    expectOnlyCheckResourcesRemoved(h);
   });
 
   it("checks liveness over the command RPC, never the public URL", async () => {
@@ -770,6 +793,39 @@ describe("executeClaimedCheck — the plan owns the verdict", () => {
 });
 
 describe("executeClaimedCheck — cleanup and heartbeat", () => {
+  it.each([
+    ["successful run", "passed"],
+    ["failed assertions", "failed"],
+    ["run timeout", "timed_out"],
+    ["run cancellation", "cancelled"],
+  ])("removes only this check's resources after a %s", async (_name, result) => {
+    const h = harness({
+      runEvalSuite: async (args) => {
+        await args.onRunStarted?.("run-1");
+        return { runId: "run-1", result };
+      },
+    });
+
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expectOnlyCheckResourcesRemoved(h);
+    expect(h.completions[0].runId).toBe("run-1");
+  });
+
+  it("removes a sandbox left behind by a build or start failure", async () => {
+    const h = harness();
+    h.deps.resolveAndStart = async (_args, overrides) => {
+      overrides.onSandbox?.(h.sandbox);
+      throw new CheckStepError("build_failed", "build exited 1");
+    };
+
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expect(h.liveSandboxes).toEqual(new Set(["sb_unrelated"]));
+    expect(h.liveServers).toEqual(new Set(["server_unrelated"]));
+    expect(h.savedEvalResults).toEqual(new Set(["run_unrelated"]));
+  });
+
   it("deletes the ephemeral server row and kills the box even when the run throws", async () => {
     const h = harness({
       runEvalSuite: async () => {
@@ -779,6 +835,7 @@ describe("executeClaimedCheck — cleanup and heartbeat", () => {
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.events).toContain("deleteServer:server-1");
     expect(h.events).toContain("killSandbox");
+    expectOnlyCheckResourcesRemoved(h);
   });
 
   it("kills the box even if deleting the server row fails", async () => {
@@ -791,6 +848,43 @@ describe("executeClaimedCheck — cleanup and heartbeat", () => {
     // A cleanup failure that costs money (a live sandbox) must not be skipped
     // because a cheaper one (a soft-deletable row) failed first.
     expect(h.events).toContain("killSandbox");
+    expect(h.completions[0].runId).toBe("run-1");
+  });
+
+  it("kills the sandbox when server deletion times out", async () => {
+    const h = harness({
+      deleteEphemeralServer: () => new Promise<void>(() => {}),
+      cleanupTimeoutMs: 5,
+    });
+
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expect(h.liveSandboxes).toEqual(new Set(["sb_unrelated"]));
+    expect(h.completions[0].runId).toBe("run-1");
+  });
+
+  it("deletes the server when sandbox cleanup fails", async () => {
+    const h = harness({
+      killSandbox: async () => {
+        throw new Error("E2B unavailable");
+      },
+    });
+
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expect(h.liveServers).toEqual(new Set(["server_unrelated"]));
+    expect(h.completions[0].runId).toBe("run-1");
+  });
+
+  it("deletes the server when sandbox cleanup times out", async () => {
+    const h = harness({
+      killSandbox: () => new Promise<void>(() => {}),
+      cleanupTimeoutMs: 5,
+    });
+
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expect(h.liveServers).toEqual(new Set(["server_unrelated"]));
     expect(h.completions[0].runId).toBe("run-1");
   });
 

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -3019,6 +3019,46 @@ export const runEvalSuiteWithAiSdk = async ({
     const renderCheckLimit = createConcurrencyLimiter(
       MAX_CONCURRENT_RENDER_CHECKS,
     );
+    if (recorder?.beginExecutionAttempt) {
+      const modelIdentifiers = Array.from(
+        new Map(
+          tests
+            .filter(
+              (test) =>
+                !isPinnedOnly({
+                  caseType: test.caseType,
+                  promptTurns: resolveEvalTestCase(test).promptTurns,
+                }),
+            )
+            .map((test) => {
+              const modelDefinition = resolveEvalCaseModelDefinition({
+                hostConfig: suiteHostConfig,
+                caseModel: buildModelDefinition(test),
+              });
+              const provider = modelDefinition.provider;
+              const model = getCanonicalModelId(
+                String(modelDefinition.id),
+                provider,
+              );
+              return [
+                `${provider}\u0000${model}`,
+                { provider, model },
+              ] as const;
+            }),
+        ).values(),
+      );
+      await recorder.beginExecutionAttempt({
+        caseCount: tests.length,
+        // Cases may configure different repeat counts. This is the total
+        // number of iteration rows expected for the whole attempt.
+        repetitionCount: tests.reduce(
+          (sum, test) => sum + (test.runs || 1),
+          0,
+        ),
+        renderConcurrencyLimit: MAX_CONCURRENT_RENDER_CHECKS,
+        modelIdentifiers,
+      });
+    }
     const runOne = (test: (typeof tests)[number]) =>
       runTestCase({
         test,
@@ -3602,6 +3642,11 @@ const runLocalIteration = async ({
     testCaseId: test.testCaseId ?? testCaseId,
     iterationNumber: runIndex + 1,
     startedAt: runStartedAt,
+    executionType: !caseNeedsModel
+      ? ("model_free" as const)
+      : resolvedExecution.harness
+        ? ("harness" as const)
+        : ("model" as const),
   };
   const shouldOmitSnapshotForPairing =
     !caseNeedsModel &&
@@ -4787,6 +4832,9 @@ const runHostedIterationWithBrowser = async (
     },
     iterationNumber: runIndex + 1,
     startedAt: runStartedAt,
+    executionType: resolvedExecution.harness
+      ? ("harness" as const)
+      : ("model" as const),
   };
 
   const iterationId = precreatedIterationId

--- a/mcpjam-inspector/server/services/evals/__tests__/recorder.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/recorder.test.ts
@@ -490,6 +490,195 @@ describe("startSuiteRunWithRecorder", () => {
 });
 
 describe("createSuiteRunRecorder", () => {
+  it("does not delay result persistence when runtime timing writes hang", async () => {
+    vi.useFakeTimers();
+    try {
+      const query = vi.fn(async (ref: string) => {
+        if (ref === "testSuites:getTestSuiteRun") return { status: "running" };
+        if (ref === "testSuites:getTestSuiteRunDetails") {
+          return {
+            iterations: [
+              { _id: "iter1", testCaseId: "tc1", iterationNumber: 1 },
+            ],
+          };
+        }
+        if (ref === "testSuites:getTestIteration") {
+          return { status: "running" };
+        }
+        throw new Error(`unexpected query ${ref}`);
+      });
+      const mutation = vi.fn((ref: string) => {
+        if (
+          ref === "testSuites:recordEvalIterationRuntimeStart" ||
+          ref === "testSuites:recordEvalIterationRuntimeEnd"
+        ) {
+          return new Promise(() => {});
+        }
+        return Promise.resolve(undefined);
+      });
+      const action = vi.fn(async (ref: string) => {
+        if (ref === "testSuites:appendEvalTurnTrace") {
+          return { skipped: false };
+        }
+        if (ref === "testSuites:updateTestIteration") return {};
+        if (ref === "testSuites:lockEvalSession") {
+          return { skipped: false, locked: true, alreadyLocked: false };
+        }
+        throw new Error(`unexpected action ${ref}`);
+      });
+      const recorder = createSuiteRunRecorder({
+        convexClient: { query, mutation, action } as any,
+        suiteId: "suite-1",
+        runId: "run-1",
+      });
+
+      await recorder.beginExecutionAttempt?.({
+        caseCount: 1,
+        repetitionCount: 1,
+        renderConcurrencyLimit: 2,
+        modelIdentifiers: [],
+      });
+      const iterationId = await recorder.startIteration({
+        testCaseId: "tc1",
+        iterationNumber: 1,
+        startedAt: Date.now(),
+      });
+      await recorder.finishIteration({
+        iterationId,
+        passed: true,
+        status: "completed",
+        toolsCalled: [],
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        messages: [{ role: "user", content: "hi" } as ModelMessage],
+      });
+
+      expect(action).toHaveBeenCalledWith(
+        "testSuites:updateTestIteration",
+        expect.any(Object)
+      );
+      await vi.advanceTimersByTimeAsync(2_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps execution available when runtime telemetry cannot start", async () => {
+    const query = vi.fn(async (ref: string) => {
+      if (ref === "testSuites:getTestSuiteRun") return { status: "running" };
+      if (ref === "testSuites:getTestSuiteRunDetails") {
+        return {
+          iterations: [
+            { _id: "iter1", testCaseId: "tc1", iterationNumber: 1 },
+          ],
+        };
+      }
+      throw new Error(`unexpected query ${ref}`);
+    });
+    const mutation = vi.fn(async (ref: string) => {
+      if (ref === "testSuites:beginEvalRuntimeAttempt") {
+        throw new Error("telemetry unavailable");
+      }
+      return undefined;
+    });
+    const recorder = createSuiteRunRecorder({
+      convexClient: { query, mutation } as any,
+      suiteId: "suite-1",
+      runId: "run-1",
+    });
+
+    await expect(
+      recorder.beginExecutionAttempt?.({
+        caseCount: 1,
+        repetitionCount: 1,
+        renderConcurrencyLimit: 2,
+        modelIdentifiers: [],
+      })
+    ).resolves.toBeUndefined();
+    await expect(
+      recorder.startIteration({
+        testCaseId: "tc1",
+        iterationNumber: 1,
+        startedAt: Date.now(),
+      })
+    ).resolves.toBe("iter1");
+    expect(
+      mutation.mock.calls.some(
+        ([ref]) => ref === "testSuites:recordEvalIterationRuntimeStart"
+      )
+    ).toBe(false);
+  });
+
+  it("records one attempt and closes timing before uploading iteration results", async () => {
+    const query = vi.fn(async (ref: string) => {
+      if (ref === "testSuites:getTestSuiteRun") return { status: "running" };
+      if (ref === "testSuites:getTestSuiteRunDetails") {
+        return {
+          iterations: [
+            { _id: "iter1", testCaseId: "tc1", iterationNumber: 1 },
+          ],
+        };
+      }
+      if (ref === "testSuites:getTestIteration") return { status: "running" };
+      throw new Error(`unexpected query ${ref}`);
+    });
+    const mutation = vi.fn(async () => undefined);
+    const action = vi.fn(async (ref: string) => {
+      if (ref === "testSuites:appendEvalTurnTrace") return { skipped: false };
+      if (ref === "testSuites:updateTestIteration") return {};
+      if (ref === "testSuites:lockEvalSession") {
+        return { skipped: false, locked: true, alreadyLocked: false };
+      }
+      throw new Error(`unexpected action ${ref}`);
+    });
+    const recorder = createSuiteRunRecorder({
+      convexClient: { query, mutation, action } as any,
+      suiteId: "suite-1",
+      runId: "run-1",
+    });
+
+    await recorder.beginExecutionAttempt?.({
+      caseCount: 1,
+      repetitionCount: 1,
+      renderConcurrencyLimit: 2,
+      modelIdentifiers: [{ provider: "openai", model: "gpt-5" }],
+    });
+    const iterationId = await recorder.startIteration({
+      testCaseId: "tc1",
+      iterationNumber: 1,
+      startedAt: Date.now(),
+      executionType: "model",
+    });
+    await recorder.finishIteration({
+      iterationId,
+      passed: true,
+      status: "completed",
+      toolsCalled: [],
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      messages: [{ role: "user", content: "hi" } as ModelMessage],
+    });
+    await recorder.finalize({ status: "completed" });
+
+    const refs = mutation.mock.calls.map(([ref]) => ref);
+    expect(refs).toContain("testSuites:beginEvalRuntimeAttempt");
+    expect(refs).toContain("testSuites:recordEvalIterationRuntimeStart");
+    expect(refs).toContain("testSuites:recordEvalIterationRuntimeEnd");
+    expect(refs).toContain("testSuites:finalizeEvalRuntimeAttempt");
+    expect(refs.indexOf("testSuites:finalizeEvalRuntimeAttempt")).toBeLessThan(
+      refs.indexOf("testSuites:updateTestSuiteRun")
+    );
+    const endCall = mutation.mock.calls.find(
+      ([ref]) => ref === "testSuites:recordEvalIterationRuntimeEnd"
+    );
+    expect(endCall?.[1]).toMatchObject({
+      iterationId: "iter1",
+      executionType: "model",
+      executionOutcome: "completed",
+    });
+    expect((endCall?.[1] as any).endOffsetMs).toBeGreaterThanOrEqual(
+      (endCall?.[1] as any).startOffsetMs
+    );
+  });
+
   it("flips runDeleted when finishIteration's shared finalize sees 'not found', short-circuiting subsequent startIteration", async () => {
     // Pre-check getTestIteration returns running; updateTestIteration throws
     // "not found" → shared finalizeEvalIteration fires `onRunDeleted` →

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -24,6 +24,7 @@ import type { IterationStatus as ContractIterationStatus } from "@mcpjam/sdk/con
 import { resolveCaseSuccessPredicates } from "@/shared/eval-matching";
 import { ErrorCode, WebRouteError } from "../../routes/web/errors.js";
 import { ConvexError } from "convex/values";
+import { randomUUID } from "node:crypto";
 import {
   environmentLaunchConflictError,
   environmentLaunchRejectionError,
@@ -40,6 +41,8 @@ type IterationStatus = ContractIterationStatus;
 // Run-level (not per-iteration) terminal stop reason, threaded into the
 // suite-run finalize so the dashboard can show why a run stopped.
 type RunStopReason = "user_cancelled" | "run_timeout" | "iteration_timeout";
+type ExecutionType = "model" | "model_free" | "harness";
+const RUNTIME_TELEMETRY_TIMEOUT_MS = 2_000;
 
 /**
  * When a Convex mutation rejects because a billing/entitlement cap was hit
@@ -88,6 +91,12 @@ type SuiteRunEnvironmentSnapshot = {
 export type SuiteRunRecorder = {
   runId: string;
   suiteId: string;
+  beginExecutionAttempt?(args: {
+    caseCount: number;
+    repetitionCount: number;
+    renderConcurrencyLimit: number;
+    modelIdentifiers: Array<{ provider: string; model: string }>;
+  }): Promise<void>;
   startIteration(args: {
     testCaseId?: string;
     testCaseSnapshot?: {
@@ -108,6 +117,7 @@ export type SuiteRunRecorder = {
     };
     iterationNumber: number;
     startedAt: number;
+    executionType?: ExecutionType;
   }): Promise<string | undefined>;
   finishIteration(args: {
     iterationId?: string;
@@ -192,11 +202,104 @@ export const createSuiteRunRecorder = ({
   runId: string;
 }): SuiteRunRecorder => {
   let runDeleted = false; // Track if run was deleted
+  let runtimeAttempt:
+    | { attemptId: string; monotonicStartedAt: number }
+    | undefined;
+  const iterationRuntime = new Map<
+    string,
+    {
+      executionType: ExecutionType;
+      startOffsetMs: number;
+    }
+  >();
+  const pendingRuntimeWrites = new Set<Promise<void>>();
+
+  const warnRuntimeFailure = (message: string, error: unknown) => {
+    logger.warn(message, {
+      runId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  };
+
+  const runRuntimeTelemetry = async <T>(
+    operation: () => Promise<T>,
+    failureMessage: string
+  ): Promise<{ ok: true; value: T } | { ok: false }> => {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const settled = Promise.resolve().then(operation).then(
+      (value) => ({ kind: "success" as const, value }),
+      (error) => ({ kind: "failure" as const, error })
+    );
+    const deadline = new Promise<{ kind: "timeout" }>((resolve) => {
+      timeout = setTimeout(
+        () => resolve({ kind: "timeout" }),
+        RUNTIME_TELEMETRY_TIMEOUT_MS
+      );
+    });
+    const result = await Promise.race([settled, deadline]);
+    if (timeout) clearTimeout(timeout);
+    if (result.kind === "success") {
+      return { ok: true, value: result.value };
+    }
+    warnRuntimeFailure(
+      failureMessage,
+      result.kind === "timeout"
+        ? new Error(
+            `runtime telemetry timed out after ${RUNTIME_TELEMETRY_TIMEOUT_MS}ms`
+          )
+        : result.error
+    );
+    return { ok: false };
+  };
+
+  const trackRuntimeWrite = (write: Promise<unknown>) => {
+    const tracked = write.then(() => undefined);
+    pendingRuntimeWrites.add(tracked);
+    void tracked.finally(() => pendingRuntimeWrites.delete(tracked));
+  };
 
   return {
     runId,
     suiteId,
-    async startIteration({ testCaseId, testCaseSnapshot, iterationNumber }) {
+    async beginExecutionAttempt(metadata) {
+      runtimeAttempt = undefined;
+      iterationRuntime.clear();
+      const attemptId = randomUUID();
+      try {
+        const currentRunResult = await runRuntimeTelemetry(
+          () =>
+            convexClient.query("testSuites:getTestSuiteRun" as any, { runId }),
+          "[evals] Failed to read current runtime attempt"
+        );
+        if (!currentRunResult.ok) return;
+        const currentRun = currentRunResult.value;
+        const beginResult = await runRuntimeTelemetry(
+          () =>
+            convexClient.mutation(
+              "testSuites:beginEvalRuntimeAttempt" as any,
+              {
+                runId,
+                attemptId,
+                ...(currentRun?.runtimeSummary?.attemptId
+                  ? { previousAttemptId: currentRun.runtimeSummary.attemptId }
+                  : {}),
+                ...metadata,
+              }
+            ),
+          "[evals] Failed to begin runtime telemetry"
+        );
+        if (!beginResult.ok) return;
+        runtimeAttempt = { attemptId, monotonicStartedAt: performance.now() };
+      } catch (error) {
+        warnRuntimeFailure("[evals] Failed to begin runtime telemetry", error);
+      }
+    },
+    async startIteration({
+      testCaseId,
+      testCaseSnapshot,
+      iterationNumber,
+      executionType = "model",
+    }) {
       if (runDeleted) {
         // Silently skip if run was deleted
         return undefined;
@@ -252,6 +355,34 @@ export const createSuiteRunRecorder = ({
           iterationId: matchingIteration._id,
         });
 
+        if (runtimeAttempt) {
+          const attempt = runtimeAttempt;
+          const iterationId = matchingIteration._id as string;
+          const startOffsetMs = Math.max(
+            0,
+            performance.now() - attempt.monotonicStartedAt
+          );
+          trackRuntimeWrite(
+            runRuntimeTelemetry(
+              () =>
+                convexClient.mutation(
+                  "testSuites:recordEvalIterationRuntimeStart" as any,
+                  {
+                    iterationId,
+                    attemptId: attempt.attemptId,
+                    executionType,
+                    startOffsetMs,
+                  }
+                ),
+              "[evals] Failed to record iteration runtime start"
+            )
+          );
+          iterationRuntime.set(iterationId, {
+            executionType,
+            startOffsetMs,
+          });
+        }
+
         return matchingIteration._id as string;
       } catch (error) {
         const errorMessage =
@@ -277,6 +408,33 @@ export const createSuiteRunRecorder = ({
     async finishIteration(params) {
       if (runDeleted) {
         return;
+      }
+      if (params.iterationId && runtimeAttempt) {
+        const timing = iterationRuntime.get(params.iterationId);
+        if (timing) {
+          const endOffsetMs = Math.max(
+            timing.startOffsetMs,
+            performance.now() - runtimeAttempt.monotonicStartedAt
+          );
+          trackRuntimeWrite(
+            runRuntimeTelemetry(
+              () =>
+                convexClient.mutation(
+                  "testSuites:recordEvalIterationRuntimeEnd" as any,
+                  {
+                    iterationId: params.iterationId,
+                    attemptId: runtimeAttempt.attemptId,
+                    executionType: timing.executionType,
+                    executionOutcome: params.status,
+                    startOffsetMs: timing.startOffsetMs,
+                    endOffsetMs,
+                  }
+                ),
+              "[evals] Failed to record iteration runtime end"
+            )
+          );
+          iterationRuntime.delete(params.iterationId);
+        }
       }
       await finalizeEvalIteration({
         convexClient,
@@ -309,6 +467,34 @@ export const createSuiteRunRecorder = ({
         if (runDeleted) {
           // Silently skip if run was deleted
           return;
+        }
+
+        if (runtimeAttempt) {
+          await Promise.allSettled([...pendingRuntimeWrites]);
+          try {
+            await runRuntimeTelemetry(
+              () =>
+                convexClient.mutation(
+                  "testSuites:finalizeEvalRuntimeAttempt" as any,
+                  {
+                    runId,
+                    attemptId: runtimeAttempt.attemptId,
+                    totalElapsedMs: Math.max(
+                      0,
+                      performance.now() - runtimeAttempt.monotonicStartedAt
+                    ),
+                    interrupted:
+                      status === "cancelled" || status === "timed_out",
+                  }
+                ),
+              "[evals] Failed to finalize runtime telemetry"
+            );
+          } catch (error) {
+            warnRuntimeFailure(
+              "[evals] Failed to finalize runtime telemetry",
+              error
+            );
+          }
         }
 
         try {

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -82,6 +82,8 @@ const ERROR_BACKOFF_MS = 60_000;
  * gets its check taken away mid-build.
  */
 const HEARTBEAT_INTERVAL_MS = 60_000;
+/** A stuck control-plane cleanup must not keep the other cleanup from running. */
+export const GITHUB_CHECK_CLEANUP_TIMEOUT_MS = 15_000;
 
 /**
  * How long to wait out a run held for its gating judge.
@@ -682,7 +684,35 @@ export type CheckExecutionDeps = {
   report: (report: PlanlessCheckReport) => Promise<void>;
   heartbeat: (triggerId: string, claimedBy: string) => Promise<void>;
   heartbeatIntervalMs: number;
+  cleanupTimeoutMs: number;
 };
+
+async function runCleanupStep(
+  operation: () => Promise<void>,
+  timeoutMs: number,
+  onFailure: (error: unknown) => void,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const operationResult = Promise.resolve()
+    .then(operation)
+    .then(
+      () => ({ ok: true as const }),
+      (error) => ({ ok: false as const, error }),
+    );
+  const deadline = new Promise<{ ok: false; error: Error }>((resolve) => {
+    timer = setTimeout(
+      () =>
+        resolve({
+          ok: false,
+          error: new Error(`cleanup timed out after ${timeoutMs}ms`),
+        }),
+      timeoutMs,
+    );
+  });
+  const result = await Promise.race([operationResult, deadline]);
+  if (timer) clearTimeout(timer);
+  if (!result.ok) onFailure(result.error);
+}
 
 /**
  * How long the post-failure liveness check gets. Short on purpose: it runs only
@@ -1376,6 +1406,7 @@ function defaultDeps(): CheckExecutionDeps {
     report: reportPlanlessOutcome,
     heartbeat: sendHeartbeat,
     heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+    cleanupTimeoutMs: GITHUB_CHECK_CLEANUP_TIMEOUT_MS,
   };
 }
 
@@ -1923,17 +1954,37 @@ export async function executeClaimedCheck(
     // Each step best-effort and independent: a failure to delete the server row
     // must not skip killing the box (which costs money), and vice versa. The
     // backend's recovery sweep and E2B's TTL are the backstops for both.
+    const cleanupSteps: Promise<void>[] = [];
     if (serverId && cleanupBearer) {
-      await deps
-        .deleteEphemeralServer({ bearer: cleanupBearer, serverId })
-        .catch((error) =>
-          logger.warn("[github-checks] ephemeral server cleanup failed", {
+      cleanupSteps.push(
+        runCleanupStep(
+          () =>
+            deps.deleteEphemeralServer({
+              bearer: cleanupBearer,
+              serverId,
+            }),
+          deps.cleanupTimeoutMs,
+          (error) =>
+            logger.warn("[github-checks] ephemeral server cleanup failed", {
+              ...logContext,
+              error: error instanceof Error ? error.message : String(error),
+            }),
+        ),
+      );
+    }
+    cleanupSteps.push(
+      runCleanupStep(
+        () => deps.killSandbox(sandbox),
+        deps.cleanupTimeoutMs,
+        (error) =>
+          logger.warn("[github-checks] sandbox cleanup failed", {
             ...logContext,
+            sandboxId: sandbox?.sandboxId,
             error: error instanceof Error ? error.message : String(error),
           }),
-        );
-    }
-    await deps.killSandbox(sandbox);
+      ),
+    );
+    await Promise.all(cleanupSteps);
   }
 }
 

--- a/mcpjam-inspector/server/services/github-checks/__tests__/cleanup.e2b.integration.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/cleanup.e2b.integration.test.ts
@@ -1,0 +1,260 @@
+import { randomUUID } from "node:crypto";
+import { Sandbox } from "e2b";
+import { describe, expect, it } from "vitest";
+import {
+  executeClaimedCheck,
+  type CheckExecutionDeps,
+  type ClaimedGithubCheck,
+} from "../../github-checks-worker";
+import type { CheckPlanSession } from "../check-plan";
+import {
+  GITHUB_CHECKS_EGRESS_DENY_CIDRS,
+  killCheckSandbox,
+  provisionCheckSandbox,
+  type CheckSandbox,
+} from "../sandbox";
+
+// Opt in with `npm run test:github-checks-cleanup:e2b -w @mcpjam/inspector`.
+// The normal suite skips these paid, credentialed sandboxes.
+
+const RUN = process.env.RUN_GITHUB_CHECKS_E2B_CLEANUP === "1";
+const API_KEY = process.env.E2B_API_KEY?.trim();
+const TEMPLATE_ID = process.env.GITHUB_CHECKS_E2B_TEMPLATE_ID?.trim();
+const VERIFY_POLL_MS = 1_000;
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+async function sandboxExists(triggerId: string, sandboxId: string) {
+  const paginator = Sandbox.list({
+    apiKey: API_KEY,
+    query: { metadata: { triggerId } },
+    limit: 100,
+    requestTimeoutMs: 10_000,
+  });
+  while (paginator.hasNext) {
+    const page = await paginator.nextItems({ requestTimeoutMs: 10_000 });
+    if (page.some((sandbox) => sandbox.sandboxId === sandboxId)) return true;
+  }
+  return false;
+}
+
+async function waitForSandboxAbsent(
+  triggerId: string,
+  sandboxId: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    if (!(await sandboxExists(triggerId, sandboxId))) return;
+    if (Date.now() >= deadline) {
+      throw new Error(`sandbox ${sandboxId} still exists after ${timeoutMs}ms`);
+    }
+    await sleep(VERIFY_POLL_MS);
+  }
+}
+
+async function emergencyCleanup(
+  scenario: string,
+  sandboxId: string | undefined,
+  verifiedAbsent: boolean,
+): Promise<void> {
+  console.info(
+    "[github-checks-cleanup-e2b]",
+    JSON.stringify({ scenario, sandboxId, verifiedAbsent }),
+  );
+  if (!sandboxId || !API_KEY) return;
+  try {
+    await Sandbox.kill(sandboxId, { apiKey: API_KEY, requestTimeoutMs: 10_000 });
+  } catch (error) {
+    console.warn("[github-checks-cleanup-e2b] emergency cleanup failed", {
+      scenario,
+      sandboxId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function requireLiveConfiguration(): void {
+  if (!API_KEY || !TEMPLATE_ID) {
+    throw new Error(
+      "RUN_GITHUB_CHECKS_E2B_CLEANUP requires E2B_API_KEY and GITHUB_CHECKS_E2B_TEMPLATE_ID",
+    );
+  }
+}
+
+const baseClaim: ClaimedGithubCheck = {
+  triggerId: "replaced-per-scenario",
+  repoFullName: "mcpjam/e2b-cleanup-fixture",
+  prNumber: 1,
+  headSha: "a".repeat(40),
+  organizationId: "cleanup-org",
+  projectId: "cleanup-project",
+  createdByExternalId: "cleanup-user",
+  suiteId: "cleanup-suite",
+  repoPrivate: false,
+  credentialPolicyVersion: 2,
+  isFork: false,
+  githubCredentialPolicy: "same_repository",
+  allowedBuiltInToolIds: [],
+};
+
+function liveDeps(
+  scenario: string,
+  created: string[],
+): Partial<CheckExecutionDeps> {
+  const session: CheckPlanSession = {
+    planId: `cleanup-plan-${scenario}`,
+    candidates: async () => ({
+      candidates: [],
+      stopPolicy: { maxCandidates: 1, wallClockMs: 60_000 },
+    }),
+    attempt: async (input) => ({
+      action: input.phase === "eval" && input.ok ? "complete" : "continue_phase",
+    }),
+    complete: async () => {},
+  };
+  return {
+    beginPlan: async () => session,
+    credentialPreflight: async (_claim, _claimedBy, mint) =>
+      mint ? "synthetic-execution-bearer" : null,
+    resolveAndStart: async (args, overrides) => {
+      const sandbox = await provisionCheckSandbox({
+        triggerId: args.triggerId,
+        repoFullName: args.repoFullName,
+        prNumber: args.prNumber,
+      });
+      created.push(sandbox.sandboxId);
+      overrides.onSandbox?.(sandbox);
+      return {
+        sandbox,
+        recipe: {
+          build: "true",
+          start: "true",
+          port: 3001,
+          mcpPath: "/mcp",
+          rung: "override",
+          ownershipProof: "verified",
+          evidence: ["synthetic cleanup fixture"],
+        },
+        candidateId: "cleanup-candidate",
+        started: {
+          url: `https://${sandbox.getHost(3001)}/mcp`,
+          readStderrTail: async () => "",
+          spawn: { pid: 1, pgrp: 1 },
+        },
+        provenance: {
+          recipeRung: "override",
+          recipeEvidence: ["synthetic cleanup fixture"],
+        },
+      };
+    },
+    killSandbox: killCheckSandbox,
+    getBearer: async () => "synthetic-control-bearer",
+    createEphemeralServer: async () => "synthetic-server",
+    deleteEphemeralServer: async () => {},
+    recordServer: async () => {},
+    reportCredentialBlocked: async () => {},
+    report: async () => {},
+    heartbeat: async () => {},
+    heartbeatIntervalMs: 60_000,
+    cleanupTimeoutMs: 15_000,
+    runConformance: async () => ({ runId: "synthetic-conformance" }),
+  };
+}
+
+describe.skipIf(!RUN)("GitHub-check sandbox cleanup — real E2B", () => {
+  it.each([
+    ["normal", "passed"],
+    ["cancellation", "cancelled"],
+    ["timeout", "timed_out"],
+  ])(
+    "removes the sandbox after %s",
+    async (scenario, result) => {
+      requireLiveConfiguration();
+      const triggerId = `cleanup-${scenario}-${randomUUID()}`;
+      const created: string[] = [];
+      let verifiedAbsent = false;
+      try {
+        await executeClaimedCheck(
+          { ...baseClaim, triggerId },
+          "cleanup-worker",
+          {
+            ...liveDeps(scenario, created),
+            runEvalSuite: async (args) => {
+              await args.onRunStarted?.(`cleanup-run-${scenario}`);
+              return { runId: `cleanup-run-${scenario}`, result };
+            },
+          },
+        );
+        expect(created).toHaveLength(1);
+        await waitForSandboxAbsent(triggerId, created[0], 60_000);
+        verifiedAbsent = true;
+      } finally {
+        await emergencyCleanup(scenario, created[0], verifiedAbsent);
+      }
+    },
+    75_000,
+  );
+
+  it(
+    "removes the sandbox after execution fails",
+    async () => {
+      requireLiveConfiguration();
+      const scenario = "execution_failure";
+      const triggerId = `cleanup-${scenario}-${randomUUID()}`;
+      const created: string[] = [];
+      let verifiedAbsent = false;
+      try {
+        await executeClaimedCheck(
+          { ...baseClaim, triggerId },
+          "cleanup-worker",
+          {
+            ...liveDeps(scenario, created),
+            runEvalSuite: async () => {
+              throw new Error("synthetic execution failure");
+            },
+          },
+        );
+        expect(created).toHaveLength(1);
+        await waitForSandboxAbsent(triggerId, created[0], 60_000);
+        verifiedAbsent = true;
+      } finally {
+        await emergencyCleanup(scenario, created[0], verifiedAbsent);
+      }
+    },
+    75_000,
+  );
+
+  it(
+    "E2B reaps an orphan after the fixture-only lifetime",
+    async () => {
+      requireLiveConfiguration();
+      const scenario = "worker_death";
+      const triggerId = `cleanup-${scenario}-${randomUUID()}`;
+      let sandbox: CheckSandbox | undefined;
+      let verifiedAbsent = false;
+      try {
+        sandbox = (await Sandbox.create(TEMPLATE_ID!, {
+          apiKey: API_KEY!,
+          timeoutMs: 60_000,
+          lifecycle: { onTimeout: "kill" },
+          network: {
+            allowPublicTraffic: true,
+            denyOut: [...GITHUB_CHECKS_EGRESS_DENY_CIDRS],
+          },
+          metadata: {
+            purpose: "github-checks-cleanup-fixture",
+            triggerId,
+            scenario,
+          },
+        })) as unknown as CheckSandbox;
+        await waitForSandboxAbsent(triggerId, sandbox.sandboxId, 90_000);
+        verifiedAbsent = true;
+      } finally {
+        await emergencyCleanup(scenario, sandbox?.sandboxId, verifiedAbsent);
+      }
+    },
+    105_000,
+  );
+});

--- a/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
@@ -175,6 +175,7 @@ type Fakes = {
   deps: Partial<ResolveAndStartDeps> & { plan: CheckPlanSession };
   events: string[];
   boxes: CheckSandbox[];
+  liveSandboxIds: Set<string>;
   attempts: RecordedAttempt[];
   /** What `cloneAndCheckout` was asked for, per box. */
   clones: CloneCall[];
@@ -197,6 +198,7 @@ function fakes(options: {
 }): Fakes {
   const events: string[] = [];
   const boxes: CheckSandbox[] = [];
+  const liveSandboxIds = new Set<string>();
   const clones: CloneCall[] = [];
   let provisioned = 0;
   const scripted = options.session ?? fakeSession();
@@ -213,6 +215,7 @@ function fakes(options: {
         kill: async () => {},
       } as unknown as CheckSandbox;
       boxes.push(box);
+      liveSandboxIds.add(box.sandboxId);
       events.push(`provision:${box.sandboxId}`);
       return box;
     },
@@ -231,6 +234,7 @@ function fakes(options: {
       };
     },
     killSandbox: async (sandbox) => {
+      if (sandbox) liveSandboxIds.delete(sandbox.sandboxId);
       events.push(`kill:${sandbox?.sandboxId ?? "none"}`);
     },
     ...(options.ladder ? { resolveLadder: () => options.ladder! } : {}),
@@ -246,7 +250,14 @@ function fakes(options: {
     now: () => 0,
   };
 
-  return { deps, events, boxes, attempts: scripted.attempts, clones };
+  return {
+    deps,
+    events,
+    boxes,
+    liveSandboxIds,
+    attempts: scripted.attempts,
+    clones,
+  };
 }
 
 async function stopOf(promise: Promise<unknown>): Promise<CheckStoppedByPlan> {
@@ -533,6 +544,7 @@ describe("resolveAndStart — degraded and refused", () => {
     );
     // Every box is dead on the failure path.
     expect(f.events).toContain("kill:sb_1");
+    expect(f.liveSandboxIds).toEqual(new Set());
   });
 
   it("an unreachable /plan/candidates executes NO local candidate", async () => {
@@ -557,6 +569,7 @@ describe("resolveAndStart — degraded and refused", () => {
       false
     );
     expect(f.events).toContain("kill:sb_1");
+    expect(f.liveSandboxIds).toEqual(new Set());
   });
 
   it("stops when the plan comes back with no candidates at all", async () => {
@@ -716,6 +729,7 @@ describe("resolveAndStart — a fresh sandbox per candidate", () => {
     const result = await resolveAndStart(ARGS, f.deps);
     expect(result.sandbox.sandboxId).toBe("sb_2");
     expect(f.boxes).toHaveLength(2);
+    expect(f.liveSandboxIds).toEqual(new Set(["sb_2"]));
     expect(f.events.indexOf("kill:sb_1")).toBeGreaterThan(-1);
     expect(f.events.indexOf("kill:sb_1")).toBeLessThan(
       f.events.indexOf("provision:sb_2")

--- a/mcpjam-inspector/server/services/webmcp-inspector/__tests__/electron-webview-provider.test.ts
+++ b/mcpjam-inspector/server/services/webmcp-inspector/__tests__/electron-webview-provider.test.ts
@@ -606,7 +606,7 @@ describe("electron-webview provider — the session surface", () => {
     ).rejects.toThrow(/no longer offers a tool named "checkout"/);
   });
 
-  it("carries WHY an invocation was cancelled, so a timeout is not a user cancel", async () => {
+  it("reports a post-dispatch timeout as an unknown outcome", async () => {
     const { session, guest } = await startSession();
     guest.debugger.emitCdp("WebMCP.toolsAdded", {
       tools: [{ name: "slow", frameId: "main" }],
@@ -621,13 +621,11 @@ describe("electron-webview provider — the session surface", () => {
     });
     await Promise.resolve();
     await Promise.resolve();
-    // The runtime owns the deadline because we handed the signal over; the
-    // browser answers every cancel `Canceled` whatever the reason, so the
-    // reason has to survive the round trip.
+    // Once dispatch happened, cancellation cannot prove the page tool stopped.
     controller.abort("timeout");
     await expect(pending).rejects.toMatchObject({
-      name: "WebMcpInvocationCancelledError",
-      reason: "timeout",
+      name: "WebMcpOutcomeUnknownError",
+      message: expect.stringContaining("after a timeout"),
     });
   });
 });

--- a/mcpjam-inspector/server/services/webmcp-inspector/__tests__/playwright-provider.bridge.test.ts
+++ b/mcpjam-inspector/server/services/webmcp-inspector/__tests__/playwright-provider.bridge.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, it } from "vitest";
 import type { Browser, BrowserContext, CDPSession, Page } from "playwright";
 import { PlaywrightWebMcpSession } from "../playwright-provider";
 import {
-  WebMcpInvocationCancelledError,
+  WebMcpOutcomeUnknownError,
   WebMcpToolGoneError,
   type ProviderToolDescriptor,
   type WebMcpSessionCallbacks,
@@ -269,7 +269,7 @@ describe("PlaywrightWebMcpSession — bridge adaptation", () => {
     ).rejects.toBeInstanceOf(WebMcpToolGoneError);
   });
 
-  it("carries WHY an invocation was cancelled", async () => {
+  it("reports a post-dispatch cancellation as an unknown outcome", async () => {
     const h = await started({ onSend: () => ({ invocationId: "inv-1" }) });
     h.emit("WebMCP.toolsAdded", { tools: [TOOL] });
 
@@ -286,12 +286,12 @@ describe("PlaywrightWebMcpSession — bridge adaptation", () => {
     });
 
     await expect(pending).rejects.toMatchObject({
-      name: "WebMcpInvocationCancelledError",
-      reason: "cancelled",
+      name: "WebMcpOutcomeUnknownError",
+      message: expect.stringContaining("Cancellation requested"),
     });
   });
 
-  it("keeps a runtime timeout a TIMEOUT, not a user cancel", async () => {
+  it("reports a post-dispatch timeout as an unknown outcome", async () => {
     const h = await started({ onSend: () => ({ invocationId: "inv-1" }) });
     h.emit("WebMCP.toolsAdded", { tools: [TOOL] });
 
@@ -301,9 +301,8 @@ describe("PlaywrightWebMcpSession — bridge adaptation", () => {
       signal: controller.signal,
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
-    // The runtime is the single deadline owner and aborts with its reason. The
-    // browser answers `Canceled` either way, so losing the reason here is what
-    // records a hung tool as something the user chose to stop.
+    // The browser may continue after the runtime stops waiting, so the final
+    // outcome cannot be inferred from its `Canceled` response.
     controller.abort("timeout");
     h.emit("WebMCP.toolResponded", {
       invocationId: "inv-1",
@@ -311,8 +310,8 @@ describe("PlaywrightWebMcpSession — bridge adaptation", () => {
     });
 
     const error = await pending.catch((e: unknown) => e);
-    expect(error).toBeInstanceOf(WebMcpInvocationCancelledError);
-    expect((error as WebMcpInvocationCancelledError).reason).toBe("timeout");
+    expect(error).toBeInstanceOf(WebMcpOutcomeUnknownError);
+    expect((error as Error).message).toContain("after a timeout");
   });
 
   it("passes a page-side failure up with the page's own message", async () => {

--- a/mcpjam-inspector/server/services/webmcp-inspector/__tests__/playwright-provider.integration.test.ts
+++ b/mcpjam-inspector/server/services/webmcp-inspector/__tests__/playwright-provider.integration.test.ts
@@ -325,14 +325,11 @@ describe.skipIf(!WEBMCP_CDP_AVAILABLE)("WebMCP provider — real browser", () =>
     // which vitest reports as an unhandled rejection and fails the run.
     const hung = runtime.invoke(`${origin}::slow`, {}, "manual");
     await expect(hung.settled).rejects.toThrow(
-      /did not respond in time|cancel/i,
+      /did not respond in time|after a timeout|cancel/i,
     );
 
-    // END TO END, through the shared bridge: the RUNTIME owns the deadline, so
-    // the browser's `Canceled` — which says nothing about why — must still be
-    // recorded as a timeout and not as a user cancellation. That distinction is
-    // the whole reason the reason is carried, and it is the exact bug a naive
-    // adoption of the bridge introduces.
+    // END TO END, through the shared bridge: after dispatch, a timeout cannot
+    // prove that page execution stopped, so the result must remain unknown.
     await vi.waitFor(() => {
       const settled = activity.find(
         (entry) =>
@@ -340,7 +337,7 @@ describe.skipIf(!WEBMCP_CDP_AVAILABLE)("WebMCP provider — real browser", () =>
           entry.invokeId === hung.invokeId,
       );
       expect(settled && "state" in settled ? settled.state : undefined).toBe(
-        "timeout",
+        "unknown",
       );
     });
 


### PR DESCRIPTION
Suite executions currently do not record when each repetition actually runs, so later analysis cannot distinguish slow work from idle time or parallelism limits. Existing cleanup tests also checked calls rather than proving temporary resources were gone.

The shared runner now records one bounded execution attempt with monotonic iteration timing, resolved model identifiers, and model/model-free/harness labels across manual, scheduled, and GitHub runs. Telemetry failures cannot delay result persistence or cleanup.

GitHub-check cleanup now deletes the temporary server and sandbox independently with finite deadlines. Stateful worker and resolver tests prove check-owned resources disappear across success, assertion failure, build/start failure, eval exceptions, timeout, cancellation, lost leases, and recipe retries while unrelated servers and saved results remain.

An opt-in integration test provisions the dedicated GitHub-checks E2B template, stubs customer execution and control-plane writes, and verifies absence through E2B's read-only list API. It also verifies E2B reaps a simulated dead worker's 60-second fixture sandbox; production remains at 45 minutes with `onTimeout: kill`.

Requires MCPJam/mcpjam-backend#1304 to be deployed first.

Validation:
- Runtime telemetry: 111 focused tests
- Cleanup automation: 143 focused tests
- Real E2B cleanup: 5/5 scenarios passed on staging credentials, including worker-death expiry
- `npm run typecheck`
- `npm run build:server -w @mcpjam/inspector`
