### PR TITLE
Run GitHub checks against OAuth servers

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
@@ -8,6 +8,8 @@ const {
   mockBindings,
   mockConnectRepo,
   mockSetRepoForkCredentials,
+  mockSetRepoPrServerOAuth,
+  mockPrServerOAuthSources,
   mockConnectVerifiedRepo,
   mockListInstallationRepos,
   mockNavigate,
@@ -27,6 +29,10 @@ const {
   mockSetRepoForkCredentials: vi.fn(async (_args?: unknown) => ({
     changed: true,
   })),
+  mockSetRepoPrServerOAuth: vi.fn(async (_args?: unknown) => ({
+    changed: true,
+  })),
+  mockPrServerOAuthSources: { value: [] as any[] },
   mockConnectRepo: vi.fn(async () => ({ configId: "cfg-legacy" })),
   // Loosely typed for the same reason as the settings-route suite: these stand
   // in for Convex actions whose arguments are hand-mirrored, and a narrow
@@ -60,8 +66,10 @@ vi.mock("@/hooks/useGithubChecksSettings", () => ({
     availability: mockAvailability.value,
     repos: mockRepos.value,
     bindings: mockBindings.value,
+    prServerOAuthSources: mockPrServerOAuthSources.value,
     connectRepo: mockConnectRepo,
     setRepoForkCredentials: mockSetRepoForkCredentials,
+    setRepoPrServerOAuth: mockSetRepoPrServerOAuth,
     connectVerifiedRepo: mockConnectVerifiedRepo,
     listInstallationRepos: mockListInstallationRepos,
   }),
@@ -80,6 +88,7 @@ const CONNECTED_HERE = {
   repoFullName: "mcpjam/mcp-check-fixture",
   enabled: true,
   suiteId: "suite-1",
+  projectId: "proj-1",
 };
 const CONNECTED_ELSEWHERE = {
   _id: "cfg-2",
@@ -490,6 +499,32 @@ it("the suite section edits the same repository credential policy", async () => 
   expect(mockSetRepoForkCredentials).toHaveBeenCalledWith({
     configId: CONNECTED_HERE._id,
     enabled: true,
+  });
+});
+
+it("the suite section selects an authorized OAuth source", async () => {
+  mockPrServerOAuthSources.value = [
+    {
+      serverId: "server-oauth",
+      projectId: "proj-1",
+      name: "Test OAuth server",
+      authorized: true,
+    },
+  ];
+  renderSection({
+    availability: { state: "enabled", canManage: true },
+    repos: [{ ...CONNECTED_HERE, connectionStatus: "verified" }],
+  });
+
+  await chooseOption(
+    userEvent.setup(),
+    `Server authentication for ${CONNECTED_HERE.repoFullName}`,
+    "Test OAuth server",
+  );
+
+  expect(mockSetRepoPrServerOAuth).toHaveBeenCalledWith({
+    configId: CONNECTED_HERE._id,
+    sourceServerId: "server-oauth",
   });
 });
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
@@ -528,6 +528,84 @@ it("the suite section selects an authorized OAuth source", async () => {
   });
 });
 
+it("keeps each repository OAuth selector busy independently", async () => {
+  let resolveFirst: ((value: unknown) => void) | undefined;
+  let resolveSecond: ((value: unknown) => void) | undefined;
+  mockSetRepoPrServerOAuth
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    )
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSecond = resolve;
+        }),
+    );
+  mockPrServerOAuthSources.value = [
+    {
+      serverId: "server-oauth",
+      projectId: "proj-1",
+      name: "Test OAuth server",
+      authorized: true,
+    },
+  ];
+  const second = {
+    ...CONNECTED_HERE,
+    _id: "cfg-2",
+    repoFullName: "mcpjam/second-fixture",
+  };
+  const user = userEvent.setup();
+  renderSection({
+    availability: { state: "enabled", canManage: true },
+    repos: [CONNECTED_HERE, second],
+  });
+  const firstLabel = `Server authentication for ${CONNECTED_HERE.repoFullName}`;
+  const secondLabel = `Server authentication for ${second.repoFullName}`;
+
+  await chooseOption(user, firstLabel, "Test OAuth server");
+  await chooseOption(user, secondLabel, "Test OAuth server");
+  expect(screen.getByLabelText(firstLabel)).toBeDisabled();
+  expect(screen.getByLabelText(secondLabel)).toBeDisabled();
+
+  await act(async () => resolveSecond?.({ changed: true }));
+  await waitFor(() => expect(screen.getByLabelText(secondLabel)).toBeEnabled());
+  expect(screen.getByLabelText(firstLabel)).toBeDisabled();
+  await act(async () => resolveFirst?.({ changed: true }));
+});
+
+it("does not toast when an OAuth write fails after the suite section is gone", async () => {
+  let rejectWrite: ((error: unknown) => void) | undefined;
+  mockSetRepoPrServerOAuth.mockImplementationOnce(
+    () =>
+      new Promise((_resolve, reject) => {
+        rejectWrite = reject;
+      }),
+  );
+  mockPrServerOAuthSources.value = [
+    {
+      serverId: "server-oauth",
+      projectId: "proj-1",
+      name: "Test OAuth server",
+      authorized: true,
+    },
+  ];
+  const { unmount } = renderSection({
+    availability: { state: "enabled", canManage: true },
+    repos: [CONNECTED_HERE],
+  });
+  await chooseOption(
+    userEvent.setup(),
+    `Server authentication for ${CONNECTED_HERE.repoFullName}`,
+    "Test OAuth server",
+  );
+  unmount();
+  await act(async () => rejectWrite?.(new Error("stale failure")));
+  expect(mockToast.error).not.toHaveBeenCalled();
+});
+
 it("the suite section keeps credential controls disabled for a member", () => {
   renderSection({
     availability: { state: "enabled", canManage: false },

--- a/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
@@ -66,8 +66,10 @@ export function SuiteGithubChecksSection({
     availability,
     repos,
     bindings,
+    prServerOAuthSources,
     connectVerifiedRepo,
     setRepoForkCredentials,
+    setRepoPrServerOAuth,
     listInstallationRepos,
   } = useGithubChecksSettings(organizationId);
 
@@ -80,6 +82,7 @@ export function SuiteGithubChecksSection({
     GithubCheckOutagePolicy | ""
   >("");
   const [connecting, setConnecting] = useState(false);
+  const [oauthBusy, setOauthBusy] = useState<string | null>(null);
 
   // Whether this instance is still on screen. The `ErrorBoundary` wrapping this
   // section in `suite-iterations-view` is KEYED BY organizationId, so switching
@@ -269,6 +272,57 @@ export function SuiteGithubChecksSection({
                 canManage={availability?.canManage === true}
                 onChange={setRepoForkCredentials}
               />
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-xs text-muted-foreground">
+                  Server authentication
+                </span>
+                <Select
+                  value={row.prServerOAuthSourceServerId ?? "none"}
+                  disabled={
+                    oauthBusy === row._id || availability?.canManage !== true
+                  }
+                  onValueChange={(value) => {
+                    setOauthBusy(row._id);
+                    void setRepoPrServerOAuth({
+                      configId: row._id,
+                      sourceServerId: value === "none" ? null : value,
+                    })
+                      .catch((error) =>
+                        toast.error(githubChecksWriteErrorMessage(error)),
+                      )
+                      .finally(() => setOauthBusy(null));
+                  }}
+                >
+                  <SelectTrigger
+                    className="w-60"
+                    aria-label={`Server authentication for ${row.repoFullName}`}
+                  >
+                    <SelectValue placeholder="No saved authorization" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">No saved authorization</SelectItem>
+                    {(prServerOAuthSources ?? [])
+                      .filter((source) => source.projectId === row.projectId)
+                      .map((source) => (
+                        <SelectItem
+                          key={source.serverId}
+                          value={source.serverId}
+                          disabled={!source.authorized}
+                        >
+                          {source.name}
+                          {source.authorized ? "" : " — authorize first"}
+                        </SelectItem>
+                      ))}
+                  </SelectContent>
+                </Select>
+                <Button
+                  variant="link"
+                  size="sm"
+                  onClick={() => appNavigate(`/p/${row.projectId}/servers`)}
+                >
+                  Authorize or reconnect
+                </Button>
+              </div>
             </div>
           ))}
         </div>

--- a/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
@@ -82,7 +82,9 @@ export function SuiteGithubChecksSection({
     GithubCheckOutagePolicy | ""
   >("");
   const [connecting, setConnecting] = useState(false);
-  const [oauthBusy, setOauthBusy] = useState<string | null>(null);
+  const [pendingOAuth, setPendingOAuth] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
 
   // Whether this instance is still on screen. The `ErrorBoundary` wrapping this
   // section in `suite-iterations-view` is KEYED BY organizationId, so switching
@@ -279,18 +281,29 @@ export function SuiteGithubChecksSection({
                 <Select
                   value={row.prServerOAuthSourceServerId ?? "none"}
                   disabled={
-                    oauthBusy === row._id || availability?.canManage !== true
+                    pendingOAuth.has(row._id) ||
+                    availability?.canManage !== true
                   }
                   onValueChange={(value) => {
-                    setOauthBusy(row._id);
+                    if (pendingOAuth.has(row._id)) return;
+                    setPendingOAuth((current) => new Set(current).add(row._id));
                     void setRepoPrServerOAuth({
                       configId: row._id,
                       sourceServerId: value === "none" ? null : value,
                     })
-                      .catch((error) =>
-                        toast.error(githubChecksWriteErrorMessage(error)),
-                      )
-                      .finally(() => setOauthBusy(null));
+                      .catch((error) => {
+                        if (mountedRef.current) {
+                          toast.error(githubChecksWriteErrorMessage(error));
+                        }
+                      })
+                      .finally(() => {
+                        if (!mountedRef.current) return;
+                        setPendingOAuth((current) => {
+                          const next = new Set(current);
+                          next.delete(row._id);
+                          return next;
+                        });
+                      });
                   }}
                 >
                   <SelectTrigger

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -704,6 +704,7 @@ export function GithubChecksRoute({
     value: string,
   ) => {
     if (pendingOAuth.has(row._id)) return;
+    const submittedForOrganization = activeOrganizationId;
     setPendingOAuth((current) => new Set(current).add(row._id));
     try {
       await setRepoPrServerOAuth({
@@ -711,7 +712,9 @@ export function GithubChecksRoute({
         sourceServerId: value === "none" ? null : value,
       });
     } catch (error) {
-      handleWriteError(error);
+      if (organizationIdRef.current === submittedForOrganization) {
+        handleWriteError(error);
+      }
     } finally {
       setPendingOAuth((current) => {
         const next = new Set(current);

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -264,6 +264,7 @@ export function GithubChecksRoute({
     availability,
     repos,
     suites,
+    prServerOAuthSources,
     bindings,
     connectVerifiedRepo,
     setRepoEnabled,
@@ -271,6 +272,7 @@ export function GithubChecksRoute({
     setRepoOutagePolicy,
     setRepoConformance,
     setRepoForkCredentials,
+    setRepoPrServerOAuth,
     setRepoFeedbackComments,
     disconnectRepo,
     listInstallationRepos,
@@ -306,7 +308,7 @@ export function GithubChecksRoute({
       activeOrganizationId
         ? sortedOrganizations.find((org) => org._id === activeOrganizationId)
         : undefined,
-    [sortedOrganizations, activeOrganizationId]
+    [sortedOrganizations, activeOrganizationId],
   );
   const canManage = canManageGithubChecks(activeOrganization);
 
@@ -338,6 +340,9 @@ export function GithubChecksRoute({
   // different writes land on one row, and a shared set would grey out a control
   // the admin has no reason to think is busy.
   const [pendingFeedback, setPendingFeedback] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const [pendingOAuth, setPendingOAuth] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
   // The picker's value is the repository's NUMERIC ID as a string, not its
@@ -694,6 +699,28 @@ export function GithubChecksRoute({
     }
   };
 
+  const handlePrServerOAuthChange = async (
+    row: GithubCheckRepoConfigRow,
+    value: string,
+  ) => {
+    if (pendingOAuth.has(row._id)) return;
+    setPendingOAuth((current) => new Set(current).add(row._id));
+    try {
+      await setRepoPrServerOAuth({
+        configId: row._id,
+        sourceServerId: value === "none" ? null : value,
+      });
+    } catch (error) {
+      handleWriteError(error);
+    } finally {
+      setPendingOAuth((current) => {
+        const next = new Set(current);
+        next.delete(row._id);
+        return next;
+      });
+    }
+  };
+
   const handleConformanceToggle = async (row: GithubCheckRepoConfigRow) => {
     if (pendingConformance.has(row._id)) return;
     setPendingConformance((current) => new Set(current).add(row._id));
@@ -951,16 +978,16 @@ export function GithubChecksRoute({
                       on somebody else's pull request, and a line that only
                       appeared once it was switched off would be an explanation
                       arriving after the decision. */}
-                  <span
-                    id={`feedback-comments-note-${row._id}`}
-                    className="text-xs text-muted-foreground"
-                  >
-                    MCPJam posts one comment per pull request and updates it in
-                    place. Turning this off stops the comments and changes
-                    nothing else.
-                  </span>
-                  {row.outagePolicy === undefined ? (
-                    /* Not the same statement as "fail open": the backend does
+                    <span
+                      id={`feedback-comments-note-${row._id}`}
+                      className="text-xs text-muted-foreground"
+                    >
+                      MCPJam posts one comment per pull request and updates it
+                      in place. Turning this off stops the comments and changes
+                      nothing else.
+                    </span>
+                    {row.outagePolicy === undefined ? (
+                      /* Not the same statement as "fail open": the backend does
                        behave that way for an unstamped row, but nobody chose
                        it, and saying so is what lets an administrator tell the
                        two apart. */
@@ -995,7 +1022,7 @@ export function GithubChecksRoute({
                     </SelectContent>
                   </Select>
 
-                {/* `?? ""` shows the placeholder rather than a value. Binding
+                  {/* `?? ""` shows the placeholder rather than a value. Binding
                     this to `fail_open` for an unstamped row would render the
                     administrator's screen as though they had already chosen
                     the default — a claim the stored row does not make. */}
@@ -1020,7 +1047,7 @@ export function GithubChecksRoute({
                     </SelectContent>
                   </Select>
 
-                {/* Each switch is captioned. Three bare switches in a row
+                  {/* Each switch is captioned. Three bare switches in a row
                     said nothing about which was which, and only a screen
                     reader could tell them apart.
 
@@ -1030,36 +1057,36 @@ export function GithubChecksRoute({
                     word the control does not answer to. That is why the third
                     reads "Comments" and not "PR comments" — keep it that way
                     if the wording changes. */}
-                <SwitchField label="Checks">
-                  <Switch
-                    checked={row.enabled}
-                    disabled={pendingToggles.has(row._id) || !canManage}
-                    onCheckedChange={() => void handleToggle(row)}
-                    aria-label={`Enable checks for ${row.repoFullName}`}
-                  />
-                </SwitchField>
+                  <SwitchField label="Checks">
+                    <Switch
+                      checked={row.enabled}
+                      disabled={pendingToggles.has(row._id) || !canManage}
+                      onCheckedChange={() => void handleToggle(row)}
+                      aria-label={`Enable checks for ${row.repoFullName}`}
+                    />
+                  </SwitchField>
 
-                {/* Dimmed with its switch while checks are off, because it is
+                  {/* Dimmed with its switch while checks are off, because it is
                     a SUB-SETTING of them — the switch has always been
                     disabled in that state, and a caption at full strength
                     beside a dead control reads as a bug rather than a rule. */}
-                <SwitchField
-                  label="Conformance"
-                  muted={!row.enabled || !canManage}
-                >
-                  <Switch
-                    checked={row.conformanceEnabled === true}
-                    disabled={
-                      pendingConformance.has(row._id) ||
-                      !row.enabled ||
-                      !canManage
-                    }
-                    onCheckedChange={() => void handleConformanceToggle(row)}
-                    aria-label={`Enable conformance check for ${row.repoFullName}`}
-                  />
-                </SwitchField>
+                  <SwitchField
+                    label="Conformance"
+                    muted={!row.enabled || !canManage}
+                  >
+                    <Switch
+                      checked={row.conformanceEnabled === true}
+                      disabled={
+                        pendingConformance.has(row._id) ||
+                        !row.enabled ||
+                        !canManage
+                      }
+                      onCheckedChange={() => void handleConformanceToggle(row)}
+                      aria-label={`Enable conformance check for ${row.repoFullName}`}
+                    />
+                  </SwitchField>
 
-                {/* `!== "off"` — ABSENT IS ON. Every row connected before
+                  {/* `!== "off"` — ABSENT IS ON. Every row connected before
                     this existed, and every row nobody has touched since, is a
                     repository MCPJam comments on; rendering those off would
                     tell an admin the opposite of what is happening on their
@@ -1067,17 +1094,17 @@ export function GithubChecksRoute({
                     conformance is: this is a policy about what MCPJam may
                     write, and it stays answerable while checks are paused —
                     so its caption is NOT muted with the others. */}
-                <SwitchField label="Comments" muted={!canManage}>
-                  <Switch
-                    checked={row.feedbackComments !== "off"}
-                    disabled={pendingFeedback.has(row._id) || !canManage}
-                    onCheckedChange={() =>
-                      void handleFeedbackCommentsToggle(row)
-                    }
-                    aria-label={`Post feedback comments on pull requests for ${row.repoFullName}`}
-                    aria-describedby={`feedback-comments-note-${row._id}`}
-                  />
-                </SwitchField>
+                  <SwitchField label="Comments" muted={!canManage}>
+                    <Switch
+                      checked={row.feedbackComments !== "off"}
+                      disabled={pendingFeedback.has(row._id) || !canManage}
+                      onCheckedChange={() =>
+                        void handleFeedbackCommentsToggle(row)
+                      }
+                      aria-label={`Post feedback comments on pull requests for ${row.repoFullName}`}
+                      aria-describedby={`feedback-comments-note-${row._id}`}
+                    />
+                  </SwitchField>
 
                   <Button
                     variant="ghost"
@@ -1096,6 +1123,51 @@ export function GithubChecksRoute({
                 canManage={canManage}
                 onChange={setRepoForkCredentials}
               />
+              <div className="flex flex-wrap items-center gap-3 border-t border-border/40 pt-3">
+                <div className="min-w-52">
+                  <p className="text-sm font-medium">Server authentication</p>
+                  <p className="text-xs text-muted-foreground">
+                    Reuse one project-shared test OAuth connection when this
+                    repository&apos;s PR server requires login.
+                  </p>
+                </div>
+                <Select
+                  value={row.prServerOAuthSourceServerId ?? "none"}
+                  disabled={pendingOAuth.has(row._id) || !canManage}
+                  onValueChange={(value) =>
+                    void handlePrServerOAuthChange(row, value)
+                  }
+                >
+                  <SelectTrigger
+                    className="w-64"
+                    aria-label={`Server authentication for ${row.repoFullName}`}
+                  >
+                    <SelectValue placeholder="No saved authorization" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">No saved authorization</SelectItem>
+                    {(prServerOAuthSources ?? [])
+                      .filter((source) => source.projectId === row.projectId)
+                      .map((source) => (
+                        <SelectItem
+                          key={source.serverId}
+                          value={source.serverId}
+                          disabled={!source.authorized}
+                        >
+                          {source.name}
+                          {source.authorized ? "" : " — authorize first"}
+                        </SelectItem>
+                      ))}
+                  </SelectContent>
+                </Select>
+                <Button
+                  variant="link"
+                  size="sm"
+                  onClick={() => appNavigate(`/p/${row.projectId}/servers`)}
+                >
+                  Authorize or reconnect
+                </Button>
+              </div>
             </div>
           ))
         )}

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -18,12 +18,14 @@ const {
   mockSetRepoOutagePolicy,
   mockSetRepoConformance,
   mockSetRepoForkCredentials,
+  mockSetRepoPrServerOAuth,
   mockSetRepoFeedbackComments,
   mockDisconnectRepo,
   mockConnectRepo,
   mockConnectVerifiedRepo,
   mockListInstallationRepos,
   mockBindings,
+  mockPrServerOAuthSources,
   mockStartInstallation,
   mockStartDirectClaim,
   mockUnbindInstallation,
@@ -41,6 +43,9 @@ const {
   mockSetRepoSuite: vi.fn(async () => ({ changed: true })),
   mockSetRepoOutagePolicy: vi.fn(async () => ({ changed: true })),
   mockSetRepoForkCredentials: vi.fn(async (_args?: unknown) => ({
+    changed: true,
+  })),
+  mockSetRepoPrServerOAuth: vi.fn(async (_args?: unknown) => ({
     changed: true,
   })),
   mockSetRepoConformance: vi.fn(async () => ({ changed: true })),
@@ -66,6 +71,7 @@ const {
     },
   ]),
   mockBindings: { value: undefined as unknown[] | undefined },
+  mockPrServerOAuthSources: { value: [] as unknown[] },
   mockStartInstallation: vi.fn(async () => ({
     installUrl: "https://github.com/apps/mcpjam/installations/new?state=abc",
   })),
@@ -92,6 +98,7 @@ vi.mock("@/hooks/useGithubChecksSettings", () => ({
     repos: mockRepos.value,
     suites: mockSuites.value,
     bindings: mockBindings.value,
+    prServerOAuthSources: mockPrServerOAuthSources.value,
     connectRepo: mockConnectRepo,
     connectVerifiedRepo: mockConnectVerifiedRepo,
     setRepoEnabled: mockSetRepoEnabled,
@@ -99,6 +106,7 @@ vi.mock("@/hooks/useGithubChecksSettings", () => ({
     setRepoOutagePolicy: mockSetRepoOutagePolicy,
     setRepoConformance: mockSetRepoConformance,
     setRepoForkCredentials: mockSetRepoForkCredentials,
+    setRepoPrServerOAuth: mockSetRepoPrServerOAuth,
     setRepoFeedbackComments: mockSetRepoFeedbackComments,
     disconnectRepo: mockDisconnectRepo,
     listInstallationRepos: mockListInstallationRepos,
@@ -1907,5 +1915,33 @@ it("Settings opts in only the selected repository", async () => {
   expect(mockSetRepoForkCredentials).toHaveBeenCalledWith({
     configId: ROW._id,
     enabled: true,
+  });
+});
+
+it("Settings selects an authorized project-shared OAuth source", async () => {
+  mockMyRole.value = "admin";
+  mockOrgsLoading.value = false;
+  mockAuthLoading.value = false;
+  mockAvailability.value = { state: "enabled" };
+  mockRepos.value = [ROW];
+  mockPrServerOAuthSources.value = [
+    {
+      serverId: "server-oauth",
+      projectId: ROW.projectId,
+      name: "Test OAuth server",
+      authorized: true,
+    },
+  ];
+  renderRoute();
+
+  await chooseOption(
+    userEvent.setup(),
+    `Server authentication for ${ROW.repoFullName}`,
+    "Test OAuth server",
+  );
+
+  expect(mockSetRepoPrServerOAuth).toHaveBeenCalledWith({
+    configId: ROW._id,
+    sourceServerId: "server-oauth",
   });
 });

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -1277,6 +1277,37 @@ describe("GithubChecksRoute organization switching", () => {
       "Fail open",
     );
   });
+
+  it("drops an OAuth failure that arrives after the organization changed", async () => {
+    mockRepos.value = [ROW];
+    mockPrServerOAuthSources.value = [
+      {
+        serverId: "server-oauth",
+        projectId: ROW.projectId,
+        name: "Test OAuth server",
+        authorized: true,
+      },
+    ];
+    mockListInstallationRepos.mockResolvedValue([]);
+    let rejectStaleWrite: ((error: unknown) => void) | undefined;
+    mockSetRepoPrServerOAuth.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectStaleWrite = reject;
+        }),
+    );
+
+    const { rerender } = render(routeTree("org-1"));
+    await chooseOption(
+      userEvent.setup(),
+      `Server authentication for ${ROW.repoFullName}`,
+      "Test OAuth server",
+    );
+    rerender(routeTree("org-2"));
+    await act(async () => rejectStaleWrite?.(new Error("stale failure")));
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/mcpjam-inspector/client/src/hooks/__tests__/useGithubChecksSettings.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useGithubChecksSettings.test.tsx
@@ -382,6 +382,7 @@ describe("useGithubChecksSettings writes", () => {
         "mutation:github/checkRepoConfigs:setRepoFeedbackComments",
         "mutation:github/checkRepoConfigs:setRepoForkCredentials",
         "mutation:github/checkRepoConfigs:setRepoOutagePolicy",
+        "mutation:github/checkRepoConfigs:setRepoPrServerOAuth",
         "mutation:github/checkRepoConfigs:setRepoSuite",
       ].sort()
     );

--- a/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
@@ -47,7 +47,8 @@ import { useIsMemberActor } from "@/hooks/use-is-member-actor";
  * would bounce a legitimately-flagged user who cold-loads the URL directly.
  */
 export type GithubChecksAvailability =
-  { state: "enabled" | "disabled"; canManage?: boolean } | undefined;
+  | { state: "enabled" | "disabled"; canManage?: boolean }
+  | undefined;
 
 /**
  * What the check concludes when MCPJam cannot run the suite — an outage, or a
@@ -104,7 +105,10 @@ export type GithubCheckConnectionStatus =
 
 export type GithubInstallationAccountType = "Organization" | "User";
 export type GithubInstallationBindingStatus =
-  "active" | "suspended" | "removed" | "unbound";
+  | "active"
+  | "suspended"
+  | "removed"
+  | "unbound";
 
 /**
  * One GitHub App installation this organization holds.
@@ -189,6 +193,8 @@ export type GithubCheckRepoConfigRow = {
    */
   conformanceEnabled?: boolean;
   allowSuiteCredentialsInForks?: boolean;
+  prServerOAuthSourceServerId?: string;
+  prServerOAuthPolicyRevision?: number;
   conformanceSuiteKinds?: Array<"protocol" | "apps" | "tasks" | "oauth">;
   /**
    * ABSENT IS `on`, NOT `off`. See {@link GithubCheckFeedbackComments}: an
@@ -239,11 +245,19 @@ export type SuiteOption = {
   projectId?: string;
 };
 
+export type PrServerOAuthSource = {
+  serverId: string;
+  projectId: string;
+  name: string;
+  authorized: boolean;
+};
+
 const AVAILABILITY_QUERY =
   "github/checkRepoConfigs:getGithubChecksSettingsAvailability";
 const LIST_QUERY = "github/checkRepoConfigs:listForOrganization";
 const SUITES_QUERY = "testSuites:getTestSuitesOverview";
 const BINDINGS_QUERY = "github/appInstallLink:listBindingsForOrganization";
+const OAUTH_SOURCES_QUERY = "github/checkRepoConfigs:listPrServerOAuthSources";
 
 // The availability message and the rest of this surface's error copy live in
 // `@/lib/github-checks-errors`, which has no React and no Convex client in it.
@@ -308,6 +322,11 @@ export function useGithubChecksSettings(
     ?.map((entry) => entry.suite)
     .filter((suite): suite is SuiteOption => Boolean(suite?._id));
 
+  const prServerOAuthSources = useQuery(
+    OAUTH_SOURCES_QUERY as any,
+    canQuery ? ({ organizationId } as any) : "skip",
+  ) as PrServerOAuthSource[] | undefined;
+
   // The SERVER-VERIFIED connect, and the only connect path this app uses. It is
   // an action because proving the selected organization-owned installation can
   // reach the repository takes a GitHub round trip, which a mutation cannot
@@ -326,6 +345,16 @@ export function useGithubChecksSettings(
   );
   const setRepoForkCredentialsMutation = useMutation(
     "github/checkRepoConfigs:setRepoForkCredentials" as any,
+  );
+  const setRepoPrServerOAuthMutation = useMutation(
+    "github/checkRepoConfigs:setRepoPrServerOAuth" as any,
+  );
+  const setRepoPrServerOAuth = useCallback(
+    (args: { configId: string; sourceServerId: string | null }) =>
+      setRepoPrServerOAuthMutation({ organizationId, ...args }) as Promise<{
+        changed: boolean;
+      }>,
+    [organizationId, setRepoPrServerOAuthMutation],
   );
   const setRepoForkCredentials = useCallback(
     (args: { configId: string; enabled: boolean }) =>
@@ -508,6 +537,7 @@ export function useGithubChecksSettings(
     isEnabled,
     repos,
     suites,
+    prServerOAuthSources,
     bindings,
     connectVerifiedRepo,
     setRepoEnabled,
@@ -515,6 +545,7 @@ export function useGithubChecksSettings(
     setRepoOutagePolicy,
     setRepoConformance,
     setRepoForkCredentials,
+    setRepoPrServerOAuth,
     setRepoFeedbackComments,
     disconnectRepo,
     listInstallationRepos,

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -22,6 +22,7 @@ import {
   CloneTokenUnavailableError,
   LeaseLostError,
   mintCloneTokenForTests,
+  resolvePrServerOAuthTokenForTests,
   startGithubChecksWorker,
   type CheckExecutionDeps,
   type PlanlessCheckReport,
@@ -331,6 +332,13 @@ describe("executeClaimedCheck — happy path", () => {
       "authorizationRequired:oauth_connection_not_selected",
     );
     expect(h.events).not.toContain("runEvalSuite");
+    expect(h.events).not.toContain("getBearer");
+    expect(h.events.some((event) => event.startsWith("createServer:"))).toBe(
+      false,
+    );
+    expect(h.events.some((event) => event.startsWith("recordServer:"))).toBe(
+      false,
+    );
     expectOnlyCheckResourcesRemoved(h);
   });
 
@@ -1876,6 +1884,19 @@ describe("the clone-token wire contract", () => {
     });
     const claimed = await claimNextForTests("worker-1");
     expect(claimed).toMatchObject({ triggerId: "trig-9", repoPrivate: true });
+  });
+
+  it("rejects an empty PR-server OAuth token", async () => {
+    stubFetch(200, { ok: true, accessToken: "   " });
+    await expect(
+      resolvePrServerOAuthTokenForTests({
+        claimed: CLAIM,
+        claimedBy: "worker-1",
+        sourceServerId: "source-server",
+        targetServerId: "target-server",
+        targetResourceUrl: "https://preview.test/mcp",
+      }),
+    ).rejects.toThrow("PR server OAuth token unavailable");
   });
 });
 

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -1,4 +1,7 @@
-import { githubExecutionPolicy, verifyGithubCredentialAccess } from "../github-checks/credential-policy.js";
+import {
+  githubExecutionPolicy,
+  verifyGithubCredentialAccess,
+} from "../github-checks/credential-policy.js";
 import {
   afterEach,
   beforeEach,
@@ -122,7 +125,8 @@ function harness(
     beginThrows?: unknown;
     attemptThrows?: (input: AttemptInput) => unknown;
     evalAction?: "complete" | "run_conformance";
-  }
+    authorizationRequired?: boolean;
+  },
 ): Harness {
   const reports: PlanlessCheckReport[] = [];
   const attempts: AttemptInput[] = [];
@@ -207,6 +211,9 @@ function harness(
           url: "https://3001-sb_1.e2b.app/mcp",
           readStderrTail: async () => "",
           spawn: { pid: 1234, pgrp: 1234 },
+          ...(planOptions?.authorizationRequired
+            ? { authorizationRequired: true }
+            : {}),
         },
         provenance: {
           recipeRung: RECIPE.rung,
@@ -220,6 +227,13 @@ function harness(
     },
     reportCredentialBlocked: async () => {
       events.push("credentialBlocked");
+    },
+    resolvePrServerOAuthToken: async () => {
+      events.push("resolvePrServerOAuthToken");
+      return "oauth-marker-token";
+    },
+    reportPrServerAuthorizationRequired: async (_claim, _holder, reason) => {
+      events.push(`authorizationRequired:${reason}`);
     },
     credentialPreflight: async (_claim, _holder, mint) =>
       mint ? "bearer" : null,
@@ -291,6 +305,35 @@ function expectOnlyCheckResourcesRemoved(h: Harness): void {
 }
 
 describe("executeClaimedCheck — happy path", () => {
+  it("uses a resource-specific OAuth token for an authenticated PR server", async () => {
+    const runEvalSuite = vi.fn(async (args) => {
+      expect(args.oauthAccessToken).toBe("oauth-marker-token");
+      await args.onRunStarted?.("run-oauth");
+      return { runId: "run-oauth", result: "passed" };
+    });
+    const h = harness({ runEvalSuite }, undefined, {
+      authorizationRequired: true,
+    });
+    await executeClaimedCheck(
+      { ...CLAIM, prServerOAuthSourceServerId: "source-server" },
+      "worker-1",
+      h.deps,
+    );
+    expect(h.events).toContain("resolvePrServerOAuthToken");
+    expect(runEvalSuite).toHaveBeenCalledOnce();
+    expectOnlyCheckResourcesRemoved(h);
+  });
+
+  it("stops with action required when no OAuth source was selected", async () => {
+    const h = harness(undefined, undefined, { authorizationRequired: true });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.events).toContain(
+      "authorizationRequired:oauth_connection_not_selected",
+    );
+    expect(h.events).not.toContain("runEvalSuite");
+    expectOnlyCheckResourcesRemoved(h);
+  });
+
   it("begins the plan FIRST, runs the suite, completes with no outcome, cleans up", async () => {
     const h = harness();
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
@@ -336,12 +379,12 @@ describe("executeClaimedCheck — happy path", () => {
         },
       },
       undefined,
-      { evalAction: "run_conformance" }
+      { evalAction: "run_conformance" },
     );
     await executeClaimedCheck(
       { ...CLAIM, conformanceEnabled: true },
       "worker-1",
-      h.deps
+      h.deps,
     );
 
     expect(h.events).toEqual(
@@ -351,10 +394,10 @@ describe("executeClaimedCheck — happy path", () => {
         "runConformance",
         "attempt:conformance:ok",
         "complete",
-      ])
+      ]),
     );
     expect(h.events.indexOf("runEvalSuite")).toBeLessThan(
-      h.events.indexOf("runConformance")
+      h.events.indexOf("runConformance"),
     );
     expect(h.completions[0]).toMatchObject({
       runId: "run-2",
@@ -416,7 +459,7 @@ describe("executeClaimedCheck — happy path", () => {
     const h = harness();
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.events.indexOf("recordServer:trig-1:server-1")).toBeLessThan(
-      h.events.indexOf("runEvalSuite")
+      h.events.indexOf("runEvalSuite"),
     );
   });
 
@@ -444,7 +487,7 @@ describe("executeClaimedCheck — the plan owns the verdict", () => {
         throw new CheckStoppedByPlan(
           "no_candidates",
           "Add `mcpjam.yaml` at the repository root:",
-          true
+          true,
         );
       },
     });
@@ -466,7 +509,7 @@ describe("executeClaimedCheck — the plan owns the verdict", () => {
         throw new CheckStepError(
           "build_failed",
           "build command exited 1",
-          "```text\nnpm ERR! missing script: build\n```"
+          "```text\nnpm ERR! missing script: build\n```",
         );
       },
     });
@@ -610,7 +653,7 @@ describe("executeClaimedCheck — the plan owns the verdict", () => {
     const h = harness(evalDies, "MCPJAM_CHECK_HTTP_ANSWERED 200\n");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.completions[0].detailsMarkdown ?? "").not.toContain(
-      "stopped answering"
+      "stopped answering",
     );
   });
 
@@ -639,7 +682,7 @@ describe("executeClaimedCheck — the plan owns the verdict", () => {
     const h = harness(evalDies, "MCPJAM_CHECK_HTTP_ANSWERED 400\n");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.completions[0].detailsMarkdown ?? "").not.toContain(
-      "stopped answering"
+      "stopped answering",
     );
   });
 
@@ -649,7 +692,7 @@ describe("executeClaimedCheck — the plan owns the verdict", () => {
     const h = harness(evalDies, "throws");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.completions[0].detailsMarkdown ?? "").not.toContain(
-      "stopped answering"
+      "stopped answering",
     );
   });
 
@@ -659,7 +702,7 @@ describe("executeClaimedCheck — the plan owns the verdict", () => {
     const h = harness(evalDies, "");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.completions[0].detailsMarkdown ?? "").not.toContain(
-      "stopped answering"
+      "stopped answering",
     );
   });
 
@@ -708,7 +751,7 @@ describe("executeClaimedCheck — the plan owns the verdict", () => {
         },
         heartbeatIntervalMs: 1,
       },
-      "MCPJAM_CHECK_PORT_CLOSED\n"
+      "MCPJAM_CHECK_PORT_CLOSED\n",
     );
     const inner = h.sandbox.commands.run;
     h.sandbox.commands.run = async (command: string, opts?: unknown) => {
@@ -741,7 +784,7 @@ describe("executeClaimedCheck — the plan owns the verdict", () => {
     };
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     const liveness = commands.find((c) =>
-      c.includes("MCPJAM_CHECK_HTTP_ANSWERED")
+      c.includes("MCPJAM_CHECK_HTTP_ANSWERED"),
     );
     expect(liveness).toBeDefined();
     expect(liveness).toContain("127.0.0.1");
@@ -798,19 +841,22 @@ describe("executeClaimedCheck — cleanup and heartbeat", () => {
     ["failed assertions", "failed"],
     ["run timeout", "timed_out"],
     ["run cancellation", "cancelled"],
-  ])("removes only this check's resources after a %s", async (_name, result) => {
-    const h = harness({
-      runEvalSuite: async (args) => {
-        await args.onRunStarted?.("run-1");
-        return { runId: "run-1", result };
-      },
-    });
+  ])(
+    "removes only this check's resources after a %s",
+    async (_name, result) => {
+      const h = harness({
+        runEvalSuite: async (args) => {
+          await args.onRunStarted?.("run-1");
+          return { runId: "run-1", result };
+        },
+      });
 
-    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+      await executeClaimedCheck(CLAIM, "worker-1", h.deps);
 
-    expectOnlyCheckResourcesRemoved(h);
-    expect(h.completions[0].runId).toBe("run-1");
-  });
+      expectOnlyCheckResourcesRemoved(h);
+      expect(h.completions[0].runId).toBe("run-1");
+    },
+  );
 
   it("removes a sandbox left behind by a build or start failure", async () => {
     const h = harness();
@@ -916,7 +962,7 @@ describe("executeClaimedCheck — cleanup and heartbeat", () => {
     };
     h.deps.beginPlan = async () => session;
     await expect(
-      executeClaimedCheck(CLAIM, "worker-1", h.deps)
+      executeClaimedCheck(CLAIM, "worker-1", h.deps),
     ).resolves.toBeUndefined();
   });
 
@@ -969,12 +1015,12 @@ describe("executeClaimedCheck — cleanup and heartbeat", () => {
           new Response(JSON.stringify({ ok: false, error: "Unauthorized" }), {
             status: 401,
             headers: { "content-type": "application/json" },
-          })
-      )
+          }),
+      ),
     );
     const { sendHeartbeatForTests } = await import("../github-checks-worker");
     await sendHeartbeatForTests("trig-1", "worker-1").catch((error) =>
-      rejections.push(error)
+      rejections.push(error),
     );
     expect(rejections).toHaveLength(1);
     expect(String(rejections[0])).toMatch(/heartbeat rejected \(401\)/);
@@ -1010,7 +1056,7 @@ describe("executeClaimedCheck — cleanup and heartbeat", () => {
 describe("describeCheckFailure", () => {
   it("names no outcome at all — that is the backend's now", () => {
     const described = describeCheckFailure(
-      new CheckStepError("build_failed", "exit 1", "```text\nlog\n```")
+      new CheckStepError("build_failed", "exit 1", "```text\nlog\n```"),
     );
     expect(described).not.toHaveProperty("outcome");
     expect(described.failureReason).toBe("exit 1");
@@ -1021,7 +1067,7 @@ describe("describeCheckFailure", () => {
     // Our prose, not clamped PR output: re-clamping would wrap a markdown block
     // — headings, a yaml example — in a `text` fence and render it as source.
     const described = describeCheckFailure(
-      new CheckStoppedByPlan("recipe_invalid", "# Your mcpjam.yaml", true)
+      new CheckStoppedByPlan("recipe_invalid", "# Your mcpjam.yaml", true),
     );
     expect(described).toMatchObject({
       failureReason: "recipe_invalid",
@@ -1031,11 +1077,11 @@ describe("describeCheckFailure", () => {
 
   it("names only the canonical billing marker, never a loose substring", () => {
     expect(
-      describeCheckFailure(new Error("billing_limit_reached: iterations"))
+      describeCheckFailure(new Error("billing_limit_reached: iterations")),
     ).toMatchObject({ failureReason: "billing_limit_reached" });
     // An MCP server error that merely mentions billing must not be relabelled.
     expect(
-      describeCheckFailure(new Error("tool failed: check your billing page"))
+      describeCheckFailure(new Error("tool failed: check your billing page")),
     ).toMatchObject({
       failureReason: "tool failed: check your billing page",
     });
@@ -1043,22 +1089,22 @@ describe("describeCheckFailure", () => {
 
   it("names the org spend budget from either canonical marker", () => {
     expect(
-      describeCheckFailure(new Error("spend_budget_reached"))
+      describeCheckFailure(new Error("spend_budget_reached")),
     ).toMatchObject({ failureReason: "spend_budget_reached" });
     expect(
       describeCheckFailure(
-        new Error('{"code":"ORGANIZATION_SPEND_BUDGET_REACHED"}')
-      )
+        new Error('{"code":"ORGANIZATION_SPEND_BUDGET_REACHED"}'),
+      ),
     ).toMatchObject({ failureReason: "spend_budget_reached" });
     // A build error that merely mentions a budget keeps its own message.
     expect(
-      describeCheckFailure(new Error("build failed: budget.ts not found"))
+      describeCheckFailure(new Error("build failed: budget.ts not found")),
     ).toMatchObject({ failureReason: "build failed: budget.ts not found" });
   });
 
   it("bounds the failure reason", () => {
     expect(
-      describeCheckFailure(new Error("x".repeat(1_000))).failureReason.length
+      describeCheckFailure(new Error("x".repeat(1_000))).failureReason.length,
     ).toBe(200);
   });
 });
@@ -1215,7 +1261,7 @@ describe("effectiveRunResult", () => {
         status: "completed",
         summary: { total: 2, passed: 2, failed: 0, passRate: 1 },
         passCriteria: { minimumPassRate: 100 },
-      })
+      }),
     ).toBe("passed");
     // And a stored rate that disagrees with the counts does not get a vote.
     expect(
@@ -1223,7 +1269,7 @@ describe("effectiveRunResult", () => {
         status: "completed",
         summary: { total: 4, passed: 1, failed: 3, passRate: 99 },
         passCriteria: { minimumPassRate: 90 },
-      })
+      }),
     ).toBe("failed");
   });
 
@@ -1234,14 +1280,14 @@ describe("effectiveRunResult", () => {
         status: "completed",
         summary,
         passCriteria: { minimumPassRate: 80 },
-      })
+      }),
     ).toBe("passed");
     expect(
       effectiveRunResult({
         status: "completed",
         summary,
         passCriteria: { minimumPassRate: 90 },
-      })
+      }),
     ).toBe("failed");
     // No criteria ⇒ 100% required, matching the client's derivation.
     expect(effectiveRunResult({ status: "completed", summary })).toBe("failed");
@@ -1253,7 +1299,7 @@ describe("effectiveRunResult", () => {
         status: "completed",
         result: "failed",
         summary: { total: 1, passed: 1, failed: 0, passRate: 1 },
-      })
+      }),
     ).toBe("failed");
   });
 
@@ -1268,7 +1314,7 @@ describe("effectiveRunResult", () => {
         status: "completed",
         result: "inconclusive",
         summary: { total: 2, passed: 2, failed: 0, passRate: 1 },
-      })
+      }),
     ).toBe("inconclusive");
     // And it stays a verdict-bearing run: `inconclusive` is a result, not an
     // abandoned run, so the worker does not raise "did not complete".
@@ -1337,7 +1383,7 @@ describe("startGithubChecksWorker loop", () => {
       () =>
         new Promise((resolve) => {
           releaseClaim = resolve;
-        })
+        }),
     );
     const handle = startGithubChecksWorker({ claim, execute: vi.fn() });
     // Wait until the loop is parked inside claim().
@@ -1439,7 +1485,7 @@ describe("verifyRunSnapshot", () => {
   const clientWith = (snapshot: unknown) =>
     ({
       query: async () => ({ configSnapshot: { environment: snapshot } }),
-    }) as unknown as Parameters<typeof verifyRunSnapshot>[0];
+    } as unknown as Parameters<typeof verifyRunSnapshot>[0]);
 
   it("passes a snapshot naming our own check", async () => {
     const snapshot = {
@@ -1447,7 +1493,7 @@ describe("verifyRunSnapshot", () => {
       serverBindings: [{ name: "gh-check-trig-1", id: "srv_1" }],
     };
     expect(
-      await verifyRunSnapshot(clientWith(snapshot), "run-1", "trig-1")
+      await verifyRunSnapshot(clientWith(snapshot), "run-1", "trig-1"),
     ).toBe("ours");
   });
 
@@ -1457,7 +1503,7 @@ describe("verifyRunSnapshot", () => {
       serverBindings: [{ name: "gh-check-trig-9", id: "srv_2" }],
     };
     expect(
-      await verifyRunSnapshot(clientWith(snapshot), "run-1", "trig-1")
+      await verifyRunSnapshot(clientWith(snapshot), "run-1", "trig-1"),
     ).toBe("stolen");
   });
 
@@ -1470,7 +1516,7 @@ describe("verifyRunSnapshot", () => {
       ],
     };
     expect(
-      await verifyRunSnapshot(clientWith(snapshot), "run-1", "trig-1")
+      await verifyRunSnapshot(clientWith(snapshot), "run-1", "trig-1"),
     ).toBe("ours");
   });
 
@@ -1481,11 +1527,11 @@ describe("verifyRunSnapshot", () => {
       await verifyRunSnapshot(
         clientWith({ servers: ["srv_manual"] }),
         "run-1",
-        "trig-1"
-      )
+        "trig-1",
+      ),
     ).toBe("ours");
     expect(
-      await verifyRunSnapshot(clientWith(undefined), "run-1", "trig-1")
+      await verifyRunSnapshot(clientWith(undefined), "run-1", "trig-1"),
     ).toBe("ours");
   });
 
@@ -1499,7 +1545,7 @@ describe("verifyRunSnapshot", () => {
       },
     } as unknown as Parameters<typeof verifyRunSnapshot>[0];
     expect(await verifyRunSnapshot(broken, "run-1", "trig-1")).toBe(
-      "unverifiable"
+      "unverifiable",
     );
   });
 });
@@ -1536,7 +1582,7 @@ describe("runReachedAVerdict", () => {
 describe("executeClaimedCheck — the private-repository clone credential", () => {
   /** Computed independently of the module under test. */
   const basic = Buffer.from(`x-access-token:${CLONE_TOKEN}`, "utf8").toString(
-    "base64"
+    "base64",
   );
   const credentialForms = [CLONE_TOKEN, basic, `AUTHORIZATION: basic ${basic}`];
 
@@ -1574,7 +1620,7 @@ describe("executeClaimedCheck — the private-repository clone credential", () =
     const h = harness({
       mintCloneToken: async () => {
         throw new CloneTokenUnavailableError(
-          "the backend could not mint a clone token (502)"
+          "the backend could not mint a clone token (502)",
         );
       },
     });
@@ -1682,7 +1728,7 @@ describe("executeClaimedCheck — the private-repository clone credential", () =
         throw new CheckStepError(
           "infra_error",
           `sandbox command failed: ${echoedCommand}`,
-          `\`\`\`text\n${echoedCommand}\n\`\`\``
+          `\`\`\`text\n${echoedCommand}\n\`\`\``,
         );
       },
     });
@@ -1711,7 +1757,7 @@ describe("executeClaimedCheck — the private-repository clone credential", () =
     const h = harness({
       mintCloneToken: async () => {
         throw new CloneTokenUnavailableError(
-          `mint failed while sending AUTHORIZATION: basic ${basic}`
+          `mint failed while sending AUTHORIZATION: basic ${basic}`,
         );
       },
     });
@@ -1722,13 +1768,13 @@ describe("executeClaimedCheck — the private-repository clone credential", () =
     expect(observable).not.toContain(`AUTHORIZATION: basic ${basic}`);
     // Redacted, not swallowed: the operator still gets a legible failure.
     expect(h.completions[0].terminalAttempt?.detailsClamped).toContain(
-      "mint failed"
+      "mint failed",
     );
     expect(h.completions[0].terminalAttempt?.detailsClamped).toContain(
-      "[redacted]"
+      "[redacted]",
     );
     expect(h.completions[0].detailsMarkdown).toContain(
-      "not a problem with the pull request"
+      "not a problem with the pull request",
     );
   });
 });
@@ -1744,7 +1790,7 @@ describe("the clone-token wire contract", () => {
         new Response(JSON.stringify(body), {
           status,
           headers: { "content-type": "application/json" },
-        })
+        }),
     );
     vi.stubGlobal("fetch", fetchMock);
     onTestFinished(() => {
@@ -1761,11 +1807,11 @@ describe("the clone-token wire contract", () => {
       expiresAt: 1_700_000_000,
     });
     await expect(mintCloneTokenForTests("trig-1", "worker-1")).resolves.toBe(
-      CLONE_TOKEN
+      CLONE_TOKEN,
     );
     const [url, init] = fetchMock.mock.calls[0] as unknown as [
       string,
-      RequestInit
+      RequestInit,
     ];
     expect(url).toContain("/internal/v1/github-checks/clone-token");
     expect(JSON.parse(String(init.body))).toEqual({
@@ -1777,14 +1823,14 @@ describe("the clone-token wire contract", () => {
   it("answers null when the backend says no token was needed", async () => {
     stubFetch(200, { ok: true, cloneToken: null });
     await expect(
-      mintCloneTokenForTests("trig-1", "worker-1")
+      mintCloneTokenForTests("trig-1", "worker-1"),
     ).resolves.toBeNull();
   });
 
   it("maps 409 to lease loss, not to a mint failure", async () => {
     stubFetch(409, { ok: false, error: "trigger_completed" });
     await expect(
-      mintCloneTokenForTests("trig-1", "worker-1")
+      mintCloneTokenForTests("trig-1", "worker-1"),
     ).rejects.toBeInstanceOf(LeaseLostError);
   });
 
@@ -1798,7 +1844,7 @@ describe("the clone-token wire contract", () => {
       "fetch",
       vi.fn(async () => {
         throw new Error("ECONNREFUSED 10.0.0.1:443");
-      })
+      }),
     );
     onTestFinished(() => {
       vi.unstubAllEnvs();
@@ -1806,7 +1852,7 @@ describe("the clone-token wire contract", () => {
     });
 
     const error = await mintCloneTokenForTests("trig-1", "worker-1").catch(
-      (e) => e
+      (e) => e,
     );
     expect(error).toBeInstanceOf(CloneTokenUnavailableError);
     expect(String(error)).toContain("ECONNREFUSED");
@@ -1815,7 +1861,7 @@ describe("the clone-token wire contract", () => {
   it("maps 502 to a mint failure, without echoing the backend's body", async () => {
     stubFetch(502, { ok: false, error: "Could not mint a clone token" });
     const error = await mintCloneTokenForTests("trig-1", "worker-1").catch(
-      (e) => e
+      (e) => e,
     );
     expect(error).toBeInstanceOf(CloneTokenUnavailableError);
     expect(String(error)).toContain("502");
@@ -1848,7 +1894,15 @@ describe("fork credential isolation", () => {
         cleanupBearer = args.bearer;
       },
     });
-    await executeClaimedCheck({ ...CLAIM, isFork: true, githubCredentialPolicy: "no_customer_credentials" }, "worker", h.deps);
+    await executeClaimedCheck(
+      {
+        ...CLAIM,
+        isFork: true,
+        githubCredentialPolicy: "no_customer_credentials",
+      },
+      "worker",
+      h.deps,
+    );
     expect(cleanupBearer).toBe("delegated-jwt");
     expect(h.completions[0].runId).toBe("fork-run");
   });
@@ -1859,7 +1913,15 @@ describe("fork credential isolation", () => {
         throw new Error("credential_policy_blocked");
       },
     });
-    await executeClaimedCheck({ ...CLAIM, isFork: true, githubCredentialPolicy: "no_customer_credentials" }, "worker", h.deps);
+    await executeClaimedCheck(
+      {
+        ...CLAIM,
+        isFork: true,
+        githubCredentialPolicy: "no_customer_credentials",
+      },
+      "worker",
+      h.deps,
+    );
     expect(h.events).toContain("credentialBlocked");
     expect(h.resolveArgs).toEqual([]);
     expect(h.events).not.toContain("runEvalSuite");
@@ -1872,7 +1934,15 @@ describe("fork credential isolation", () => {
         throw new Error("credential_policy_blocked");
       },
     });
-    await executeClaimedCheck({ ...CLAIM, isFork: true, githubCredentialPolicy: "no_customer_credentials" }, "worker", h.deps);
+    await executeClaimedCheck(
+      {
+        ...CLAIM,
+        isFork: true,
+        githubCredentialPolicy: "no_customer_credentials",
+      },
+      "worker",
+      h.deps,
+    );
     expect(h.events).toContain("credentialBlocked");
     expect(h.events).toContain("killSandbox");
     expect(h.completions).toEqual([]);
@@ -1886,7 +1956,7 @@ describe("fork credential isolation", () => {
         },
       },
       undefined,
-      { evalAction: "run_conformance" }
+      { evalAction: "run_conformance" },
     );
     await executeClaimedCheck(
       {
@@ -1896,7 +1966,7 @@ describe("fork credential isolation", () => {
         conformanceEnabled: true,
       },
       "worker",
-      h.deps
+      h.deps,
     );
     expect(h.events).toContain("credentialBlocked");
     expect(h.events).toContain("killSandbox");
@@ -1915,17 +1985,20 @@ describe("fork credential isolation", () => {
   });
 });
 
-
 it("runs an opted-in fork under the scoped suite policy", async () => {
   const h = harness({
-    runEvalSuite: async args => {
+    runEvalSuite: async (args) => {
       expect(githubExecutionPolicy()).toBe("suite_credentials");
       await verifyGithubCredentialAccess();
       await args.onRunStarted?.("opted-in-run");
       return { runId: "opted-in-run" };
     },
   });
-  await executeClaimedCheck({ ...CLAIM, isFork: true, githubCredentialPolicy: "suite_credentials" }, "worker", h.deps);
+  await executeClaimedCheck(
+    { ...CLAIM, isFork: true, githubCredentialPolicy: "suite_credentials" },
+    "worker",
+    h.deps,
+  );
   expect(h.completions[0].runId).toBe("opted-in-run");
   expect(h.events).toContain("killSandbox");
 });

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -42,9 +42,7 @@ import { WEB_CALL_TIMEOUT_MS } from "../config.js";
 import { logger } from "../utils/logger";
 import { getConvexBearerForDelegation } from "../utils/v1-convex-token.js";
 import { createAuthorizedManager } from "../routes/web/auth.js";
-import { prepareEvalRun,
-  shouldSkipExecution,
-} from "../routes/shared/evals.js";
+import { prepareEvalRun, shouldSkipExecution } from "../routes/shared/evals.js";
 import { createConvexClient } from "./evals/route-helpers.js";
 import type { CheckRecipe } from "./github-checks/recipes.js";
 import {
@@ -106,7 +104,9 @@ const JUDGE_GRADING_POLL_MS = 15_000;
 export type ClaimedGithubCheck = {
   credentialPolicyVersion: 2;
   githubCredentialPolicy:
-    "no_customer_credentials" | "suite_credentials" | "same_repository";
+    | "no_customer_credentials"
+    | "suite_credentials"
+    | "same_repository";
   allowedBuiltInToolIds: string[];
   isFork: boolean;
   triggerId: string;
@@ -135,6 +135,8 @@ export type ClaimedGithubCheck = {
   conformanceSuiteKinds?: Array<"protocol" | "apps" | "tasks" | "oauth">;
   /** Repo-config id for grouping GitHub preview conformance history. */
   repoConfigId?: string;
+  /** Explicit project-shared OAuth source selected for this repository. */
+  prServerOAuthSourceServerId?: string;
 };
 
 export type CheckSummary = {
@@ -203,6 +205,55 @@ async function reportCredentialBlocked(
     throw new Error("Credential refusal could not be recorded");
 }
 
+export class PrServerAuthorizationRequiredError extends Error {
+  constructor(readonly reason: string) {
+    super(reason);
+  }
+}
+
+async function reportPrServerAuthorizationRequired(
+  claimed: ClaimedGithubCheck,
+  claimedBy: string,
+  reason: string,
+): Promise<void> {
+  const { status } = await postServiceRoute(
+    `${SERVICE_BASE}/authorization-required`,
+    { triggerId: claimed.triggerId, claimedBy, reason },
+  );
+  if (status !== 200 && status !== 409)
+    throw new Error("Authorization refusal could not be recorded");
+}
+
+async function resolvePrServerOAuthToken(args: {
+  claimed: ClaimedGithubCheck;
+  claimedBy: string;
+  sourceServerId: string;
+  targetServerId: string;
+  targetResourceUrl: string;
+}): Promise<string> {
+  const { status, body } = await postServiceRoute(
+    `${SERVICE_BASE}/oauth-token`,
+    {
+      triggerId: args.claimed.triggerId,
+      claimedBy: args.claimedBy,
+      sourceServerId: args.sourceServerId,
+      targetServerId: args.targetServerId,
+      targetResourceUrl: args.targetResourceUrl,
+    },
+  );
+  if (status === 409)
+    throw new PrServerAuthorizationRequiredError(
+      typeof body?.error === "string" ? body.error : "authorization_required",
+    );
+  if (
+    status !== 200 ||
+    body?.ok !== true ||
+    typeof body.accessToken !== "string"
+  )
+    throw new Error("PR server OAuth token unavailable");
+  return body.accessToken;
+}
+
 async function credentialPreflight(
   claimed: ClaimedGithubCheck,
   claimedBy: string,
@@ -225,7 +276,7 @@ async function credentialPreflight(
 }
 
 async function claimNext(
-  claimedBy: string
+  claimedBy: string,
 ): Promise<ClaimedGithubCheck | null | "disabled"> {
   const { status, body } = await postServiceRoute(`${SERVICE_BASE}/claim`, {
     credentialPolicyVersion: 2,
@@ -241,12 +292,12 @@ async function claimNext(
 }
 
 async function reportPlanlessOutcome(
-  report: PlanlessCheckReport
+  report: PlanlessCheckReport,
 ): Promise<void> {
   try {
     const { status, body } = await postServiceRoute(
       `${SERVICE_BASE}/complete`,
-      report as unknown as Record<string, unknown>
+      report as unknown as Record<string, unknown>,
     );
     if (status !== 200 || !body?.ok) {
       logger.warn("[github-checks] completion rejected", {
@@ -276,7 +327,7 @@ async function reportPlanlessOutcome(
  */
 async function sendHeartbeat(
   triggerId: string,
-  claimedBy: string
+  claimedBy: string,
 ): Promise<void> {
   const { status, body } = await postServiceRoute(`${SERVICE_BASE}/heartbeat`, {
     triggerId,
@@ -352,7 +403,7 @@ export class CloneTokenUnavailableError extends Error {
  */
 async function mintCloneToken(
   triggerId: string,
-  claimedBy: string
+  claimedBy: string,
 ): Promise<string | null> {
   let status: number;
   let body: any;
@@ -373,7 +424,7 @@ async function mintCloneToken(
     throw new CloneTokenUnavailableError(
       `the clone-token route could not be reached: ${
         error instanceof Error ? error.message : String(error)
-      }`
+      }`,
     );
   }
   if (status === 409) {
@@ -381,7 +432,7 @@ async function mintCloneToken(
   }
   if (status !== 200 || !body?.ok) {
     throw new CloneTokenUnavailableError(
-      `the backend could not mint a clone token (${status})`
+      `the backend could not mint a clone token (${status})`,
     );
   }
   const token = body.cloneToken;
@@ -422,17 +473,17 @@ export const defaultRunEvalSuiteForTests = () => defaultRunEvalSuite;
  */
 async function recordEphemeralServer(
   triggerId: string,
-  serverId: string
+  serverId: string,
 ): Promise<void> {
   const { status, body } = await postServiceRoute(
     `${SERVICE_BASE}/ephemeral-server`,
-    { triggerId, serverId }
+    { triggerId, serverId },
   );
   if (status !== 200 || !body?.ok) {
     throw new Error(
       `ephemeral-server registration rejected (${status}): ${JSON.stringify(
-        body
-      )}`
+        body,
+      )}`,
     );
   }
 }
@@ -472,7 +523,7 @@ export function describeCheckFailure(error: unknown): {
         ? {
             detailsMarkdown: error.detailsMarkdown.slice(
               0,
-              RESOLVER_DETAILS_MAX_CHARS
+              RESOLVER_DETAILS_MAX_CHARS,
             ),
             ...(error.detailsPreformatted ? { detailsPreformatted: true } : {}),
           }
@@ -562,7 +613,7 @@ export function effectiveRunResult(
     result?: string;
     summary?: CheckSummary | null;
     passCriteria?: { minimumPassRate?: number } | null;
-  } | null
+  } | null,
 ): string | undefined {
   if (!run) return undefined;
   if (run.result) return run.result;
@@ -573,7 +624,7 @@ export function effectiveRunResult(
       // way is what keeps the check's verdict and the eval UI's badge from
       // disagreeing on a fractional rate (2/3 is 67% to both, not 66.67% to one).
       const passRatePercent = Math.round(
-        ((run.summary?.passed ?? 0) / total) * 100
+        ((run.summary?.passed ?? 0) / total) * 100,
       );
       return passRatePercent >= (run.passCriteria?.minimumPassRate ?? 100)
         ? "passed"
@@ -610,7 +661,7 @@ export type CheckExecutionDeps = {
    */
   mintCloneToken: (
     triggerId: string,
-    claimedBy: string
+    claimedBy: string,
   ) => Promise<string | null>;
   /**
    * The deterministic ladder plus the sandboxes it needs — provisioning,
@@ -635,7 +686,10 @@ export type CheckExecutionDeps = {
     projectId: string;
     name: string;
     url: string;
+    useOAuth?: boolean;
   }) => Promise<string>;
+  resolvePrServerOAuthToken: typeof resolvePrServerOAuthToken;
+  reportPrServerAuthorizationRequired: typeof reportPrServerAuthorizationRequired;
   reportCredentialBlocked: typeof reportCredentialBlocked;
   deleteEphemeralServer: (args: {
     bearer: string;
@@ -647,6 +701,7 @@ export type CheckExecutionDeps = {
     bearer: string;
     serverId: string;
     serverName: string;
+    oauthAccessToken?: string;
     /**
      * Called with the run's id THE MOMENT IT EXISTS, before the suite is
      * executed. That call is what posts the `eval` attempt, and that attempt is
@@ -678,6 +733,7 @@ export type CheckExecutionDeps = {
     bearer: string;
     serverUrl: string;
     candidateId: string;
+    oauthAccessToken?: string;
     onRunStarted?: (runId: string) => Promise<void>;
   }) => Promise<{ runId: string }>;
   /** The PLANLESS completion. Only reachable when `/plan/begin` gave us none. */
@@ -765,7 +821,7 @@ const LIVENESS_PROBE_PROTOCOL_VERSION = "2025-11-25";
  */
 async function serverStillResponding(
   sandbox: CheckSandbox,
-  recipe: CheckRecipe
+  recipe: CheckRecipe,
 ): Promise<boolean | null> {
   const body = JSON.stringify({
     jsonrpc: "2.0",
@@ -794,7 +850,7 @@ async function serverStillResponding(
   try {
     const result = (await sandbox.commands.run(
       `node -e ${JSON.stringify(script)}`,
-      { timeoutMs: EVAL_FAILURE_PROBE_TIMEOUT_MS }
+      { timeoutMs: EVAL_FAILURE_PROBE_TIMEOUT_MS },
     )) as { stdout?: unknown } | null;
     stdout = typeof result?.stdout === "string" ? result.stdout : "";
   } catch {
@@ -848,7 +904,7 @@ async function serverStillResponding(
 async function describeEvalFailure(
   error: unknown,
   sandbox: CheckSandbox,
-  recipe: CheckRecipe
+  recipe: CheckRecipe,
 ): Promise<string | undefined> {
   // Our own typed failures and the lease guard already say what they are.
   if (error instanceof CheckStepError || error instanceof LeaseLostError) {
@@ -858,7 +914,7 @@ async function describeEvalFailure(
     return undefined;
   const message = error instanceof Error ? error.message : String(error);
   return clampOutput(
-    `The server answered the health probe, then stopped answering on port ${recipe.port} while the eval suite was running — it either refused the connection or accepted it and sent nothing back. Checked from inside the sandbox, so this is the server process and not the network path to it.\n\n${message}`
+    `The server answered the health probe, then stopped answering on port ${recipe.port} while the eval suite was running — it either refused the connection or accepted it and sent nothing back. Checked from inside the sandbox, so this is the server process and not the network path to it.\n\n${message}`,
   );
 }
 
@@ -867,6 +923,7 @@ async function defaultCreateEphemeralServer(args: {
   projectId: string;
   name: string;
   url: string;
+  useOAuth?: boolean;
 }): Promise<string> {
   const client = createConvexClient(args.bearer);
   const serverId = await client.mutation("servers:createServer" as any, {
@@ -875,6 +932,7 @@ async function defaultCreateEphemeralServer(args: {
     enabled: true,
     transportType: "http",
     url: args.url,
+    ...(args.useOAuth ? { useOAuth: true, oauthResourceUrl: args.url } : {}),
   });
   return String(serverId);
 }
@@ -928,7 +986,7 @@ type RunTerminality =
 
 async function runTerminality(
   client: { query: (name: any, args: any) => Promise<any> },
-  runId: string
+  runId: string,
 ): Promise<RunTerminality> {
   try {
     const run = (await client.query("testSuites:getTestSuiteRun" as any, {
@@ -967,7 +1025,7 @@ export async function awaitJudgeVerdict(
     sleep?: (ms: number) => Promise<void>;
     /** False once the claim stops being ours — stop waiting for somebody else. */
     isLeaseHeld?: () => boolean;
-  }
+  },
 ): Promise<{
   status?: string;
   result?: string;
@@ -1032,7 +1090,7 @@ export function runReachedAVerdict(status: string | undefined): boolean {
  */
 async function runCompleted(
   client: { query: (name: any, args: any) => Promise<any> },
-  runId: string
+  runId: string,
 ): Promise<boolean> {
   try {
     const run = (await client.query("testSuites:getTestSuiteRun" as any, {
@@ -1065,7 +1123,7 @@ async function runCompleted(
 export async function verifyRunSnapshot(
   client: ReturnType<typeof createConvexClient>,
   runId: string,
-  triggerId: string
+  triggerId: string,
 ): Promise<"ours" | "stolen" | "unverifiable"> {
   let snapshot: unknown;
   try {
@@ -1109,7 +1167,7 @@ export async function verifyRunSnapshot(
 async function abandonPreparedRun(
   client: ReturnType<typeof createConvexClient>,
   prepared: Awaited<ReturnType<typeof prepareEvalRun>>,
-  ctx: { triggerId: string; reason: string; what: string }
+  ctx: { triggerId: string; reason: string; what: string },
 ): Promise<void> {
   const notes = ctx.reason.slice(0, 500);
   await client
@@ -1127,7 +1185,7 @@ async function abandonPreparedRun(
             cleanupError instanceof Error
               ? cleanupError.message
               : String(cleanupError),
-        }
+        },
       );
     });
   if (prepared.recorder) {
@@ -1137,7 +1195,7 @@ async function abandonPreparedRun(
         logger.error(
           `[github-checks] failed to finalize ${ctx.what}`,
           finalizeError,
-          { triggerId: ctx.triggerId, runId: prepared.runId }
+          { triggerId: ctx.triggerId, runId: prepared.runId },
         );
       });
   }
@@ -1153,6 +1211,7 @@ async function defaultRunEvalSuite(args: {
   bearer: string;
   serverId: string;
   serverName: string;
+  oauthAccessToken?: string;
   onRunStarted?: (runId: string) => Promise<void>;
   isLeaseHeld?: () => boolean;
 }): Promise<{ runId: string; result?: string; summary?: CheckSummary }> {
@@ -1164,9 +1223,11 @@ async function defaultRunEvalSuite(args: {
     args.claimed.projectId,
     [args.serverId],
     WEB_CALL_TIMEOUT_MS,
+    args.oauthAccessToken
+      ? { [args.serverId]: args.oauthAccessToken }
+      : undefined,
     undefined,
-    undefined,
-    { serverNames: [args.serverName] }
+    { serverNames: [args.serverName] },
   );
 
   try {
@@ -1193,7 +1254,7 @@ async function defaultRunEvalSuite(args: {
     const ownership = await verifyRunSnapshot(
       client,
       prepared.runId,
-      args.claimed.triggerId
+      args.claimed.triggerId,
     );
     if (ownership !== "ours") {
       const reason =
@@ -1281,7 +1342,7 @@ async function defaultRunEvalSuite(args: {
             logger.error(
               "[github-checks] failed to finalize a non-terminal eval run",
               finalizeError,
-              { triggerId: args.claimed.triggerId, runId: prepared.runId }
+              { triggerId: args.claimed.triggerId, runId: prepared.runId },
             );
           });
       }
@@ -1326,7 +1387,7 @@ async function defaultRunEvalSuite(args: {
       throw new Error(
         `eval run ${prepared.runId} did not complete (status: ${
           run?.status ?? "unknown"
-        })`
+        })`,
       );
     }
 
@@ -1346,6 +1407,7 @@ async function defaultRunConformance(args: {
   bearer: string;
   serverUrl: string;
   candidateId: string;
+  oauthAccessToken?: string;
   onRunStarted?: (runId: string) => Promise<void>;
 }): Promise<{ runId: string }> {
   // The configured snapshot is passed through INTACT, `oauth` included. The
@@ -1373,7 +1435,10 @@ async function defaultRunConformance(args: {
   const result = await executePersistedConformanceRun({
     convexToken: args.bearer,
     projectId: args.claimed.projectId,
-    server: { url: args.serverUrl },
+    server: {
+      url: args.serverUrl,
+      ...(args.oauthAccessToken ? { accessToken: args.oauthAccessToken } : {}),
+    },
     suites,
     source: "github_app",
     target,
@@ -1397,6 +1462,8 @@ function defaultDeps(): CheckExecutionDeps {
     killSandbox: killCheckSandbox,
     credentialPreflight,
     reportCredentialBlocked,
+    resolvePrServerOAuthToken,
+    reportPrServerAuthorizationRequired,
     getBearer: getConvexBearerForDelegation,
     createEphemeralServer: defaultCreateEphemeralServer,
     deleteEphemeralServer: defaultDeleteEphemeralServer,
@@ -1417,7 +1484,7 @@ function defaultDeps(): CheckExecutionDeps {
 export async function executeClaimedCheck(
   claimed: ClaimedGithubCheck,
   claimedBy: string,
-  overrides?: Partial<CheckExecutionDeps>
+  overrides?: Partial<CheckExecutionDeps>,
 ): Promise<void> {
   const deps: CheckExecutionDeps = { ...defaultDeps(), ...overrides };
   const logContext = {
@@ -1465,6 +1532,7 @@ export async function executeClaimedCheck(
   let serverId: string | null = null;
   let bearer: string | null = null;
   let cleanupBearer: string | null = null;
+  let oauthAccessToken: string | undefined;
 
   // Reporting is the last thing that can fail, and it must not turn a delivered
   // completion into a thrown error — the poll loop would read that as a
@@ -1638,7 +1706,7 @@ export async function executeClaimedCheck(
         throw error instanceof CloneTokenUnavailableError
           ? error
           : new CloneTokenUnavailableError(
-              error instanceof Error ? error.message : String(error)
+              error instanceof Error ? error.message : String(error),
             );
       }
       if (!cloneToken) {
@@ -1647,7 +1715,7 @@ export async function executeClaimedCheck(
         // answer rather than a silent anonymous attempt that would 404 and read
         // as the repository having vanished.
         throw new CloneTokenUnavailableError(
-          "the backend returned no clone token for a private repository"
+          "the backend returned no clone token for a private repository",
         );
       }
       assertLeaseHeld();
@@ -1676,7 +1744,7 @@ export async function executeClaimedCheck(
           sandbox = box;
         },
         assertLeaseHeld,
-      }
+      },
     );
     sandbox = resolved.sandbox;
     acceptedCandidateId = resolved.candidateId;
@@ -1694,7 +1762,7 @@ export async function executeClaimedCheck(
 
     bearer = await deps.getBearer(
       claimed.createdByExternalId,
-      claimed.organizationId
+      claimed.organizationId,
     );
 
     cleanupBearer = bearer;
@@ -1704,10 +1772,26 @@ export async function executeClaimedCheck(
       projectId: claimed.projectId,
       name: serverName,
       url: started.url,
+      useOAuth: started.authorizationRequired === true,
     });
     // Tell the backend before running anything: if this worker dies mid-eval,
     // recovery needs the pointer to soft-delete the row.
     await deps.recordServer(claimed.triggerId, serverId);
+    if (started.authorizationRequired) {
+      const sourceServerId = claimed.prServerOAuthSourceServerId;
+      if (!sourceServerId) {
+        throw new PrServerAuthorizationRequiredError(
+          "oauth_connection_not_selected",
+        );
+      }
+      oauthAccessToken = await deps.resolvePrServerOAuthToken({
+        claimed,
+        claimedBy,
+        sourceServerId,
+        targetServerId: serverId,
+        targetResourceUrl: started.url,
+      });
+    }
     // Switch before interpreting any untrusted MCP result. Only this bearer
     // reaches the eval manager, model tools, and conformance executor.
     const executionBearer = await deps.credentialPreflight(
@@ -1721,7 +1805,8 @@ export async function executeClaimedCheck(
     const executionPolicy = claimed.isFork
       ? {
           policy: claimed.githubCredentialPolicy as
-            "no_customer_credentials" | "suite_credentials",
+            | "no_customer_credentials"
+            | "suite_credentials",
           allowedBuiltInToolIds: claimed.allowedBuiltInToolIds,
           checkAccess: () => deps.credentialPreflight(claimed, claimedBy),
         }
@@ -1739,6 +1824,7 @@ export async function executeClaimedCheck(
           bearer: executionBearer,
           serverId: executionServerId,
           serverName,
+          ...(oauthAccessToken ? { oauthAccessToken } : {}),
           // STEP 9 — the attempt that BINDS the run, posted AT LAUNCH.
           onRunStarted: async (runId) => {
             const decision = await session.attempt({
@@ -1799,6 +1885,7 @@ export async function executeClaimedCheck(
               bearer: executionBearer,
               serverUrl: started.url,
               candidateId: resolved.candidateId,
+              ...(oauthAccessToken ? { oauthAccessToken } : {}),
               onRunStarted: async (boundId) => {
                 await session.attempt({
                   candidateId: resolved.candidateId,
@@ -1848,6 +1935,17 @@ export async function executeClaimedCheck(
       ...(run.summary ? { summary: run.summary } : {}),
     });
   } catch (error) {
+    if (error instanceof PrServerAuthorizationRequiredError) {
+      await deps
+        .reportPrServerAuthorizationRequired(claimed, claimedBy, error.reason)
+        .catch(() =>
+          logger.warn(
+            "[github-checks] authorization requirement could not be recorded",
+            logContext,
+          ),
+        );
+      return;
+    }
     if (isCredentialPolicyBlocked(error)) {
       await deps
         .reportCredentialBlocked(claimed, claimedBy)
@@ -1877,12 +1975,12 @@ export async function executeClaimedCheck(
       // reading of it that is the pull request's fault.
       const detail = redactCloneCredential(error.detail, cloneToken).slice(
         0,
-        500
+        500,
       );
       logger.error(
         "[github-checks] could not mint a clone token",
         redactErrorForLog(error, cloneToken),
-        { ...logContext, planId: session.planId, detail }
+        { ...logContext, planId: session.planId, detail },
       );
       await safeComplete({
         detailsMarkdown:
@@ -1904,7 +2002,7 @@ export async function executeClaimedCheck(
     // secret is in play.
     const failureReason = redactCloneCredential(
       described.failureReason,
-      cloneToken
+      cloneToken,
     );
     logger.error(
       "[github-checks] check failed",
@@ -1914,7 +2012,7 @@ export async function executeClaimedCheck(
         planId: session.planId,
         reason: failureReason,
         candidate: acceptedCandidateId,
-      }
+      },
     );
     // NO OUTCOME. Every failure that got this far was reported as an attempt at
     // the phase it happened at; the backend derives what it adds up to. The only
@@ -1941,7 +2039,7 @@ export async function executeClaimedCheck(
                 ? {
                     detailsClamped: redactCloneCredential(
                       marker.detailsClamped,
-                      cloneToken
+                      cloneToken,
                     ),
                   }
                 : {}),
@@ -1995,7 +2093,7 @@ export async function executeClaimedCheck(
  */
 function rawOf(detailsMarkdown: string): string {
   const fenced = /^(?:_[^\n]*_\n)?(`{3,})text\n([\s\S]*)\n\1$/.exec(
-    detailsMarkdown
+    detailsMarkdown,
   );
   return fenced ? fenced[2] : detailsMarkdown;
 }
@@ -2049,7 +2147,7 @@ export function startGithubChecksWorker(options?: {
 
   if (!requiredEnv()) {
     logger.warn(
-      "[github-checks] worker enabled but CONVEX_HTTP_URL / INSPECTOR_SERVICE_TOKEN missing; not starting"
+      "[github-checks] worker enabled but CONVEX_HTTP_URL / INSPECTOR_SERVICE_TOKEN missing; not starting",
     );
     return { stop: async () => {} };
   }
@@ -2062,7 +2160,7 @@ export function startGithubChecksWorker(options?: {
   // reason as the sandbox gate below, checked here instead.
   if (!process.env.CONVEX_URL) {
     logger.warn(
-      "[github-checks] worker enabled but CONVEX_URL missing; not starting (queued checks stay claimable)"
+      "[github-checks] worker enabled but CONVEX_URL missing; not starting (queued checks stay claimable)",
     );
     return { stop: async () => {} };
   }
@@ -2073,7 +2171,7 @@ export function startGithubChecksWorker(options?: {
   // those checks queued until the deployment is fixed.
   if (!isGithubChecksSandboxConfigured()) {
     logger.warn(
-      "[github-checks] worker enabled but E2B_API_KEY / GITHUB_CHECKS_E2B_TEMPLATE_ID missing; not starting (queued checks stay claimable)"
+      "[github-checks] worker enabled but E2B_API_KEY / GITHUB_CHECKS_E2B_TEMPLATE_ID missing; not starting (queued checks stay claimable)",
     );
     return { stop: async () => {} };
   }

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -248,10 +248,11 @@ async function resolvePrServerOAuthToken(args: {
   if (
     status !== 200 ||
     body?.ok !== true ||
-    typeof body.accessToken !== "string"
+    typeof body.accessToken !== "string" ||
+    body.accessToken.trim().length === 0
   )
     throw new Error("PR server OAuth token unavailable");
-  return body.accessToken;
+  return body.accessToken.trim();
 }
 
 async function credentialPreflight(
@@ -447,6 +448,9 @@ export const sendHeartbeatForTests = sendHeartbeat;
  * mapping (409 ⇒ lease loss, 502 ⇒ mint failure) is worth pinning at the wire.
  */
 export const mintCloneTokenForTests = mintCloneToken;
+
+/** Test seam for the hand-mirrored OAuth token route contract. */
+export const resolvePrServerOAuthTokenForTests = resolvePrServerOAuthToken;
 
 /**
  * Test seam: `repoPrivate` arriving intact is the difference between cloning a
@@ -1751,6 +1755,14 @@ export async function executeClaimedCheck(
     const recipe = resolved.recipe;
     const started = resolved.started;
     assertLeaseHeld();
+    const sourceServerId = started.authorizationRequired
+      ? claimed.prServerOAuthSourceServerId
+      : undefined;
+    if (started.authorizationRequired && !sourceServerId) {
+      throw new PrServerAuthorizationRequiredError(
+        "oauth_connection_not_selected",
+      );
+    }
 
     logger.info("[github-checks] PR server is reachable", {
       ...logContext,
@@ -1778,12 +1790,6 @@ export async function executeClaimedCheck(
     // recovery needs the pointer to soft-delete the row.
     await deps.recordServer(claimed.triggerId, serverId);
     if (started.authorizationRequired) {
-      const sourceServerId = claimed.prServerOAuthSourceServerId;
-      if (!sourceServerId) {
-        throw new PrServerAuthorizationRequiredError(
-          "oauth_connection_not_selected",
-        );
-      }
       oauthAccessToken = await deps.resolvePrServerOAuthToken({
         claimed,
         claimedBy,

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -886,7 +886,9 @@ describe("waitForMcpInitialize", () => {
     const fetchImpl = vi.fn(async () =>
       new Response("unauthorized", {
         status: 401,
-        headers: { "www-authenticate": 'Bearer realm="mcp"' },
+        headers: {
+          "www-authenticate": 'Basic realm="legacy", Bearer realm="mcp"',
+        },
       })
     );
     const options = {

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -8,6 +8,7 @@ import {
   OUTPUT_CLAMP_CHARS,
   redactCloneCredential,
   PROBE_MAX_RESPONSE_BYTES,
+  probeMcpInitialize,
   waitForMcpInitialize,
   type CheckSandbox,
 } from "../sandbox";
@@ -881,6 +882,25 @@ describe("redactCloneCredential", () => {
 });
 
 describe("waitForMcpInitialize", () => {
+  it("reports a Bearer challenge as authorization required", async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response("unauthorized", {
+        status: 401,
+        headers: { "www-authenticate": 'Bearer realm="mcp"' },
+      })
+    );
+    const options = {
+      timeoutMs: 50,
+      intervalMs: 1,
+      fetchImpl: fetchImpl as typeof fetch,
+    };
+
+    expect(await probeMcpInitialize("https://box/mcp", options)).toBe(
+      "authorization_required"
+    );
+    expect(await waitForMcpInitialize("https://box/mcp", options)).toBe(false);
+  });
+
   const seams = {
     intervalMs: 1,
     sleep: async () => {},

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -32,6 +32,7 @@
  */
 
 import { Sandbox } from "e2b";
+import { hasBearerChallenge } from "@mcpjam/sdk/browser";
 import {
   DEFAULT_EGRESS_DENY_CIDRS,
   resolveEgressPolicy,
@@ -1171,7 +1172,7 @@ export async function probeMcpInitialize(
       const challenge = response.headers.get("www-authenticate") ?? "";
       if (
         (response.status === 401 || response.status === 403) &&
-        /^\s*Bearer(?:\s|$)/i.test(challenge)
+        hasBearerChallenge(challenge)
       ) {
         return "authorization_required";
       }

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -752,6 +752,8 @@ export type StartedServer = {
   readStderrTail: () => Promise<string>;
   /** See `SpawnIdentity` — the only identity the verifier is allowed to trust. */
   spawn: SpawnIdentity;
+  /** The verified listener requires OAuth before it can answer initialize. */
+  authorizationRequired?: boolean;
 };
 
 /**
@@ -859,12 +861,12 @@ export async function buildAndStart(
 
   const readServerLogTail = () => readLogTail(sandbox);
   const url = `https://${sandbox.getHost(recipe.port)}${recipe.mcpPath}`;
-  const healthy = await waitForMcpInitialize(url, {
+  const probe = await probeMcpInitialize(url, {
     timeoutMs: options?.healthTimeoutMs ?? HEALTH_TIMEOUT_MS,
     intervalMs: options?.healthIntervalMs ?? HEALTH_INTERVAL_MS,
     fetchImpl: options?.fetchImpl,
   });
-  if (!healthy) {
+  if (probe === "unhealthy") {
     throw new CheckStepError(
       "server_unhealthy",
       `server never completed MCP initialize on port ${recipe.port}${recipe.mcpPath}`,
@@ -872,7 +874,14 @@ export async function buildAndStart(
     );
   }
 
-  return { url, readStderrTail: readServerLogTail, spawn };
+  return {
+    url,
+    readStderrTail: readServerLogTail,
+    spawn,
+    ...(probe === "authorization_required"
+      ? { authorizationRequired: true }
+      : {}),
+  };
 }
 
 /** Marker the process-group read prints on. Matched, never parsed for. */
@@ -1096,6 +1105,25 @@ export async function waitForMcpInitialize(
     sleep?: (ms: number) => Promise<void>;
   }
 ): Promise<boolean> {
+  return (await probeMcpInitialize(url, options)) === "healthy";
+}
+
+export type McpInitializeProbeResult =
+  | "healthy"
+  | "authorization_required"
+  | "unhealthy";
+
+/** Detailed probe used by GitHub checks to distinguish an OAuth challenge. */
+export async function probeMcpInitialize(
+  url: string,
+  options?: {
+    timeoutMs?: number;
+    intervalMs?: number;
+    fetchImpl?: typeof fetch;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+  }
+): Promise<McpInitializeProbeResult> {
   const timeoutMs = options?.timeoutMs ?? HEALTH_TIMEOUT_MS;
   const intervalMs = options?.intervalMs ?? HEALTH_INTERVAL_MS;
   const doFetch = options?.fetchImpl ?? fetch;
@@ -1140,11 +1168,18 @@ export async function waitForMcpInitialize(
         // bounded too.
         signal: abort.signal,
       });
+      const challenge = response.headers.get("www-authenticate") ?? "";
+      if (
+        (response.status === 401 || response.status === 403) &&
+        /^\s*Bearer(?:\s|$)/i.test(challenge)
+      ) {
+        return "authorization_required";
+      }
       if (
         transportProcessesBody(response) &&
         (await probeResponseIsHealthy(response, era.accepts))
       ) {
-        return true;
+        return "healthy";
       }
     } catch {
       // Connection refused, DNS not ready, this era rejected outright, or our
@@ -1162,7 +1197,7 @@ export async function waitForMcpInitialize(
     url,
     attempts,
   });
-  return false;
+  return "unhealthy";
 }
 
 /** One era's probe: what to send, and what counts as an answer. */


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Runs GitHub checks against PR servers that require OAuth login, instead of failing them at the health probe as `server_unhealthy`.

- Detects a Bearer `www-authenticate` challenge during the MCP initialize probe and marks the server as requiring authorization.
- Resolves an OAuth token from a project-shared OAuth source selected on the repo config, and passes it to the eval suite and conformance runs.
- Reports `authorization_required` (`oauth_connection_not_selected`) and skips execution when no source is selected.
- Adds a "Server authentication" selector to the checks settings and suite sections, listing authorized project-shared sources and linking to the servers page to authorize or reconnect.
- Requires the new backend routes (`/oauth-token`, `/authorization-required`) to be deployed alongside the worker.

<sup>Written for commit a6f66a6d0a34fc4d773d924a9b7cff807a7b185f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

