### PR TITLE
Fix WebMCP input disappearing in React Strict Mode

### DIFF
--- a/.changeset/webmcp-dev-scroll.md
+++ b/.changeset/webmcp-dev-scroll.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Fix WebMCP scrolling and keyboard/mouse input in development mode by keeping the input forwarder alive when React Strict Mode replays effect setup.

--- a/mcpjam-inspector/client/src/components/webmcp-inspector/WebmcpInspectorTab.tsx
+++ b/mcpjam-inspector/client/src/components/webmcp-inspector/WebmcpInspectorTab.tsx
@@ -915,19 +915,27 @@ function ViewportPane({
       .getState()
       .sendCommand({ type: "set_viewport", ...size });
   }, behaviour.drivesPage);
-  const forwarder = useMemo(
-    () =>
-      createInputForwarder((events) =>
+  const inputLifecycle = useMemo(
+    () => ({
+      forwarder: createInputForwarder((events) =>
         onInput(events.map(fromBrowserPaneInput)),
       ),
+      attached: false,
+    }),
     [onInput],
   );
-  useEffect(
-    () => () => {
-      queueMicrotask(() => forwarder.cancel());
-    },
-    [forwarder],
-  );
+  const { forwarder } = inputLifecycle;
+  useEffect(() => {
+    inputLifecycle.attached = true;
+    return () => {
+      inputLifecycle.attached = false;
+      // Child cleanup still needs to release held input. Strict Mode may also
+      // reattach this same forwarder before the deferred cleanup runs.
+      queueMicrotask(() => {
+        if (!inputLifecycle.attached) inputLifecycle.forwarder.cancel();
+      });
+    };
+  }, [inputLifecycle]);
   const input = useCallback(
     (events: Parameters<typeof forwarder.push>[0]) => {
       if (behaviour.drivesPage) forwarder.push(events);

--- a/mcpjam-inspector/client/src/components/webmcp-inspector/__tests__/WebmcpInspectorTab.viewport.test.tsx
+++ b/mcpjam-inspector/client/src/components/webmcp-inspector/__tests__/WebmcpInspectorTab.viewport.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { waitFor } from "@testing-library/react";
 /**
  * The pane's two jobs: ask for frames only while someone is looking, and show
@@ -645,6 +646,49 @@ describe("WebmcpInspectorTab — viewport", () => {
     // And Escape itself never reaches the page, in either transition, so it
     // cannot close a dialog there on the way out.
     expect(sendInput).not.toHaveBeenCalled();
+  });
+
+  it("keeps wheel input alive after Strict Mode replays effect setup", async () => {
+    const sendInput = vi.fn(async () => {});
+    useWebmcpInspectorStore.setState({
+      session: session({
+        viewportTransport: { kind: "frame-stream", width: 1280, height: 800 },
+      }),
+      liveFrame: liveFrame("scroll-frame"),
+      sendInput,
+    });
+    stubViewportActions({ screencastAccepted: true });
+    const view = render(
+      <StrictMode>
+        <WebmcpInspectorTab />
+      </StrictMode>,
+    );
+    await act(async () => {});
+    await act(async () => {
+      useWebmcpInspectorStore.setState({
+        liveFrame: liveFrame("scroll-frame"),
+      });
+    });
+    const canvas = screen.getByRole("img", {
+      name: "Live view of the inspected page",
+    });
+    canvas.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 1280, height: 800 }) as DOMRect;
+    const wheel = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 200,
+      clientY: 200,
+      deltaY: 120,
+    });
+    act(() => canvas.dispatchEvent(wheel));
+    expect(wheel.defaultPrevented).toBe(true);
+    await waitFor(() =>
+      expect(sendInput).toHaveBeenCalledWith([
+        expect.objectContaining({ kind: "wheel", deltaY: 120 }),
+      ]),
+    );
+    view.unmount();
   });
 
   it("sends a paste once, as text, and never as its keystrokes", async () => {


### PR DESCRIPTION
In local development, React Strict Mode replays effect cleanup/setup. The WebMCP pane queued an unconditional cancellation during that replay, permanently disabling the memoized input forwarder. Wheel events were consumed without reaching the page; clicks and keyboard input were affected too.

Track whether that specific forwarder is reattached before cancelling it. Real unmount/replacement still cancels it after child cleanup can release held input.

Validation: the new Strict Mode wheel regression fails with zero forwarded events before the fix and passes afterward. All 79 focused viewport, surface and input tests pass; client typecheck and import guards pass. Includes a patch changeset. Follow-up to #4882.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WebMCP scrolling and keyboard/mouse input in development mode, where React Strict Mode's effect replay was cancelling the input forwarder permanently and swallowing events.

- Tracks whether the forwarder is reattached before deferring cancellation; real unmounts still cancel it.
- Adds a regression test that fails before the fix when wheel events are forwarded in Strict Mode.
- Includes a patch changeset for `@mcpjam/inspector`.

<sup>Written for commit 7409d915d99a43fcc62bbe3cd636ec8c5f515e8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to WebMCP viewport input lifecycle in dev Strict Mode; behavior on true unmount is preserved via the attached guard.
> 
> **Overview**
> Fixes WebMCP live-view input (scroll, click, keyboard) breaking in **development** when React Strict Mode replays effect cleanup/setup.
> 
> `ViewportPane` no longer **always** calls `forwarder.cancel()` on effect teardown. The memoized forwarder is tracked with an **`attached`** flag; cleanup still defers cancel via `queueMicrotask`, but cancel runs only if the same forwarder was **not** reattached—so Strict Mode’s fake unmount does not permanently disable forwarding. Real unmounts still release held keys/buttons as before.
> 
> Adds a **StrictMode** regression test that wheel events reach `sendInput`, plus a patch **changeset** for `@mcpjam/inspector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7409d915d99a43fcc62bbe3cd636ec8c5f515e8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->