### PR TITLE
chore: add release changeset for inspector, CLI, and SDK

### DIFF
--- a/.changeset/republish-inspector-cli-sdk.md
+++ b/.changeset/republish-inspector-cli-sdk.md
@@ -1,0 +1,9 @@
+---
+"@mcpjam/inspector": patch
+"@mcpjam/cli": patch
+"@mcpjam/sdk": patch
+---
+
+Cut a fresh patch of @mcpjam/inspector, @mcpjam/cli, and @mcpjam/sdk.
+
+The last release job reported `@mcpjam/sdk@8.7.0` as published, but that version never reached the npm registry — `latest` is still 8.6.0, while `@mcpjam/cli@5.7.0` and `@mcpjam/inspector@3.4.0` from the same run did land. This changeset is a version bump only, with no code changes, so the release job re-publishes the three packages together and the SDK on npm catches up with main.


### PR DESCRIPTION
- One changeset file, no code changes. It bumps `@mcpjam/inspector`, `@mcpjam/cli`, and `@mcpjam/sdk` a patch each.
- The last release job said it published `@mcpjam/sdk@8.7.0`, but that version is not on npm — `latest` is still 8.6.0.
- `@mcpjam/cli@5.7.0` and `@mcpjam/inspector@3.4.0` from that same run did land, so only the SDK is behind main.
- Merging this makes the release job cut and publish the three packages again, which gets the SDK back in sync.
- Nothing else is pending: main has no other changesets and no commits after the release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a release changeset so the release job re-publishes `@mcpjam/inspector`, `@mcpjam/cli`, and `@mcpjam/sdk` as patches.

The previous release run reported `@mcpjam/sdk@8.7.0` as published, but that version never reached npm — `latest` is still 8.6.0. The CLI and inspector releases from that run did land, so this changeset (version bump only, no code changes) gets the SDK back in sync with main.

<sup>Written for commit 94504cac12dc0952da4bd901788c57a65f889d34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

