### PR TITLE
Attach Browser directly and offer local consent in its panel

### DIFF
--- a/mcpjam-inspector/client/src/components/browser/LocalBrowserBody.tsx
+++ b/mcpjam-inspector/client/src/components/browser/LocalBrowserBody.tsx
@@ -8,6 +8,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { PaneMessage } from "@/components/computer/PaneMessage";
+import { LocalComputerConsentGate } from "@/components/computer/LocalComputerConsentGate";
+import { useLocalComputerConsent } from "@/hooks/useLocalComputerConsent";
 import {
   BrowserPaneSurface,
   type PaneControl,
@@ -138,6 +140,7 @@ export function LocalBrowserBody({
   active?: boolean;
 }) {
   const workspaceEnabled = useBrowserWorkspaceEnabled();
+  const { grant: grantConsent } = useLocalComputerConsent();
   const [status, setStatus] = useState<LocalBrowserStatus | null>(null);
   const [session, setSession] = useState<{ bootId: string } | null>(null);
   const [lease, setLease] = useState<LocalBrowserLease>({ state: "free" });
@@ -884,13 +887,14 @@ export function LocalBrowserBody({
    */
   const placeholder = (() => {
     if (!consentGranted) {
-      // A pointer, not a second consent gate: the Computer tab owns the grant.
       return (
         <PaneMessage dashed>
-          <span data-testid="rail-browser-unconsented">
-            This machine isn&apos;t authorized yet. Open the Computer tab to
-            allow the agent to use it.
-          </span>
+          <div data-testid="rail-browser-unconsented">
+            <LocalComputerConsentGate
+              onAllow={grantConsent}
+              location="playground_browser"
+            />
+          </div>
         </PaneMessage>
       );
     }

--- a/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserBody.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserBody.test.tsx
@@ -2,6 +2,11 @@ import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+const grantConsent = vi.hoisted(() => vi.fn(async () => true));
+vi.mock("@/hooks/useLocalComputerConsent", () => ({
+  useLocalComputerConsent: () => ({ grant: grantConsent }),
+}));
+
 const api = vi.hoisted(() => ({
   workspaceEnabled: true,
   status: {
@@ -210,9 +215,27 @@ function renderBody(over: Record<string, unknown> = {}) {
 }
 
 describe("the agent browser pane", () => {
-  it("points at the Computer tab instead of asking for consent twice", async () => {
+  it("grants shared device consent from the Browser panel", async () => {
     renderBody({ consentGranted: false });
     expect(await screen.findByTestId("rail-browser-unconsented")).toBeTruthy();
+    expect(screen.queryByText(/Open the Computer tab/)).toBeNull();
+    expect(
+      screen.getByText(/permission covers both commands and browser control/),
+    ).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Allow" }));
+    expect(grantConsent).toHaveBeenCalled();
+    expect(api.ensures).toEqual([]);
+  });
+
+  it("shows a failed grant inline and allows retry", async () => {
+    grantConsent.mockResolvedValueOnce(false);
+    renderBody({ consentGranted: false });
+    await userEvent.click(await screen.findByRole("button", { name: "Allow" }));
+    expect(await screen.findByTestId("consent-error")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Allow" }));
+    await waitFor(() =>
+      expect(screen.queryByTestId("consent-error")).toBeNull(),
+    );
   });
 
   it("offers the download when this machine has no Chromium", async () => {

--- a/mcpjam-inspector/client/src/components/computer/LocalComputerConsentGate.tsx
+++ b/mcpjam-inspector/client/src/components/computer/LocalComputerConsentGate.tsx
@@ -4,10 +4,9 @@ import { Button } from "@mcpjam/design-system/button";
 import { track } from "@/lib/analytics";
 
 /**
- * First-run consent for the local computer engine. Allowing it grants the
- * device capability (see `useLocalComputerConsent`) that lets agents run bash
- * — and, once the terminal ships, a shell — on THIS machine as the user's own
- * account. Deliberately blunt about that: it is not a sandbox.
+ * Shared device consent for local commands and agent browser control. Both
+ * surfaces use the same grant (see `useLocalComputerConsent`); this dialog
+ * describes that scope regardless of which surface opens it.
  *
  * `onUseCloud` is shown only when a cloud computer is also available, so a
  * pure-local inspector doesn't offer a fallback that doesn't exist.
@@ -15,9 +14,11 @@ import { track } from "@/lib/analytics";
 export function LocalComputerConsentGate({
   onAllow,
   onUseCloud,
+  location = "computer_tab_local",
 }: {
   onAllow: () => Promise<boolean> | boolean;
   onUseCloud?: () => void;
+  location?: "computer_tab_local" | "playground_browser";
 }) {
   const [granting, setGranting] = useState(false);
   const [error, setError] = useState(false);
@@ -29,10 +30,10 @@ export function LocalComputerConsentGate({
   const cloudOffered = !!onUseCloud;
   useEffect(() => {
     track("local_computer_consent_gate_shown", {
-      location: "computer_tab_local",
+      location,
       cloud_offered: cloudOffered,
     });
-  }, [cloudOffered]);
+  }, [cloudOffered, location]);
 
   const handleAllow = async () => {
     setGranting(true);
@@ -41,13 +42,13 @@ export function LocalComputerConsentGate({
       const ok = await onAllow();
       if (!ok) setError(true);
       track("local_computer_consent_granted", {
-        location: "computer_tab_local",
+        location,
         outcome: ok ? "stored" : "failed",
       });
     } catch {
       setError(true);
       track("local_computer_consent_granted", {
-        location: "computer_tab_local",
+        location,
         outcome: "failed",
       });
     } finally {
@@ -56,7 +57,7 @@ export function LocalComputerConsentGate({
   };
 
   const handleUseCloud = () => {
-    track("local_computer_consent_denied", { location: "computer_tab_local" });
+    track("local_computer_consent_denied", { location });
     onUseCloud?.();
   };
 
@@ -67,17 +68,22 @@ export function LocalComputerConsentGate({
     >
       <ShieldQuestion className="size-6 text-muted-foreground" aria-hidden />
       <h2 className="text-base font-semibold text-foreground">
-        Allow agents to run commands on this machine?
+        Allow agents to run commands and control a browser on this machine?
       </h2>
       <p className="text-sm leading-relaxed text-muted-foreground">
-        The bash tool runs real commands on this computer, as your user
-        account. The project folder is only a starting directory, not a
-        sandbox — commands can read or change any files and credentials your
-        user can access. Each agent command still asks for approval in chat
-        before it runs.
+        Enabled tools can run commands and control a browser as your user
+        account, including websites you sign into in that browser. This device
+        permission covers both commands and browser control; it does not enable
+        the Bash tool on this host. The project folder is not a sandbox —
+        commands can read or change files and credentials your user can access.
+        Chat approval settings still apply.
       </p>
       <div className="mt-1 flex items-center gap-2">
-        <Button size="sm" onClick={() => void handleAllow()} disabled={granting}>
+        <Button
+          size="sm"
+          onClick={() => void handleAllow()}
+          disabled={granting}
+        >
           {granting ? "Allowing…" : "Allow"}
         </Button>
         {onUseCloud ? (
@@ -93,8 +99,8 @@ export function LocalComputerConsentGate({
       </div>
       {error ? (
         <p className="text-xs text-destructive" data-testid="consent-error">
-          Couldn't enable the local computer. Check that you're signed in and
-          try again.
+          Couldn't authorize this machine. Check that you're signed in and try
+          again.
         </p>
       ) : null}
     </div>

--- a/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.test.tsx
@@ -103,7 +103,7 @@ describe("LocalComputerView", () => {
       expect(screen.getByTestId("consent-error")).toBeInTheDocument(),
     );
     expect(screen.getByTestId("consent-error").textContent).toMatch(
-      /Couldn't enable the local computer/i,
+      /Couldn't authorize this machine/i,
     );
     expect(setEngine).not.toHaveBeenCalled();
   });

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ComputerTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ComputerTab.tsx
@@ -5,7 +5,6 @@ import type { HostConfigInputV2 } from "@/lib/client-config-v2";
 import { FieldRow, FocusBlock } from "./primitives";
 import { useBuiltInToolCatalog } from "@/hooks/useBuiltInToolCatalog";
 import { HARNESS_DISPLAY_NAME } from "@/lib/harness-capabilities";
-import { BrowserProfilePicker } from "./BrowserProfilePicker";
 import {
   attachComputerPatch,
   detachComputerPatch,
@@ -37,7 +36,6 @@ interface ComputerTabProps {
  * (see `detachComputerPatch`).
  */
 export function ComputerTab({
-  projectId,
   draft,
   onDraftChange,
   readOnly = false,
@@ -135,18 +133,6 @@ export function ComputerTab({
             }
           />
         )}
-        <FieldRow
-          label="Browser profile"
-          description="Optionally pin a saved browser profile for this host. Without a pin, new chats use your selected default profile."
-          control={
-            <BrowserProfilePicker
-              projectId={projectId}
-              value={draft.browserProfileId}
-              onChange={(browserProfileId) => update({ browserProfileId })}
-              disabled={readOnly}
-            />
-          }
-        />
       </FocusBlock>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusDialog.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusDialog.tsx
@@ -266,7 +266,11 @@ export function HostFocusDialog({
               />
             ) : null}
             {activeTab === "tools" ? (
-              <ToolsTab draft={draft} onDraftChange={onDraftChange} />
+              <ToolsTab
+                projectId={projectId}
+                draft={draft}
+                onDraftChange={onDraftChange}
+              />
             ) : null}
             {activeTab === "computer" ? (
               <ComputerTab

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusPanel.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusPanel.tsx
@@ -170,7 +170,11 @@ export function HostFocusPanel({
           />
         ) : null}
         {activeTab === "tools" ? (
-          <ToolsTab draft={draft} onDraftChange={onDraftChange} />
+          <ToolsTab
+            projectId={projectId}
+            draft={draft}
+            onDraftChange={onDraftChange}
+          />
         ) : null}
         {activeTab === "computer" ? (
           <ComputerTab

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ToolsTab.tsx
@@ -1,5 +1,6 @@
 import type { HostConfigInputV2 } from "@/lib/client-config-v2";
-import { FocusBlock } from "./primitives";
+import { FieldRow, FocusBlock } from "./primitives";
+import { BrowserProfilePicker } from "./BrowserProfilePicker";
 import { useBuiltInToolCatalog } from "@/hooks/useBuiltInToolCatalog";
 import { BuiltInToolCheckboxList } from "@/components/client-config/BuiltInToolCheckboxList";
 import { visibleBuiltInToolCatalog } from "@/lib/host-config-computer";
@@ -7,6 +8,7 @@ import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { useHarnessBuiltinToolCatalog } from "@/hooks/useHarnessBuiltinTools";
 
 interface ToolsTabProps {
+  projectId?: string;
   draft: HostConfigInputV2;
   onDraftChange: (
     updater: (prev: HostConfigInputV2) => HostConfigInputV2,
@@ -27,6 +29,7 @@ interface ToolsTabProps {
  * to the Computer tab).
  */
 export function ToolsTab({
+  projectId,
   draft,
   onDraftChange,
   readOnly = false,
@@ -66,6 +69,23 @@ export function ToolsTab({
           onChange={(builtInToolIds) => update({ builtInToolIds })}
         />
       </FocusBlock>
+
+      {(draft.builtInToolIds.includes("browser") || draft.browserProfileId) && (
+        <FocusBlock title="Browser">
+          <FieldRow
+            label="Browser profile"
+            description="Optionally pin a saved browser profile for this host. Without a pin, new chats use your selected default profile."
+            control={
+              <BrowserProfilePicker
+                projectId={projectId}
+                value={draft.browserProfileId}
+                onChange={(browserProfileId) => update({ browserProfileId })}
+                disabled={readOnly}
+              />
+            }
+          />
+        </FocusBlock>
+      )}
 
       {draft.harness && (
         <FocusBlock

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ToolsComputerTabs.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ToolsComputerTabs.test.tsx
@@ -1,11 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
 
 // Catalog with one GA tool (Web Search) plus a computer-backed tool (Bash),
 // so we can exercise both the plain row and the requiresComputer gating.
 vi.mock("@/hooks/useBuiltInToolCatalog", () => ({
   useBuiltInToolCatalog: () => [
+    {
+      id: "browser",
+      displayLabel: "Browser",
+      description: "Browse",
+      category: "code",
+      billable: false,
+      requiresComputer: false,
+    },
     {
       id: "web_search",
       displayLabel: "Web Search",
@@ -22,6 +30,20 @@ vi.mock("@/hooks/useBuiltInToolCatalog", () => ({
       requiresComputer: true,
     },
   ],
+}));
+vi.mock("../BrowserProfilePicker", () => ({
+  BrowserProfilePicker: ({ projectId, value, onChange, disabled }: any) => (
+    <select
+      aria-label="Browser profile"
+      data-project={projectId}
+      value={value ?? ""}
+      onChange={(event) => onChange(event.target.value || undefined)}
+      disabled={disabled}
+    >
+      <option value="">Default</option>
+      <option value="profile-1">Saved</option>
+    </select>
+  ),
 }));
 // Flag on so computer-backed rows (Bash) are visible in the Tools tab.
 vi.mock("posthog-js/react", () => ({
@@ -57,6 +79,38 @@ import { ToolsTab } from "../ToolsTab";
 import { ComputerTab } from "../ComputerTab";
 
 describe("ToolsTab", () => {
+  it("enables Browser without a computer and edits its profile from Tools", () => {
+    const onDraftChange = vi.fn();
+    const draft = emptyHostConfigInputV2({ builtInToolIds: ["browser"] });
+    render(
+      <ToolsTab
+        projectId="project-1"
+        draft={draft}
+        onDraftChange={onDraftChange}
+      />,
+    );
+    expect(screen.getByRole("switch", { name: "Browser" })).toBeEnabled();
+    const picker = screen.getByRole("combobox", { name: "Browser profile" });
+    expect(picker).toHaveAttribute("data-project", "project-1");
+    fireEvent.change(picker, { target: { value: "profile-1" } });
+    const updated = onDraftChange.mock.calls[0][0](draft);
+    expect(updated.browserProfileId).toBe("profile-1");
+    expect(updated.computer).toBeUndefined();
+  });
+
+  it("disables the profile picker for read-only hosts", () => {
+    render(
+      <ToolsTab
+        projectId="project-1"
+        draft={emptyHostConfigInputV2({ builtInToolIds: ["browser"] })}
+        onDraftChange={vi.fn()}
+        readOnly
+      />,
+    );
+    expect(
+      screen.getByRole("combobox", { name: "Browser profile" }),
+    ).toBeDisabled();
+  });
   it("renders system tools as minimal switch rows", () => {
     render(
       <ToolsTab draft={emptyHostConfigInputV2()} onDraftChange={vi.fn()} />,

--- a/mcpjam-inspector/client/src/lib/__tests__/host-config-computer.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-config-computer.test.ts
@@ -145,7 +145,7 @@ describe("shouldShowComputerToggle", () => {
       shouldShowComputerToggle({
         catalogHasComputerBackedTool: true,
         computerAttached: false,
-      })
+      }),
     ).toBe(true);
   });
 
@@ -154,7 +154,7 @@ describe("shouldShowComputerToggle", () => {
       shouldShowComputerToggle({
         catalogHasComputerBackedTool: false,
         computerAttached: true,
-      })
+      }),
     ).toBe(true);
   });
 
@@ -163,7 +163,7 @@ describe("shouldShowComputerToggle", () => {
       shouldShowComputerToggle({
         catalogHasComputerBackedTool: false,
         computerAttached: false,
-      })
+      }),
     ).toBe(false);
   });
 
@@ -173,18 +173,49 @@ describe("shouldShowComputerToggle", () => {
         catalogHasComputerBackedTool: true,
         computerAttached: true,
         disallowed: true,
-      })
+      }),
     ).toBe(false);
   });
 });
 
 describe("visibleBuiltInToolCatalog", () => {
+  it("keeps Browser in the rollout cohort without requiring a computer", () => {
+    const browser = { ...CATALOG[1], id: "browser", requiresComputer: false };
+    expect(
+      visibleBuiltInToolCatalog([browser], {
+        computersEnabled: false,
+        selectedIds: [],
+      }),
+    ).toEqual([]);
+    expect(
+      visibleBuiltInToolCatalog([browser], {
+        computersEnabled: true,
+        selectedIds: [],
+      }),
+    ).toEqual([browser]);
+    expect(
+      visibleBuiltInToolCatalog([browser], {
+        computersEnabled: false,
+        selectedIds: ["browser"],
+      }),
+    ).toEqual([browser]);
+    const draft = emptyHostConfigInputV2({
+      computer: { kind: "personal" },
+      builtInToolIds: ["browser"],
+    });
+    expect(detachComputerPatch(draft, [browser]).builtInToolIds).toEqual([
+      "browser",
+    ]);
+    expect(
+      sanitizeHostConfigForEvalSuite(draft, [browser]).builtInToolIds,
+    ).toEqual(["browser"]);
+  });
   it("returns the catalog unchanged when the computers flag is on", () => {
     expect(
       visibleBuiltInToolCatalog(CATALOG, {
         computersEnabled: true,
         selectedIds: [],
-      })
+      }),
     ).toBe(CATALOG);
   });
 
@@ -193,7 +224,7 @@ describe("visibleBuiltInToolCatalog", () => {
       visibleBuiltInToolCatalog(CATALOG, {
         computersEnabled: false,
         selectedIds: [],
-      })
+      }),
     ).toEqual([CATALOG[0]]);
   });
 
@@ -202,7 +233,7 @@ describe("visibleBuiltInToolCatalog", () => {
       visibleBuiltInToolCatalog(CATALOG, {
         computersEnabled: false,
         selectedIds: ["bash"],
-      })
+      }),
     ).toEqual(CATALOG);
   });
 
@@ -211,7 +242,7 @@ describe("visibleBuiltInToolCatalog", () => {
       visibleBuiltInToolCatalog(undefined, {
         computersEnabled: false,
         selectedIds: [],
-      })
+      }),
     ).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/lib/host-config-computer.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-computer.ts
@@ -71,7 +71,11 @@ export function visibleBuiltInToolCatalog(
 ): ReadonlyArray<BuiltInToolCatalogEntry> | undefined {
   if (catalog === undefined || opts.computersEnabled) return catalog;
   const selected = new Set(opts.selectedIds);
-  return catalog.filter((t) => !t.requiresComputer || selected.has(t.id));
+  // Browser no longer needs a computer attachment, but authoring still uses
+  // the same rollout cohort as hosted desktop provisioning.
+  return catalog.filter(
+    (t) => (!t.requiresComputer && t.id !== "browser") || selected.has(t.id),
+  );
 }
 
 /** Patch that attaches a personal computer (the only MVP resource shape). */

--- a/mcpjam-inspector/docs/browser-attachment-launch.md
+++ b/mcpjam-inspector/docs/browser-attachment-launch.md
@@ -1,0 +1,92 @@
+# Browser attachment launch
+
+September 9, 2026. Backend first, then Inspector. This is the launch subset of
+the broader browser-attachment proposal.
+
+## Behavior in this change
+
+- A host can select Browser in Tools without attaching Computer. The saved
+  browser profile is edited in Tools too.
+- Browser authoring stays in the existing `computers-enabled` cohort. The
+  backend has an explicit `browser` gate aliased to that flag, including partial
+  host edits. Do not widen authoring independently of desktop reservation and
+  the `projectComputers` entitlement.
+- The local Browser panel offers the existing device-consent dialog directly.
+  Its copy explicitly covers commands and browser control. There is one device
+  grant; existing consent continues working. Granting does not enable Bash on
+  the host, and Browser+Bash remains an invalid authored combination.
+- Eval snapshots allocate an ephemeral resource for Browser-only hosts and
+  preserve their unattended policy. Journey desktop provisioning already uses
+  Browser intent; its estimates now include desktop time without a Computer
+  attachment.
+- Existing Browser+Computer configurations remain valid. No SDK field, schema
+  migration, historical-config rewrite, or consent protocol is introduced.
+
+## Deployment checklist
+
+1. Deploy the backend catalog change and explicit Browser gate together. They
+   must not ship separately: removing `requiresComputer` without the gate opens
+   authoring outside the intended cohort. Include the eval/snapshot changes.
+2. Deploy the companion Inspector change. Refresh the built-in catalog in an
+   already-open client before testing. An old backend still reports the Computer
+   prerequisite; do not override that verdict client-side.
+3. For hosted Browser, verify the backend desktop template and positive desktop
+   credit rate via `projectComputers.getDesktopRuntimeTemplateConfig` / the deployment's
+   runtime configuration. The relevant internal setters are
+   `projectComputers.setDesktopRuntimeTemplate` and
+   `projectComputers.setDesktopRuntimeRate`. Verify the configured desktop image
+   actually contains the expected browserd/browser runtime.
+4. Verify the Inspector data plane is configured and
+   `HOSTED_BROWSER_TOOLS_ENABLED=1` on serving replicas. Confirm the backend
+   hosted-browser exposure verdict is available, including template and rate.
+5. Target the launch users/orgs with `computers-enabled` and the appropriate
+   computer entitlement. There is no new Browser-authoring PostHog key in this
+   release. `browser-workspace-enabled` selects the expanded workspace; when
+   false, the Browser remains available in the right rail.
+6. For the local agent browser, confirm `local-computer-enabled`, the existing
+   local computer engine, and `MCPJAM_LOCAL_BROWSER_ENABLED` are enabled, the
+   account is signed in, and Chromium is installed (or Electron supplies it).
+   This release still inherits Bash availability and the local computer switch
+   through the existing engine resolver. It removes the **host attachment**
+   prerequisite, not those local runtime dependencies.
+7. If WebMCP Inspector is also part of the launch, verify
+   `webmcp-inspector-enabled`, `MCPJAM_WEBMCP_INSPECTOR_ENABLED`, and, for hosted,
+   `MCPJAM_WEBMCP_INSPECTOR_HOSTED_ENABLED=1`. Its hosted transport still reserves
+   a member desktop with its own flag/entitlement checks. Local WebMCP launches
+   Playwright directly and its consent model is unchanged by this PR.
+
+Do not log or paste runtime credentials while checking configuration. These PRs
+do not change deployment flags, rates, templates, or entitlements themselves.
+
+## Release smoke checks
+
+- Fresh host, no Computer: Browser is selectable for the cohort, Bash remains
+  blocked without Computer, the host saves, and its Browser profile picker works.
+- A user outside the cohort cannot create or patch in Browser via the API. A
+  de-flagged user can remove Browser or edit an unrelated field.
+- Fresh signed-in local installation in the launch cohort: Browser panel →
+  Allow → install if necessary → Open browser. No visit to Computer is needed;
+  the permission text describes the actual shared grant. Existing grants do not
+  cause a second prompt. Failed grants offer an inline retry.
+- Hosted Browser-only host: open a conversation, launch/navigate, reload and
+  reconnect, and confirm ownership, idle behavior, and metering still work.
+- Browser-only eval and journey with an explicit unattended policy: confirm a
+  per-run desktop is provisioned and Browser tools are usable. Policy-less runs
+  must not gain unrestricted browser access.
+- Legacy Browser+Computer host still loads and runs; Browser+Bash still fails
+  authored-config validation.
+
+Unit/integration tests cover catalog validation, feature-gated direct and patch
+writes, eval resource/policy snapshots, journey snapshot/provisioning/cost
+behavior, editor visibility/profile editing, and the inline consent entry point.
+Real local, Electron, and hosted smoke checks remain release verification; unit
+tests do not substitute for them.
+
+## Follow-ups
+
+Browser-specific local engine selection (including the unused `browserAvailable`
+bit), scoped browser consent and revocation, standalone OSS admission, preference
+migration, sandbox-image relabeling, and hosted WebMCP conversation desktops are
+separate changes. Account verification and the shared device grant remain in
+place for launch. In particular, this release does not claim Browser works with
+the local shell engine disabled or without a configured account.

--- a/mcpjam-inspector/docs/browser-attachment-launch.md
+++ b/mcpjam-inspector/docs/browser-attachment-launch.md
@@ -30,6 +30,10 @@ the broader browser-attachment proposal.
 2. Deploy the companion Inspector change. Refresh the built-in catalog in an
    already-open client before testing. An old backend still reports the Computer
    prerequisite; do not override that verdict client-side.
+   Older packaged/Electron clients derive Browser visibility from the catalog's
+   Computer prerequisite alone: after the backend deploy, they may show Browser
+   outside the cohort, but saving is still rejected by the backend gate. Those
+   installations need a client upgrade, not just a catalog refresh.
 3. For hosted Browser, verify the backend desktop template and positive desktop
    credit rate via `projectComputers.getDesktopRuntimeTemplateConfig` / the deployment's
    runtime configuration. The relevant internal setters are
@@ -70,9 +74,10 @@ do not change deployment flags, rates, templates, or entitlements themselves.
   cause a second prompt. Failed grants offer an inline retry.
 - Hosted Browser-only host: open a conversation, launch/navigate, reload and
   reconnect, and confirm ownership, idle behavior, and metering still work.
-- Browser-only eval and journey with an explicit unattended policy: confirm a
-  per-run desktop is provisioned and Browser tools are usable. Policy-less runs
-  must not gain unrestricted browser access.
+- Browser-only eval and journey: first author an explicit `browserToolPolicy`
+  through the SDK/API (there is no policy editor in the UI for this launch),
+  then confirm a per-run desktop is provisioned and Browser tools are usable.
+  Policy-less runs must not gain unrestricted browser access.
 - Legacy Browser+Computer host still loads and runs; Browser+Bash still fails
   authored-config validation.
 


### PR DESCRIPTION
Depends on https://github.com/MCPJam/mcpjam-backend/pull/1307 — deploy the backend first.

Make Browser attachable directly from host Tools without a Computer attachment, and let local users authorize the existing shared device grant inside the Browser panel.

- Preserve the existing computers rollout cohort even though Browser no longer has a catalog Computer prerequisite. The backend catalog still owns attachment validation; this client does not override an old backend.
- Move the saved Browser profile picker from Computer to Tools, including project scoping and read-only behavior.
- Offer the shared consent dialog inline in the Browser panel with retry on failure. Reword it to explicitly cover commands and browser control; granting permission does not enable Bash on the host. Existing grants remain valid.
- Document backend-first rollout, template/rate/flag/entitlement checks, smoke tests, and deferred work in `mcpjam-inspector/docs/browser-attachment-launch.md`.

Validation:

- Targeted editor, visibility, Browser panel, consent, analytics, and Playground tests passed (70 tests in the focused run; 277 in the wider regression run, with overlap).
- Client typecheck/renderer guard and design parity checks passed. Design lint reports zero errors and existing warnings.
- Real local, Electron, and hosted launch smoke checks have not been run; the release checklist calls them out explicitly.

Scope: this removes the host-attachment prerequisite, not the existing local-engine eligibility. The local computer switch, Bash availability, account verification, and shared device grant still apply. Browser-specific engine selection, scoped browser consent, standalone OSS admission, and WebMCP transport changes are deferred. No deployment settings are changed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes host tool authoring, feature-gated Browser visibility, and local device consent entry points; mis-deployed backend/client pairs could expose or reject Browser authoring incorrectly.
> 
> **Overview**
> Hosts can enable **Browser** from **Tools** without attaching **Computer**, and the saved **browser profile** picker moves from the Computer tab to Tools (shown when Browser is selected or a profile is already pinned). Client catalog visibility keeps Browser in the existing `computers-enabled` cohort even though it no longer requires a computer attachment.
> 
> The Playground **Browser** rail replaces the “open the Computer tab” message with the shared **`LocalComputerConsentGate`**, including inline retry on failed grants. Consent copy and analytics now distinguish **commands + browser control** via a `location` prop (`playground_browser` vs `computer_tab_local`); granting still does not turn on Bash on the host.
> 
> Adds **`browser-attachment-launch.md`** with backend-first rollout, smoke checks, and follow-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bb10cfd78181e02316cfc8565e314113940dc13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets hosts attach Browser directly from Tools without a Computer attachment, and moves the saved profile picker there. The Browser panel now offers the shared device-consent dialog inline instead of pointing users to the Computer tab.

**Migration**
- Deploy the backend catalog and Browser gate change first; the client preserves the existing computers rollout cohort and defers to an old backend's verdict.
- Existing consent grants remain valid. The updated dialog covers commands and browser control and clarifies that it does not enable Bash.
- Rollout, smoke-check, and follow-up steps are captured in `docs/browser-attachment-launch.md`.

<sup>Written for commit 7bb10cfd78181e02316cfc8565e314113940dc13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

