### PR TITLE
Gate WebMCP tab with local and hosted Browser rollouts

### DIFF
--- a/mcpjam-inspector/client/src/__tests__/WebmcpInspectorRoute.flag-hydration.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/WebmcpInspectorRoute.flag-hydration.test.tsx
@@ -10,7 +10,7 @@ import { routePaths } from "../lib/app-navigation";
 let flagState: boolean | undefined = undefined;
 
 vi.mock("../hooks/useWebmcpInspectorEnabled", () => ({
-  WEBMCP_INSPECTOR_FEATURE_FLAG: "webmcp-inspector-enabled",
+  WEBMCP_INSPECTOR_FEATURE_FLAG: "local-browser-enabled",
   useWebmcpInspectorEnabledState: () => flagState,
   useWebmcpInspectorEnabled: () => flagState === true,
 }));

--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { WEBMCP_INSPECTOR_FEATURE_FLAG } from "../../hooks/useWebmcpInspectorEnabled";
 import {
   applyBillingGateNavState,
   filterByFeatureFlags,
@@ -217,6 +218,21 @@ describe("filterByFeatureFlags", () => {
 });
 
 describe("declared nav flags are actually resolved", () => {
+  it("WebMCP uses the deployment Browser flag, not the legacy flag", () => {
+    const titles = (flags: Record<string, boolean>) =>
+      filterByFeatureFlags(navigationSections, flags)
+        .flatMap((section) => section.items)
+        .map((item) => item.title);
+    expect(titles({ "webmcp-inspector-enabled": true })).not.toContain(
+      "WebMCP",
+    );
+    expect(titles({ [WEBMCP_INSPECTOR_FEATURE_FLAG]: true })).toContain(
+      "WebMCP",
+    );
+    expect(titles({ [WEBMCP_INSPECTOR_FEATURE_FLAG]: false })).not.toContain(
+      "WebMCP",
+    );
+  });
   // The bug this guards: a nav item can declare `featureFlag: "x"` while the
   // sidebar's `featureFlags` map never sets `x`. `filterByFeatureFlags` then
   // reads `undefined`, hides the item permanently, and — because nothing ever

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -126,7 +126,7 @@ export const SIDEBAR_RESOLVED_FLAG_KEYS = [
   "project-environments-enabled",
   "unified-sessions-enabled",
   "evaluate-enabled",
-  "webmcp-inspector-enabled",
+  WEBMCP_INSPECTOR_FEATURE_FLAG,
 ] as const;
 
 /**
@@ -361,7 +361,7 @@ export const navigationSections: NavSection[] = [
         title: "WebMCP",
         url: "/webmcp",
         icon: Globe,
-        featureFlag: "webmcp-inspector-enabled",
+        featureFlag: WEBMCP_INSPECTOR_FEATURE_FLAG,
       },
     ],
   },
@@ -634,11 +634,9 @@ export function MCPSidebar({
       // Project-scoped like the rows above: every screen behind it needs a
       // project to resolve suites against.
       "evaluate-enabled": evaluateEnabled === true && isAuthenticated,
-      // Not auth-scoped, unlike the rows above: the browser and the page run
-      // on this machine, so a signed-out local user has everything the surface
-      // needs. It is hostedBlocked, so hosted builds drop it before this map
-      // is consulted.
-      "webmcp-inspector-enabled": webmcpInspectorEnabled === true,
+      // Deployment-specific Browser rollout; local guests are eligible too.
+      // Hosted execution retains its server-side sign-in/entitlement checks.
+      [WEBMCP_INSPECTOR_FEATURE_FLAG]: webmcpInspectorEnabled === true,
     }),
     [
       learningEnabled,

--- a/mcpjam-inspector/client/src/hooks/__tests__/useWebmcpInspectorEnabled.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useWebmcpInspectorEnabled.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  hosted: false,
+  flags: {} as Record<string, boolean | undefined>,
+  reads: [] as string[],
+}));
+
+vi.mock("@/lib/config", () => ({
+  get HOSTED_MODE() {
+    return state.hosted;
+  },
+}));
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: (key: string) => {
+    state.reads.push(key);
+    return state.flags[key];
+  },
+}));
+
+describe.each([false, true])("WebMCP visibility, hosted=%s", (hosted) => {
+  beforeEach(() => {
+    vi.resetModules();
+    state.hosted = hosted;
+    state.flags = {};
+    state.reads = [];
+  });
+
+  it.each([true, false, undefined])(
+    "uses only the deployment's Browser flag (%s), preserving hydration",
+    async (enabled) => {
+      const key = hosted ? "hosted-browser-enabled" : "local-browser-enabled";
+      const other = hosted ? "local-browser-enabled" : "hosted-browser-enabled";
+      state.flags = {
+        [key]: enabled,
+        [other]: true,
+        "webmcp-inspector-enabled": true,
+        "computers-enabled": true,
+      };
+      const hooks = await import("../useWebmcpInspectorEnabled");
+      expect(hooks.WEBMCP_INSPECTOR_FEATURE_FLAG).toBe(key);
+      const { result } = renderHook(() => ({
+        state: hooks.useWebmcpInspectorEnabledState(),
+        visible: hooks.useWebmcpInspectorEnabled(),
+      }));
+      expect(result.current).toEqual({
+        state: enabled,
+        visible: enabled === true,
+      });
+      expect(new Set(state.reads)).toEqual(new Set([key]));
+    },
+  );
+
+  it("needs neither Computers nor the legacy WebMCP flag", async () => {
+    const key = hosted ? "hosted-browser-enabled" : "local-browser-enabled";
+    state.flags[key] = true;
+    const { useWebmcpInspectorEnabled } = await import(
+      "../useWebmcpInspectorEnabled"
+    );
+    const { result } = renderHook(useWebmcpInspectorEnabled);
+    expect(result.current).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useWebmcpInspectorEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useWebmcpInspectorEnabled.ts
@@ -1,20 +1,23 @@
 import { useFeatureFlagEnabled } from "posthog-js/react";
+import { HOSTED_MODE } from "@/lib/config";
+import {
+  HOSTED_BROWSER_FEATURE_FLAG,
+  LOCAL_BROWSER_FEATURE_FLAG,
+} from "./useComputersEnabled";
 
 /**
  * PostHog rollout gate for the WebMCP Inspector — the `/webmcp` nav tab and
  * workspace, and the page-tools section in Playground. Flag off ⇒ invisible, so
  * the surface can roll out per-user without a deploy.
  *
- * This is the VISIBILITY gate only. Two other gates sit under it and neither is
- * a substitute: `/api/mcp/*` is mounted only outside hosted mode, and
- * `MCPJAM_WEBMCP_INSPECTOR_ENABLED` is the server-side emergency stop. A
- * flagged-in user on a hosted deployment still gets nothing, which is correct:
- * the browser would have to open on the machine running the inspector.
- *
- * Named `webmcp-inspector-*` rather than `webmcp-*` throughout the code, since
- * `client/src/lib/webmcp/` is the unrelated in-app agent bridge.
+ * Select by deployment, not by the OR used for Browser host authoring:
+ * Node/Electron follow local Browser; hosted follows hosted Browser. Neither
+ * Computers nor the retired WebMCP flag can expose this surface. Server
+ * authentication, runtime readiness, and emergency stops remain independent.
  */
-export const WEBMCP_INSPECTOR_FEATURE_FLAG = "webmcp-inspector-enabled";
+export const WEBMCP_INSPECTOR_FEATURE_FLAG = HOSTED_MODE
+  ? HOSTED_BROWSER_FEATURE_FLAG
+  : LOCAL_BROWSER_FEATURE_FLAG;
 
 /**
  * Tri-state flag: `true` enabled, `false` explicitly disabled, `undefined`

--- a/mcpjam-inspector/docs/browser-public-rollout.md
+++ b/mcpjam-inspector/docs/browser-public-rollout.md
@@ -7,7 +7,10 @@ Two rollout flags, neither dependent on `computers-enabled`:
 | `local-browser-enabled`  | Verified guests and signed-in users in local Node/Electron | Browser on this machine, after explicit Browser consent                            |
 | `hosted-browser-enabled` | Signed-in users                                            | Hosted Browser, subject to existing account, entitlement, image, and credit checks |
 
-`webmcp-inspector-enabled` is unchanged. There is no third Browser master flag.
+The WebMCP tab, direct route, and Playground page-tools section follow
+`local-browser-enabled` in Node/Electron and `hosted-browser-enabled` in hosted
+deployments. The old `webmcp-inspector-enabled` flag no longer controls these
+surfaces. There is no third Browser master flag.
 The existing workspace-layout experiment is not required: with it off, Browser
 uses the right rail's Browser tab.
 

--- a/mcpjam-inspector/docs/webmcp-inspector.md
+++ b/mcpjam-inspector/docs/webmcp-inspector.md
@@ -3,7 +3,8 @@
 A managed browser pointed at a page, so the WebMCP tools that page registers can
 be listed, invoked, watched across navigations, and handed to a model.
 
-Local only, behind `webmcp-inspector-enabled`.
+Visibility follows `local-browser-enabled` in Node/Electron and
+`hosted-browser-enabled` in hosted deployments.
 
 ## What it is for
 
@@ -342,7 +343,7 @@ a window opened.
 | Server kill switch | `MCPJAM_WEBMCP_INSPECTOR_ENABLED` (default on)        | same                                                                     |
 | Reachability       | —                                                     | `MCPJAM_WEBMCP_INSPECTOR_HOSTED_ENABLED=1`                               |
 | Backend verdict    | —                                                     | `desktopProvisionable` from the runtime-config bootstrap                 |
-| Client visibility  | `webmcp-inspector-enabled` (PostHog)                  | same                                                                     |
+| Client visibility  | `local-browser-enabled` (PostHog)                   | `hosted-browser-enabled` (PostHog)                                       |
 
 Off means **404, not 403**: a disabled capability should not be discoverable.
 The nav item's flag key must stay in `SIDEBAR_RESOLVED_FLAG_KEYS` or the item is

--- a/mcpjam-inspector/server/config.ts
+++ b/mcpjam-inspector/server/config.ts
@@ -109,8 +109,8 @@ export const SCHEDULED_EVALS_WRITE_ENABLED =
  * unreachable.
  *
  * Hosted reachability is a second, independent gate — see
- * `webmcpInspectorHostedEnabled` — and the client-side gate is still the
- * `webmcp-inspector-enabled` PostHog flag.
+ * `webmcpInspectorHostedEnabled` — and client visibility follows the
+ * deployment's `local-browser-enabled` / `hosted-browser-enabled` rollout.
  */
 export const WEBMCP_INSPECTOR_ENABLED =
   process.env.MCPJAM_WEBMCP_INSPECTOR_ENABLED !== "false";

--- a/mcpjam-inspector/server/routes/mcp/webmcp-inspector.ts
+++ b/mcpjam-inspector/server/routes/mcp/webmcp-inspector.ts
@@ -88,7 +88,7 @@ import {
  * code the UI can explain beats a 404 on a route the client can plainly see.
  * `WEBMCP_INSPECTOR_ENABLED` is the kill switch in both modes;
  * `webmcpInspectorHostedEnabled()` is the separate hosted-reachability gate;
- * the client-side gate is the `webmcp-inspector-enabled` flag.
+ * client visibility follows the deployment's local/hosted Browser rollout.
  *
  * The browser opens as a real window on the machine running the inspector: the
  * developer drives their own page directly, and this API is the instrument


### PR DESCRIPTION
Replaces the legacy WebMCP visibility flag with local-browser-enabled in Node/Electron and hosted-browser-enabled in hosted deployments. Sidebar, direct route hydration, and Playground page-tools visibility remain aligned. Computer flags and runtime authorization are unchanged; no live PostHog settings changed. All 40 targeted tests pass across four suites. Ship this client change before widening the local flag; keep hosted restricted or off for the local-first public launch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Misaligned PostHog rollouts could hide or expose WebMCP for the wrong deployment until flags are configured, but auth, billing, and API enforcement are unchanged.
> 
> **Overview**
> **WebMCP visibility** no longer reads PostHog `webmcp-inspector-enabled`. The `/webmcp` sidebar entry, route guard, and related UI now follow **`local-browser-enabled`** in Node/Electron and **`hosted-browser-enabled`** in hosted builds, via a deployment-selected `WEBMCP_INSPECTOR_FEATURE_FLAG` in `useWebmcpInspectorEnabled`. Legacy or Computers flags cannot turn the surface on; tri-state hydration behavior for direct `/webmcp` loads is unchanged.
> 
> The sidebar wires the WebMCP nav item and `SIDEBAR_RESOLVED_FLAG_KEYS` through that constant so the resolved flag map stays aligned with PostHog. **Tests** assert the legacy key no longer shows WebMCP and add hook coverage for hosted vs local flag reads only.
> 
> **Docs and server comments** are updated to describe the new client gates; server kill switches and hosted reachability env vars are not changed in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f5c43696da65b8e42a75f8895e7b91eebeb1c32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the WebMCP inspector tab, direct route, and Playground page-tools by the deployment's Browser rollout flag instead of the legacy `webmcp-inspector-enabled` flag, so local and hosted rollouts can diverge.

- Node/Electron follows `local-browser-enabled`; hosted deployments follow `hosted-browser-enabled`.
- Each deployment reads only its own flag, preserving server-side hydration.
- Server authentication, runtime authorization, and Computer flags are unchanged.
- Ship this client change before widening the local flag; keep hosted restricted or off for the local-first public launch.

<sup>Written for commit 4f5c43696da65b8e42a75f8895e7b91eebeb1c32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

