### PR TITLE
fix(changeset): drop the ignored @mcpjam/mcp from a mixed changeset

### DIFF
--- a/.changeset/uvc-server-facts-agent-surface.md
+++ b/.changeset/uvc-server-facts-agent-surface.md
@@ -1,7 +1,6 @@
 ---
 "@mcpjam/sdk": minor
 "@mcpjam/cli": minor
-"@mcpjam/mcp": minor
 "@mcpjam/inspector": patch
 ---
 


### PR DESCRIPTION
- The release preflight dies at `npx changeset status` with "Found mixed changeset uvc-server-facts-agent-surface".
- That changeset lists `@mcpjam/mcp`, which is in the ignore list in `.changeset/config.json`. Changesets refuses a file that mixes ignored and non-ignored packages.
- This removes the one `"@mcpjam/mcp": minor` line. The package is never versioned or published either way, so nothing changes about the release except that the gate passes.
- The changeset came in with #4800; the sdk, cli and inspector bumps in it are untouched.
- `changeset status` now succeeds: minor for sdk, cli and inspector, patch for chat-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `@mcpjam/mcp` from the `uvc-server-facts-agent-surface` changeset so the release preflight's `changeset status` no longer fails on a mixed changeset. The package is in the ignore list and is never versioned or published, so the release output is unchanged aside from the gate now passing.

<sup>Written for commit e4ab5fd08add34ab832a245835775aa2eb45c7a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

