### PR TITLE
Stop the unshipped url-history query from taking down the Servers page

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/ServerUrlChangeHistory.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerUrlChangeHistory.tsx
@@ -13,6 +13,14 @@
  */
 
 import { useQuery } from "convex/react";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { isConvexQueryUnavailable } from "@/lib/convex-error";
+
+/**
+ * Exported so the test can build the exact message the client sees, and so a
+ * rename here cannot drift from the predicate below.
+ */
+export const SERVER_URL_CHANGES_QUERY = "auditEvents:listServerUrlChanges";
 
 interface ServerUrlChangeEvent {
   // Convex system field. The sibling audit reader (`useOrganizationAudit`)
@@ -58,12 +66,58 @@ function formatWhen(timestamp: number): string {
   }
 }
 
+/**
+ * The failure this panel EXPECTS: the deployment does not serve its query.
+ *
+ * The Inspector half of MJ-003 shipped ahead of the backend half, and
+ * `useQuery` throws during render while the function is missing. That throw
+ * escaped to the route boundary and took the whole Servers page down the
+ * moment anyone opened a hosted server's details (PostHog issue
+ * 01a08999-8c34-77a2-922e-557c0e515919). The boundary below is what keeps a
+ * read-only, renders-nothing-by-default panel from ever doing that again.
+ *
+ * `isConvexQueryUnavailable` alone is not enough here: it names the DEV
+ * shapes ("Could not find public function"), and production redacts every
+ * non-`ConvexError` to `[CONVEX Q(<name>)] [Request ID: …] Server Error`. The
+ * function name in that prefix is the only thing left to match on, so a
+ * redacted failure of THIS query is treated as the dark-ship state. A
+ * `ConvexError` from it (`NOT_FOUND` for a non-member) carries its own
+ * message, matches neither branch, and still reports.
+ */
+export function isServerUrlHistoryUnavailable(error: Error): boolean {
+  const message = typeof error?.message === "string" ? error.message : "";
+  if (!message.includes(`Q(${SERVER_URL_CHANGES_QUERY})`)) return false;
+  return isConvexQueryUnavailable(error) || message.includes("Server Error");
+}
+
 export function ServerUrlChangeHistory({
   serverId,
 }: ServerUrlChangeHistoryProps) {
+  return (
+    // KEYED by the server: a boundary that has caught stays in its fallback
+    // for the life of the element, so without the key one failure would hide
+    // the history for every server opened after it in the same modal.
+    //
+    // `fallback={null}` is this panel's own contract — nothing to say, draw
+    // nothing. `isExpectedError` suppresses only the telemetry, and only for
+    // the shape the predicate can name; a genuine render bug still reports.
+    <ErrorBoundary
+      key={serverId ?? "no-server"}
+      name="server-url-change-history"
+      fallback={null}
+      isExpectedError={isServerUrlHistoryUnavailable}
+    >
+      <ServerUrlChangeHistoryPanel serverId={serverId} />
+    </ErrorBoundary>
+  );
+}
+
+function ServerUrlChangeHistoryPanel({
+  serverId,
+}: ServerUrlChangeHistoryProps) {
   const events = useQuery(
-    "auditEvents:listServerUrlChanges" as never,
-    serverId ? ({ serverId } as never) : "skip"
+    SERVER_URL_CHANGES_QUERY as never,
+    serverId ? ({ serverId } as never) : "skip",
   ) as ServerUrlChangeEvent[] | undefined;
 
   // `Array.isArray`, not a truthiness-and-length check. `undefined` is still

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerUrlChangeHistory.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerUrlChangeHistory.test.tsx
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const { useQueryMock, reportBoundaryError } = vi.hoisted(() => ({
+  useQueryMock: vi.fn(),
+  reportBoundaryError: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+}));
+
+vi.mock("@/lib/error-reporting", () => ({
+  reportBoundaryError,
+  reportCaught: vi.fn(),
+}));
+
+import {
+  SERVER_URL_CHANGES_QUERY,
+  ServerUrlChangeHistory,
+  isServerUrlHistoryUnavailable,
+} from "../ServerUrlChangeHistory";
+
+// The exact string `convex/react` throws from render in PRODUCTION: the
+// server redacts "Could not find public function" to "Server Error", so the
+// function name in the prefix is all the client gets. Copied from the PostHog
+// issue that motivated the boundary.
+const PROD_DARK_SHIP = new Error(
+  `[CONVEX Q(${SERVER_URL_CHANGES_QUERY})] [Request ID: 5eb87f6c9d3ef8d5] Server Error\n  Called by client`,
+);
+const DEV_DARK_SHIP = new Error(
+  `[CONVEX Q(${SERVER_URL_CHANGES_QUERY})] [Request ID: abc] Could not find public function for '${SERVER_URL_CHANGES_QUERY}'`,
+);
+
+const urlChange = {
+  _id: "evt_1",
+  action: "server.url.changed",
+  actorEmail: "editor@example.com",
+  timestamp: Date.UTC(2026, 8, 9, 12, 0, 0),
+  metadata: {
+    previousOrigin: "https://old.example.com",
+    nextOrigin: "https://new.example.com",
+    originChanged: true,
+    clearedOnOriginChange: true,
+    clearedKinds: ["headers", "legacy_headers"],
+  },
+};
+
+describe("ServerUrlChangeHistory", () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    useQueryMock.mockReset();
+    reportBoundaryError.mockReset();
+    // React logs caught boundary errors; keep the suite output readable.
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => consoleError.mockRestore());
+
+  it("renders nothing, and does not report, when production does not serve the query yet", () => {
+    // The Inspector half of MJ-003 deployed before its backend half. That
+    // throw used to escape to the route boundary and take the Servers page
+    // down for anyone opening a hosted server's details.
+    useQueryMock.mockImplementation(() => {
+      throw PROD_DARK_SHIP;
+    });
+
+    const { container } = render(<ServerUrlChangeHistory serverId="srv_1" />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(reportBoundaryError).not.toHaveBeenCalled();
+  });
+
+  it("treats the dev-deployment shape of a missing function the same way", () => {
+    useQueryMock.mockImplementation(() => {
+      throw DEV_DARK_SHIP;
+    });
+
+    const { container } = render(<ServerUrlChangeHistory serverId="srv_1" />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(reportBoundaryError).not.toHaveBeenCalled();
+  });
+
+  it("still renders nothing but DOES report a failure it did not expect", () => {
+    // The predicate is narrow on purpose: a boundary that suppressed
+    // everything would also swallow the real bug it exists to surface.
+    useQueryMock.mockImplementation(() => {
+      throw new Error("kaboom");
+    });
+
+    const { container } = render(<ServerUrlChangeHistory serverId="srv_1" />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(reportBoundaryError).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-probes for the next server after one has failed", () => {
+    // A boundary that has caught stays in its fallback for the life of the
+    // element. Keyed by server, a failure on one does not hide history on
+    // the next one opened in the same modal.
+    //
+    // Persistent, not `Once`: React retries a render that threw concurrently
+    // before handing it to a boundary, and a one-shot throw lets that retry
+    // succeed — which React then reports as an uncaught recovery error.
+    useQueryMock.mockImplementation(() => {
+      throw PROD_DARK_SHIP;
+    });
+    const { rerender } = render(<ServerUrlChangeHistory serverId="srv_1" />);
+    expect(screen.queryByText("URL history")).not.toBeInTheDocument();
+
+    useQueryMock.mockReset();
+    useQueryMock.mockReturnValue([urlChange]);
+    rerender(<ServerUrlChangeHistory serverId="srv_2" />);
+
+    expect(screen.getByText("URL history")).toBeInTheDocument();
+  });
+
+  it("renders the history when the backend answers", () => {
+    useQueryMock.mockReturnValue([
+      urlChange,
+      { ...urlChange, _id: "evt_2", action: "server.credentials.cleared" },
+    ]);
+
+    render(<ServerUrlChangeHistory serverId="srv_1" />);
+
+    expect(useQueryMock).toHaveBeenCalledWith(SERVER_URL_CHANGES_QUERY, {
+      serverId: "srv_1",
+    });
+    expect(screen.getByText("https://old.example.com")).toBeInTheDocument();
+    expect(screen.getByText("https://new.example.com")).toBeInTheDocument();
+    expect(screen.getByText(/editor@example\.com/)).toBeInTheDocument();
+    // Duplicate labels collapse, and only the url-change row renders.
+    expect(
+      screen.getByText(/Saved credentials were cleared.*request headers\./),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(1);
+  });
+
+  it("skips the query while the server id is unresolved", () => {
+    useQueryMock.mockReturnValue(undefined);
+
+    const { container } = render(<ServerUrlChangeHistory serverId={null} />);
+
+    expect(useQueryMock).toHaveBeenCalledWith(SERVER_URL_CHANGES_QUERY, "skip");
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("isServerUrlHistoryUnavailable", () => {
+  it("names both dark-ship shapes of THIS query only", () => {
+    expect(isServerUrlHistoryUnavailable(PROD_DARK_SHIP)).toBe(true);
+    expect(isServerUrlHistoryUnavailable(DEV_DARK_SHIP)).toBe(true);
+    // Another query's redacted failure is not this panel's to suppress.
+    expect(
+      isServerUrlHistoryUnavailable(
+        new Error("[CONVEX Q(servers:get)] [Request ID: x] Server Error"),
+      ),
+    ).toBe(false);
+    // A ConvexError from this query carries its own message and still reports.
+    expect(
+      isServerUrlHistoryUnavailable(
+        new Error(
+          `[CONVEX Q(${SERVER_URL_CHANGES_QUERY})] [Request ID: x] Uncaught ConvexError: Server not found`,
+        ),
+      ),
+    ).toBe(false);
+    expect(isServerUrlHistoryUnavailable(new Error("kaboom"))).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/components/shared/user-value-chain/StageFunnelPanels.tsx
+++ b/mcpjam-inspector/client/src/components/shared/user-value-chain/StageFunnelPanels.tsx
@@ -21,6 +21,12 @@
 import { useEffect } from "react";
 import { useQuery } from "convex/react";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { isConvexQueryUnavailable } from "@/lib/convex-error";
+
+// Lives in `@/lib/convex-error` now, beside the other Convex error shapes, so
+// `ServerUrlChangeHistory` can share it without importing this panel.
+// Re-exported so the tests and any caller here keep their import.
+export { isConvexQueryUnavailable };
 import { StageFunnel } from "./StageFunnel";
 import type {
   ChatSessionStageFunnel,
@@ -189,16 +195,6 @@ export function SuiteRunStageFunnelPanel({
  * fails for any OTHER reason is a real failure and still reports. Anyone
  * widening this list is turning off an alarm, and should have to say so here.
  */
-export function isConvexQueryUnavailable(error: Error): boolean {
-  const message = typeof error?.message === "string" ? error.message : "";
-  return (
-    // The function is not deployed (dark ship, or a browser outliving a rollback).
-    message.includes("Could not find public function") ||
-    // No ConvexProvider above this tree.
-    message.includes("Could not find Convex client")
-  );
-}
-
 export function SuiteRunStageFunnelAvailability({
   suiteRunId,
   onChange,

--- a/mcpjam-inspector/client/src/lib/convex-error.ts
+++ b/mcpjam-inspector/client/src/lib/convex-error.ts
@@ -22,3 +22,21 @@ export function convexErrMessage(err: unknown, fallback: string): string {
   }
   return fallback;
 }
+
+/**
+ * Whether a `useQuery` throw means the deployment does not serve the function
+ * at all — a dark ship, or a browser outliving a rollback — rather than the
+ * function failing. Only the DEV shapes are nameable: production redacts
+ * every non-`ConvexError` message to "Server Error", so a caller that must
+ * recognise a dark ship in production has to match on the function name in
+ * the `[CONVEX Q(<name>)]` prefix instead (see `ServerUrlChangeHistory`).
+ */
+export function isConvexQueryUnavailable(error: Error): boolean {
+  const message = typeof error?.message === "string" ? error.message : "";
+  return (
+    // The function is not deployed (dark ship, or a browser outliving a rollback).
+    message.includes("Could not find public function") ||
+    // No ConvexProvider above this tree.
+    message.includes("Could not find Convex client")
+  );
+}


### PR DESCRIPTION
- Opening a hosted server's details white-screened the whole Servers page in production. PostHog issue [01a08999](https://us.posthog.com/project/212744/error_tracking/01a08999-8c34-77a2-922e-557c0e515919), 8 hits across 2 users.
- Cause: the URL-history panel from #4761 asks the backend for `auditEvents:listServerUrlChanges`, and no deployment serves that yet. Its backend half is still open as MCPJam/mcpjam-backend#1260 and MCPJam/mcpjam-backend#1268. A missing Convex function throws while React renders, and nothing was there to catch it.
- Fix: wrap the panel in the same error boundary the other dark-shipped query already uses. The panel already draws nothing when a server has no URL history, so a missing backend now looks the same to the user, and the page stays up.
- The boundary only stays quiet for this one query being absent. A real failure of it still reports to Sentry and PostHog as before.
- Nothing else changes. When the backend PRs land the panel starts showing history on its own, with no follow-up here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the unshipped URL-history query from white-screening the Servers page in production. Opening a hosted server's details threw during render because no deployment serves `auditEvents:listServerUrlChanges` yet; the panel now sits behind an error boundary and draws nothing when the query is missing, so the page stays up and real failures still report.

- Caused PostHog issue [01a08999](https://us.posthog.com/project/212744/error_tracking/01a08999-8c34-77a2-922e-557c0e515919) (8 hits across 2 users).
- The boundary is keyed by server, so one failure doesn't hide history for every server opened afterward in the same modal.
- Production redacts the error to `Server Error`, so suppression only matches the `[CONVEX Q(<name>)]` prefix for this exact query.
- Moves `isConvexQueryUnavailable` to `@/lib/convex-error` and re-exports it from its old home so both callers share one definition.
- When the backend half lands, the panel starts showing history with no follow-up needed here.

<sup>Written for commit 91fde8cfbe1fd939c7f89771b04c79012ef05a11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

