### PR TITLE
Give the browser panel the chat's session, as the rail tab had

### DIFF
--- a/mcpjam-inspector/client/src/components/playground/PlaygroundBrowserPanel.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundBrowserPanel.tsx
@@ -1,10 +1,15 @@
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { Maximize2, Minimize2, PanelRightClose } from "lucide-react";
 import { cn } from "@mcpjam/design-system/cn";
 import { LocalBrowserBody } from "@/components/browser/LocalBrowserBody";
 import { HostedBrowserBody } from "@/components/browser/HostedBrowserBody";
 import { useComputerEngine } from "@/hooks/useComputerEngine";
-import { useMintBrowserToken } from "@/hooks/useProjectComputer";
+import {
+  useMintBrowserToken,
+  useMintConversationBrowserToken,
+} from "@/hooks/useProjectComputer";
+import { useBrowserSessionsEnabled } from "@/hooks/useBrowserSessionsEnabled";
+import { useActiveChatSessionStore } from "@/stores/active-chat-session-store";
 import { useBrowserWorkspaceStore } from "@/stores/browser-workspace-store";
 
 /**
@@ -48,6 +53,30 @@ export function PlaygroundBrowserPanel({
 }: PlaygroundBrowserPanelProps) {
   const engine = useComputerEngine(projectId);
   const mintBrowserToken = useMintBrowserToken();
+  // THE DURABLE SESSION, in the panel as well as in the rail tab it replaces.
+  // The browser a chat owns keeps its logins and its saved profile across
+  // turns, and that identity travels on the token: minting the project-scoped
+  // one here would have handed the workspace a fresh anonymous browser every
+  // time the flag was on, which is every time this panel is the browser.
+  // @see PlaygroundRightRail, which wires the fallback tab identically.
+  const mintConversationBrowserToken = useMintConversationBrowserToken();
+  const browserSessionsEnabled = useBrowserSessionsEnabled();
+  const activeChatSessionId = useActiveChatSessionStore(
+    (state) => state.sessionId,
+  );
+  const browserSessionId = browserSessionsEnabled
+    ? (activeChatSessionId ?? undefined)
+    : undefined;
+  const mintHostedBrowserToken = useCallback(
+    ({ projectId: tokenProjectId }: { projectId: string }) =>
+      browserSessionId
+        ? mintConversationBrowserToken({
+            projectId: tokenProjectId,
+            conversationId: browserSessionId,
+          })
+        : mintBrowserToken({ projectId: tokenProjectId }),
+    [browserSessionId, mintBrowserToken, mintConversationBrowserToken],
+  );
   const expanded = useBrowserWorkspaceStore((state) => state.expanded);
   const setExpanded = useBrowserWorkspaceStore((state) => state.setExpanded);
 
@@ -109,6 +138,7 @@ export function PlaygroundBrowserPanel({
         {isLocal ? (
           <LocalBrowserBody
             projectId={projectId}
+            sessionId={browserSessionId}
             consentGranted={engine.consent.granted}
             consentToken={engine.consent.token}
             active={visible}
@@ -116,7 +146,8 @@ export function PlaygroundBrowserPanel({
         ) : (
           <HostedBrowserBody
             projectId={projectId}
-            mintToken={mintBrowserToken}
+            sessionId={browserSessionId}
+            mintToken={mintHostedBrowserToken}
             active={visible}
           />
         )}

--- a/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundBrowserPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundBrowserPanel.test.tsx
@@ -25,31 +25,74 @@ vi.mock("@/hooks/useComputerEngine", () => ({
   }),
 }));
 
+const sessionState = {
+  enabled: true,
+  sessionId: "chat-1" as string | null,
+};
+
+// Which mint the panel reached for is the whole question, so the two are told
+// apart by the token they return rather than by a call count.
 vi.mock("@/hooks/useProjectComputer", () => ({
   useMintBrowserToken: () => async () => ({
-    token: "tok",
+    token: "project-tok",
     expiresAt: Date.now() + 60_000,
   }),
+  useMintConversationBrowserToken: () => async () => ({
+    token: "conversation-tok",
+    expiresAt: Date.now() + 60_000,
+  }),
+}));
+
+vi.mock("@/hooks/useBrowserSessionsEnabled", () => ({
+  useBrowserSessionsEnabled: () => sessionState.enabled,
+}));
+
+vi.mock("@/stores/active-chat-session-store", () => ({
+  useActiveChatSessionStore: (select: (s: { sessionId: string | null }) => unknown) =>
+    select({ sessionId: sessionState.sessionId }),
 }));
 
 // Both bodies are exercised in their own suites; here they only have to say
 // which one the panel mounted and whether it considers itself watched.
 vi.mock("@/components/browser/LocalBrowserBody", () => ({
-  LocalBrowserBody: ({ active }: { active?: boolean }) => (
+  LocalBrowserBody: ({
+    active,
+    sessionId,
+  }: {
+    active?: boolean;
+    sessionId?: string;
+  }) => (
     <div
       data-testid="browser-pane"
       data-engine="local"
       data-active={String(active)}
+      data-session={sessionId ?? ""}
     />
   ),
 }));
 
 vi.mock("@/components/browser/HostedBrowserBody", () => ({
-  HostedBrowserBody: ({ active }: { active?: boolean }) => (
+  HostedBrowserBody: ({
+    active,
+    sessionId,
+    mintToken,
+  }: {
+    active?: boolean;
+    sessionId?: string;
+    mintToken?: (args: { projectId: string }) => Promise<{ token: string }>;
+  }) => (
     <div
       data-testid="browser-pane"
       data-engine="hosted"
       data-active={String(active)}
+      data-session={sessionId ?? ""}
+      onClick={() => {
+        void mintToken?.({ projectId: "proj-1" }).then((t) => {
+          document
+            .querySelector("[data-testid=browser-pane]")
+            ?.setAttribute("data-token", t.token);
+        });
+      }}
     />
   ),
 }));
@@ -78,6 +121,8 @@ beforeEach(() => {
   engineState.engine = "local";
   engineState.selectedEngine = "local";
   engineState.granted = true;
+  sessionState.enabled = true;
+  sessionState.sessionId = "chat-1";
   useBrowserWorkspaceStore.setState({
     open: true,
     size: DEFAULT_BROWSER_PANEL_SIZE,
@@ -225,5 +270,61 @@ describe("browserPanelAvailable", () => {
         localBrowserRunning: false,
       }),
     ).toBe(true);
+  });
+});
+
+describe("the browser a chat owns", () => {
+  /**
+   * The panel REPLACES the rail's Browser tab whenever the workspace flag is
+   * on, so anything the tab wired and the panel does not is not a difference
+   * between two surfaces — it is a capability that disappears the moment the
+   * flag flips. Durable sessions and saved profiles both hang off the chat's
+   * session id travelling with the browser, and the panel shipped without it:
+   * turning the workspace on quietly handed you a fresh anonymous browser.
+   */
+  it("hands the local body the chat's session", () => {
+    renderPanel();
+    expect(screen.getByTestId("browser-pane")).toHaveAttribute(
+      "data-session",
+      "chat-1",
+    );
+  });
+
+  it("hands the hosted body the chat's session", () => {
+    engineState.engine = "cloud";
+    engineState.selectedEngine = "cloud";
+    renderPanel();
+    expect(screen.getByTestId("browser-pane")).toHaveAttribute(
+      "data-session",
+      "chat-1",
+    );
+  });
+
+  it("mints the CONVERSATION token, not the project one", async () => {
+    // The identity rides on the token. A project-scoped mint returns a browser
+    // with no memory of this chat, which is the same bug one layer down.
+    engineState.engine = "cloud";
+    engineState.selectedEngine = "cloud";
+    renderPanel();
+    const pane = screen.getByTestId("browser-pane");
+    fireEvent.click(pane);
+    await vi.waitFor(() =>
+      expect(pane).toHaveAttribute("data-token", "conversation-tok"),
+    );
+  });
+
+  it("falls back to the project token when sessions are off", async () => {
+    // `browser-sessions` off is not "no browser" — it is the old shared
+    // project browser, which is exactly what the project mint returns.
+    sessionState.enabled = false;
+    engineState.engine = "cloud";
+    engineState.selectedEngine = "cloud";
+    renderPanel();
+    const pane = screen.getByTestId("browser-pane");
+    expect(pane).toHaveAttribute("data-session", "");
+    fireEvent.click(pane);
+    await vi.waitFor(() =>
+      expect(pane).toHaveAttribute("data-token", "project-tok"),
+    );
   });
 });


