### PR TITLE
chore: add release changeset for inspector, CLI, and SDK

### DIFF
--- a/.changeset/releases-2026-09-09.md
+++ b/.changeset/releases-2026-09-09.md
@@ -1,0 +1,17 @@
+---
+"@mcpjam/inspector": patch
+"@mcpjam/cli": patch
+"@mcpjam/sdk": patch
+---
+
+Release @mcpjam/inspector, @mcpjam/cli, and @mcpjam/sdk.
+
+Cuts a version for the work that landed since the last release without a changeset of its own:
+
+- **Agent Browser** — durable sessions with saved profiles, a Tools-shaped three-panel WebMCP Inspector, first-class page tools, recordings and motion, viewport fidelity, and an observation that names what the model can actually click.
+- **User Testing** — a Findings tab that leads the run, a study that analyzes itself instead of asking to be asked, first-land consent with a two-step create, and a blocked run that names the allowance that ran out instead of "Unknown error".
+- **Evaluate** — a redesigned run and suite surface, scoped authoring with client matrices, one case workspace with an explicit negative-test flag, an org spend budget, and GitHub checks that work for environment suites.
+- **GitHub Checks** — one way to connect an account, per-repository approved-fork credential controls, fork checkout and eval execution that stay credential-free, controls offered only to an org admin, and pickers that require installation identity.
+- **Sign-in and sessions** — fixes for the cached project sign-in race, team checkout handoff routing, sign-out landing on the login page, the Electron logout wait, and false "unavailable" project routes.
+- **Tool approval** — one mechanism and one setting, `web_search` following that same switch, and a resumed tool call answered only after it is re-introduced.
+- **Clients** — Claude Desktop as its own client, Claude Code and Codex in Compare, disambiguated saved client names, and a verification date that reads as a verdict.


### PR DESCRIPTION
- Adds one changeset that bumps `@mcpjam/inspector`, `@mcpjam/cli`, and `@mcpjam/sdk` a patch version each.
- No code changes — this just tells the release job to cut new versions of those three packages.
- Covers the work that landed since the last release without a changeset of its own: the Agent Browser and WebMCP Inspector, User Testing's Findings tab and auto-analysis, the Evaluate run/suite redesign, the GitHub Checks fork and admin controls, a batch of sign-in and sign-out fixes, one tool-approval setting, and the client Compare updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a changeset that patches `@mcpjam/inspector`, `@mcpjam/cli`, and `@mcpjam/sdk` for the next release. No code changes; this covers the Agent Browser, User Testing findings, Evaluate redesign, GitHub Checks fork controls, sign-in fixes, tool approval settings, and client Compare updates that landed without changesets of their own.

<sup>Written for commit 30bf7e9b3d3e018e38268a9075b299d2df403300. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

