### PR TITLE
Fix Electron WebMCP browser closing during startup

### DIFF
--- a/mcpjam-inspector/server/services/webmcp-inspector/__tests__/session-runtime.test.ts
+++ b/mcpjam-inspector/server/services/webmcp-inspector/__tests__/session-runtime.test.ts
@@ -832,6 +832,53 @@ describe("viewport frames", () => {
     expect(runtime.toPublic().status).not.toBe("error");
   });
 
+  it("replays the attached transport without a provisional native-window session", () => {
+    const runtime = new WebMcpSessionRuntime("https://example.test/", {
+      sessionId: "session-embedded",
+    });
+    const callbacks = runtime.callbacks();
+    // Providers navigate and discover tools inside createSession, before the
+    // returned browser can be attached to the runtime.
+    callbacks.onNavigated("https://example.test/", "https://example.test");
+    callbacks.onToolsChanged([fakeTool()]);
+
+    const session = new FakeBrowserSession(callbacks);
+    session.transport = { kind: "electron-webview" };
+    runtime.attach(session);
+    runtime.expiresAt = 2_000;
+    runtime.hardExpiresAt = 3_000;
+    runtime.publishSession();
+
+    const replay: WebMcpEvent[] = [];
+    runtime.hub.subscribe((event) => replay.push(event));
+    const sessions = replay.filter((event) => event.type === "session");
+    // Even a transient native-window replay makes the client unmount its
+    // webview, destroying the guest before the correct snapshot arrives.
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].session).toMatchObject({
+      status: "ready",
+      viewportTransport: { kind: "electron-webview" },
+      expiresAt: 2_000,
+      hardExpiresAt: 3_000,
+    });
+    expect(replay.some((event) => event.type === "tools")).toBe(true);
+    expect(
+      replay.some(
+        (event) =>
+          event.type === "activity" && event.entry.kind === "navigated",
+      ),
+    ).toBe(true);
+
+    callbacks.onCrashed("The embedded page was closed.");
+    expect(replay.at(-2)).toMatchObject({
+      type: "session",
+      session: {
+        status: "error",
+        viewportTransport: { kind: "electron-webview" },
+      },
+    });
+  });
+
   it("does not publish a quality change before a browser is attached", () => {
     const runtime = new WebMcpSessionRuntime("https://example.test/", {
       sessionId: "session-1",

--- a/mcpjam-inspector/server/services/webmcp-inspector/session-runtime.ts
+++ b/mcpjam-inspector/server/services/webmcp-inspector/session-runtime.ts
@@ -972,11 +972,11 @@ export class WebMcpSessionRuntime {
   private setStatus(status: WebMcpSessionStatus, detail?: string): void {
     this.status = status;
     this.statusDetail = detail;
-    this.publish({
-      type: "session",
-      seq: this.nextSeq(),
-      session: this.toPublic(),
-    });
+    // Initial navigation fires inside the provider's createSession, before
+    // attach supplies the real transport. Replaying that provisional
+    // native-window snapshot would make the client destroy its webview.
+    // Retain the status; the registry publishes once the browser is attached.
+    if (this.session) this.publishSession();
   }
 
   /**


### PR DESCRIPTION
Opening a WebMCP page in Electron can discover its tools and immediately fail with ‘The embedded page was closed.’ Initial navigation publishes a session snapshot before the provider is attached, so the snapshot advertises the fallback native-window transport. Replaying that snapshot makes the client unmount and destroy its embedded browser.

Defer status publication until the browser is attached, while retaining status and navigation/tool activity. Add a regression test covering startup replay with the correct Electron transport and deadlines, preserved discovery activity, and subsequent crash reporting.

Validation: the regression test failed before the fix; all 172 tests across the session runtime, registry, Electron provider, and WebMCP route suites pass after the fix. Formatting and git diff checks pass. The running Electron UI has not been manually verified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when session snapshots hit the replay buffer during startup and navigation; wrong timing could still confuse clients, but scope is limited to WebMCP session runtime event ordering.
> 
> **Overview**
> Fixes Electron WebMCP startup where the embedded page closed right after tool discovery. **Early navigation** used to emit a **session** replay snapshot while the browser was not attached yet, so `viewportTransport` fell back to **`native-window`**. Replaying that snapshot made the client tear down its **electron-webview** before the real session arrived.
> 
> **`setStatus`** now updates internal state only and calls **`publishSession`** when a browser session is attached (same idea as stream-quality updates). Tools, navigation activity, and post-attach status—including **error** on crash—still reach subscribers; the registry’s first publish carries the correct transport and expiry.
> 
> Adds a regression test for pre-attach navigation/tools, attach with **electron-webview**, replay contents, and crash reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbb131d3565b84d4c9d0a7978e7000feb6315879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Electron WebMCP pages closing during startup by deferring session snapshot publication until the browser is attached. Previously, initial navigation published a snapshot with a fallback native-window transport, and replaying that snapshot made the client destroy its embedded browser.

**Bug Fixes**
- Defer session publication until the browser is attached, while retaining status and navigation/tool activity.
- Add a regression test covering startup replay with the Electron transport, preserved discovery activity, and subsequent crash reporting.

<sup>Written for commit cbb131d3565b84d4c9d0a7978e7000feb6315879. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

