### PR TITLE
fix: authenticate local browser panel requests

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/session-token.local-browser.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/session-token.local-browser.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({ hosted: false }));
+const getApiAuthorizationHeader = vi.hoisted(() =>
+  vi.fn<() => Promise<string | null>>(),
+);
+vi.mock("@/lib/config", () => ({
+  get HOSTED_MODE() {
+    return state.hosted;
+  },
+}));
+vi.mock("@/lib/apis/web/context", () => ({
+  getApiAuthorizationHeader,
+  resetTokenCache: vi.fn(),
+  shouldRetryApiAuth401: vi.fn(() => false),
+}));
+vi.mock("@/lib/convex-site-url", () => ({ getConvexSiteUrl: () => null }));
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
+import { authFetch } from "../session-token";
+
+function sentHeaders() {
+  return new Headers(vi.mocked(fetch).mock.calls[0]?.[1]?.headers);
+}
+
+describe("local browser authentication across deployment modes", () => {
+  beforeEach(() => {
+    state.hosted = false;
+    window.__MCP_SESSION_TOKEN__ = "local-session";
+    getApiAuthorizationHeader
+      .mockReset()
+      .mockResolvedValue("Bearer account-token");
+    vi.mocked(fetch).mockReset().mockResolvedValue(new Response("{}"));
+  });
+
+  afterEach(() => {
+    delete window.__MCP_SESSION_TOKEN__;
+    state.hosted = false;
+  });
+
+  it.each([
+    ["status", "GET"],
+    ["ensure", "POST"],
+    ["sessions", "POST"],
+    ["token", "POST"],
+    ["page-tools", "POST"],
+    ["profile/export", "POST"],
+  ])("sends both credentials for local/Electron %s", async (path, method) => {
+    await authFetch(`/api/mcp/computers/local-browser/${path}`, { method });
+    expect(sentHeaders().get("Authorization")).toBe("Bearer account-token");
+    expect(sentHeaders().get("X-MCP-Session-Auth")).toBe(
+      "Bearer local-session",
+    );
+  });
+
+  it("preserves consent and a caller-provided account credential", async () => {
+    await authFetch("/api/mcp/computers/local-browser/ensure", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer explicit",
+        "X-MCPJam-Local-Consent": "consent",
+      },
+    });
+    expect(sentHeaders().get("Authorization")).toBe("Bearer explicit");
+    expect(sentHeaders().get("X-MCPJam-Local-Consent")).toBe("consent");
+  });
+
+  it("does not fabricate account credentials for an OSS client without a bearer", async () => {
+    getApiAuthorizationHeader.mockResolvedValue(null);
+    await authFetch("/api/mcp/computers/local-browser/status");
+    expect(sentHeaders().get("Authorization")).toBeNull();
+    expect(sentHeaders().get("X-MCP-Session-Auth")).toBe(
+      "Bearer local-session",
+    );
+  });
+
+  it("keeps hosted browser requests bearer-only", async () => {
+    state.hosted = true;
+    await authFetch("/api/web/computers/browser/status");
+    expect(sentHeaders().get("Authorization")).toBe("Bearer account-token");
+    expect(sentHeaders().get("X-MCP-Session-Auth")).toBeNull();
+  });
+
+  it.each([
+    "/api/mcp/computers/local-browser-other/status",
+    "/api/mcp/tools/list",
+    "https://example.com/api/mcp/computers/local-browser/status",
+  ])("does not attach account credentials to %s", async (path) => {
+    await authFetch(path);
+    expect(getApiAuthorizationHeader).not.toHaveBeenCalled();
+    expect(sentHeaders().get("Authorization")).toBeNull();
+    if (path.startsWith("https:")) {
+      expect(sentHeaders().get("X-MCP-Session-Auth")).toBeNull();
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -403,7 +403,10 @@ const HOSTED_AUTH_PATH_PREFIXES = [
   // bearer before the consent check ever runs, and the terminal can never
   // open on a WorkOS-signed-in inspector.
   "/api/mcp/computers/local-terminal-token",
-  "/api/mcp/computers/local-browser/profile/export",
+  // Every local-browser route mounts bearerAuthMiddleware + requireVerifiedAuth,
+  // including status, launch, and activity reads. Local/Electron clients need
+  // the account bearer alongside their local session token.
+  "/api/mcp/computers/local-browser",
   // Convex HTTP actions called via absolute URL (OAuth completion, etc.).
   "/web/oauth/",
   // Registry catalog/star routes are Convex HTTP actions called via absolute


### PR DESCRIPTION
The Playground browser panel returns 401 `Bearer token required` on status, launch, and session-history requests even when the user is signed in. The server gates all `/api/mcp/computers/local-browser/*` routes with bearer authentication, but the client only attached the account bearer to profile export.

Expand the existing authFetch allowlist entry to the local-browser route family. Local development and Electron requests now carry the account bearer alongside the local session token. Hosted browser requests remain bearer-only. Preserve consent headers, explicit caller credentials, path boundaries, and the foreign-origin credential guard.

This does not change server authorization policy: OSS clients without an account bearer still send only their local session token; anonymous local browser access is not enabled by this fix.

Validation: 120 client session-token tests and 39 local browser route tests passed. New coverage checks local/Electron credentials, hosted credentials, absent account credentials, consent preservation, explicit Authorization, sibling paths, and foreign origins. No live Electron or hosted end-to-end test was run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only header attachment scoped to an existing route family; server auth policy and OSS no-bearer behavior are unchanged.
> 
> **Overview**
> Fixes **401 `Bearer token required`** on the Playground local browser panel by widening the `authFetch` hosted-bearer allowlist from **`/api/mcp/computers/local-browser/profile/export` only** to the full **`/api/mcp/computers/local-browser`** prefix, so status, launch, sessions, and related calls get the WorkOS account bearer in addition to the local session token.
> 
> Adds **`session-token.local-browser.test.ts`** to lock in behavior: dual credentials on local/Electron browser routes, bearer-only hosted `/api/web/computers/browser/*`, no invented bearer when none exists, preserved explicit `Authorization` and consent headers, and no account credentials on sibling paths or foreign origins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d105f9b8f5548125fa32d5e0a3759d0b422df4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Playground local browser panel returning 401 `Bearer token required` on status, launch, and session-history requests even when signed in. The account bearer is now attached to all `/api/mcp/computers/local-browser` routes instead of only `profile/export`, so local and Electron requests send it alongside the local session token.

- Hosted browser requests stay bearer-only and unchanged.
- OSS clients without an account bearer still send only their local session token; anonymous local browser access is not enabled.
- Consent headers, explicit caller `Authorization`, sibling paths, and the foreign-origin credential guard are preserved.
- New tests cover local/Electron, hosted, and missing-account credentials plus those preserved behaviors; no live Electron or hosted end-to-end test was run.

<sup>Written for commit 7d105f9b8f5548125fa32d5e0a3759d0b422df4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