### PR DESCRIPTION
With `browser-workspace-enabled` on, #4830's durable browser sessions and saved profiles silently stop working. The panel mints the plain project token and passes no `sessionId`, so you get a fresh anonymous browser — no retained logins, no saved profile — with nothing on screen to say why.

## Why it slipped through

The panel **replaces** the rail's Browser tab whenever the workspace flag is on. So anything the tab wired and the panel does not isn't a difference between two surfaces — it's a capability that disappears the moment the flag flips.

The rail does this ([`PlaygroundRightRail.tsx`](https://github.com/MCPJam/inspector/blob/main/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx)):

```tsx
const browserSessionId = browserSessionsEnabled ? (activeChatSessionId ?? undefined) : undefined;
// mintConversationBrowserToken({ projectId, conversationId: browserSessionId })
<LocalBrowserBody  sessionId={browserSessionId} … />
<HostedBrowserBody sessionId={browserSessionId} … />
```

The panel did this:

```tsx
const mintBrowserToken = useMintBrowserToken();
<LocalBrowserBody  … />                      // no sessionId
<HostedBrowserBody mintToken={mintBrowserToken} … />   // project-scoped
```

#4830 (durable sessions) and #4838 (the workspace panel) landed on main within two minutes of each other from separate branches. Neither side's tests could have caught it: #4830 wired the surface it knew about, #4838 added a surface that did not exist when #4830 was written, and the panel's own suite asserted which body mounted and whether it considered itself watched — never what it was handed.

## The fix

The panel now wires exactly what the rail wires: `useBrowserSessionsEnabled` + the active chat session id, `useMintConversationBrowserToken` when there is a session, and `sessionId` through to both bodies. With `browser-sessions` **off** it still takes the project mint — that flag off is not "no browser", it's the old shared project browser, which is what that token returns.

## Tests

Four cases in `PlaygroundBrowserPanel.test.tsx`. Three fail against main's panel; the fourth (project-token fallback) is the negative control and passes either way, since main always used the project mint.

The body mocks now surface `sessionId` and the minted token, which is the part that keeps this from recurring — the previous mocks rendered `data-engine` and `data-active` only, so the panel could drop the session and every assertion still passed. That is how this shipped.

| Check | Result |
|---|---|
| `PlaygroundBrowserPanel.test.tsx` | 15 passed |
| `client` playground + browser + browser-shell + stores | 459 passed (35 files) |
| `client/tsconfig.typecheck.json` | clean |
| `design:lint` | 0 errors |
| Reverted-fix check | 3 of the 4 new tests fail, as intended |

## Provenance

Ported from the parallel merge on `claude/codex-browser-workspace-nffow9`, which resolved the same #4830 conflict about a minute after #4838 squashed — so that resolution never reached main. That commit also predates #4825, which is why this is a fresh branch off current `main` carrying only the panel change rather than a rebase of it.

Not a regression from either PR in isolation, and not currently user-visible: `browser-workspace-enabled` is off, and #4838's release criteria (hosted image validation, streaming measurements, the Electron shield on a real window, the light/dark pass) are still unmet. This wants to be in before that flag goes on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfeJpqfbjRxfZrQWpjMbvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfeJpqfbjRxfZrQWpjMbvp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hosted browser token minting and session identity for the panel path; behavior is gated by feature flags but affects login/profile persistence when the workspace browser is enabled.
> 
> **Overview**
> **Fixes durable browser sessions in the workspace browser panel** so it matches the right-rail Browser tab it replaces when `browser-workspace-enabled` is on.
> 
> `PlaygroundBrowserPanel` now reads `useBrowserSessionsEnabled` and the active chat `sessionId`, passes `sessionId` into `LocalBrowserBody` / `HostedBrowserBody`, and mints a **conversation-scoped** hosted token when sessions are enabled (project mint when they are off). Tests assert session propagation and which token is minted, with mocks exposing `sessionId` and mint results so dropping session wiring cannot pass silently again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55ad4d4c5bed98fd824253d9e2fcd7f63d3e5b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The browser panel now passes the chat's session to both browser bodies, matching what the rail tab does, so durable sessions and saved profiles work when `browser-workspace-enabled` is on. Previously the panel minted a project-scoped token and no `sessionId`, which produced a fresh anonymous browser with no retained logins or saved profile.

- With browser sessions disabled, it still falls back to the project mint, which is the old shared project browser.
- Body mocks now surface `sessionId` and the minted token, so a future drop fails the tests.

<sup>Written for commit 55ad4d4c5bed98fd824253d9e2fcd7f63d3e5b3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

