### PR TITLE
feat: let coding agents drive isolated cloud browsers

### DIFF
--- a/.changeset/cloud-agent-browser.md
+++ b/.changeset/cloud-agent-browser.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/cli": minor
+"@mcpjam/inspector": minor
+---
+
+Allow coding agents to open and drive isolated cloud browsers using `mcpjam browser --cloud`, with cloud authentication, durable command admission/history, screenshots, and the shared browser lifecycle.

--- a/cli/src/commands/browser.ts
+++ b/cli/src/commands/browser.ts
@@ -677,6 +677,91 @@ export function registerBrowserCommands(program: Command): void {
       });
     });
 
+  for (const op of ["back", "forward", "reload"] as const) {
+    addCommonOptions(
+      browser.command(op).description(`${op} the current browser tab`),
+    )
+      .option("--tab <id>", "Tab to drive")
+      .option("--command-id <id>", "Idempotency key for this command")
+      .action(async (options, command) => {
+        const global = getGlobalOptions(
+          command,
+          options.cloud ? 120_000 : 30_000,
+        );
+        const projectId = projectOf(options);
+        const sessionId = sessionOf(options, projectId);
+        const result = await post(
+          options,
+          "/command",
+          {
+            projectId,
+            sessionId,
+            command: { op, observeAfter: "a11y" },
+            ...identity(options),
+            ...(options.tab ? { tabId: options.tab } : {}),
+            ...(options.commandId ? { commandId: options.commandId } : {}),
+          },
+          global.timeout,
+        );
+        await emit(result, {
+          options,
+          projectId,
+          sessionId,
+          format: global.format,
+          saveScreenshots: false,
+        });
+      });
+  }
+
+  addCommonOptions(
+    browser
+      .command("invoke <toolKey>")
+      .description("Invoke a WebMCP tool listed by observe --mode page_tools"),
+  )
+    .option("--input <json>", "Tool arguments as JSON", "{}")
+    .option("--frame <id>", "Frame declaring the tool")
+    .option("--tab <id>", "Tab declaring the tool")
+    .option("--command-id <id>", "Idempotency key for this invocation")
+    .action(async (toolKey, options, command) => {
+      let input: unknown;
+      try {
+        input = JSON.parse(options.input);
+      } catch {
+        throw usageError("--input must be valid JSON");
+      }
+      const global = getGlobalOptions(
+        command,
+        options.cloud ? 120_000 : 30_000,
+      );
+      const projectId = projectOf(options);
+      const sessionId = sessionOf(options, projectId);
+      const result = await post(
+        options,
+        "/command",
+        {
+          projectId,
+          sessionId,
+          command: {
+            op: "invoke_page_tool",
+            toolKey,
+            input,
+            ...(options.frame ? { frameId: options.frame } : {}),
+          },
+          ...identity(options),
+          ...(options.tab ? { tabId: options.tab } : {}),
+          ...(options.commandId ? { commandId: options.commandId } : {}),
+        },
+        global.timeout,
+      );
+      await emit(result, {
+        options,
+        projectId,
+        sessionId,
+        format: global.format,
+        saveScreenshots: false,
+      });
+    });
+
   // ---- note -------------------------------------------------------------
   addCommonOptions(
     browser

--- a/cli/src/commands/browser.ts
+++ b/cli/src/commands/browser.ts
@@ -19,6 +19,7 @@
  *     one ledger row, and no window in which the page moves between an act and
  *     the observation that was supposed to describe it.
  */
+import { buildPlatformClient } from "../lib/platform-client.js";
 import { Command } from "commander";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -50,6 +51,9 @@ const BROWSER_ROUTE = "/api/mcp/computers/local-browser";
 const CLIENT_KIND = "cli";
 
 interface CommonOptions {
+  cloud?: boolean;
+  apiKey?: string;
+  apiUrl?: string;
   inspectorUrl?: unknown;
   project?: unknown;
   session?: unknown;
@@ -59,9 +63,21 @@ interface CommonOptions {
 
 function addCommonOptions(command: Command): Command {
   return command
+    .option("--cloud", "Drive an isolated MCPJam cloud browser")
+    .option(
+      "--api-url <url>",
+      "Cloud API URL (for example https://staging.mcpjam.com/api/v1)",
+    )
+    .option(
+      "--api-key <key>",
+      "Cloud API key (or use MCPJAM_API_KEY / cloud login)",
+    )
     .option("--inspector-url <url>", "Local Inspector base URL")
     .option("--project <id>", "Project whose browser to drive", "default")
-    .option("--session <id>", "Browser session id (defaults to the last opened)")
+    .option(
+      "--session <id>",
+      "Browser session id (defaults to the last opened)",
+    )
     .option(
       "--consent <token>",
       "Local computer consent capability (defaults to the stored one)",
@@ -106,7 +122,14 @@ function consentOf(options: CommonOptions): string {
 }
 
 /** The session for this project: explicit, else the last one opened here. */
+function sessionStoreKey(options: CommonOptions, projectId: string): string {
+  if (!options.cloud) return projectId;
+  const { baseUrl } = buildPlatformClient(options);
+  return `cloud:${baseUrl.replace(/\/$/, "")}:${projectId}`;
+}
+
 function sessionOf(options: CommonOptions, projectId: string): string {
+  const storeKey = sessionStoreKey(options, projectId);
   if (typeof options.session === "string" && options.session.trim()) {
     return options.session.trim();
   }
@@ -115,8 +138,8 @@ function sessionOf(options: CommonOptions, projectId: string): string {
   // function and be handed on as though it were a session id.
   const sessions = readBrowserState(getBrowserStateFilePath()).sessions;
   const stored =
-    sessions && Object.hasOwn(sessions, projectId)
-      ? sessions[projectId]
+    sessions && Object.hasOwn(sessions, storeKey)
+      ? sessions[storeKey]
       : undefined;
   if (typeof stored === "string" && stored) return stored;
   throw usageError(
@@ -156,7 +179,10 @@ function browserBaseUrl(options: CommonOptions): string {
   // `ws://localhost` — not a cleartext risk, but a URL this cannot talk to,
   // failing later inside a fetch instead of here where the message is about
   // the argument the caller actually typed.
-  if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && loopback)) {
+  if (
+    parsed.protocol !== "https:" &&
+    !(parsed.protocol === "http:" && loopback)
+  ) {
     throw usageError(
       `Refusing to send the local computer consent capability to ${baseUrl} in cleartext.`,
       "Use https:// for a remote Inspector; http:// is allowed for localhost only.",
@@ -171,6 +197,22 @@ async function post(
   body: Record<string, unknown>,
   timeoutMs?: number,
 ): Promise<Record<string, unknown>> {
+  if (options.cloud) {
+    if (options.inspectorUrl || options.consent)
+      throw usageError(
+        "--cloud uses cloud credentials, not --inspector-url or --consent",
+      );
+    if (body.projectId === "default")
+      throw usageError("Pass --project <cloud-project-id>");
+    const { client } = buildPlatformClient({
+      ...options,
+      timeoutMs: timeoutMs ?? 120000,
+    });
+    return client.browserSession(
+      path.slice(1) as Parameters<typeof client.browserSession>[0],
+      body,
+    );
+  }
   const client = new InspectorApiClient({ baseUrl: browserBaseUrl(options) });
   const result = await client.request(`${BROWSER_ROUTE}${path}`, {
     method: "POST",
@@ -256,6 +298,25 @@ async function fetchScreenshot(
       detail: "the screenshot was captured but its payload is no longer kept",
     };
   }
+  if (options.cloud) {
+    const body = await post(
+      options,
+      "/artifact",
+      { projectId, sessionId, artifactId: artifact.id },
+      timeoutMs,
+    );
+    if (typeof body.screenshot !== "string")
+      return { kind: "failed", detail: "Screenshot is no longer available" };
+    if (inline)
+      return {
+        kind: "inline",
+        base64: body.screenshot,
+        mediaType: "image/jpeg",
+      };
+    const file = join(outDir ?? tmpdir(), `mcpjam-browser-${artifact.id}.jpg`);
+    await writeFile(file, Buffer.from(body.screenshot, "base64"));
+    return { kind: "file", path: file };
+  }
   const baseUrl = browserBaseUrl(options);
   // Its OWN fetch, rather than the shared `request` helper, and for a reason
   // that is easy to get wrong: that helper reads every response with
@@ -308,22 +369,28 @@ function extensionFor(mediaType: string | undefined): string {
 export function registerBrowserCommands(program: Command): void {
   const browser = program
     .command("browser")
-    .description("Drive this machine's browser and read its session trace");
+    .description("Drive a local or cloud browser and read its session trace");
 
   // ---- consent ----------------------------------------------------------
   browser
     .command("consent")
     .description("Store the local computer capability granted in the Inspector")
-    .requiredOption("--token <token>", "The capability the Inspector showed once")
+    .requiredOption(
+      "--token <token>",
+      "The capability the Inspector showed once",
+    )
     .action(async (options, command) => {
-      const globalOptions = getGlobalOptions(command);
+      const globalOptions = getGlobalOptions(
+        command,
+        options.cloud ? 120_000 : 30_000,
+      );
       const file = getBrowserStateFilePath();
       const state = readBrowserState(file);
-      await writeBrowserState(file, { ...state, consent: String(options.token) });
-      writeResult(
-        { success: true, stored: file },
-        globalOptions.format,
-      );
+      await writeBrowserState(file, {
+        ...state,
+        consent: String(options.token),
+      });
+      writeResult({ success: true, stored: file }, globalOptions.format);
     });
 
   // ---- open -------------------------------------------------------------
@@ -352,15 +419,15 @@ export function registerBrowserCommands(program: Command): void {
       "Keep a ledger without pictures for this session",
     )
     .action(async (options, command) => {
-      const globalOptions = getGlobalOptions(command);
+      const globalOptions = getGlobalOptions(
+        command,
+        options.cloud ? 120_000 : 30_000,
+      );
       const projectId = projectOf(options);
       // Caught here as well as at the door, because `--profile ephermal` asks
       // for a throwaway browser and would otherwise open the real logged-in
       // one. A usage error names the flag the person actually typed.
-      if (
-        options.profile !== "persistent" &&
-        options.profile !== "ephemeral"
-      ) {
+      if (options.profile !== "persistent" && options.profile !== "ephemeral") {
         throw usageError(
           `Unknown --profile \`${String(options.profile)}\`.`,
           "Use --profile persistent or --profile ephemeral.",
@@ -382,9 +449,13 @@ export function registerBrowserCommands(program: Command): void {
               ? { toolAllowlist: options.tool }
               : {}),
           },
-          ...(options.screenshots === false ? { captureScreenshots: false } : {}),
+          ...(options.screenshots === false
+            ? { captureScreenshots: false }
+            : {}),
           ...(options.observe ? { observe: options.observe } : {}),
-          ...(typeof options.runKey === "string" ? { runKey: options.runKey } : {}),
+          ...(typeof options.runKey === "string"
+            ? { runKey: options.runKey }
+            : {}),
           ...identity(options),
         },
         globalOptions.timeout,
@@ -395,7 +466,7 @@ export function registerBrowserCommands(program: Command): void {
         // an explicit flag always wins.
         await rememberSession(
           getBrowserStateFilePath(),
-          projectId,
+          sessionStoreKey(options, projectId),
           session.sessionId,
         );
       }
@@ -417,15 +488,26 @@ export function registerBrowserCommands(program: Command): void {
           detail: error instanceof Error ? error.message : String(error),
         }));
         if (shot.kind === "file") extra = { screenshotPath: shot.path };
-        else if (shot.kind === "failed") extra = { screenshotError: shot.detail };
+        else if (shot.kind === "failed")
+          extra = { screenshotError: shot.detail };
       }
       writeResult({ success: true, ...body, ...extra }, globalOptions.format);
     });
 
-  // ---- observe ----------------------------------------------------------
   addCommonOptions(
-    browser.command("observe").description("Look at the page"),
-  )
+    browser.command("sessions").description("List browser sessions"),
+  ).action(async (options, command) => {
+    const body = await post(
+      options,
+      "/sessions",
+      { projectId: projectOf(options) },
+      getGlobalOptions(command).timeout,
+    );
+    writeResult(body, getGlobalOptions(command).format);
+  });
+
+  // ---- observe ----------------------------------------------------------
+  addCommonOptions(browser.command("observe").description("Look at the page"))
     .option(
       "--mode <mode>",
       "a11y | screenshot | text | dom | console | network | dialog | url | page_tools",
@@ -442,7 +524,10 @@ export function registerBrowserCommands(program: Command): void {
     .option("--out-dir <dir>", "Where to write a screenshot")
     .option("--inline", "Return screenshot bytes instead of a file path")
     .action(async (options, command) => {
-      const globalOptions = getGlobalOptions(command);
+      const globalOptions = getGlobalOptions(
+        command,
+        options.cloud ? 120_000 : 30_000,
+      );
       const projectId = projectOf(options);
       const sessionId = sessionOf(options, projectId);
       const result = await post(
@@ -490,13 +575,12 @@ export function registerBrowserCommands(program: Command): void {
       "--command-id <id>",
       "Idempotency key: reuse it to retry safely after a transport failure",
     )
-    .option(
-      "--observe-after <mode>",
-      "a11y | screenshot | none",
-      "a11y",
-    )
+    .option("--observe-after <mode>", "a11y | screenshot | none", "a11y")
     .action(async (url, options, command) => {
-      const globalOptions = getGlobalOptions(command);
+      const globalOptions = getGlobalOptions(
+        command,
+        options.cloud ? 120_000 : 30_000,
+      );
       const projectId = projectOf(options);
       const sessionId = sessionOf(options, projectId);
       const result = await post(
@@ -532,7 +616,9 @@ export function registerBrowserCommands(program: Command): void {
   addCommonOptions(
     browser
       .command("act")
-      .description("Click, type, press, scroll, hover, drag, select, or move tabs"),
+      .description(
+        "Click, type, press, scroll, hover, drag, select, or move tabs",
+      ),
   )
     .requiredOption(
       "--verb <verb>",
@@ -549,14 +635,13 @@ export function registerBrowserCommands(program: Command): void {
       "--command-id <id>",
       "Idempotency key: reuse it to retry safely after a transport failure",
     )
-    .option(
-      "--observe-after <mode>",
-      "a11y | screenshot | none",
-      "a11y",
-    )
+    .option("--observe-after <mode>", "a11y | screenshot | none", "a11y")
     .option("--out-dir <dir>", "Where to write a screenshot")
     .action(async (options, command) => {
-      const globalOptions = getGlobalOptions(command);
+      const globalOptions = getGlobalOptions(
+        command,
+        options.cloud ? 120_000 : 30_000,
+      );
       const projectId = projectOf(options);
       const sessionId = sessionOf(options, projectId);
       const result = await post(
@@ -598,7 +683,10 @@ export function registerBrowserCommands(program: Command): void {
       .command("note <text>")
       .description("Write a marker into the session trace"),
   ).action(async (text, options, command) => {
-    const globalOptions = getGlobalOptions(command);
+    const globalOptions = getGlobalOptions(
+      command,
+      options.cloud ? 120_000 : 30_000,
+    );
     const projectId = projectOf(options);
     const sessionId = sessionOf(options, projectId);
     const body = await post(
@@ -612,15 +700,16 @@ export function registerBrowserCommands(program: Command): void {
 
   // ---- trace ------------------------------------------------------------
   addCommonOptions(
-    browser
-      .command("trace")
-      .description("Read this session's command history"),
+    browser.command("trace").description("Read this session's command history"),
   )
     .option("--after-seq <seq>", "Only rows after this seq")
     .option("--command-id <id>", "Find one command's row")
     .option("--limit <n>", "How many rows", "100")
     .action(async (options, command) => {
-      const globalOptions = getGlobalOptions(command);
+      const globalOptions = getGlobalOptions(
+        command,
+        options.cloud ? 120_000 : 30_000,
+      );
       const projectId = projectOf(options);
       const sessionId = sessionOf(options, projectId);
       const body = await post(
@@ -651,7 +740,10 @@ export function registerBrowserCommands(program: Command): void {
       "Close the browser itself, not just this participant",
     )
     .action(async (options, command) => {
-      const globalOptions = getGlobalOptions(command);
+      const globalOptions = getGlobalOptions(
+        command,
+        options.cloud ? 120_000 : 30_000,
+      );
       const projectId = projectOf(options);
       const sessionId = sessionOf(options, projectId);
       const body = await post(
@@ -666,7 +758,11 @@ export function registerBrowserCommands(program: Command): void {
         globalOptions.timeout,
       );
       // Only if it was the remembered one; see `forgetSessionIf`.
-      await forgetSessionIf(getBrowserStateFilePath(), projectId, sessionId);
+      await forgetSessionIf(
+        getBrowserStateFilePath(),
+        sessionStoreKey(options, projectId),
+        sessionId,
+      );
       writeResult({ success: true, ...body }, globalOptions.format);
     });
 }
@@ -680,7 +776,9 @@ function targetFrom(options: {
 }): Record<string, unknown> | undefined {
   const named = [
     typeof options.ref === "string" && options.ref ? "ref" : null,
-    typeof options.selector === "string" && options.selector ? "selector" : null,
+    typeof options.selector === "string" && options.selector
+      ? "selector"
+      : null,
     options.x !== undefined || options.y !== undefined ? "coordinates" : null,
   ].filter(Boolean);
   if (named.length === 0) return undefined;
@@ -691,7 +789,8 @@ function targetFrom(options: {
       `Give one target, not ${named.length}: ${named.join(", ")}.`,
     );
   }
-  if (typeof options.ref === "string" && options.ref) return { ref: options.ref };
+  if (typeof options.ref === "string" && options.ref)
+    return { ref: options.ref };
   if (typeof options.selector === "string" && options.selector) {
     return { selector: options.selector };
   }

--- a/cli/tests/browser-command.test.ts
+++ b/cli/tests/browser-command.test.ts
@@ -38,6 +38,10 @@ test("browser commands are registered and documented", async () => {
     "trace",
     "close",
     "consent",
+    "invoke",
+    "back",
+    "forward",
+    "reload",
   ]) {
     assert.match(result.stdout, new RegExp(`\\b${verb}\\b`));
   }
@@ -415,12 +419,33 @@ test("cloud uses bearer auth and deployment-scoped session storage without local
       { env: env(file) },
     );
     assert.equal(observed.exitCode, 0, observed.stderr);
+    const invoked = await runCli(
+      [
+        "--format",
+        "json",
+        "browser",
+        "invoke",
+        "getAvailability",
+        "--input",
+        '{"day":"Monday"}',
+        ...flags,
+      ],
+      undefined,
+      { env: env(file) },
+    );
+    assert.equal(invoked.exitCode, 0, invoked.stderr);
+    assert.deepEqual(calls[3].body.command, {
+      op: "invoke_page_tool",
+      toolKey: "getAvailability",
+      input: { day: "Monday" },
+    });
     assert.deepEqual(
       calls.map((c) => c.url),
       [
         "/api/v1/browser-sessions/session",
         "/api/v1/browser-sessions/command",
         "/api/v1/browser-sessions/artifact",
+        "/api/v1/browser-sessions/command",
       ],
     );
     assert.ok(

--- a/cli/tests/browser-command.test.ts
+++ b/cli/tests/browser-command.test.ts
@@ -66,9 +66,8 @@ test("`browser consent` stores what a person granted in the UI", async () => {
     { env: env(file) },
   );
   assert.equal(result.exitCode, 0);
-  const { readBrowserState } = await import(
-    "../src/lib/browser-session-store.js"
-  );
+  const { readBrowserState } =
+    await import("../src/lib/browser-session-store.js");
   assert.equal(readBrowserState(file).consent, "cap-xyz");
 });
 
@@ -139,7 +138,10 @@ test("coordinates must both be numbers", async () => {
     { env: env(file) },
   );
   assert.notEqual(result.exitCode, 0);
-  assert.match(result.stderr + result.stdout, /--x and --y must both be numbers/);
+  assert.match(
+    result.stderr + result.stdout,
+    /--x and --y must both be numbers/,
+  );
 });
 
 test("an executed-but-failed command is not reported as a success", async () => {
@@ -282,9 +284,8 @@ test("a REFUSED command is a structured result, not a thrown error", async () =>
   // transport throws those away, `refused` (nothing ran, retry is safe) and
   // `unknown` (it may have run, do NOT retry) become one generic failure — and
   // a script that retries on error re-submits a command that already happened.
-  const { isContractResultForTests } = await import(
-    "../src/commands/browser.js"
-  );
+  const { isContractResultForTests } =
+    await import("../src/commands/browser.js");
   // THE SHAPE THE DOOR ACTUALLY SENDS. `/local-browser/command` answers
   // `c.json(ran.result, ran.status)`, so the contract result is the whole body
   // — not nested under `result`. Asserting the nested shape is what let this
@@ -331,5 +332,110 @@ test("act and navigate expose an idempotency key for a safe retry", async () => 
   for (const verb of ["act", "navigate"]) {
     const help = await runCli(["browser", verb, "--help"]);
     assert.match(help.stdout, /--command-id/);
+  }
+});
+
+test("cloud uses bearer auth and deployment-scoped session storage without local consent", async () => {
+  const { createServer } = await import("node:http");
+  const { readFile } = await import("node:fs/promises");
+  const calls: Array<{
+    url: string | undefined;
+    auth: string | undefined;
+    consent: string | string[] | undefined;
+    body: Record<string, unknown>;
+  }> = [];
+  const server = createServer(async (req, res) => {
+    let raw = "";
+    for await (const chunk of req) raw += chunk;
+    calls.push({
+      url: req.url,
+      auth: req.headers.authorization,
+      consent: req.headers["x-mcpjam-local-consent"],
+      body: JSON.parse(raw),
+    });
+    res.setHeader("content-type", "application/json");
+    res.end(
+      JSON.stringify(
+        req.url?.endsWith("/session")
+          ? { session: { sessionId: "cloud-session" } }
+          : req.url?.endsWith("/artifact")
+            ? { screenshot: "aGVsbG8=" }
+            : {
+                status: "executed",
+                ok: true,
+                commandId: "cmd",
+                page: {
+                  artifacts: {
+                    screenshot: { id: "cmd", mediaType: "image/jpeg" },
+                  },
+                },
+              },
+      ),
+    );
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const apiUrl = `http://127.0.0.1:${
+    (server.address() as { port: number }).port
+  }/api/v1`;
+  const file = await stateFile({
+    version: 1,
+    consent: "NEVER-SEND",
+    sessions: { p: "local-session" },
+  });
+  const flags = [
+    "--cloud",
+    "--api-url",
+    apiUrl,
+    "--api-key",
+    "sk_test",
+    "--project",
+    "p",
+  ];
+  try {
+    const opened = await runCli(
+      ["--format", "json", "browser", "open", ...flags],
+      undefined,
+      { env: env(file) },
+    );
+    assert.equal(opened.exitCode, 0, opened.stderr);
+    const observed = await runCli(
+      [
+        "--format",
+        "json",
+        "browser",
+        "observe",
+        "--mode",
+        "screenshot",
+        ...flags,
+      ],
+      undefined,
+      { env: env(file) },
+    );
+    assert.equal(observed.exitCode, 0, observed.stderr);
+    assert.deepEqual(
+      calls.map((c) => c.url),
+      [
+        "/api/v1/browser-sessions/session",
+        "/api/v1/browser-sessions/command",
+        "/api/v1/browser-sessions/artifact",
+      ],
+    );
+    assert.ok(
+      calls.every(
+        (c) => c.auth === "Bearer sk_test" && c.consent === undefined,
+      ),
+    );
+    assert.equal(calls[1].body.sessionId, "cloud-session");
+    const state = JSON.parse(await readFile(file, "utf8"));
+    assert.equal(state.sessions.p, "local-session");
+    assert.equal(state.sessions[`cloud:${apiUrl}:p`], "cloud-session");
+    const output = JSON.parse(observed.stdout);
+    assert.equal(await readFile(output.screenshotPath, "utf8"), "hello");
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
   }
 });

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -22,6 +22,10 @@
   ],
   "tags": [
     {
+      "name": "Agent browsers",
+      "description": "Isolated cloud browser sessions for coding agents. Requires authenticated project membership and a configured desktop runtime."
+    },
+    {
       "name": "Clients",
       "description": "Clients — the named, reusable configurations that define how MCPJam connects to and talks to your MCP servers. The original `/hosts` paths remain as deprecated, ID-only compatibility aliases with their original DTOs and their original (tokenless) write contracts; every alias response carries `Deprecation: true`. New integrations should use `/clients`."
     },
@@ -115,6 +119,603 @@
     }
   ],
   "paths": {
+    "/browser-sessions/session": {
+      "post": {
+        "tags": [
+          "Agent browsers"
+        ],
+        "operationId": "browserAgentSession",
+        "summary": "Open a cloud browser session",
+        "description": "Returns session identity, engine, bootId and runKey. Same runKey and policy reuse the session; omit runKey for a new isolated browser. Request bodies are limited to 64,000 characters.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "policy": {
+                    "type": "object",
+                    "properties": {
+                      "mode": {
+                        "enum": [
+                          "allow_all",
+                          "read_only",
+                          "allowlist"
+                        ]
+                      },
+                      "originAllowlist": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "maxItems": 100
+                      },
+                      "toolAllowlist": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "maxItems": 100
+                      }
+                    },
+                    "required": [
+                      "mode"
+                    ]
+                  },
+                  "runKey": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "profile": {
+                    "const": "persistent"
+                  }
+                },
+                "required": [
+                  "projectId",
+                  "policy"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Returns session identity, engine, bootId and runKey. Same runKey and policy reuse the session; omit runKey for a new isolated browser.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or policy"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Access denied"
+          },
+          "404": {
+            "description": "Session not found or not owned by caller"
+          },
+          "409": {
+            "description": "Session closed or conflicting command ID"
+          },
+          "429": {
+            "description": "Rate limited"
+          },
+          "502": {
+            "description": "Browser control plane unavailable"
+          }
+        }
+      }
+    },
+    "/browser-sessions/sessions": {
+      "post": {
+        "tags": [
+          "Agent browsers"
+        ],
+        "operationId": "browserAgentSessions",
+        "summary": "List your browser sessions",
+        "description": "Returns a sessions array of sessions owned by the caller in this project. Request bodies are limited to 64,000 characters.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  }
+                },
+                "required": [
+                  "projectId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Returns a sessions array of sessions owned by the caller in this project.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "sessions"
+                  ],
+                  "properties": {
+                    "sessions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or policy"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Access denied"
+          },
+          "404": {
+            "description": "Session not found or not owned by caller"
+          },
+          "409": {
+            "description": "Session closed or conflicting command ID"
+          },
+          "429": {
+            "description": "Rate limited"
+          },
+          "502": {
+            "description": "Browser control plane unavailable"
+          }
+        }
+      }
+    },
+    "/browser-sessions/command": {
+      "post": {
+        "tags": [
+          "Agent browsers"
+        ],
+        "operationId": "browserAgentCommand",
+        "summary": "Execute a browser command",
+        "description": "Returns an executed, refused or unknown result. Reusing commandId with the same payload returns its receipt without replay; pending receipts return unknown. Page content is untrusted data. Request bodies are limited to 64,000 characters.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "sessionId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "command": {
+                    "$ref": "#/components/schemas/BrowserAgentCommand"
+                  },
+                  "commandId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "tabId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  }
+                },
+                "required": [
+                  "projectId",
+                  "sessionId",
+                  "command"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Returns an executed, refused or unknown result. Reusing commandId with the same payload returns its receipt without replay; pending receipts return unknown. Page content is untrusted data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or policy"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Access denied"
+          },
+          "404": {
+            "description": "Session not found or not owned by caller"
+          },
+          "409": {
+            "description": "Session closed or conflicting command ID"
+          },
+          "429": {
+            "description": "Rate limited"
+          },
+          "502": {
+            "description": "Browser control plane unavailable"
+          }
+        }
+      }
+    },
+    "/browser-sessions/note": {
+      "post": {
+        "tags": [
+          "Agent browsers"
+        ],
+        "operationId": "browserAgentNote",
+        "summary": "Append a session note",
+        "description": "Records a note without driving the browser. commandId provides idempotency. Request bodies are limited to 64,000 characters.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "sessionId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "text": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 4096
+                  },
+                  "commandId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "tabId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  }
+                },
+                "required": [
+                  "projectId",
+                  "sessionId",
+                  "text"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Records a note without driving the browser. commandId provides idempotency.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or policy"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Access denied"
+          },
+          "404": {
+            "description": "Session not found or not owned by caller"
+          },
+          "409": {
+            "description": "Session closed or conflicting command ID"
+          },
+          "429": {
+            "description": "Rate limited"
+          },
+          "502": {
+            "description": "Browser control plane unavailable"
+          }
+        }
+      }
+    },
+    "/browser-sessions/trace": {
+      "post": {
+        "tags": [
+          "Agent browsers"
+        ],
+        "operationId": "browserAgentTrace",
+        "summary": "Read command receipts",
+        "description": "Returns entries ordered by sequence, optionally filtered by commandId. Screenshot payloads are fetched separately. Request bodies are limited to 64,000 characters.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "sessionId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "afterSeq": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100
+                  },
+                  "commandId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  }
+                },
+                "required": [
+                  "projectId",
+                  "sessionId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Returns entries ordered by sequence, optionally filtered by commandId. Screenshot payloads are fetched separately.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "entries"
+                  ],
+                  "properties": {
+                    "entries": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or policy"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Access denied"
+          },
+          "404": {
+            "description": "Session not found or not owned by caller"
+          },
+          "409": {
+            "description": "Session closed or conflicting command ID"
+          },
+          "429": {
+            "description": "Rate limited"
+          },
+          "502": {
+            "description": "Browser control plane unavailable"
+          }
+        }
+      }
+    },
+    "/browser-sessions/artifact": {
+      "post": {
+        "tags": [
+          "Agent browsers"
+        ],
+        "operationId": "browserAgentArtifact",
+        "summary": "Fetch a browser screenshot",
+        "description": "Returns screenshot as base64 PNG, or null when absent. artifactId is the command ID from the result. Request bodies are limited to 64,000 characters.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "sessionId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "artifactId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  }
+                },
+                "required": [
+                  "projectId",
+                  "sessionId",
+                  "artifactId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Returns screenshot as base64 PNG, or null when absent. artifactId is the command ID from the result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "screenshot"
+                  ],
+                  "properties": {
+                    "screenshot": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Base64-encoded PNG when present."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or policy"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Access denied"
+          },
+          "404": {
+            "description": "Session not found or not owned by caller"
+          },
+          "409": {
+            "description": "Session closed or conflicting command ID"
+          },
+          "429": {
+            "description": "Rate limited"
+          },
+          "502": {
+            "description": "Browser control plane unavailable"
+          }
+        }
+      }
+    },
+    "/browser-sessions/close": {
+      "post": {
+        "tags": [
+          "Agent browsers"
+        ],
+        "operationId": "browserAgentClose",
+        "summary": "Close a browser session",
+        "description": "Closes the durable session and releases its desktop. Use a new runKey for another browser. Request bodies are limited to 64,000 characters.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "sessionId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  }
+                },
+                "required": [
+                  "projectId",
+                  "sessionId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Closes the durable session and releases its desktop. Use a new runKey for another browser.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or policy"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Access denied"
+          },
+          "404": {
+            "description": "Session not found or not owned by caller"
+          },
+          "409": {
+            "description": "Session closed or conflicting command ID"
+          },
+          "429": {
+            "description": "Rate limited"
+          },
+          "502": {
+            "description": "Browser control plane unavailable"
+          }
+        }
+      }
+    },
     "/host-catalog": {
       "get": {
         "operationId": "getHostCompatCatalog",
@@ -11921,6 +12522,264 @@
       }
     },
     "schemas": {
+      "BrowserAgentCommand": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "op": {
+                "const": "back"
+              },
+              "observeAfter": {
+                "enum": [
+                  "a11y",
+                  "screenshot",
+                  "none"
+                ]
+              }
+            },
+            "required": [
+              "op"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "op": {
+                "const": "forward"
+              },
+              "observeAfter": {
+                "enum": [
+                  "a11y",
+                  "screenshot",
+                  "none"
+                ]
+              }
+            },
+            "required": [
+              "op"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "op": {
+                "const": "reload"
+              },
+              "observeAfter": {
+                "enum": [
+                  "a11y",
+                  "screenshot",
+                  "none"
+                ]
+              }
+            },
+            "required": [
+              "op"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "op": {
+                "const": "navigate"
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "maxLength": 8192
+              },
+              "newTab": {
+                "type": "boolean"
+              },
+              "observeAfter": {
+                "enum": [
+                  "a11y",
+                  "screenshot",
+                  "none"
+                ]
+              }
+            },
+            "required": [
+              "op",
+              "url"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "op": {
+                "const": "observe"
+              },
+              "mode": {
+                "enum": [
+                  "a11y",
+                  "screenshot",
+                  "text",
+                  "dom",
+                  "console",
+                  "network",
+                  "dialog",
+                  "url",
+                  "page_tools"
+                ]
+              },
+              "requestId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128
+              },
+              "rootRef": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128
+              },
+              "rootSelector": {
+                "type": "string",
+                "maxLength": 4096
+              },
+              "filter": {
+                "enum": [
+                  "interactive",
+                  "all"
+                ]
+              }
+            },
+            "required": [
+              "op",
+              "mode"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "op": {
+                "const": "act"
+              },
+              "verb": {
+                "enum": [
+                  "click",
+                  "type",
+                  "press",
+                  "scroll",
+                  "hover",
+                  "drag",
+                  "select",
+                  "close_tab",
+                  "activate_tab",
+                  "accept_dialog",
+                  "dismiss_dialog"
+                ]
+              },
+              "target": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "ref": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 128
+                      }
+                    },
+                    "required": [
+                      "ref"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "selector": {
+                        "type": "string",
+                        "maxLength": 4096
+                      }
+                    },
+                    "required": [
+                      "selector"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "coordinates": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    },
+                    "required": [
+                      "coordinates"
+                    ]
+                  }
+                ]
+              },
+              "value": {
+                "type": "string",
+                "maxLength": 16000
+              },
+              "expectedState": {
+                "type": "string",
+                "maxLength": 4096
+              },
+              "observeAfter": {
+                "enum": [
+                  "a11y",
+                  "screenshot",
+                  "none"
+                ]
+              }
+            },
+            "required": [
+              "op",
+              "verb"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "op": {
+                "const": "invoke_page_tool"
+              },
+              "toolKey": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128
+              },
+              "frameId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128
+              },
+              "input": {}
+            },
+            "required": [
+              "op",
+              "toolKey",
+              "input"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "op": {
+                "const": "cancel_page_tool"
+              },
+              "invocationId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128
+              }
+            },
+            "required": [
+              "op",
+              "invocationId"
+            ]
+          }
+        ]
+      },
       "Error": {
         "type": "object",
         "required": ["code", "message"],

--- a/mcpjam-inspector/docs/cloud-agent-browser.md
+++ b/mcpjam-inspector/docs/cloud-agent-browser.md
@@ -1,0 +1,75 @@
+# Drive a cloud browser from a coding agent
+
+The `browser` CLI commands accept `--cloud`. Each `open` creates a separate,
+blank browser profile in a metered desktop. No project computer attachment or
+host configuration is required. The caller must be a project member, and the
+cloud deployment needs its desktop template, rate and browser JWT keys configured.
+
+Use your existing `mcpjam cloud login` or `MCPJAM_API_KEY`. Select staging with
+`MCPJAM_API_URL=https://staging.mcpjam.com/api/v1`; credentials must belong to that
+deployment. Local consent is never sent to the cloud.
+
+```sh
+export MCPJAM_API_URL=https://staging.mcpjam.com/api/v1
+mcpjam browser open --cloud --project PROJECT_ID --run-key my-task --mode allow_all
+mcpjam browser navigate https://example.com --cloud --project PROJECT_ID --command-id first-navigation
+mcpjam browser observe --cloud --project PROJECT_ID --mode a11y
+mcpjam browser act --cloud --project PROJECT_ID --verb click --ref e3 --command-id click-one
+mcpjam browser observe --cloud --project PROJECT_ID --mode screenshot
+mcpjam browser trace --cloud --project PROJECT_ID
+mcpjam browser sessions --cloud --project PROJECT_ID
+mcpjam browser close --cloud --project PROJECT_ID
+```
+
+The CLI remembers the last session separately for each deployment and project.
+Pass `--session SESSION_ID` on commands to select another. `open --run-key KEY`
+reattaches the same agent session with the same policy; omit the key for a fresh
+session. A closed key cannot be reopened: use a new key. `close` in cloud mode
+ends the session and releases its desktop (unlike local participant-only close).
+
+A policy is stored when the session opens. `--mode read_only` permits observation
+only. `--mode allowlist --origin https://example.com` restricts navigation and
+returned observations. The same daemon handoff protections apply: taking human
+control blocks agent commands until control is handed back.
+
+A browser sleeps through the existing Playground idle lifecycle and wakes when
+its agent next issues a command. Profile state lasts within that session, subject
+to the existing retention policy. Cloud sessions currently start blank; saved
+profile selection and joining a Playground-owned browser are not exposed here.
+Cloud `--profile ephemeral`, `--attach require`, initial `--observe`, and capture
+configuration flags are rejected rather than silently changing their meaning.
+
+## Retry and history contract
+
+Use a stable `--command-id` for mutating commands. Admission is persisted before
+execution. A completed retry returns the saved result; an in-flight or interrupted
+claim returns `unknown` and is never executed again. Check `trace` before deciding
+what to do next. Never retry an unknown action under a new ID without checking the
+page: the original action may have happened. Reusing an ID with different input
+is rejected. A history write failure is reported on the result.
+
+Screenshots are downloaded to files by default. The cloud stores at most 512,000
+base64 characters per screenshot and 64,000 JSON characters per result; oversized
+pictures report an omission. History is bounded to 10,000 commands per session.
+Trace lists at most 100 entries; continue with `--after-seq`. Screenshots are
+fetched separately and are not embedded in trace listings.
+
+## API and rollout
+
+`POST /api/v1/browser-sessions/{session,sessions,command,trace,note,artifact,close}`
+uses the existing public bearer authentication. Requests include `projectId`, and
+all operations other than open/list include `sessionId`. Command bodies use the
+existing browser agent contract (`navigate`, `act`, `observe`); outcomes are
+`executed`, `refused`, or `unknown`, returned in-band with HTTP 200. Protocol and
+authorization failures use the standard v1 error envelope.
+
+Deploy the backend changes first (`browserAgentSessions`, `browserAgentCommands`
+and `/agent-browser/*`), then Inspector. Publish the SDK containing
+`PlatformApiClient.browserSession` before publishing the CLI that consumes it.
+A mismatched backend refuses before any desktop is provisioned.
+
+Verification covers the real CLI against a loopback cloud endpoint, the Inspector
+route against mocked control-plane/daemon transports, and Convex mutations with
+its test database. Live E2B provisioning must still be smoke-tested on staging:
+open two keys, navigate them independently, sleep/wake one, and close both while
+checking their desktop usage records.

--- a/mcpjam-inspector/docs/cloud-agent-browser.md
+++ b/mcpjam-inspector/docs/cloud-agent-browser.md
@@ -16,6 +16,8 @@ mcpjam browser navigate https://example.com --cloud --project PROJECT_ID --comma
 mcpjam browser observe --cloud --project PROJECT_ID --mode a11y
 mcpjam browser act --cloud --project PROJECT_ID --verb click --ref e3 --command-id click-one
 mcpjam browser observe --cloud --project PROJECT_ID --mode screenshot
+mcpjam browser observe --cloud --project PROJECT_ID --mode page_tools
+mcpjam browser invoke TOOL_KEY --input '{}' --cloud --project PROJECT_ID --command-id tool-call-one
 mcpjam browser trace --cloud --project PROJECT_ID
 mcpjam browser sessions --cloud --project PROJECT_ID
 mcpjam browser close --cloud --project PROJECT_ID
@@ -59,7 +61,8 @@ fetched separately and are not embedded in trace listings.
 `POST /api/v1/browser-sessions/{session,sessions,command,trace,note,artifact,close}`
 uses the existing public bearer authentication. Requests include `projectId`, and
 all operations other than open/list include `sessionId`. Command bodies use the
-existing browser agent contract (`navigate`, `act`, `observe`); outcomes are
+existing browser agent contract (`navigate`, `back`, `forward`, `reload`, `act`, `observe`,
+`invoke_page_tool`, `cancel_page_tool`); outcomes are
 `executed`, `refused`, or `unknown`, returned in-band with HTTP 200. Protocol and
 authorization failures use the standard v1 error envelope.
 

--- a/mcpjam-inspector/server/routes/v1/__tests__/browser-sessions.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/browser-sessions.test.ts
@@ -196,6 +196,28 @@ describe("cloud agent browser route", () => {
     expect(mocks.fetch.mock.calls).toHaveLength(1);
     expect(mocks.ensure).not.toHaveBeenCalled();
   });
+  it("maps a WebMCP invocation through the same agent command boundary", async () => {
+    const response = await request("command", {
+      sessionId: "s1",
+      command: {
+        op: "invoke_page_tool",
+        toolKey: "getAvailability",
+        input: { day: "Monday" },
+      },
+    });
+    expect((await response.json()).status).toBe("executed");
+    expect(mocks.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "agent",
+        action: {
+          kind: "webmcp_invoke",
+          toolKey: "getAvailability",
+          input: { day: "Monday" },
+        },
+      }),
+      "boot",
+    );
+  });
   it("maps handoff refusal without capturing a page", async () => {
     mocks.send.mockResolvedValue({ status: "lease_blocked", lease: "parked" });
     const response = await request("command", {

--- a/mcpjam-inspector/server/routes/v1/__tests__/browser-sessions.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/browser-sessions.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+const mocks = vi.hoisted(() => ({
+  ensure: vi.fn(),
+  send: vi.fn(),
+  fetch: vi.fn(),
+}));
+vi.mock("../../../utils/v1-convex-token.js", () => ({
+  getConvexBearerForRequest: async () => "verified-bearer",
+}));
+vi.mock("../../../utils/built-in-tools/browser.js", () => ({
+  ensureHostedConversationSession: mocks.ensure,
+}));
+import router from "../browser-sessions.js";
+const session = {
+  sessionId: "s1",
+  ownerUserId: "u1",
+  owner: { kind: "conversation", id: "agent-owner" },
+  policy: { mode: "allow_all" },
+  state: "active",
+};
+function request(op: string, body: Record<string, unknown>) {
+  return router.request(`/browser-sessions/${op}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ projectId: "p1", ...body }),
+  });
+}
+beforeEach(() => {
+  vi.stubEnv("CONVEX_HTTP_URL", "https://backend.test");
+  vi.stubGlobal("fetch", mocks.fetch);
+  mocks.fetch.mockReset();
+  mocks.ensure.mockReset();
+  mocks.send.mockReset();
+  mocks.ensure.mockResolvedValue({
+    bootId: "boot",
+    client: { sendCommand: mocks.send },
+  });
+  mocks.send.mockResolvedValue({
+    status: "ok",
+    result: { ok: true, output: { url: "https://example.com", text: "Hello" } },
+  });
+  mocks.fetch.mockImplementation(async (url: URL) => {
+    const op = url.pathname.split("/").pop();
+    return Response.json(
+      op === "get" || op === "open"
+        ? { session }
+        : op === "claim"
+          ? { claimed: true, seq: 1 }
+          : { ok: true },
+    );
+  });
+});
+describe("cloud agent browser route", () => {
+  it("opens its own logical owner through the shared hosted lifecycle", async () => {
+    const response = await request("session", {
+      policy: { mode: "allow_all" },
+      runKey: "test",
+    });
+    expect(response.status).toBe(200);
+    expect(mocks.ensure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        logicalSessionId: "agent-owner",
+        ownerKind: "conversation",
+        bearer: "verified-bearer",
+      }),
+    );
+  });
+  it("claims before driving and stamps agent source regardless of caller fields", async () => {
+    const response = await request("command", {
+      sessionId: "s1",
+      commandId: "cmd",
+      command: { op: "navigate", url: "https://example.com" },
+      source: "manual",
+      actor: { id: "admin" },
+    });
+    expect((await response.json()).status).toBe("executed");
+    expect(mocks.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "agent",
+        actor: expect.objectContaining({ label: "u1" }),
+      }),
+      "boot",
+    );
+    expect(mocks.fetch.mock.calls.map((c) => c[0].pathname)).toEqual([
+      "/agent-browser/get",
+      "/agent-browser/claim",
+      "/agent-browser/finish",
+    ]);
+  });
+  it("never executes a pending claim again", async () => {
+    mocks.fetch.mockImplementation(async (url: URL) =>
+      Response.json(
+        url.pathname.endsWith("get")
+          ? { session }
+          : { claimed: false, result: null, seq: 1 },
+      ),
+    );
+    const response = await request("command", {
+      sessionId: "s1",
+      commandId: "cmd",
+      command: { op: "navigate", url: "https://example.com" },
+    });
+    expect((await response.json()).status).toBe("unknown");
+    expect(mocks.ensure).not.toHaveBeenCalled();
+  });
+  it("denies ownership failure before any daemon or provisioning call", async () => {
+    mocks.fetch.mockResolvedValue(
+      Response.json({ error: "Browser session not found" }, { status: 404 }),
+    );
+    expect(
+      (
+        await request("command", {
+          sessionId: "other",
+          command: { op: "observe", mode: "a11y" },
+        })
+      ).status,
+    ).toBe(404);
+    expect(mocks.ensure).not.toHaveBeenCalled();
+  });
+  it("applies stored read-only policy before provisioning", async () => {
+    mocks.fetch.mockImplementation(async (url: URL) =>
+      Response.json(
+        url.pathname.endsWith("get")
+          ? { session: { ...session, policy: { mode: "read_only" } } }
+          : { claimed: true, seq: 1 },
+      ),
+    );
+    const response = await request("command", {
+      sessionId: "s1",
+      command: { op: "navigate", url: "https://example.com" },
+    });
+    expect((await response.json()).status).toBe("refused");
+    expect(mocks.ensure).not.toHaveBeenCalled();
+  });
+  it("withholds screenshot artifacts after an off-policy redirect", async () => {
+    mocks.fetch.mockImplementation(async (url: URL) =>
+      Response.json(
+        url.pathname.endsWith("get")
+          ? {
+              session: {
+                ...session,
+                policy: {
+                  mode: "allowlist",
+                  originAllowlist: ["https://example.com"],
+                },
+              },
+            }
+          : { claimed: true, seq: 1 },
+      ),
+    );
+    mocks.send.mockResolvedValue({
+      status: "ok",
+      result: {
+        ok: true,
+        output: { url: "https://outside.test", screenshot: "aGVsbG8=" },
+      },
+    });
+    const response = await request("command", {
+      sessionId: "s1",
+      command: { op: "navigate", url: "https://example.com" },
+    });
+    const result = await response.json();
+    expect(result.ok).toBe(false);
+    expect(result.page).toBeUndefined();
+    const finish = JSON.parse(mocks.fetch.mock.calls.at(-1)![1].body);
+    expect(finish.screenshot).toBeUndefined();
+  });
+  it("reports provisioning failure as a refusal and transport failure as unknown", async () => {
+    mocks.ensure.mockRejectedValueOnce(
+      new Error("Desktop capacity unavailable"),
+    );
+    const first = await request("command", {
+      sessionId: "s1",
+      command: { op: "navigate", url: "https://example.com" },
+    });
+    expect(await first.json()).toMatchObject({
+      status: "refused",
+      refusal: {
+        code: "browser_unavailable",
+        message: "Desktop capacity unavailable",
+      },
+    });
+    mocks.send.mockRejectedValueOnce(new Error("socket closed"));
+    const second = await request("command", {
+      sessionId: "s1",
+      command: { op: "navigate", url: "https://example.com" },
+    });
+    expect((await second.json()).status).toBe("unknown");
+  });
+  it("validates malformed commands before command admission", async () => {
+    const response = await request("command", {
+      sessionId: "s1",
+      command: { op: "act", verb: "execute_code" },
+    });
+    expect(response.status).toBe(400);
+    expect(mocks.fetch.mock.calls).toHaveLength(1);
+    expect(mocks.ensure).not.toHaveBeenCalled();
+  });
+  it("maps handoff refusal without capturing a page", async () => {
+    mocks.send.mockResolvedValue({ status: "lease_blocked", lease: "parked" });
+    const response = await request("command", {
+      sessionId: "s1",
+      command: { op: "observe", mode: "screenshot" },
+    });
+    expect(await response.json()).toMatchObject({
+      status: "refused",
+      refusal: { code: "lease_parked" },
+    });
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
@@ -48,6 +48,15 @@ function appInventory(): Set<string> {
 
 /** Route -> the `PlatformApiClient` method that calls it. */
 const ROUTE_TO_SDK: Readonly<Record<string, string>> = {
+  // The browser operation transport is shared by all agent-session routes.
+  "post /browser-sessions/session": "browserSession",
+  "post /browser-sessions/sessions": "browserSession",
+  "post /browser-sessions/command": "browserSession",
+  "post /browser-sessions/trace": "browserSession",
+  "post /browser-sessions/note": "browserSession",
+  "post /browser-sessions/artifact": "browserSession",
+  "post /browser-sessions/close": "browserSession",
+
   // Identity and catalogs
   // Spend budget — the organization's ceiling on MCPJam-billed spend.
   "get /organizations/{organizationId}/spend-budget": "getSpendBudget",

--- a/mcpjam-inspector/server/routes/v1/browser-sessions.ts
+++ b/mcpjam-inspector/server/routes/v1/browser-sessions.ts
@@ -30,6 +30,25 @@ const router = new Hono();
 const id = z.string().min(1).max(128);
 const commandSchema = z.discriminatedUnion("op", [
   z.object({
+    op: z.literal("back"),
+    observeAfter: z.enum(["a11y", "screenshot", "none"]).optional(),
+  }),
+  z.object({
+    op: z.literal("forward"),
+    observeAfter: z.enum(["a11y", "screenshot", "none"]).optional(),
+  }),
+  z.object({
+    op: z.literal("reload"),
+    observeAfter: z.enum(["a11y", "screenshot", "none"]).optional(),
+  }),
+  z.object({
+    op: z.literal("invoke_page_tool"),
+    toolKey: id,
+    frameId: id.optional(),
+    input: z.unknown(),
+  }),
+  z.object({ op: z.literal("cancel_page_tool"), invocationId: id }),
+  z.object({
     op: z.literal("navigate"),
     url: z.string().url().max(8192),
     newTab: z.boolean().optional(),

--- a/mcpjam-inspector/server/routes/v1/browser-sessions.ts
+++ b/mcpjam-inspector/server/routes/v1/browser-sessions.ts
@@ -1,0 +1,375 @@
+/** Public coding-agent browser API. Identity, admission and history live in Convex. */
+import { createHash, randomUUID } from "node:crypto";
+import { Hono } from "hono";
+import { z } from "zod";
+import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
+import { ensureHostedConversationSession } from "../../utils/built-in-tools/browser.js";
+import {
+  BrowserSessionService,
+  BrowserSessionServiceError,
+} from "../../services/browserd/session-service.js";
+import {
+  parseSessionPolicy,
+  policyRefusalFor,
+  resolveAgentActor,
+  toContractResult,
+} from "../../services/browserd/local/agent-door.js";
+import {
+  toDaemonAction,
+  refusedResult,
+  unknownResult,
+} from "../../services/browserd/agent-contract-mapper.js";
+import type {
+  BrowserAgentCommand,
+  BrowserAgentSessionPolicy,
+  BrowserAgentResult,
+} from "../../../shared/browser-agent-contract.js";
+import { v1Error, v1Resource } from "./envelope.js";
+
+const router = new Hono();
+const id = z.string().min(1).max(128);
+const commandSchema = z.discriminatedUnion("op", [
+  z.object({
+    op: z.literal("navigate"),
+    url: z.string().url().max(8192),
+    newTab: z.boolean().optional(),
+    observeAfter: z.enum(["a11y", "screenshot", "none"]).optional(),
+  }),
+  z.object({
+    op: z.literal("observe"),
+    mode: z.enum([
+      "a11y",
+      "screenshot",
+      "text",
+      "dom",
+      "console",
+      "network",
+      "dialog",
+      "url",
+      "page_tools",
+    ]),
+    requestId: id.optional(),
+    rootRef: id.optional(),
+    rootSelector: z.string().max(4096).optional(),
+    filter: z.enum(["interactive", "all"]).optional(),
+  }),
+  z.object({
+    op: z.literal("act"),
+    verb: z.enum([
+      "click",
+      "type",
+      "press",
+      "scroll",
+      "hover",
+      "drag",
+      "select",
+      "close_tab",
+      "activate_tab",
+      "accept_dialog",
+      "dismiss_dialog",
+    ]),
+    target: z
+      .union([
+        z.object({ ref: id }),
+        z.object({ selector: z.string().max(4096) }),
+        z.object({ coordinates: z.tuple([z.number(), z.number()]) }),
+      ])
+      .optional(),
+    value: z.string().max(16000).optional(),
+    expectedState: z.string().max(4096).optional(),
+    observeAfter: z.enum(["a11y", "screenshot", "none"]).optional(),
+  }),
+]);
+type AgentSession = {
+  ownerUserId: string;
+  sessionId: string;
+  owner: { kind: "conversation"; id: string };
+  policy: BrowserAgentSessionPolicy;
+  state?: string;
+};
+
+async function control<T>(
+  bearer: string,
+  op: Parameters<BrowserSessionService["agentRequest"]>[0],
+  body: Record<string, unknown>,
+): Promise<T> {
+  return new BrowserSessionService().agentRequest<T>(op, {
+    bearer,
+    projectId: String(body.projectId),
+    body,
+    signal: AbortSignal.timeout(75_000),
+  });
+}
+
+for (const op of [
+  "session",
+  "sessions",
+  "command",
+  "trace",
+  "note",
+  "artifact",
+  "close",
+] as const) {
+  router.post(`/browser-sessions/${op}`, async (c) => {
+    const text = await c.req.text();
+    if (Buffer.byteLength(text) > 64000)
+      return v1Error(c, "VALIDATION_ERROR", "Request too large");
+    let input: Record<string, unknown>;
+    try {
+      input = JSON.parse(text);
+    } catch {
+      return v1Error(c, "VALIDATION_ERROR", "Invalid JSON");
+    }
+    const parsed = z
+      .object({ projectId: id, sessionId: id.optional() })
+      .safeParse(input);
+    if (!parsed.success)
+      return v1Error(c, "VALIDATION_ERROR", "projectId is required");
+    const { projectId, sessionId } = parsed.data;
+    const bearer = await getConvexBearerForRequest(c);
+    try {
+      if (op === "sessions")
+        return v1Resource(c, await control(bearer, "list", { projectId }));
+      if (op === "session") {
+        const policy = parseSessionPolicy(input.policy);
+        if (!policy)
+          return v1Error(
+            c,
+            "VALIDATION_ERROR",
+            "Declare a browser session policy",
+          );
+        if (input.profile !== undefined && input.profile !== "persistent")
+          return v1Error(
+            c,
+            "VALIDATION_ERROR",
+            "Cloud agent sessions use an isolated persistent profile; omit --profile",
+          );
+        if (input.attach === "require")
+          return v1Error(
+            c,
+            "VALIDATION_ERROR",
+            "Use --session to address an existing cloud session",
+          );
+        if (
+          input.observe !== undefined ||
+          input.captureTypedText === true ||
+          input.captureScreenshots === false
+        )
+          return v1Error(
+            c,
+            "VALIDATION_ERROR",
+            "Use observe after open; cloud capture options are not supported",
+          );
+        const key =
+          input.runKey === undefined ? randomUUID() : id.parse(input.runKey);
+        const opened = await control<{ session: AgentSession }>(
+          bearer,
+          "open",
+          { projectId, key, policy },
+        );
+        const handle = await ensureHostedConversationSession({
+          bearer,
+          projectId,
+          contextMode: "persistent",
+          logicalSessionId: opened.session.owner.id,
+          ownerKind: "conversation",
+        });
+        return v1Resource(c, {
+          session: {
+            ...opened.session,
+            engine: "hosted",
+            bootId: handle.bootId,
+          },
+          runKey: key,
+        });
+      }
+      if (!sessionId)
+        return v1Error(c, "VALIDATION_ERROR", "sessionId is required");
+      const ids = { projectId, sessionId };
+      const { session } = await control<{ session: AgentSession }>(
+        bearer,
+        "get",
+        ids,
+      );
+      if (op === "trace")
+        return v1Resource(
+          c,
+          await control(bearer, "trace", {
+            ...ids,
+            ...z
+              .object({
+                afterSeq: z.number().int().nonnegative().optional(),
+                limit: z.number().int().min(1).max(100).optional(),
+                commandId: id.optional(),
+              })
+              .parse(input),
+          }),
+        );
+      if (op === "artifact")
+        return v1Resource(
+          c,
+          await control(bearer, "artifact", {
+            ...ids,
+            commandId: id.parse(input.artifactId),
+          }),
+        );
+      if (op === "close")
+        return v1Resource(c, await control(bearer, "close", ids));
+      if (session.state === "closed")
+        return v1Error(c, "CONFLICT", "Browser session closed");
+      const command =
+        op === "command"
+          ? (commandSchema.parse(input.command) as BrowserAgentCommand)
+          : undefined;
+      const note =
+        op === "note"
+          ? z.string().min(1).max(4096).parse(input.text)
+          : undefined;
+      const commandId =
+        input.commandId === undefined
+          ? randomUUID()
+          : id.parse(input.commandId);
+      const tabId =
+        input.tabId === undefined ? undefined : id.parse(input.tabId);
+      const fingerprint = createHash("sha256")
+        .update(JSON.stringify({ command, note, tabId }))
+        .digest("hex");
+      const claim = await control<{
+        claimed: boolean;
+        seq: number;
+        result: BrowserAgentResult | null;
+      }>(bearer, "claim", { ...ids, commandId, fingerprint });
+      // Never replay a pending claim: an earlier replica may still be executing it.
+      if (!claim.claimed)
+        return v1Resource(
+          c,
+          claim.result ?? unknownResult({ commandId, reason: "transport" }),
+        );
+      const ledger = { sessionId, seq: claim.seq };
+      let result: BrowserAgentResult & { note?: string };
+      let screenshot: string | undefined;
+      if (note)
+        result = { status: "executed", ok: true, commandId, ledger, note };
+      else {
+        const mapped = toDaemonAction(command!);
+        const refusal =
+          policyRefusalFor(session.policy, command!) ??
+          (!mapped.ok ? mapped.refusal : undefined);
+        if (refusal) result = refusedResult({ commandId, ledger, ...refusal });
+        else {
+          let sent = false;
+          try {
+            const handle = await ensureHostedConversationSession({
+              bearer,
+              projectId,
+              contextMode: "persistent",
+              logicalSessionId: session.owner.id,
+              ownerKind: "conversation",
+            });
+            sent = true;
+            const response = await handle.client.sendCommand(
+              {
+                commandId,
+                source: "agent",
+                sessionId,
+                actor: resolveAgentActor({
+                  userId: session.ownerUserId,
+                  clientKind: input.client,
+                  clientId: input.clientId,
+                }),
+                ...(tabId ? { tabId } : {}),
+                action: mapped.action!,
+              },
+              handle.bootId,
+            );
+            const raw =
+              response.status === "ok" ||
+              response.status === "stale_observation"
+                ? (response.result?.output as
+                    { screenshot?: unknown } | undefined)
+                : undefined;
+            const candidate =
+              typeof raw?.screenshot === "string" &&
+              raw.screenshot.length <= 512000
+                ? raw.screenshot
+                : undefined;
+            const artifacts = candidate
+              ? {
+                  screenshot: {
+                    id: commandId,
+                    mediaType: "image/jpeg",
+                    bytes: Buffer.byteLength(candidate, "base64"),
+                  },
+                }
+              : undefined;
+            result = toContractResult({
+              response,
+              commandId,
+              policy: session.policy,
+              ledger,
+              ...(artifacts ? { artifacts } : {}),
+            }).result;
+            // Only persist pixels the policy-filtered result actually exposes.
+            if (
+              (result.status === "executed" &&
+                result.page?.artifacts?.screenshot) ||
+              (result.status === "refused" &&
+                result.refusal.page?.artifacts?.screenshot)
+            )
+              screenshot = candidate;
+            if (typeof raw?.screenshot === "string" && !candidate)
+              result = {
+                ...result,
+                historyWarning:
+                  "Screenshot exceeded the cloud artifact limit; request a smaller observation.",
+              };
+          } catch (error) {
+            result = sent
+              ? unknownResult({ commandId, reason: "transport" })
+              : refusedResult({
+                  commandId,
+                  ledger,
+                  code: "browser_unavailable",
+                  message:
+                    error instanceof Error
+                      ? error.message
+                      : "The cloud browser could not be started",
+                });
+          }
+        }
+      }
+      try {
+        await control(bearer, "finish", {
+          ...ids,
+          commandId,
+          result,
+          ...(screenshot ? { screenshot } : {}),
+        });
+      } catch {
+        result = {
+          ...result,
+          historyWarning:
+            "The command outcome could not be saved; do not replay with a new command id.",
+        };
+      }
+      return v1Resource(c, result);
+    } catch (error) {
+      if (error instanceof z.ZodError)
+        return v1Error(c, "VALIDATION_ERROR", error.message);
+      if (error instanceof BrowserSessionServiceError)
+        return v1Error(
+          c,
+          error.status === 404
+            ? "NOT_FOUND"
+            : error.status === 401
+              ? "UNAUTHORIZED"
+              : error.status === 403
+                ? "FORBIDDEN"
+                : "CONFLICT",
+          error.detail,
+        );
+      throw error;
+    }
+  });
+}
+export default router;

--- a/mcpjam-inspector/server/routes/v1/index.ts
+++ b/mcpjam-inspector/server/routes/v1/index.ts
@@ -60,6 +60,7 @@ import capabilities from "./capabilities.js";
 import evalDisclosure from "./eval-disclosure.js";
 import publicModels from "./public-models.js";
 import hostCatalog from "./host-catalog.js";
+import browserSessions from "./browser-sessions.js";
 import tunnels from "./tunnels.js";
 import readiness from "./readiness.js";
 import conformanceRuns from "./conformance-runs.js";
@@ -249,6 +250,7 @@ v1.route("/", capabilities);
 // would actually matter.
 v1.route("/", evalDisclosure);
 v1.route("/", tunnels);
+v1.route("/", browserSessions);
 
 v1.onError((error, c) => v1OnError(error, c));
 

--- a/mcpjam-inspector/server/services/browserd/local/agent-door.ts
+++ b/mcpjam-inspector/server/services/browserd/local/agent-door.ts
@@ -322,7 +322,7 @@ export async function runAgentCommand(
 }
 
 /** Map one daemon response onto the contract's three outcomes. */
-function toContractResult(args: {
+export function toContractResult(args: {
   response: BrowserdCommandResponse;
   commandId: string;
   policy: BrowserAgentSessionPolicy;

--- a/mcpjam-inspector/server/services/browserd/session-service.ts
+++ b/mcpjam-inspector/server/services/browserd/session-service.ts
@@ -232,6 +232,24 @@ export class BrowserSessionService {
     return (await response.json()) as T;
   }
 
+  /** The external-agent door uses the same authenticated control-plane transport. */
+  async agentRequest<T>(
+    operation:
+      | "open"
+      | "get"
+      | "list"
+      | "claim"
+      | "finish"
+      | "trace"
+      | "artifact"
+      | "close",
+    args: RequestArgs,
+  ): Promise<T> {
+    const result = await this.post<T>(`/agent-browser/${operation}`, args);
+    if (result === null) throw new Error("Browser sessions are not configured");
+    return result;
+  }
+
   async resolveSession(args: {
     owner: BrowserSessionOwner;
     projectId: string;

--- a/mcpjam-inspector/server/utils/__tests__/web-chat-turn-page-tools.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/web-chat-turn-page-tools.test.ts
@@ -9,8 +9,8 @@
  *  1. the entries reach `prepareChatV2`, which is what turns them into tools
  *     the model can see at all;
  *  2. the tools it builds reach the engine still carrying their approval
- *     declaration. A page tool that arrives without one strands the turn: the
- *     client defers the call and waits for a pill the server never sends.
+ *     declaration when the user enables approval. With approval disabled,
+ *     the tool must remain ungated so the client can fulfill it directly.
  *
  * The second one used to be a separate name set the route had to remember to
  * thread. It is now a property of the tool, so this asserts it where the
@@ -48,14 +48,16 @@ vi.mock("../org-model-config.js", () => ({
 }));
 
 const prepareChatV2 = vi.hoisted(() =>
-  vi.fn(async (_args: { pageTools?: unknown }) => ({
-    allTools: {} as Record<string, unknown>,
-    enhancedSystemPrompt: "",
-    resolvedTemperature: undefined,
-    scrubMessages: (m: unknown[]) => m,
-    progressivePlan: undefined,
-    discoveryState: undefined,
-  })),
+  vi.fn(
+    async (_args: { requireToolApproval?: boolean; pageTools?: unknown }) => ({
+      allTools: {} as Record<string, unknown>,
+      enhancedSystemPrompt: "",
+      resolvedTemperature: undefined,
+      scrubMessages: (m: unknown[]) => m,
+      progressivePlan: undefined,
+      discoveryState: undefined,
+    }),
+  ),
 );
 
 vi.mock("../chat-v2-orchestration.js", async () => {
@@ -65,17 +67,19 @@ vi.mock("../chat-v2-orchestration.js", async () => {
   // The REAL page-tool builder behind the mock, so what the engine is handed
   // here is what production hands it — declaration included. A stub returning
   // `{}` would pass this file while the turn stranded in production.
-  prepareChatV2.mockImplementation(async (args: { pageTools?: unknown }) => ({
-    allTools: actual.buildPageTools(args.pageTools as never) as Record<
-      string,
-      unknown
-    >,
-    enhancedSystemPrompt: "",
-    resolvedTemperature: undefined,
-    scrubMessages: (m: unknown[]) => m,
-    progressivePlan: undefined,
-    discoveryState: undefined,
-  }));
+  prepareChatV2.mockImplementation(
+    async (args: { requireToolApproval?: boolean; pageTools?: unknown }) => ({
+      allTools: actual.buildPageTools(
+        args.pageTools as never,
+        args.requireToolApproval,
+      ) as Record<string, unknown>,
+      enhancedSystemPrompt: "",
+      resolvedTemperature: undefined,
+      scrubMessages: (m: unknown[]) => m,
+      progressivePlan: undefined,
+      discoveryState: undefined,
+    }),
+  );
   return {
     prepareChatV2,
     buildWidgetModelContextSystemPrompt: vi.fn(() => ""),
@@ -105,7 +109,7 @@ const PAGE_TOOL = {
   inputSchema: { type: "object" as const, properties: {} },
 };
 
-function args(pageTools?: unknown[]) {
+function args(pageTools?: unknown[], requireToolApproval = false) {
   const c = {
     req: {
       raw: { headers: new Headers(), signal: undefined },
@@ -118,6 +122,7 @@ function args(pageTools?: unknown[]) {
       hasServer: () => false,
     } as never,
     prepare: {
+      requireToolApproval,
       selectedServerIds: [],
       modelDefinition: {
         name: "m",
@@ -160,10 +165,17 @@ describe("streamWebChatTurn — WebMCP page tools", () => {
     expect(prepareChatV2.mock.calls[0]?.[0]?.pageTools).toEqual([PAGE_TOOL]);
   });
 
-  it("gates every page alias, so the turn cannot strand on a missing pill", async () => {
-    await streamWebChatTurn(args([PAGE_TOOL]) as never);
+  it("gates page aliases when the user requires approval", async () => {
+    await streamWebChatTurn(args([PAGE_TOOL], true) as never);
     const tools = handlers.mcpjamFree.mock.calls[0]?.[0]?.tools;
     expect(tools?.page_1a2b3c4d?.needsApproval).toBe(true);
+  });
+
+  it("leaves page aliases ungated when approval is disabled", async () => {
+    await streamWebChatTurn(args([PAGE_TOOL], false) as never);
+    const tools = handlers.mcpjamFree.mock.calls[0]?.[0]?.tools;
+    expect(tools?.page_1a2b3c4d).toBeDefined();
+    expect(tools?.page_1a2b3c4d?.needsApproval).not.toBe(true);
   });
 
   it("leaves a turn with no page tools exactly as it was", async () => {

--- a/mcpjam-inspector/server/utils/built-in-tools/browser.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/browser.ts
@@ -2454,7 +2454,7 @@ function defaultEnsureSession(
  * desktop. Opening a chat advertises browser tools but does not spend a
  * sandbox; the first browser command is the provisioning boundary.
  */
-async function ensureHostedConversationSession(args: {
+export async function ensureHostedConversationSession(args: {
   bearer: string;
   projectId: string;
   contextMode: BrowserContextMode;

--- a/mcpjam-inspector/shared/browser-agent-contract.ts
+++ b/mcpjam-inspector/shared/browser-agent-contract.ts
@@ -336,7 +336,9 @@ export type BrowserAgentRefusalCode =
   | "session_revoked"
   | "session_closed"
   | "busy"
-  | "daemon_at_capacity";
+  | "daemon_at_capacity"
+  /** Provisioning or wake failed before a command could be sent. */
+  | "browser_unavailable";
 
 /** Why an outcome is unknowable. @see BrowserAgentResult */
 export type BrowserAgentUnknownReason =

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -530,6 +530,27 @@ export class PlatformApiClient {
       : undefined;
   }
 
+  /** Coding-agent browser entry point; command outcomes are returned in-band. */
+  browserSession(
+    operation:
+      | "session"
+      | "sessions"
+      | "command"
+      | "trace"
+      | "note"
+      | "artifact"
+      | "close",
+    body: Record<string, unknown>,
+    options?: RequestOptions
+  ): Promise<Record<string, unknown>> {
+    return this.request(
+      "POST",
+      `/browser-sessions/${operation}`,
+      { body },
+      options
+    );
+  }
+
   getMe(options?: RequestOptions): Promise<PlatformMe> {
     return this.request("GET", "/me", {}, options);
   }
@@ -616,8 +637,8 @@ export class PlatformApiClient {
             params.connectableOnly === undefined
               ? undefined
               : params.connectableOnly
-              ? "true"
-              : "false",
+                ? "true"
+                : "false",
           ...pageQuery({ cursor: params.cursor, limit: params.limit }),
         },
       },


### PR DESCRIPTION
Coding agents can currently drive only the local browser. This adds `mcpjam browser … --cloud` and a bearer-authenticated v1 API backed by the shared hosted browser lifecycle. Each new key gets its own persistent browser; commands wake it as needed, and cloud close releases it. No project-computer attachment or host configuration is required.

The CLI supports open/list, navigate/back/forward/reload, act, observe/screenshots, WebMCP invocation, note, trace, and close. It uses the existing cloud login/API key and remembers sessions per deployment/project without sending local consent. The gateway reuses the agent policy/result mapper and daemon handoff protections. Durable admission prevents re-executing a command after a replica or network failure; transport uncertainty is returned as unknown rather than success. Provisioning failures are explicit refusals.

Depends on backend https://github.com/MCPJam/mcpjam-backend/pull/1306, which must deploy first. SDK and CLI changesets are included; publish the SDK before the CLI. Usage and limits: `mcpjam-inspector/docs/cloud-agent-browser.md`. Saved-profile selection and attaching to an existing Playground browser are not exposed by this initial agent API.

Validation: 121 focused Inspector tests and 16 CLI tests pass, including a real CLI process talking to a loopback cloud endpoint and downloading a screenshot/invoking WebMCP. SDK and CLI builds pass. Full app typecheck is not clean (repository-wide diagnostics, including the existing ComputerStatus/sleeping mismatch in the reused lifecycle helper); no diagnostics were reported in the new API module. Live E2B/staging smoke test not run. Draft pending cross-repo review and that smoke test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets coding agents drive isolated cloud browsers with `mcpjam browser --cloud` and a bearer-authenticated v1 API, backed by the shared hosted browser lifecycle. Each runKey gets its own persistent browser; commands wake it on demand, and close releases it.

**What's included**
- CLI supports open/list, navigate/back/forward/reload, act, observe/screenshots, WebMCP invocation, note, trace, and close.
- Durable admission prevents replay after transport failures; transport uncertainty returns `unknown`, provisioning failures are explicit refusals.
- Uses existing cloud login/API key and remembers sessions per deployment/project without sending local consent.
- WebMCP page tools are gated only when approval is enabled; with approval off, clients fulfill them directly.

**Rollout**
- Depends on backend PR `MCPJam/mcpjam-backend#1306` — deploy backend first.
- Publish `@mcpjam/sdk` before `@mcpjam/cli`.
- Usage and limits documented in `mcpjam-inspector/docs/cloud-agent-browser.md`.
- Saved-profile selection and attaching to an existing Playground browser are not exposed in this initial API.

<sup>Written for commit 1855a88f58f54222283181a064d18719db292ed7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New authenticated API provisions remote desktops and executes browser commands with durable admission; mis-handled `unknown`/`command-id` retries or backend ordering could cause duplicate actions or failed provisioning in production.
> 
> **Overview**
> Adds **`mcpjam browser --cloud`** so coding agents drive **isolated hosted browsers** via bearer auth (`--api-url` / `--api-key` or existing cloud login), without local Inspector consent. The CLI routes through **`PlatformApiClient.browserSession`**, remembers sessions per **deployment + project**, fetches cloud screenshots via the artifact API, and extends commands with **`sessions`**, **`back` / `forward` / `reload`**, and **`invoke`** (WebMCP).
> 
> Ships a new **v1 `POST /browser-sessions/*`** surface (documented in OpenAPI) that opens sessions through Convex **`/agent-browser/*`**, **claims** commands for durable idempotency (pending claims return **`unknown`**, never replay), enforces stored **policy** before provisioning, provisions via the shared **`ensureHostedConversationSession`** path, and maps daemon outcomes through the existing agent contract (including **`browser_unavailable`** on provisioning failure).
> 
> Minor related fixes: **page tools** are gated with `needsApproval` only when the user requires tool approval; SDK coverage ratchet maps the new routes to **`browserSession`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1855a88f58f54222283181a064d18719db292ed7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->