### PR TITLE
fix: allow browser consent when analytics is disabled

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/PartSwitch.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/PartSwitch.test.tsx
@@ -120,7 +120,8 @@ vi.mock("@/state/app-state-context", () => ({
 vi.mock("../thread/thread-helpers", () => ({
   isToolPart: (part: any) => part.type === "tool-invocation",
   isDynamicTool: (part: any) => part.type === "dynamic-tool",
-  isDataPart: (part: any) => part.type?.endsWith("-data"),
+  isDataPart: (part: any) =>
+    part.type?.startsWith("data-") || part.type?.endsWith("-data"),
   getToolInfo: (part: any) => ({
     toolName: part.toolName || "test-tool",
     toolCallId: part.toolCallId || "call-123",
@@ -188,6 +189,19 @@ describe("PartSwitch", () => {
     vi.clearAllMocks();
     mockDetectUIType.mockReturnValue(null);
   });
+
+  it.each([null, "browser_consent_required"])(
+    "hides internal browser readiness (%s)",
+    (reason) => {
+      const { container } = render(
+        <PartSwitch
+          {...defaultProps}
+          part={{ type: "data-browser-readiness", data: { reason } } as any}
+        />,
+      );
+      expect(container.textContent).toBe("");
+    },
+  );
 
   describe("text parts", () => {
     it("renders TextPart for text type", () => {

--- a/mcpjam-inspector/server/utils/__tests__/analytics.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/analytics.test.ts
@@ -2,10 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Context } from "hono";
 
 const captureMock = vi.fn();
+const flagMock = vi.fn();
 const shutdownMock = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("posthog-node", () => ({
-  PostHog: vi.fn(() => ({ capture: captureMock, shutdown: shutdownMock })),
+  PostHog: vi.fn(() => ({
+    capture: captureMock,
+    shutdown: shutdownMock,
+    isFeatureEnabled: flagMock,
+  })),
 }));
 
 // HOSTED_MODE is a module-load-time const computed from the ambient
@@ -18,7 +23,11 @@ vi.mock("../../config.js", async (importOriginal) => {
   return { ...actual, HOSTED_MODE: false };
 });
 
-import { captureServerEvent, shutdownAnalytics } from "../analytics.js";
+import {
+  captureServerEvent,
+  evaluateBrowserRollout,
+  shutdownAnalytics,
+} from "../analytics.js";
 
 function fakeContext(overrides: {
   requestLogContext?: Record<string, unknown>;
@@ -27,7 +36,7 @@ function fakeContext(overrides: {
   return {
     var: { requestLogContext: overrides.requestLogContext },
     get: (key: string) =>
-      key === "guestId" ? (overrides.guestId ?? undefined) : undefined,
+      key === "guestId" ? overrides.guestId ?? undefined : undefined,
   } as unknown as Context;
 }
 
@@ -85,6 +94,25 @@ describe("captureServerEvent", () => {
     captureServerEvent(fakeContext({}), "send_message_server");
     expect(captureMock).not.toHaveBeenCalled();
   });
+
+  it.each(["VITE_DISABLE_POSTHOG_LOCAL", "DO_NOT_TRACK"])(
+    "evaluates browser rollout with %s disabled without capturing events",
+    async (setting) => {
+      process.env[setting] = "true";
+      flagMock.mockResolvedValueOnce(true);
+      expect(await evaluateBrowserRollout("local-browser-enabled", "u1")).toBe(
+        true,
+      );
+      expect(flagMock).toHaveBeenLastCalledWith("local-browser-enabled", "u1", {
+        sendFeatureFlagEvents: false,
+      });
+      captureServerEvent(
+        fakeContext({ requestLogContext: { userExternalId: "u1" } }),
+        "send_message_server",
+      );
+      expect(captureMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("honors DO_NOT_TRACK", () => {
     process.env.DO_NOT_TRACK = "1";

--- a/mcpjam-inspector/server/utils/analytics.ts
+++ b/mcpjam-inspector/server/utils/analytics.ts
@@ -55,8 +55,10 @@ function serverPlatform(): string {
 
 let client: PostHog | null = null;
 
-function getClient(): PostHog | null {
-  if (isAnalyticsDisabled()) return null;
+// Feature evaluation controls product availability, independently of tracking.
+// Callers using this exception must suppress feature-flag exposure events.
+function getClient(forFeatureFlags = false): PostHog | null {
+  if (!forFeatureFlags && isAnalyticsDisabled()) return null;
   if (!client) {
     client = new PostHog(POSTHOG_PROJECT_KEY, {
       host: POSTHOG_HOST,
@@ -169,7 +171,7 @@ export async function evaluateBrowserRollout(
   if (!distinctId) return false;
   try {
     return (
-      (await getClient()?.isFeatureEnabled(key, distinctId, {
+      (await getClient(true)?.isFeatureEnabled(key, distinctId, {
         sendFeatureFlagEvents: false,
       })) === true
     );


### PR DESCRIPTION
When local analytics is disabled, clicking Allow in the Browser panel fails because server-side browser rollout evaluation never creates its PostHog client. Evaluate feature flags independently of tracking opt-outs, while continuing to suppress analytics captures and feature-flag exposure events. Authentication, rollout decisions, and browser consent enforcement remain in place.

The readiness JSON rendering fix is already on main; strengthen its regression coverage for both ready and blocked states.

Validation: 47 tests pass across analytics, browser rollout, and transcript rendering suites. The user confirmed local browser authorization and navigation work with this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when PostHog is contacted for product gating vs analytics opt-out; behavior is scoped to browser rollout with exposure events suppressed, but it affects consent/rollout in privacy-sensitive local installs.
> 
> **Overview**
> **Browser consent with analytics off:** Server-side `evaluateBrowserRollout` now obtains a PostHog client even when `DO_NOT_TRACK` or `VITE_DISABLE_POSTHOG_LOCAL` is set, by treating feature-flag checks as separate from event capture. `getClient(forFeatureFlags)` skips the analytics opt-out only for that path; `captureServerEvent` still does not send events, and rollout still uses `sendFeatureFlagEvents: false`.
> 
> **Tests:** Analytics tests assert rollout evaluation works under both opt-out env vars while capture stays disabled. `PartSwitch` tests broaden the `isDataPart` mock (`data-*` types) and add cases that `data-browser-readiness` renders empty for ready and consent-required reasons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74549490ef7d95dce6f055232b669893bad36523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Browser panel so clicking Allow works when local analytics is disabled. Browser rollout now evaluates feature flags independently of tracking opt-outs, while analytics captures and feature-flag exposure events stay suppressed.

- Feature-flag checks use a PostHog client even with `DO_NOT_TRACK` or `VITE_DISABLE_POSTHOG_LOCAL` set; event capture still honors those opt-outs.
- Rollout keeps `sendFeatureFlagEvents: false` so no exposure events are sent.
- Adds regression tests for rollout under both opt-out settings and for `data-browser-readiness` rendering empty in ready and consent-required states.

<sup>Written for commit 74549490ef7d95dce6f055232b669893bad36523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

