### PR TITLE
docs(changelog): remove CI/CD integration from coming soon list

### DIFF
--- a/docs/changelog/overview.mdx
+++ b/docs/changelog/overview.mdx
@@ -180,7 +180,6 @@ We're working on:
 - More LLM provider integrations
 - Advanced debugging tools
 - Performance analytics dashboard
-- CI/CD integration support
 
 ## Stay Updated
 


### PR DESCRIPTION
## What does this PR do?

This PR resolves a discrepancy identified in the marketing vs docs consistency audit (#4) by removing "CI/CD integration support" from the "Coming Soon" section of the changelog.

**Changes made:**
- Removed the CI/CD integration line from `docs/changelog/overview.mdx` to reflect our current priorities and avoid mismatch with our active CI/CD documentation.


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removes CI/CD integration from the changelog's "coming soon" list so the roadmap reflects current plans.

<sup>Written for commit 076e5631f9c89c1a0db3222890909d454c9d761c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

