### PR TITLE
Fix Electron browser startup, tools, and viewport in Playground

### DIFF
--- a/mcpjam-inspector/client/src/components/browser/ElectronNativeBody.tsx
+++ b/mcpjam-inspector/client/src/components/browser/ElectronNativeBody.tsx
@@ -61,6 +61,7 @@ export function ElectronNativeBody({
   engine = "local",
   extra,
   chrome = "bar",
+  onViewportSize,
 }: {
   chrome?: "bar" | "none";
   /** The browser this pane is looking at, or null while none is running. */
@@ -87,6 +88,8 @@ export function ElectronNativeBody({
   active?: boolean;
   engine?: string;
   extra?: ReactNode;
+  /** Negotiate the page size through the session's resize barrier. */
+  onViewportSize?: (size: { width: number; height: number }) => void;
 }) {
   const [statsOpen, setStatsOpen] = useState(() => paneFrameStats.enabled());
   const slotRef = useRef<HTMLDivElement | null>(null);
@@ -135,6 +138,8 @@ export function ElectronNativeBody({
   consentTokenRef.current = consentToken;
   const wantVisibleRef = useRef(wantVisible);
   wantVisibleRef.current = wantVisible;
+  const onViewportSizeRef = useRef(onViewportSize);
+  onViewportSizeRef.current = onViewportSize;
 
   const push = useCallback(() => {
     const api = window.electronAPI?.agentBrowser;
@@ -163,6 +168,9 @@ export function ElectronNativeBody({
     // does — and it is applied in the MAIN process, which is the side that
     // actually knows it.
     const rect = element?.getBoundingClientRect();
+    if (visible && rect && rect.width > 0 && rect.height > 0) {
+      onViewportSizeRef.current?.({ width: rect.width, height: rect.height });
+    }
     void api
       .setViewport({
         consentToken: consentTokenRef.current,

--- a/mcpjam-inspector/client/src/components/browser/LocalBrowserBody.tsx
+++ b/mcpjam-inspector/client/src/components/browser/LocalBrowserBody.tsx
@@ -1055,7 +1055,7 @@ export function LocalBrowserBody({
   }, [bootId, holder, consentToken, setLeaseAction]);
 
   useEffect(() => {
-    if (!workspaceEnabled && bootId)
+    if (!workspaceEnabled && !native && bootId)
       void reportLocalPaneViewport({
         bootId,
         consentToken,
@@ -1063,7 +1063,22 @@ export function LocalBrowserBody({
         height: 768,
         policy: "fixed",
       });
-  }, [workspaceEnabled, bootId, consentToken]);
+  }, [workspaceEnabled, native, bootId, consentToken]);
+
+  // Native views cannot be scaled by the renderer's CSS like streamed frames.
+  // Fit the actual page to its slot even when the workspace chrome is disabled.
+  const reportNativeViewport = useCallback(
+    (size: { width: number; height: number }) => {
+      if (!bootId) return;
+      void reportLocalPaneViewport({
+        bootId,
+        consentToken,
+        ...size,
+        policy: "followPane",
+      });
+    },
+    [bootId, consentToken],
+  );
 
   const shell = useBrowserSession({
     transport: workspaceEnabled ? shellTransport : null,
@@ -1148,6 +1163,7 @@ export function LocalBrowserBody({
           <ElectronNativeBody
             consentToken={consentToken}
             session={session}
+            onViewportSize={reportNativeViewport}
             holder={holder}
             control={control}
             holding={holding}
@@ -1213,9 +1229,8 @@ export function LocalBrowserBody({
           onCommand={shell.run}
           {...(session && holding ? { onResumeAgent: shell.resume } : {})}
           resuming={shell.resuming}
-          // The shell owns the picture's SIZE, so it is the shell that
-          // measures. @see BrowserShellProps.onViewportMeasured
-          onViewportMeasured={shell.reportViewport}
+          // Native bodies measure their own slot, including any stats strip.
+          onViewportMeasured={native ? undefined : shell.reportViewport}
           // Not just "is there a browser": an engine too old to answer pane
           // commands has a perfectly real session, and controls that look live
           // and swallow every click read as broken rather than old.
@@ -1249,6 +1264,7 @@ export function LocalBrowserBody({
             <ElectronNativeBody
               consentToken={consentToken}
               session={session}
+              onViewportSize={reportNativeViewport}
               holder={holder}
               control={control}
               holding={holding}

--- a/mcpjam-inspector/client/src/components/browser/__tests__/ElectronNativeBody.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/ElectronNativeBody.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ElectronNativeBody } from "../ElectronNativeBody";
 import {
   BROWSER_PANE_STATS_FLAG,
@@ -101,6 +101,41 @@ describe("the native Electron browser pane", () => {
     expect(document.querySelector("canvas")).toBeNull();
     expect(document.querySelector("img")).toBeNull();
   });
+
+  it("reports the visible slot on mount and after a resize", async () => {
+    const onViewportSize = vi.fn();
+    renderBody({ onViewportSize });
+    await waitFor(() =>
+      expect(onViewportSize).toHaveBeenCalledWith({
+        width: RECT.width,
+        height: RECT.height,
+      }),
+    );
+    const slot = screen.getByTestId("rail-browser-native-slot");
+    const rect = vi.spyOn(slot, "getBoundingClientRect").mockReturnValue({
+      ...slot.getBoundingClientRect(),
+      width: 480,
+      height: 600,
+    });
+    fireEvent(window, new Event("resize"));
+    await waitFor(() =>
+      expect(onViewportSize).toHaveBeenLastCalledWith({
+        width: 480,
+        height: 600,
+      }),
+    );
+    rect.mockRestore();
+  });
+
+  it.each([{ active: false }, { consentGranted: false }, { session: null }])(
+    "does not resize a browser the pane cannot show: %j",
+    async (props) => {
+      const onViewportSize = vi.fn();
+      renderBody({ ...props, onViewportSize });
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      expect(onViewportSize).not.toHaveBeenCalled();
+    },
+  );
 
   it("takes the view out of the window when the pane stops being visible", async () => {
     // A native view is a SIBLING of the renderer: it keeps painting a live

--- a/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserBody.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserBody.test.tsx
@@ -55,7 +55,7 @@ const api = vi.hoisted(() => ({
    */
   paneUnsupported: false,
   /** Every panel measurement reported. */
-  viewports: [] as Array<{ width: number; height: number }>,
+  viewports: [] as Array<{ width: number; height: number; policy?: string }>,
   /** The last socket handed to the pane, so a test can deliver a frame. */
   socket: null as {
     readyState: number;
@@ -148,7 +148,11 @@ vi.mock("@/lib/local-browser/client", async () => {
       return { ok: true as const };
     },
     reportLocalPaneViewport: async (args: any) => {
-      api.viewports.push({ width: args.width, height: args.height });
+      api.viewports.push({
+        width: args.width,
+        height: args.height,
+        policy: args.policy,
+      });
       return { width: args.width, height: args.height, revision: 1 };
     },
     openLocalBrowserFrameStream: (args: { bootId: string }) => {
@@ -741,6 +745,41 @@ describe("the agent browser pane — the desktop app's own browser", () => {
     await userEvent.click(await screen.findByText("Open the browser"));
     await screen.findByTestId("rail-browser-native-slot");
     await waitFor(() => expect(api.watches).toContain("boot-proj-1"));
+  });
+
+  it("fits the native page to its slot with workspace chrome disabled", async () => {
+    asDesktopApp();
+    api.workspaceEnabled = false;
+    const rect = vi
+      .spyOn(Element.prototype, "getBoundingClientRect")
+      .mockReturnValue({
+        x: 700,
+        y: 100,
+        left: 700,
+        top: 100,
+        width: 480,
+        height: 600,
+        right: 1180,
+        bottom: 700,
+        toJSON: () => ({}),
+      } as DOMRect);
+    try {
+      renderBody();
+      await screen.findByTestId("rail-browser-native-slot");
+      await userEvent.click(await screen.findByText("Open the browser"));
+      await screen.findByTestId("rail-browser-native-slot");
+      await waitFor(() =>
+        expect(api.viewports).toContainEqual({
+          width: 480,
+          height: 600,
+          policy: "followPane",
+        }),
+      );
+      expect(api.viewports.at(-1)?.policy).toBe("followPane");
+      expect(api.socket).toBeNull();
+    } finally {
+      rect.mockRestore();
+    }
   });
 
   it("falls back to frames when the box turned the native surface off", async () => {

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -923,6 +923,18 @@ export function PlaygroundMain({
     isAuthenticated: isConvexAuthenticated,
     hostId: previewedHostId,
   });
+  const projectDefaultHostConfig = useQuery(
+    "hostConfigsV2:getProjectDefault" as never,
+    isConvexAuthenticated && convexProjectId
+      ? ({ projectId: convexProjectId } as never)
+      : "skip",
+  ) as HostConfigDtoV2 | null | undefined;
+  // Match the Tools and Browser rails: no explicit selection means the
+  // project default. An explicit host still loading must not inherit another
+  // host's capabilities, and an explicit empty list must stay empty.
+  const effectiveBuiltInToolIds = previewedHostId
+    ? previewedHost?.config?.builtInToolIds
+    : projectDefaultHostConfig?.builtInToolIds;
   // A newly selected host is unknown for one render while its config loads.
   // Fail closed in that gap: it may resolve to Codex or Claude Code, whose
   // opaque harness sessions cannot be safely rewound. Ordinary model hosts get
@@ -1196,10 +1208,10 @@ export function PlaygroundMain({
       previewedHost?.config?.modelVisibleMcpToolResults,
     mcpToolResultImageRendering: effectiveMcpToolResultImageRendering,
     // Same live-source pattern: built-in tool attachments flow from the
-    // previewed host's hostConfig. The server re-resolves via the shared
+    // effective host's hostConfig. The server re-resolves via the shared
     // execution-context helper, so this also flows through scenario sessions
     // (where the persisted host config wins via the runtime-config fetch).
-    builtInToolIds: previewedHost?.config?.builtInToolIds,
+    builtInToolIds: effectiveBuiltInToolIds,
     // For the RAW view of a reopened session only. Live turns stream the real
     // advertised set; a rehydrated one has nothing to show, and the browser is
     // the capability most likely to be a host's ONLY one — so without this Raw
@@ -5713,8 +5725,7 @@ export function PlaygroundMain({
                                   ?.modelVisibleMcpToolResults,
                               mcpToolResultImageRendering:
                                 effectiveMcpToolResultImageRendering,
-                              builtInToolIds:
-                                previewedHost?.config?.builtInToolIds,
+                              builtInToolIds: effectiveBuiltInToolIds,
                             }}
                             hostedContext={{
                               projectId: convexProjectId,

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -42,6 +42,7 @@ const mockReactiveHistoryState = vi.hoisted(() => ({
 }));
 
 const mockHostQueryState = vi.hoisted(() => ({ result: null as unknown }));
+const mockDefaultHostConfig = vi.hoisted(() => ({ result: null as unknown }));
 // Non-null `harnessId` means the chat executes inside a harness runtime
 // (Claude Code, Codex). Default null = an ordinary model host.
 const mockHarnessState = vi.hoisted(() => ({
@@ -203,6 +204,9 @@ vi.mock("convex/react", () => ({
   useQuery: (name: string, args: unknown) => {
     if (args === "skip") return undefined;
     if (name === "hosts:getHost") return mockHostQueryState.result;
+    if (name === "hostConfigsV2:getProjectDefault") {
+      return mockDefaultHostConfig.result;
+    }
     // The reactive chat-history subscription. `useResumedThreadPersistence`
     // reconciles a failed/absent persist receipt against this, so it needs a
     // real cell rather than the blanket null the other queries get.
@@ -748,6 +752,7 @@ describe("PlaygroundMain", () => {
     localStorage.clear();
     mockConvexAuthState.isAuthenticated = false;
     mockHostQueryState.result = null;
+    mockDefaultHostConfig.result = null;
     mockReactiveHistoryState.session = undefined;
     mockReactiveHistoryState.widgetSnapshots = undefined;
     mockHarnessState.harnessId = null;
@@ -804,6 +809,40 @@ describe("PlaygroundMain", () => {
   });
 
   describe("rendering", () => {
+    it("sends the project default's browser capability when no host is selected", () => {
+      mockConvexAuthState.isAuthenticated = true;
+      mockDefaultHostConfig.result = { builtInToolIds: ["browser"] };
+      mockSharedAppState.projects = { default: { sharedProjectId: "project-1" } };
+      try {
+        render(<PlaygroundMain {...defaultProps} />);
+        expect(capturedChatSessionOptions.builtInToolIds).toEqual(["browser"]);
+      } finally {
+        mockSharedAppState.projects = {};
+      }
+    });
+
+    it("does not inherit default capabilities while an explicit host loads or disables them", () => {
+      const hostId = "hlk3m9x2q7v5b8n1t4r6s0dc";
+      mockConvexAuthState.isAuthenticated = true;
+      mockDefaultHostConfig.result = { builtInToolIds: ["browser"] };
+      localStorage.setItem(
+        "mcp-previewed-host-id",
+        JSON.stringify({ "project-1": hostId })
+      );
+      mockHostQueryState.result = undefined;
+      const props = { ...defaultProps, activeProjectId: "project-1" };
+      const { rerender } = render(<PlaygroundMain {...props} />);
+      expect(capturedChatSessionOptions.builtInToolIds).toBeUndefined();
+
+      mockHostQueryState.result = {
+        hostId,
+        name: "Explicit host",
+        config: { builtInToolIds: [] },
+      };
+      rerender(<PlaygroundMain {...props} />);
+      expect(capturedChatSessionOptions.builtInToolIds).toEqual([]);
+    });
+
     it("renders the component", () => {
       render(<PlaygroundMain {...defaultProps} />);
 

--- a/mcpjam-inspector/server/services/browserd/electron/__tests__/electron-context.test.ts
+++ b/mcpjam-inspector/server/services/browserd/electron/__tests__/electron-context.test.ts
@@ -61,6 +61,15 @@ describe("electron context — the windows it opens", () => {
     });
   });
 
+  it("resizes the hidden window's content when the driver resizes its page", async () => {
+    const electron = fakeElectron();
+    const context = await launchElectronContext({ electron });
+    const page = await context.newPage();
+    await page.setViewportSize!({ width: 480, height: 600 });
+    expect(electron.windows[0]?.contentSize).toEqual({ width: 480, height: 600 });
+    await context.close();
+  });
+
   it("refuses every permission a page asks for", async () => {
     const electron = fakeElectron();
     await launchElectronContext({ electron });
@@ -182,6 +191,18 @@ describe("electron context — lifecycle", () => {
 });
 
 describe("electron context — the page it hands back", () => {
+  it("closes a window whose initial document fails to load", async () => {
+    const contents = new FakeBrowserWebContents({
+      loadError: new Error("load failed"),
+    });
+    const electron = fakeElectron([contents]);
+    const context = await launchElectronContext({ electron });
+    await expect(context.newPage()).rejects.toThrow("load failed");
+    expect(electron.windows[0]?.isDestroyed()).toBe(true);
+    expect(agentBrowserWindowCount()).toBe(0);
+    await context.close();
+  });
+
   it("drives the webContents the window was built with", async () => {
     const contents = new FakeBrowserWebContents();
     const electron = fakeElectron([contents]);
@@ -190,7 +211,10 @@ describe("electron context — the page it hands back", () => {
     const page = await context.newPage();
     await page.goto("https://example.test/");
 
-    expect(contents.navigations).toEqual(["https://example.test/"]);
+    expect(contents.navigations).toEqual([
+      "about:blank",
+      "https://example.test/",
+    ]);
     expect(page.url()).toBe("https://example.test/");
   });
 
@@ -254,7 +278,6 @@ describe("electron context — outside Electron", () => {
   });
 });
 
-
 /**
  * V-3. Tabs as VIEWS on one hidden holder, which is what makes the browser
  * showable: the pane reparents the active view into the app's own window and
@@ -277,6 +300,7 @@ describe("the native surface", () => {
         setViewport: () => {},
         setShieldFactory: () => {},
         isShown: () => false,
+        visibilityAllowed: () => true,
         isShielded: () => false,
         inputAllowed: () => false,
         dispose: () => calls.push({ kind: "dispose", view: undefined }),

--- a/mcpjam-inspector/server/services/browserd/electron/__tests__/electron-driver.test.ts
+++ b/mcpjam-inspector/server/services/browserd/electron/__tests__/electron-driver.test.ts
@@ -12,11 +12,12 @@
  * every observation, classifies thrown prose, and pins a state token to a DOM
  * signal. Nothing here mocks the driver.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ChromiumDriver } from "../../daemon/chromium-driver";
 import { HandoffLease } from "../../daemon/lease";
 import type { BrowserCommand } from "../../protocol";
 import { launchElectronContext } from "../electron-context";
+import { createContextSurface } from "../agent-surface";
 import {
   elementAt,
   fakeElectron,
@@ -54,6 +55,96 @@ async function electronDriver(
 }
 
 describe("the driver over Electron — it does not notice the engine", () => {
+  it.each([true, false])(
+    "resizes native views only when the session allows pane resizing (%s)",
+    async (allowPaneResize) => {
+      const electron = fakeElectron([pageContents()]);
+      const surface = createContextSurface();
+      const context = await launchElectronContext({
+        electron,
+        nativeSurface: true,
+        surface,
+      });
+      const driver = new ChromiumDriver(context, {
+        viewport: {
+          policy: "fixed",
+          allowPaneResize,
+          debounceMs: 0,
+          onChange: (size) => surface.setViewport(size),
+        },
+      });
+      try {
+        const result = await driver.execute(
+          cmd({ kind: "navigate", url: "https://example.test/" }),
+        );
+        expect(result.ok).toBe(true);
+        const view = electron.views[0]!;
+        view.setBounds({ x: 40, y: 90, width: 1024, height: 768 });
+        const viewport = await driver.requestViewport({
+          width: 480,
+          height: 550,
+          policy: "followPane",
+        });
+        const expected = allowPaneResize
+          ? { width: 480, height: 550, revision: 1 }
+          : { width: 1024, height: 768, revision: 0 };
+        expect(viewport).toEqual(expected);
+        expect(view.getBounds()).toEqual({
+          x: 40,
+          y: 90,
+          width: expected.width,
+          height: expected.height,
+        });
+      } finally {
+        await driver.close();
+      }
+    },
+  );
+
+  it("loads the initial document before attaching the debugger and navigating", async () => {
+    const contents = pageContents();
+    const evaluate = contents.executeJavaScript.bind(contents);
+    let releaseLoad!: () => void;
+    const loaded = new Promise<void>((resolve) => {
+      releaseLoad = resolve;
+    });
+    const send = contents.debugger.sendCommand.bind(contents.debugger);
+    vi.spyOn(contents.debugger, "sendCommand").mockImplementation(
+      async (...args) => {
+        // A real, never-loaded WebContents also stalls DOM.enable.
+        if (contents.navigations.length === 0) await loaded;
+        return send(...args);
+      },
+    );
+    vi.spyOn(contents, "executeJavaScript").mockImplementation(async (code) => {
+      // Electron defers executeJavaScript until a page has loaded. Waiting
+      // for it before goto creates a cycle that never reaches loadURL.
+      if (contents.navigations.length === 0) await loaded;
+      return evaluate(code);
+    });
+    const load = contents.loadURL.bind(contents);
+    vi.spyOn(contents, "loadURL").mockImplementation(async (url) => {
+      await load(url);
+      releaseLoad();
+    });
+    const { driver } = await electronDriver([contents]);
+    try {
+      const navigation = driver.execute(
+        cmd({ kind: "navigate", url: "https://example.test/" }),
+      );
+      await vi.waitFor(() =>
+        expect(contents.navigations).toEqual([
+          "about:blank",
+          "https://example.test/",
+        ]),
+      );
+      expect((await navigation).ok).toBe(true);
+    } finally {
+      releaseLoad();
+      await driver.close();
+    }
+  });
+
   it("navigates and folds the observation in", async () => {
     const contents = pageContents();
     const { driver } = await electronDriver([contents]);

--- a/mcpjam-inspector/server/services/browserd/electron/__tests__/electron-page.test.ts
+++ b/mcpjam-inspector/server/services/browserd/electron/__tests__/electron-page.test.ts
@@ -30,6 +30,43 @@ function keyEvents(dbg: FakeBrowserWebContents["debugger"]) {
     .map((c) => c.params as Record<string, unknown>);
 }
 
+describe("electron page — WebMCP support", () => {
+  it.each([
+    [{ result: { value: true } }, true],
+    [{ result: { value: false } }, false],
+    [{}, false],
+    [{ result: { value: true }, exceptionDetails: { text: "failed" } }, false],
+  ])("reads support from the CDP evaluation %j", async (reply, supported) => {
+    const { page, dbg } = makePage();
+    dbg.replies.set("Runtime.evaluate", reply);
+    const bridge = await page.webmcp();
+    expect(bridge?.isSupported()).toBe(supported);
+    bridge?.dispose();
+  });
+
+  it("rechecks support when navigation replaces the initial document", async () => {
+    const { page, dbg } = makePage();
+    dbg.replies.set("Runtime.evaluate", { result: { value: false } });
+    const bridge = await page.webmcp();
+    expect(bridge?.isSupported()).toBe(false);
+
+    dbg.replies.set("Runtime.evaluate", { result: { value: true } });
+    dbg.emitCdp("Page.frameNavigated", {
+      frame: { id: "main", url: "https://example.test/" },
+    });
+    await bridge?.probeSettled();
+    expect(bridge?.isSupported()).toBe(true);
+
+    dbg.replies.set("Runtime.evaluate", { result: { value: false } });
+    dbg.emitCdp("Page.frameNavigated", {
+      frame: { id: "main", url: "https://other.test/" },
+    });
+    await bridge?.probeSettled();
+    expect(bridge?.isSupported()).toBe(false);
+    bridge?.dispose();
+  });
+});
+
 describe("electron page — clicking", () => {
   it("moves before it presses, and releases the button it pressed", async () => {
     // Hover handlers and menus that open on mouseover both need the pointer to

--- a/mcpjam-inspector/server/services/browserd/electron/__tests__/fake-electron-browser.ts
+++ b/mcpjam-inspector/server/services/browserd/electron/__tests__/fake-electron-browser.ts
@@ -209,6 +209,11 @@ export class FakeBrowserWindow implements ElectronWindowLike {
   readonly id: number;
   destroyed = false;
   focusCount = 0;
+  contentSize: { width: number; height: number } | undefined;
+
+  setContentSize(width: number, height: number): void {
+    this.contentSize = { width, height };
+  }
 
   constructor(
     readonly options: Record<string, unknown>,
@@ -251,6 +256,10 @@ export class FakeWebContentsView {
 
   setBounds(next: { x: number; y: number; width: number; height: number }): void {
     this.bounds = next;
+  }
+
+  getBounds() {
+    return this.bounds ?? { x: 0, y: 0, width: 0, height: 0 };
   }
 }
 

--- a/mcpjam-inspector/server/services/browserd/electron/agent-surface.ts
+++ b/mcpjam-inspector/server/services/browserd/electron/agent-surface.ts
@@ -186,6 +186,8 @@ export interface ContextSurface {
   paneHolder(): string | undefined;
   /** Is the active view currently parented into a visible window? */
   isShown(): boolean;
+  /** Does the lease permit this pane to see the page, even before a tab exists? */
+  visibilityAllowed(): boolean;
   /** May the person's clicks reach the page right now? */
   inputAllowed(): boolean;
   dispose(): void;
@@ -520,6 +522,7 @@ export function createContextSurface(
       apply();
     },
     isShown: () => !!parented,
+    visibilityAllowed: visible,
     paneHolder: () => paneHolder,
     isShielded: () => shielded,
     setShieldFactory(factory) {

--- a/mcpjam-inspector/server/services/browserd/electron/electron-context.ts
+++ b/mcpjam-inspector/server/services/browserd/electron/electron-context.ts
@@ -102,6 +102,7 @@ export interface ElectronLike {
     id?: number;
   };
   WebContentsView?: new (options: Record<string, unknown>) => SurfaceView & {
+    getBounds(): { x: number; y: number; width: number; height: number };
     webContents: PageWebContents & {
       setWindowOpenHandler?(
         handler: (details: { url: string }) => { action: "deny" | "allow" },
@@ -131,6 +132,7 @@ export interface ElectronWindowLike {
   isDestroyed(): boolean;
   destroy(): void;
   focus?(): void;
+  setContentSize?(width: number, height: number): void;
 }
 
 /**
@@ -260,6 +262,8 @@ export async function launchElectronContext(
     const shim: ElectronWindowLike = {
       ...(view.webContents.id !== undefined ? { id: view.webContents.id } : {}),
       webContents: view.webContents,
+      setContentSize: (width, height) =>
+        view.setBounds({ ...view.getBounds(), width, height }),
       isDestroyed: () => view.webContents.isDestroyed?.() ?? false,
       destroy: () => {
         options.surface?.forget(view);
@@ -320,12 +324,29 @@ export async function launchElectronContext(
   }
 
   async function adopt(window: ElectronWindowLike): Promise<DriverPage> {
+    // A newly constructed Electron view has no loaded document. Debugger
+    // commands (including DOM.enable) can wait indefinitely in that state,
+    // while the driver waits for its WebMCP bridge before navigating. Load a
+    // blank document first so attachment can finish before the requested URL.
+    try {
+      await window.webContents.loadURL("about:blank");
+    } catch (error) {
+      forget(window);
+      if (!window.isDestroyed()) window.destroy();
+      throw error;
+    }
     const page = createElectronPage(window.webContents, {
       onClose() {
         forget(window);
         if (!window.isDestroyed()) window.destroy();
       },
       onBringToFront: () => window.focus?.(),
+      ...(window.setContentSize
+        ? {
+            onResize: (size: { width: number; height: number }) =>
+              window.setContentSize!(size.width, size.height),
+          }
+        : {}),
     });
 
     // Denied, and that is the honest v1 answer rather than a limitation being

--- a/mcpjam-inspector/server/services/browserd/electron/electron-page.ts
+++ b/mcpjam-inspector/server/services/browserd/electron/electron-page.ts
@@ -167,6 +167,8 @@ export interface ElectronPageDeps {
   onClose(): Promise<void> | void;
   /** Bring the page's window forward — what `activate_tab` means here. */
   onBringToFront?(): void;
+  /** Resize the native view or window when the session barrier accepts it. */
+  onResize?(size: { width: number; height: number }): void;
 }
 
 /**
@@ -860,6 +862,13 @@ export function createElectronPage(
   }
 
   const page: DriverPage = {
+    ...(deps.onResize
+      ? {
+          async setViewportSize(size: { width: number; height: number }) {
+            deps.onResize!(size);
+          },
+        }
+      : {}),
     async goto(url) {
       // BEFORE the load, not inside the settle that follows it: `Network.enable`
       // does not replay, so a request this navigation starts before the monitor
@@ -1258,14 +1267,21 @@ export function createElectronPage(
         if (!cdp) return null;
         try {
           const bridge = new Bridge(cdp);
-          await bridge.start(async () => {
-            // `WebMCP.enable` resolves even where the feature is off; the page
-            // API is the only honest probe. Same rule as every other engine.
-            const supported = await wc
-              .executeJavaScript(`(() => ${PAGE_API_PROBE})()`)
-              .catch(() => false);
-            return supported === true;
-          });
+          const probe = async () => {
+            // Electron's executeJavaScript waits for the first load. The
+            // driver awaits this bridge BEFORE navigating, so using it here
+            // deadlocks a fresh tab. CDP evaluates the current document
+            // directly while preserving discovery before the first load.
+            const result = (await cdp.send("Runtime.evaluate", {
+              expression: PAGE_API_PROBE,
+              returnByValue: true,
+            })) as { result?: { value?: unknown }; exceptionDetails?: unknown };
+            return !result.exceptionDetails && result.result?.value === true;
+          };
+          // The initial document may lack the API. Recheck each destination
+          // rather than retaining about:blank's answer for the whole session.
+          bridge.resupport(probe);
+          await bridge.start(probe);
           return bridge;
         } catch {
           return null;

--- a/mcpjam-inspector/src/ipc/agent-browser/agent-browser-listeners.test.ts
+++ b/mcpjam-inspector/src/ipc/agent-browser/agent-browser-listeners.test.ts
@@ -251,6 +251,28 @@ describe("agent-browser:set-viewport", () => {
     expect(window_.children).not.toContain(view);
   });
 
+  it("does not report a lease conflict before the first tab exists", async () => {
+    const surface = createContextSurface();
+    const api = install({
+      surfaces: new Map([["boot-1", surface]]),
+    });
+    expect(
+      await api.setViewport({
+        bootId: "boot-1",
+        holder: "rail-1",
+        visible: true,
+        bounds: BOUNDS,
+      }),
+    ).toEqual({ shown: false, inputAllowed: false });
+
+    // The placement request survives startup, so the first tab appears
+    // without requiring another resize or a change of control.
+    const view = fakeView();
+    surface.registerTab(view);
+    expect(window_.children).toContain(view);
+    expect(surface.isShown()).toBe(true);
+  });
+
   it("hides rather than shows a browser somebody else holds", async () => {
     // THE LEASE DECIDES, not the renderer. A visible native view of a page
     // another person is typing their password into is an observation, which is

--- a/mcpjam-inspector/src/ipc/agent-browser/agent-browser-listeners.ts
+++ b/mcpjam-inspector/src/ipc/agent-browser/agent-browser-listeners.ts
@@ -276,9 +276,9 @@ export function registerAgentBrowserListeners(
       return {
         shown,
         inputAllowed: surface.inputAllowed(),
-        // Not shown despite a good rectangle means the LEASE refused it, which
-        // is the one refusal the pane has something to say about.
-        ...(shown ? {} : { reason: "lease" as const }),
+        // A surface may exist before its first tab does. Only blame another
+        // holder when the lease actually refuses observation.
+        ...(surface.visibilityAllowed() ? {} : { reason: "lease" as const }),
       };
     },
   );


### PR DESCRIPTION
Playground could list browser tools without sending them to the model, hang on the first Electron navigation, show a false control-conflict message during startup, or draw a fixed 1024×768 page outside the browser pane.

This change uses the project default host's built-in tools when no explicit host is selected, loads a blank document before debugger attachment, rechecks WebMCP support after navigation, and distinguishes an empty surface from a lease refusal. The native pane reports its measured size through the session resize barrier, and the Electron page adapter resizes the underlying view or window.

Validation:
- 324 tests pass across Playground, native browser components, Electron adapters, and IPC.
- Client TypeScript check passes.
- Real Electron verification loaded the pizza-maker demo, discovered its seven WebMCP tools, and confirmed matching page/view dimensions at 480×550 and 620×420.

Resizing remains deferred during browser actions to preserve coordinate validity; a page may visibly reflow when the queued resize is applied. Main-process changes require an Electron restart.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Electron browser lifecycle, viewport/lease IPC, and chat tool resolution; behavior changes need desktop restart and affect first-tab placement and model tool lists.
> 
> **Overview**
> Fixes **Electron native browser** sizing and startup, **Playground tool attachment** when no host is picked, and several **false lease / hang** cases on first navigation.
> 
> **Native viewport:** `ElectronNativeBody` now calls optional `onViewportSize` from measured slot bounds (mount, resize, scroll). `LocalBrowserBody` forwards that as `reportLocalPaneViewport` with `followPane` instead of a fixed 1024×768 when workspace chrome is off; streamed panes still use the shell for measurement.
> 
> **Playground:** When no previewed host is selected, `builtInToolIds` come from the project default host config (`hostConfigsV2:getProjectDefault`), matching Tools/Browser rails. An explicit host that is loading or has an empty list does not inherit the default.
> 
> **Electron engine:** Tabs load `about:blank` before CDP attach (avoids first-navigation deadlock); failed initial load destroys the window. `setViewportSize` resizes the hidden window/view when pane resize is allowed. WebMCP support is probed via CDP and re-checked on navigation. IPC uses `visibilityAllowed()` so an empty surface before the first tab is not reported as a lease conflict; placement can apply when the tab registers.
> 
> **Tests** cover viewport callbacks, native `followPane`, default host tools, driver resize gating, and WebMCP re-probing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7173fa37ed83a8ab62db7ad624df7c7cd692a0c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Electron browser startup, tool discovery, and viewport sizing in Playground so native sessions no longer hang on first navigation, list tools the model never receives, show a false control-conflict message during startup, or paint a fixed 1024×768 page.

**Bug Fixes**
- Playground falls back to the project default host's built-in tool list when no host is explicitly selected.
- Electron loads a blank document before debugger attachment so the first navigation can complete.
- WebMCP support is re-probed after each navigation instead of caching the blank document's answer.
- An empty surface with no tab yet no longer counts as a lease refusal, removing the false conflict message.
- The native pane reports its measured slot size through the session resize barrier, and the adapter resizes the underlying view or window to match.

**Notes**
- Viewport resizing stays deferred while browser actions run; a page may visibly reflow when the queued resize applies.
- Main-process changes require an Electron restart.

<sup>Written for commit 7173fa37ed83a8ab62db7ad624df7c7cd692a0c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

