### PR TITLE
Stop a second Update click from calling quitAndInstall twice

### DIFF
--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -535,11 +535,20 @@ export function MCPSidebar({
     HOSTED_MODE && !user && (isWorkOsAuthLoading || isConvexAuthLoading);
   const learningEnabled = !!learningFlagEnabled && isAuthenticated;
   const themeMode = usePreferencesStore((s) => s.themeMode);
-  const { status: updateStatus, restartAndInstall } = useUpdateNotification();
+  const {
+    status: updateStatus,
+    restartRequested,
+    restartAndInstall,
+  } = useUpdateNotification();
   const showUpdateButton =
     updateStatus.kind === "pending" || updateStatus.kind === "downloaded";
+  // Two ways to be mid-install, and both must disable the button: waiting on a
+  // download that was asked to install when it finishes, and waiting on the
+  // app to quit for one already downloaded. The second is the one a repeat
+  // click used to get through.
   const updateInstalling =
-    updateStatus.kind === "pending" && updateStatus.installRequested;
+    restartRequested ||
+    (updateStatus.kind === "pending" && updateStatus.installRequested);
   const handleUpdateClick = () => {
     if (!updateInstalling) {
       restartAndInstall();

--- a/mcpjam-inspector/client/src/hooks/__tests__/useUpdateNotification.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useUpdateNotification.test.ts
@@ -219,10 +219,8 @@ describe("useUpdateNotification", () => {
     });
 
     it("removes listener on unmount", () => {
-      const {
-        mockRemoveUpdateStatusListener,
-        mockRemoveUpdateErrorListener,
-      } = setupElectronMock();
+      const { mockRemoveUpdateStatusListener, mockRemoveUpdateErrorListener } =
+        setupElectronMock();
 
       const { unmount } = renderHook(() => useUpdateNotification());
       unmount();
@@ -251,6 +249,42 @@ describe("useUpdateNotification", () => {
       act(() => {
         result.current.restartAndInstall();
       });
+    });
+
+    it("reports the restart as requested so the caller can disable its button", () => {
+      // INSPECTOR-ELECTRON-GT. The main process does not change the status
+      // when it starts an install from `downloaded` — it hands off to Electron
+      // and the app tears down — so only the click distinguishes "ready to
+      // install" from "installing", and without this the button stays live
+      // through the teardown and a second click fires quitAndInstall twice.
+      setupElectronMock();
+
+      const { result } = renderHook(() => useUpdateNotification());
+      expect(result.current.restartRequested).toBe(false);
+
+      act(() => {
+        result.current.restartAndInstall();
+      });
+
+      expect(result.current.restartRequested).toBe(true);
+    });
+
+    it("re-arms after the install fails so the user can try again", () => {
+      const { mockOnUpdateError } = setupElectronMock();
+
+      const { result } = renderHook(() => useUpdateNotification());
+      act(() => {
+        result.current.restartAndInstall();
+      });
+      expect(result.current.restartRequested).toBe(true);
+
+      // The main process broadcasts `update-error` when quitAndInstall throws
+      // (a mis-signed staged build, a corrupted Squirrel staging dir).
+      act(() => {
+        mockOnUpdateError.mock.calls[0][0]();
+      });
+
+      expect(result.current.restartRequested).toBe(false);
     });
   });
 

--- a/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
+++ b/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
@@ -8,6 +8,17 @@ const RELEASES_URL = "https://github.com/MCPJam/inspector/releases";
 
 export function useUpdateNotification() {
   const [status, setStatus] = useState<UpdateStatus>({ kind: "idle" });
+  /**
+   * The user asked to install, and we are waiting for the app to go away.
+   *
+   * Tracked here rather than read off `status` because the main process does
+   * not change the status when it starts a `downloaded` install — it hands off
+   * to Electron and the app tears down — so `downloaded` is both "ready to
+   * install" and "installing", and only the click tells them apart. Without
+   * this the button stays enabled through the whole teardown and a second
+   * click fires `quitAndInstall` twice (INSPECTOR-ELECTRON-GT).
+   */
+  const [restartRequested, setRestartRequested] = useState(false);
 
   useEffect(() => {
     if (!window.isElectron || !window.electronAPI?.update) {
@@ -24,6 +35,9 @@ export function useUpdateNotification() {
       setStatus(next);
     });
     api.onUpdateError(() => {
+      // The install did not happen, so let the user ask again. Its own toast
+      // offers the manual download; this re-arms the button behind it.
+      setRestartRequested(false);
       // Surface a fallback path — auto-update can stall silently on macOS
       // (Squirrel staging / signing issues), so always offer a manual
       // download as an escape hatch.
@@ -44,7 +58,8 @@ export function useUpdateNotification() {
     // Initial snapshot — apply only if a live event hasn't already overtaken it.
     // Avoids a startup race where an older idle snapshot overwrites a live
     // pending/downloaded event and hides the button until the next broadcast.
-    api.getUpdateStatus()
+    api
+      .getUpdateStatus()
       .then((initial) => {
         if (!cancelled && !liveEventReceived) setStatus(initial);
       })
@@ -60,6 +75,7 @@ export function useUpdateNotification() {
   }, []);
 
   const restartAndInstall = useCallback(() => {
+    setRestartRequested(true);
     window.electronAPI?.update?.restartAndInstall();
   }, []);
 
@@ -77,6 +93,7 @@ export function useUpdateNotification() {
 
   return {
     status,
+    restartRequested,
     restartAndInstall,
     simulateUpdate,
     simulateUpdateDownloaded,

--- a/mcpjam-inspector/server/__tests__/update-listeners.test.ts
+++ b/mcpjam-inspector/server/__tests__/update-listeners.test.ts
@@ -32,7 +32,7 @@ const {
     ipcHandleMock: vi.fn(
       (channel: string, handler: (...args: any[]) => any) => {
         ipcHandlers.set(channel, handler);
-      }
+      },
     ),
     ipcOnMock: vi.fn((channel: string, handler: (...args: any[]) => void) => {
       ipcListeners.set(channel, handler);
@@ -93,7 +93,8 @@ function emitAutoUpdaterEvent(event: string, ...args: any[]) {
   }
 }
 
-type UpdateListenersModule = typeof import("../../src/ipc/update/update-listeners.js");
+type UpdateListenersModule =
+  typeof import("../../src/ipc/update/update-listeners.js");
 let lastLoadedModule: UpdateListenersModule | null = null;
 
 async function loadUpdateListeners() {
@@ -140,7 +141,7 @@ describe("update-listeners", () => {
       installRequested: false,
     });
     expect(
-      ipcHandlers.get("app:get-update-status")?.({ sender: { id: 1 } })
+      ipcHandlers.get("app:get-update-status")?.({ sender: { id: 1 } }),
     ).toEqual({ kind: "pending", installRequested: false });
   });
 
@@ -393,6 +394,46 @@ describe("update-listeners", () => {
     emitAutoUpdaterEvent("error", new Error("network died"));
 
     expect(window.webContents.send).not.toHaveBeenCalledWith("update-error");
+  });
+
+  it("ignores a second Update click while the install is already underway", async () => {
+    // INSPECTOR-ELECTRON-GT. `quitAndInstall` is not idempotent: with a window
+    // still open Electron registers the AutoUpdater on the window list and
+    // waits for the windows to close, so a second call re-registers the same
+    // observer and Chromium reports "Observers can only be added once!".
+    // Nothing clears `downloaded`, so the button stays live for the whole
+    // teardown — which is the window a double-click lands in.
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    emitAutoUpdaterEvent("update-available");
+    emitAutoUpdaterEvent("update-downloaded", {}, "Notes", "2.5.0");
+
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+
+    expect(quitAndInstallMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a repeat click after the install started from a queued download", async () => {
+    // The other way in: the user clicks while still downloading, so
+    // `update-downloaded` starts the install itself. A click after that lands
+    // on a `downloaded` status with the quit already in flight.
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    emitAutoUpdaterEvent("update-available");
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+    emitAutoUpdaterEvent("update-downloaded", {}, "Notes", "2.5.0");
+    expect(quitAndInstallMock).toHaveBeenCalledTimes(1);
+
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+
+    expect(quitAndInstallMock).toHaveBeenCalledTimes(1);
   });
 
   it("catches quitAndInstall throws and surfaces an error broadcast", async () => {

--- a/mcpjam-inspector/src/ipc/update/update-listeners.ts
+++ b/mcpjam-inspector/src/ipc/update/update-listeners.ts
@@ -38,10 +38,7 @@ function startStalledInstallWatchdog(): void {
   stalledInstallTimer = setTimeout(() => {
     stalledInstallTimer = null;
     // Re-check at fire-time: if anything succeeded or moved on, do nothing.
-    if (
-      currentStatus.kind === "pending" &&
-      currentStatus.installRequested
-    ) {
+    if (currentStatus.kind === "pending" && currentStatus.installRequested) {
       log.error(
         `Auto-updater stalled in pending+installRequested for ${stalledInstallTimeoutMs}ms — surfacing error`,
       );
@@ -216,6 +213,22 @@ export function registerUpdateListeners(mainWindow: BrowserWindow): void {
       return;
     }
     if (currentStatus.kind === "downloaded") {
+      // The same guard `update-downloaded` and `installUpdateOnQuit` already
+      // carry, and this handler is the one that was missing it. `quitAndInstall`
+      // is NOT idempotent: with a window still open Electron registers this
+      // AutoUpdater on the window list and waits for the windows to close, so a
+      // second call re-registers the same observer and Chromium reports
+      // "Observers can only be added once!" via DumpWithoutCrashing
+      // (INSPECTOR-ELECTRON-GT).
+      //
+      // Nothing here clears the status, so the button stays live for the whole
+      // teardown — which is exactly the window a double-click lands in. The
+      // renderer disables it too; this is the half that also covers a resend
+      // from anywhere else.
+      if (isQuittingForUpdate) {
+        log.info("Install already underway — ignoring repeat restart request");
+        return;
+      }
       log.info("Restarting app to install update...");
       isQuittingForUpdate = true;
       try {


### PR DESCRIPTION
Fixes INSPECTOR-ELECTRON-GT.

- Pressing the desktop app's Update button twice made Electron try to install the update twice. Chromium noticed and filed a crash report each time. 15 of them since March.
- Nothing broke for the user, the update still installs and the app does not die. It was just a recurring Sentry alert into Slack.
- The main-process handler for the restart request was the only one of three install paths missing the "already quitting" check the other two had. It now ignores a repeat request.
- The button also stayed clickable the whole time the app was shutting down, because the update status never changes once an install starts. It now switches to "Updating…" on the first click, and becomes clickable again if the install fails.
- Two main-process tests cover both ways a second click could get through, and both fail without the fix. Two more cover the button state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double `quitAndInstall` calls from a second Update click, which has been firing Chromium crash reports (15 since March, INSPECTOR-ELECTRON-GT). The update always installed fine; this was just a recurring Sentry alert.

**Bug Fixes**
- The `app:restart-for-update` handler now ignores a repeat request while an install is already underway, matching the guard the other two install paths had.
- The Update button now shows "Updating…" on the first click and re-enables if the install fails, instead of staying clickable through the whole teardown.
- Tests cover both ways a second click could get through, plus the button's disabled and re-armed states.

<sup>Written for commit 1c4c28eb8881cc2cc6e4792102450be23d48f801. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

