### PR TITLE
Say which link of the chain each check measures

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -156,6 +156,7 @@
               "sdk/concepts/connecting-servers",
               "sdk/concepts/testing-with-llms",
               "sdk/concepts/running-evals",
+              "sdk/concepts/user-value-chain",
               "sdk/concepts/saving-results",
               "sdk/concepts/multi-provider"
             ]

--- a/docs/sdk/concepts/running-evals.mdx
+++ b/docs/sdk/concepts/running-evals.mdx
@@ -178,38 +178,39 @@ Predicates express richer pass/fail criteria than tool-call matching — without
 
 Predicates are authored in the corpus JSON (the Inspector's per-case **Checks** editor writes the same shape) and threaded through the runner automatically; there is no predicate field to set on individual uploaded results. A case passes iff every **gating** predicate passes — an advisory one is recorded and never fails the case, and neither does one that could not be scored. An absent or empty list means no predicate gate.
 
-The built-in predicate types:
+The built-in predicate types. **Measures** is the link of the [user-value chain](/sdk/concepts/user-value-chain) the check is filed at — nothing files at Connection or Discovery, which the runner decides for you:
 
-| Type | What it checks |
-|------|----------------|
-| `toolCalledWith` | A specific tool was called with matching args (partial/exact/ignore mode) |
-| `toolCalledAtLeastOnce` | A tool was called at least once |
-| `toolNeverCalled` | A forbidden tool was never called |
-| `firstToolWas` | The first tool call in the transcript was a specific tool |
-| `responseContains` | The final assistant message contains a substring |
-| `responseMatches` | The final assistant message matches a regex |
-| `noToolErrors` | No tool produced an error (MCP `isError` or transport failure) |
-| `finalAssistantMessageNonEmpty` | The final assistant message is non-empty |
-| `tokenBudgetUnder` | Total token usage is strictly under a budget |
-| `widgetRendered` | At least one MCP App widget rendered successfully (optionally scoped to one tool) |
-| `widgetRenderLatencyUnder` | Every rendered widget mounted in strictly under a millisecond budget |
-| `widgetNoConsoleErrors` | No widget render captured console errors |
-| `turnCountUnder` | The iteration used strictly fewer than N user turns |
-| `noEndingQuestion` | **Observation.** The final message does not end with a question. Warn/Report only |
-| `toolLatencyUnder` | Every observed call settled under a millisecond ceiling |
-| `toolResultContains` | A tool result contains a substring |
-| `toolResultMatchesSchema` | Every tool result matches an authored JSON Schema (any JSON root) |
-| `toolResultSizeUnder` | Every tool result is under a byte ceiling, measured before our storage cap |
-| `argumentsMatchToolSchema` | Every call's arguments validate against the tool's declared inputSchema |
-| `noRepeatedIdenticalCall` | **Observation.** No identical call repeated back-to-back. Warn/Report only |
-| `toolCallCountUnder` | Strictly fewer than N tool calls |
-| `toolCalledBefore` | Every call to one tool was preceded by a call to another |
-| `noDeprecatedToolCalled` | **Observation.** No called tool's description marks it deprecated. Warn/Report only |
-| `noDestructiveToolCalled` | No called tool declares `destructiveHint` |
-| `toolErrorNamesInput` | **Observation.** Tool errors name an input key or a sent value. Warn/Report only |
-| `fullPageHasContinuation` | **Observation.** Full pages carry continuation metadata. Warn/Report only |
+| Type | Measures | What it checks |
+|------|----------|----------------|
+| `toolCalledWith` | Selection | A specific tool was called with matching args (partial/exact/ignore mode) |
+| `toolCalledAtLeastOnce` | Selection | A tool was called at least once |
+| `toolNeverCalled` | Selection | A forbidden tool was never called |
+| `onlyToolsCalled` | Selection | Every tool called was in an allowed set; an empty set claims no tool was called |
+| `firstToolWas` | Selection | The first tool call in the transcript was a specific tool |
+| `responseContains` | User value | The final assistant message contains a substring |
+| `responseMatches` | User value | The final assistant message matches a regex |
+| `noToolErrors` | Response | No tool produced an error (MCP `isError` or transport failure) |
+| `finalAssistantMessageNonEmpty` | User value | The final assistant message is non-empty |
+| `tokenBudgetUnder` | User value | Total token usage is strictly under a budget |
+| `widgetRendered` | User value | At least one MCP App widget rendered successfully (optionally scoped to one tool) |
+| `widgetRenderLatencyUnder` | User value | Every rendered widget mounted in strictly under a millisecond budget |
+| `widgetNoConsoleErrors` | User value | No widget render captured console errors |
+| `turnCountUnder` | User value | The iteration used strictly fewer than N user turns |
+| `noEndingQuestion` | User value | **Observation.** The final message does not end with a question. Warn/Report only |
+| `toolLatencyUnder` | Response | Every observed call settled under a millisecond ceiling |
+| `toolResultContains` | Response | A tool result contains a substring |
+| `toolResultMatchesSchema` | Response | Every tool result matches an authored JSON Schema (any JSON root) |
+| `toolResultSizeUnder` | Response | Every tool result is under a byte ceiling, measured before our storage cap |
+| `argumentsMatchToolSchema` | Tool call | Every call's arguments validate against the tool's declared inputSchema |
+| `noRepeatedIdenticalCall` | Tool call | **Observation.** No identical call repeated back-to-back. Warn/Report only |
+| `toolCallCountUnder` | Selection | Strictly fewer than N tool calls |
+| `toolCalledBefore` | Selection | Every call to one tool was preceded by a call to another |
+| `noDeprecatedToolCalled` | Selection | **Observation.** No called tool's description marks it deprecated. Warn/Report only |
+| `noDestructiveToolCalled` | Selection | No called tool declares `destructiveHint` |
+| `toolErrorNamesInput` | Response | **Observation.** Tool errors name an input key or a sent value. Warn/Report only |
+| `fullPageHasContinuation` | Response | **Observation.** Full pages carry continuation metadata. Warn/Report only |
 
-When an iteration records no widget render observations, the three `widget*` predicates fail rather than pass — a missing signal counts as a failure. See [Predicate gate reference](/sdk/reference/eval-reporting#predicate-gate) for the full type definitions and a code example.
+When an iteration records no widget render observations, the three `widget*` predicates fail rather than pass — a missing signal counts as a failure. See [Predicate gate reference](/sdk/reference/eval-reporting#predicate-gate) for the full type definitions and a code example, and [The user-value chain](/sdk/concepts/user-value-chain) for what a set of checks leaves unmeasured.
 
 ### Suite Results
 

--- a/docs/sdk/concepts/user-value-chain.mdx
+++ b/docs/sdk/concepts/user-value-chain.mdx
@@ -1,0 +1,85 @@
+---
+title: "The User-Value Chain"
+description: "Which link of the chain each check you write measures"
+icon: "link"
+---
+
+A run of one eval case walks six links, in order. MCPJam reports where it stopped being good, rather than a single pass or fail, because the six answer different questions and have different owners.
+
+| # | Link | The question it answers | What good looks like |
+|---|------|-------------------------|----------------------|
+| 1 | **Connection** | Could the client reach the server and initialize a session? | Session connected |
+| 2 | **Discovery** | Did the client receive usable primitives and metadata? | Tools and resources discovered |
+| 3 | **Selection** | Did the model choose the right tool for the request? | Right tool selected |
+| 4 | **Tool call** | Was the call made with usable arguments? | Valid call made |
+| 5 | **Response** | Did the server return data the model could use? | Usable response returned |
+| 6 | **User value** | Was the user's actual request satisfied? | Request satisfied |
+
+Most documentation describes the chain as something you read after a run. This page is the other direction: when you write a check, you are choosing a link.
+
+## Which links you can write a check for
+
+Four of the six. Every [predicate](/sdk/reference/eval-reporting#predicate-gate) you author is filed at one link, and the count per link is uneven:
+
+| Link | Checks you can author |
+|------|-----------------------|
+| Connection | none |
+| Discovery | none |
+| Selection | 9 |
+| Tool call | 2 |
+| Response | 7 |
+| User value | 9 |
+
+**Connection and Discovery have no authorable checks, and this is deliberate.** The runner decides both before your case runs, from what it observed setting the run up: whether `initialize` completed, whether `tools/list` answered, and — when a connection failed — whether an egress canary proves the network path out of the runner works at all. That last one is why there is nothing to author. From inside the runner, "their server is down" and "our egress is broken" look identical, and a check you wrote could not tell them apart. Absent positive evidence that our own side worked, the honest answer is that the link was not measured, not that the server failed.
+
+So a suite with checks on every kind still measures Connection and Discovery exactly as much as a suite with none.
+
+## The stage is where the evidence is filed
+
+A check's link says where its evidence is recorded. It does not assert that a failure originated there.
+
+`noToolErrors` is the clearest case. It files at **Response**, because a tool error is the server's answer. Until analyzer version 11 it filed at User value, and the same defect was counted twice: the analyzer already failed Response on an observed tool error, while the predicate row failed User value. Which link a reader saw as the first break depended on which row they looked at first.
+
+Two consequences worth keeping in mind:
+
+- A failure at one link is frequently caused upstream of it. Selection failing because two tools have near-identical descriptions is a Discovery problem wearing a Selection label.
+- Moving a check to a different link changes where historical failures are attributed, so it is a versioned analyzer change rather than an edit anyone can make locally. The three `widget*` kinds are current candidates to move to Response.
+
+## Graders that are not predicates
+
+Three graders file at a link without being checks you write in a list:
+
+| Grader | Link | What it is |
+|--------|------|------------|
+| Tool-call matcher | Selection | The `expectedToolCalls` comparison, configured by [match options](/sdk/reference/validators) rather than authored as a predicate |
+| Goal completion judge | User value | The hosted LLM judge scoring whether the request was satisfied |
+| Groundedness judge | User value | Advisory only, run on demand; it has no score definition and never decides a link |
+
+A **gating** `toolCalledWith` is promoted into the matcher's expectations and graded there. An **advisory** one stays a predicate row, because promoting it would create an expectation that can fail the trial, which an advisory check must never do.
+
+## What a suite is not measuring
+
+Coverage is the question the six links exist to answer, and it is easy to write a plausible-looking suite that leaves most of the chain untouched.
+
+A case with `toolCalledWith`, `noToolErrors` and `responseContains` measures Selection, Response and User value. It says nothing about Tool call — whether the arguments the model sent were valid against the tool's own schema — and nothing about Connection or Discovery, which no check can reach.
+
+To cover Tool call, add `argumentsMatchToolSchema`. To read Connection and Discovery, read the run's chain rather than authoring anything: the stage rows report what the runner observed.
+
+Two habits keep coverage honest:
+
+- Read the chain on a passing run, not only a failing one. Six links reading `notMeasured` is not the same as six links passing, and only one of those is worth shipping on.
+- Treat a link with no check as unmeasured rather than fine. `notMeasured` is an absence, and absence is not a pass.
+
+## Observations never decide a link
+
+Five kinds are marked **Observation** in the reference tables: `noEndingQuestion`, `noRepeatedIdenticalCall`, `noDeprecatedToolCalled`, `toolErrorNamesInput` and `fullPageHasContinuation`.
+
+Each is a heuristic that can be right about what it saw and wrong about what it means. A poll loop and a wasteful retry are the same shape; a full page is not proof that more results exist; "Rate limited. Retry in 30 seconds." names no input key and is a good error message. So they carry one rule everywhere: `role: "advisory"` is required, a gating one is refused when written, and they are recorded beside a verdict without changing it.
+
+They still file at a link, which is what places them in the right group when you are reading what a suite measures. They do not make that link pass or fail.
+
+## Where to go next
+
+- [Predicate gate reference](/sdk/reference/eval-reporting#predicate-gate) — every kind, its fields, and the link it measures
+- [Running evals](/sdk/concepts/running-evals) — authoring a suite and reading its results
+- [Validators](/sdk/reference/validators) — the tool-call matcher that files at Selection

--- a/docs/sdk/reference/eval-reporting.mdx
+++ b/docs/sdk/reference/eval-reporting.mdx
@@ -471,34 +471,37 @@ The three widget predicates — `widgetRendered`, `widgetRenderLatencyUnder`, `w
 
 #### Predicate types
 
-| Type | Fields | Description |
-|------|--------|-------------|
-| `toolCalledWith` | `toolName`, `args` ([`ArgMatcher`](#argmatcher)), `minCount?` | A call to `toolName` whose args satisfy `args` occurred at least `minCount` (default 1) times. |
-| `toolCalledAtLeastOnce` | `toolName` | `toolName` was called at least once (args irrelevant). |
-| `toolNeverCalled` | `toolName` | `toolName` was never called (forbidden-tool check). |
-| `firstToolWas` | `toolName` | The first tool call observed in the transcript was `toolName`. |
-| `responseContains` | `needle`, `caseSensitive?` | The final assistant message contains `needle`. Case-insensitive by default. |
-| `responseMatches` | `pattern` | The final assistant message matches the regular expression `pattern` (regex source string, no flags). |
-| `noToolErrors` | — | No tool produced an error (neither MCP `isError: true` nor a JSON-RPC/transport failure). |
-| `finalAssistantMessageNonEmpty` | — | The final assistant message is a non-empty, non-whitespace string. |
-| `tokenBudgetUnder` | `tokens` | Total token usage for the iteration is strictly under `tokens`. Fails when usage was not measured. |
-| `widgetRendered` | `toolName?` | At least one MCP App widget render observation (narrowed to `toolName` when set) has `status === "rendered"`. Fails when the iteration recorded no render observations in scope. |
-| `widgetRenderLatencyUnder` | `ms`, `toolName?` | Every rendered widget observation (narrowed to `toolName` when set) mounted in strictly under `ms` milliseconds. Fails when nothing in scope rendered — an unrendered widget has no latency to check. |
-| `widgetNoConsoleErrors` | `toolName?` | No widget render observation (narrowed to `toolName` when set) captured console errors. Fails when the iteration recorded no render observations in scope. |
-| `turnCountUnder` | `turns` | The iteration used strictly fewer than `turns` user turns. Fails when the transcript carries no turn count. |
-| `noEndingQuestion` | — | **Observation.** The final assistant message's last non-empty line does not end with `?`. Cannot tell an offer ("Would you like a breakdown?") from a request for missing input, so it is Warn/Report only — `role: "advisory"` is required and a gating one is refused. |
-| `toolLatencyUnder` | `ms`, `toolName?` | Every observed call in scope settled in strictly under `ms`. Reports `status: "error"` when the run captured no per-call timing. |
-| `toolResultContains` | `needle`, `caseSensitive?`, `toolName?` | A tool result in scope contains `needle`, searched over the model-visible text and the structured payload. |
-| `toolResultMatchesSchema` | `schema`, `toolName?` | Every tool result in scope validates against the authored JSON Schema. Any JSON root — 2026-07-28 dropped the object-only restriction on `structuredContent`. |
-| `toolResultSizeUnder` | `maxBytes`, `toolName?` | Every tool result in scope is strictly under `maxBytes`, measured on what the server returned and **before** the transcript's own 64 000-character text cap. Bytes, not tokens. |
-| `argumentsMatchToolSchema` | `toolName?` | Every call's arguments validate against the tool's declared `inputSchema`, classified as `missing-required`, `wrong-type`, `bad-enum` or `hallucinated-param`. A key merely absent from `properties` is legal and is reported, never failed. Schema validity does not establish that the arguments match the user's intent. |
-| `noRepeatedIdenticalCall` | `toolName?` | **Observation.** No call repeated the one immediately before it with equal arguments. A poll loop and a transient retry are the same shape and both correct, so it is Warn/Report only. |
-| `toolCallCountUnder` | `count`, `toolName?` | Strictly fewer than `count` calls in scope. Total calls, which is not the same as calls before the right tool. |
-| `toolCalledBefore` | `toolName`, `beforeToolName` | Every call to `beforeToolName` was preceded by a call to `toolName`. Vacuously true when `beforeToolName` never ran. |
-| `noDeprecatedToolCalled` | — | **Observation.** No called tool's own description marks it deprecated. Anchored to self-deprecation, so "Replaces the deprecated `old_search` tool" does not fire. Warn/Report only. |
-| `noDestructiveToolCalled` | — | No called tool declares `annotations.destructiveHint`. Reports `status: "error"` when no tool in the inventory declares annotations at all. |
-| `toolErrorNamesInput` | `toolName?` | **Observation.** Every tool error message names one of that tool's input keys or a value the call sent. It does not measure recovery quality — "Rate limited. Retry in 30 seconds." names nothing and is a good message. Warn/Report only. |
-| `fullPageHasContinuation` | `toolName?` | **Observation.** A page whose length equals its requested limit carries recognized continuation metadata. A full page is not proof that more results exist, so this reports rather than fails. Warn/Report only. |
+The **Measures** column is the link of the [user-value chain](/sdk/concepts/user-value-chain) each kind's evidence is filed at. It is where the evidence is recorded, not a claim about where a failure originated. No predicate files at Connection or Discovery: the runner decides those two from what it observed setting the run up, before your case runs.
+
+| Type | Fields | Measures | Description |
+|------|--------|----------|-------------|
+| `toolCalledWith` | `toolName`, `args` ([`ArgMatcher`](#argmatcher)), `minCount?` | Selection | A call to `toolName` whose args satisfy `args` occurred at least `minCount` (default 1) times. |
+| `toolCalledAtLeastOnce` | `toolName` | Selection | `toolName` was called at least once (args irrelevant). |
+| `toolNeverCalled` | `toolName` | Selection | `toolName` was never called (forbidden-tool check). |
+| `onlyToolsCalled` | `toolNames` | Selection | Every tool called appears in `toolNames`. An empty array is the "no tool was called" claim. Generalizes `toolNeverCalled` from one forbidden tool to an allowed set. |
+| `firstToolWas` | `toolName` | Selection | The first tool call observed in the transcript was `toolName`. |
+| `responseContains` | `needle`, `caseSensitive?` | User value | The final assistant message contains `needle`. Case-insensitive by default. |
+| `responseMatches` | `pattern` | User value | The final assistant message matches the regular expression `pattern` (regex source string, no flags). |
+| `noToolErrors` | — | Response | No tool produced an error (neither MCP `isError: true` nor a JSON-RPC/transport failure). |
+| `finalAssistantMessageNonEmpty` | — | User value | The final assistant message is a non-empty, non-whitespace string. |
+| `tokenBudgetUnder` | `tokens` | User value | Total token usage for the iteration is strictly under `tokens`. Fails when usage was not measured. |
+| `widgetRendered` | `toolName?` | User value | At least one MCP App widget render observation (narrowed to `toolName` when set) has `status === "rendered"`. Fails when the iteration recorded no render observations in scope. |
+| `widgetRenderLatencyUnder` | `ms`, `toolName?` | User value | Every rendered widget observation (narrowed to `toolName` when set) mounted in strictly under `ms` milliseconds. Fails when nothing in scope rendered — an unrendered widget has no latency to check. |
+| `widgetNoConsoleErrors` | `toolName?` | User value | No widget render observation (narrowed to `toolName` when set) captured console errors. Fails when the iteration recorded no render observations in scope. |
+| `turnCountUnder` | `turns` | User value | The iteration used strictly fewer than `turns` user turns. Fails when the transcript carries no turn count. |
+| `noEndingQuestion` | — | User value | **Observation.** The final assistant message's last non-empty line does not end with `?`. Cannot tell an offer ("Would you like a breakdown?") from a request for missing input, so it is Warn/Report only — `role: "advisory"` is required and a gating one is refused. |
+| `toolLatencyUnder` | `ms`, `toolName?` | Response | Every observed call in scope settled in strictly under `ms`. Reports `status: "error"` when the run captured no per-call timing. |
+| `toolResultContains` | `needle`, `caseSensitive?`, `toolName?` | Response | A tool result in scope contains `needle`, searched over the model-visible text and the structured payload. |
+| `toolResultMatchesSchema` | `schema`, `toolName?` | Response | Every tool result in scope validates against the authored JSON Schema. Any JSON root — 2026-07-28 dropped the object-only restriction on `structuredContent`. |
+| `toolResultSizeUnder` | `maxBytes`, `toolName?` | Response | Every tool result in scope is strictly under `maxBytes`, measured on what the server returned and **before** the transcript's own 64 000-character text cap. Bytes, not tokens. |
+| `argumentsMatchToolSchema` | `toolName?` | Tool call | Every call's arguments validate against the tool's declared `inputSchema`, classified as `missing-required`, `wrong-type`, `bad-enum` or `hallucinated-param`. A key merely absent from `properties` is legal and is reported, never failed. Schema validity does not establish that the arguments match the user's intent. |
+| `noRepeatedIdenticalCall` | `toolName?` | Tool call | **Observation.** No call repeated the one immediately before it with equal arguments. A poll loop and a transient retry are the same shape and both correct, so it is Warn/Report only. |
+| `toolCallCountUnder` | `count`, `toolName?` | Selection | Strictly fewer than `count` calls in scope. Total calls, which is not the same as calls before the right tool. |
+| `toolCalledBefore` | `toolName`, `beforeToolName` | Selection | Every call to `beforeToolName` was preceded by a call to `toolName`. Vacuously true when `beforeToolName` never ran. |
+| `noDeprecatedToolCalled` | — | Selection | **Observation.** No called tool's own description marks it deprecated. Anchored to self-deprecation, so "Replaces the deprecated `old_search` tool" does not fire. Warn/Report only. |
+| `noDestructiveToolCalled` | — | Selection | No called tool declares `annotations.destructiveHint`. Reports `status: "error"` when no tool in the inventory declares annotations at all. |
+| `toolErrorNamesInput` | `toolName?` | Response | **Observation.** Every tool error message names one of that tool's input keys or a value the call sent. It does not measure recovery quality — "Rate limited. Retry in 30 seconds." names nothing and is a good message. Warn/Report only. |
+| `fullPageHasContinuation` | `toolName?` | Response | **Observation.** A page whose length equals its requested limit carries recognized continuation metadata. A full page is not proof that more results exist, so this reports rather than fails. Warn/Report only. |
 
 #### ArgMatcher
 
@@ -510,6 +513,8 @@ Used by `toolCalledWith` to specify expected arguments and matching mode.
 | `argumentMatching` | `"partial" \| "exact" \| "ignore"` | Matching mode. `"partial"` (default) checks only the keys present in `args`; `"exact"` requires deep equality; `"ignore"` skips argument comparison. |
 
 #### A predicate never passes by default
+
+A predicate that cannot be evaluated fails the case instead of silently passing. That covers malformed predicates (unknown type, missing required fields, invalid `minCount`, empty `needle`/`pattern`) and predicates with nothing to measure: `tokenBudgetUnder` when usage was not captured, and the `widget*` predicates when the iteration recorded no render observations. `responseMatches` also rejects patterns with nested quantifiers (ReDoS guard) and messages over 100,000 characters.
 
 #### Observations may never gate
 
@@ -526,8 +531,6 @@ The kinds that read tool results, per-call timings or the tool inventory report
 carries no value, keeps its scorer in `unresolvedScorerIds`, and leaves its
 stage `notMeasured`. A gate with an unscored row does not pass — but nothing is
 attributed to the server for a measurement we could not take.
-
-A predicate that cannot be evaluated fails the case instead of silently passing. That covers malformed predicates (unknown type, missing required fields, invalid `minCount`, empty `needle`/`pattern`) and predicates with nothing to measure: `tokenBudgetUnder` when usage was not captured, and the `widget*` predicates when the iteration recorded no render observations. `responseMatches` also rejects patterns with nested quantifiers (ReDoS guard) and messages over 100,000 characters.
 
 #### Example
 

--- a/docs/sdk/reference/validators.mdx
+++ b/docs/sdk/reference/validators.mdx
@@ -6,6 +6,8 @@ icon: "book"
 
 The SDK provides 9 boolean validator functions for asserting tool call behavior in tests, plus `evaluateToolCalls` — a richer, configurable matcher that returns structured results.
 
+The matcher's verdict is filed at the **Selection** link of the [user-value chain](/sdk/concepts/user-value-chain), alongside the predicates that measure which tool the model reached for.
+
 ## Import
 
 ```typescript

--- a/sdk/tests/uvc-docs-parity.test.ts
+++ b/sdk/tests/uvc-docs-parity.test.ts
@@ -1,0 +1,169 @@
+/**
+ * THE DOCS' STAGE COLUMN IS THE CONTRACT'S, OR IT IS WRONG.
+ *
+ * Two published tables tell an author which link of the user-value chain each
+ * check measures. Both are hand-written prose, and the map they claim to
+ * reflect — `PREDICATE_STAGE` — is derived from the predicate union itself.
+ * So the failure mode is silent and one-directional: someone adds a kind, the
+ * union grows, the contract grows with it, and the tables do not. The kind
+ * then exists, is authorable, files at a stage, and is documented nowhere.
+ *
+ * That already happened. `onlyToolsCalled` shipped and neither table gained a
+ * row, so both listed 26 kinds against a union of 27 until this test was
+ * written.
+ *
+ * Three claims, each of which would otherwise rot:
+ *
+ *  1. **Every kind is documented.** A new predicate fails here until its row
+ *     exists in both tables.
+ *  2. **No table invents a kind.** A renamed or removed kind fails here rather
+ *     than lingering as a row nobody can author.
+ *  3. **Every documented stage matches the contract.** Moving a kind between
+ *     links is a versioned analyzer change; this makes the docs part of that
+ *     change rather than a thing discovered later.
+ *
+ * Deliberately parses the shipped `.mdx` rather than generating it. These are
+ * prose tables with per-kind descriptions that a generator would flatten, and
+ * the thing worth pinning is the column, not the sentence beside it.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  PREDICATE_KINDS,
+  PREDICATE_STAGE,
+} from "../src/contract/grader-stage.js";
+import { USER_VALUE_STAGE_LABELS } from "../src/contract/decision-labels.js";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../.."
+);
+
+/** The published tables that carry a `Measures` column. */
+const DOC_TABLES = [
+  "docs/sdk/reference/eval-reporting.mdx",
+  "docs/sdk/concepts/running-evals.mdx",
+] as const;
+
+/** `| \`kind\` | … |` → the cells, trimmed. */
+function rowCells(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+/**
+ * Read the one table whose header carries a `Measures` column.
+ *
+ * Located by its header rather than by line number, so moving the table down
+ * the page does not quietly stop this test from checking anything, and the
+ * `Measures` cell is read by header position rather than by index so a column
+ * inserted before it does not shift the assertion onto prose.
+ *
+ * The kind itself is read from the FIRST cell, which both tables use. A row
+ * whose first cell is not a single backticked identifier is skipped — that is
+ * what lets the separator row and any prose row pass through harmlessly, and
+ * it is why a kind moved out of column one would read as missing rather than
+ * as passing.
+ */
+function readMeasuresTable(relativePath: string): Map<string, string> {
+  const lines = readFileSync(path.join(REPO_ROOT, relativePath), "utf8").split(
+    "\n"
+  );
+
+  const headerIndex = lines.findIndex(
+    (line) =>
+      line.trimStart().startsWith("|") &&
+      rowCells(line).some((cell) => cell === "Measures")
+  );
+  expect(
+    headerIndex,
+    `${relativePath} has no table with a "Measures" column. The stage column is ` +
+      `how an author learns which link a check measures; if it moved, point ` +
+      `this test at its new home rather than deleting the column.`
+  ).toBeGreaterThan(-1);
+
+  const header = rowCells(lines[headerIndex]);
+  const measuresColumn = header.indexOf("Measures");
+
+  const found = new Map<string, string>();
+  // Skip the header and its `|---|` separator.
+  for (let i = headerIndex + 2; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.trimStart().startsWith("|")) break;
+    const cells = rowCells(line);
+    const kindMatch = /^`([A-Za-z][A-Za-z0-9]*)`$/.exec(cells[0] ?? "");
+    if (!kindMatch) continue;
+    found.set(kindMatch[1], cells[measuresColumn] ?? "");
+  }
+  return found;
+}
+
+describe.each(DOC_TABLES)("%s documents every check's stage", (docPath) => {
+  const documented = readMeasuresTable(docPath);
+
+  it("lists every predicate kind the schema admits", () => {
+    const missing = [...PREDICATE_KINDS].filter(
+      (kind) => !documented.has(kind)
+    );
+    expect(
+      missing,
+      `Undocumented predicate kind(s). They are authorable and file at a chain ` +
+        `link, so an author can write one and never be told what it measures. ` +
+        `Add a row to ${docPath} with its Measures column.`
+    ).toEqual([]);
+  });
+
+  it("invents no kind that the schema does not admit", () => {
+    const unknown = [...documented.keys()].filter(
+      (kind) => !(PREDICATE_KINDS as readonly string[]).includes(kind)
+    );
+    expect(
+      unknown,
+      `${docPath} documents kind(s) that no longer exist. A reader who ` +
+        `authors one gets "unknown predicate type" on every trial.`
+    ).toEqual([]);
+  });
+
+  it("agrees with PREDICATE_STAGE on every kind", () => {
+    const disagreements = [...documented.entries()]
+      .filter(([kind]) => (PREDICATE_KINDS as readonly string[]).includes(kind))
+      .map(([kind, documentedStage]) => ({
+        kind,
+        documented: documentedStage,
+        contract:
+          USER_VALUE_STAGE_LABELS[
+            PREDICATE_STAGE[kind as keyof typeof PREDICATE_STAGE]
+          ],
+      }))
+      .filter((row) => row.documented !== row.contract);
+
+    expect(
+      disagreements,
+      `${docPath} disagrees with PREDICATE_STAGE. Moving a kind between links ` +
+        `re-attributes historical failures and is a versioned analyzer change; ` +
+        `the docs move with it, not after it.`
+    ).toEqual([]);
+  });
+});
+
+describe("the chain's unauthorable links", () => {
+  it("keeps connection and discovery free of authored checks", () => {
+    const authorable = [...PREDICATE_KINDS].filter((kind) =>
+      ["connection", "discovery"].includes(PREDICATE_STAGE[kind])
+    );
+    expect(
+      authorable,
+      `A predicate now files at connection or discovery. Both docs state ` +
+        `plainly that no check can reach those links — the runner decides them ` +
+        `from setup signals and the egress canary before the case runs. Update ` +
+        `that claim in docs/sdk/concepts/user-value-chain.mdx before shipping.`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

The docs taught the user-value chain as something you **read after a run**, and checks as something you **write before one**, and never joined the two.

None of the five SDK pages that teach assertions mentioned the chain at all — `validators.mdx`, `eval-test.mdx`, `eval-suite.mdx`, `eval-reporting.mdx`, `running-evals.mdx` all scored zero for any stage vocabulary. It appeared only in `inspector/evals.mdx` and the CLI/API references, every one of which describes reading a result.

So an author choosing `toolCalledWith`, `noToolErrors` and `responseContains` was never told those measure Selection, Response and User value, nor that the three together leave Tool call untouched and Connection and Discovery unreachable by any check.

The mapping was never missing, only undocumented. `PREDICATE_STAGE` and `GRADER_STAGE` in `sdk/src/contract/grader-stage.ts` are the same contract the suite settings page groups its rows by. Docs were the only surface not using it.

## What changed

**A `Measures` column** on both predicate tables, in `eval-reporting.mdx` and `running-evals.mdx`.

**A new concept page**, `sdk/concepts/user-value-chain.mdx`, for what a table cannot carry:

- Four of the six links are authorable; two are not, and the page says why rather than leaving a reader hunting. From inside the runner, "their server is down" and "our egress is broken" look identical, so a check you wrote could not tell them apart. Absent positive evidence that our own side worked, the honest answer is that the link was not measured.
- A stage is where the evidence is **filed**, not a claim about where the failure originated. `noToolErrors` is the worked example: it files at Response, and until analyzer 11 it filed at User value, so one defect was counted twice and the first break depended on which row you read first.
- The three graders that are not predicates, and why a gating `toolCalledWith` is promoted into the matcher while an advisory one is not.
- What a suite is **not** measuring, which is the question the six links exist to answer, plus the two habits that keep coverage honest: read the chain on a passing run, and treat a link with no check as unmeasured rather than fine.
- Why the five observation kinds file at a link without deciding it.

**Staleness fixed while in there.** Both tables listed **26** kinds against a union of **27**, `onlyToolsCalled` was missing from both, and in `eval-reporting.mdx` an earlier edit had separated `#### A predicate never passes by default` from its paragraph, which was sitting under the wrong heading.

## The ratchet

`sdk/tests/uvc-docs-parity.test.ts` reads the shipped `.mdx` and asserts it against the contract: every `PREDICATE_KINDS` member appears in each table with exactly the stage `PREDICATE_STAGE` gives it, no table invents a kind, and none files at Connection or Discovery. This follows the house pattern of `cli-docs-4-0.test.ts` and `openapi-drift.test.ts` — a doc that claims something the source of truth can check should be checked against it.

Mutation-checked three ways, each failing the intended assertion and no other: deleting the `onlyToolsCalled` row, flipping `noToolErrors` from Response to User value, and inventing a kind.

Stage counts documented, verified by running the map rather than counting by eye: **Connection 0, Discovery 0, Selection 9, Tool call 2, Response 7, User value 9 — 27 total.**

## Deliberately not in this PR

`validators.mdx`'s `EvalMatchOptions` table is separately stale — `toolCallOrder` is documented as `"ignore" | "strict"` and has had a third mode, `"superset"`, for some time; and it documents `allowExtraToolCalls`, which the SDK marks legacy with a shim and a removal note, instead of the current `maxExtraToolCalls`. That is its own fix. This PR only adds a one-line cross-reference from that page.

## Test plan

```
sdk/tests/uvc-docs-parity.test.ts   7 passed
sdk (full)                          337 files, 7737 passed | 8 skipped
cli-docs-4-0 (node:test)            8 passed
openapi-drift                       6 passed
docs.json                           parses; nav entry present
```

No changeset: the last four docs-only merges carry none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a contract-parity test only; no runtime or scoring behavior changes.
> 
> **Overview**
> Connects **writing eval checks** to the **user-value chain** by documenting which chain link each predicate measures, instead of only describing the chain when reading results.
> 
> Adds **`sdk/concepts/user-value-chain.mdx`** (nav in `docs.json`) covering authorable vs runner-only links, filing vs root-cause, non-predicate graders, coverage gaps, and observation kinds. Predicate tables in **`running-evals.mdx`** and **`eval-reporting.mdx`** gain a **`Measures`** column tied to that page; **`onlyToolsCalled`** is added to both tables; **`eval-reporting.mdx`** restores the **“A predicate never passes by default”** paragraph under the right heading. **`validators.mdx`** notes the tool-call matcher files at **Selection**.
> 
> Adds **`sdk/tests/uvc-docs-parity.test.ts`** so both `Measures` tables stay aligned with `PREDICATE_KINDS` / `PREDICATE_STAGE` (no missing, stale, or wrong-stage rows; no predicates on Connection/Discovery).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6cfd9f9d1b4721eaf0e2ba9dcf3528d1bdb8830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents which link of the user-value chain each predicate check measures, and fixes stale predicate tables. The docs previously treated the chain as read-after-run and checks as write-before-run with no page joining the two; both predicate tables also listed 26 kinds against a union of 27 and omitted `onlyToolsCalled`.

- Adds a Measures column to both predicate tables and a new `user-value-chain.mdx` concept page covering why only four of six links are authorable, where a check's evidence is filed, and what a suite is not measuring.
- Adds a parity test that fails when a table misses a kind, invents one, or disagrees with the `PREDICATE_STAGE` contract.
- Fixes the "A predicate never passes by default" paragraph that had drifted under the wrong heading in `eval-reporting.mdx`.

<sup>Written for commit e6cfd9f9d1b4721eaf0e2ba9dcf3528d1bdb8830. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

