### PR TITLE
Fix Electron browser display and live page tools

### DIFF
--- a/mcpjam-inspector/client/src/components/browser/LocalBrowserBody.tsx
+++ b/mcpjam-inspector/client/src/components/browser/LocalBrowserBody.tsx
@@ -829,7 +829,25 @@ export function LocalBrowserBody({
   const shellTransport = useMemo(() => {
     if (!bootId) return null;
     return {
-      readState: () => fetchLocalBrowserState({ bootId, holder, consentToken }),
+      readState: async () => {
+        const state = await fetchLocalBrowserState({
+          bootId,
+          holder,
+          consentToken,
+        });
+        if (projectId && state) {
+          // Native Electron has no frame socket to publish tool changes.
+          noteWebmcpStats(
+            browserPageToolsKey(projectId, "local"),
+            {
+              webmcp: state.webmcp,
+              tabs: { active: state.activeTabId ?? undefined },
+            },
+            bootId,
+          );
+        }
+        return state;
+      },
       sendCommand: (args: {
         command: BrowserPaneCommand;
         commandId?: string;
@@ -861,7 +879,7 @@ export function LocalBrowserBody({
         await setLeaseAction("resume");
       },
     };
-  }, [bootId, holder, consentToken, setLeaseAction]);
+  }, [bootId, holder, consentToken, setLeaseAction, projectId]);
 
   // Native views cannot be scaled by the renderer's CSS like streamed frames.
   // Fit the actual page to its slot even when the workspace chrome is disabled.

--- a/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserBody.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserBody.test.tsx
@@ -1,4 +1,5 @@
 import { releaseBrowserForChat } from "@/lib/browser-shell/chat-handoff";
+import { useBrowserPageToolsStore } from "@/stores/browser-page-tools-store";
 import { beforeAll } from "vitest";
 beforeAll(() => {
   window.PointerEvent = MouseEvent as typeof PointerEvent;
@@ -777,6 +778,44 @@ describe("the agent browser pane — the desktop app's own browser", () => {
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(api.socket).toBeNull();
     expect(screen.queryByTestId("rail-browser-frame")).toBeNull();
+  });
+
+  it("publishes page-tool changes without a frame socket", async () => {
+    asDesktopApp();
+    useBrowserPageToolsStore.setState({ live: {}, epoch: {} });
+    api.state = {
+      seq: 1,
+      tabs: [
+        {
+          id: "pizza-tab",
+          url: "https://pizza.test",
+          title: "Pizza",
+          loading: false,
+          navCounter: 0,
+        },
+      ],
+      activeTabId: "pizza-tab",
+      canGoBack: false,
+      canGoForward: false,
+      viewport: { width: 1024, height: 768, revision: 0 },
+      policy: "fixed",
+      control: { kind: "agent" },
+      webmcp: { revision: 4, hash: "pizza", count: 7 },
+    };
+    renderBody();
+    await screen.findByTestId("rail-browser-native-slot");
+    await waitFor(() =>
+      expect(
+        useBrowserPageToolsStore.getState().live["proj-1:local"],
+      ).toMatchObject({
+        revision: 4,
+        hash: "pizza",
+        count: 7,
+        tabId: "pizza-tab",
+        bootId: "boot-proj-1",
+      }),
+    );
+    expect(api.socket).toBeNull();
   });
 
   it("still says somebody is watching, with no socket to say it", async () => {

--- a/mcpjam-inspector/client/src/components/webmcp-inspector/WebmcpInspectorTab.tsx
+++ b/mcpjam-inspector/client/src/components/webmcp-inspector/WebmcpInspectorTab.tsx
@@ -539,6 +539,7 @@ export function WebmcpInspectorTab() {
         ) : live ? (
           <WebMcpBrowserShell
             key={session?.sessionId}
+            consentToken={consent.token}
             streaming={streaming}
             transport={session?.viewportTransport}
             behaviour={behaviour}
@@ -655,7 +656,9 @@ export function WebmcpInspectorTab() {
  * the picture wrongly.
  */
 function WebMcpBrowserShell(
-  props: Parameters<typeof SubscribedViewportPane>[0],
+  props: Parameters<typeof SubscribedViewportPane>[0] & {
+    consentToken: string | null;
+  },
 ) {
   const transport = useMemo<BrowserSessionTransport>(
     () => ({
@@ -711,6 +714,7 @@ function WebMcpBrowserShell(
           control="agent"
           holding={false}
           consentGranted
+          consentToken={props.consentToken}
           chrome="none"
         />
       ) : (

--- a/mcpjam-inspector/client/src/components/webmcp-inspector/__tests__/WebmcpInspectorTab.native.test.tsx
+++ b/mcpjam-inspector/client/src/components/webmcp-inspector/__tests__/WebmcpInspectorTab.native.test.tsx
@@ -24,8 +24,16 @@ vi.mock("@/components/ui/resizable", () => ({
 }));
 
 vi.mock("@/components/browser/ElectronNativeBody", () => ({
-  ElectronNativeBody: ({ session }: { session: { bootId: string } }) => (
-    <div data-testid="native-browser">{session.bootId}</div>
+  ElectronNativeBody: ({
+    session,
+    consentToken,
+  }: {
+    session: { bootId: string };
+    consentToken?: string | null;
+  }) => (
+    <div data-testid="native-browser" data-consent-token={consentToken}>
+      {session.bootId}
+    </div>
   ),
 }));
 class FakeEventSource {
@@ -86,6 +94,12 @@ describe("main-owned browser surface", () => {
     expect(document.querySelector("webview")).toBeNull();
     expect(await screen.findByTestId("native-browser")).toHaveTextContent(
       "native-boot",
+    );
+    // Electron rejects native placement without the device consent used to
+    // start the session, even though navigation and tool discovery succeed.
+    expect(screen.getByTestId("native-browser")).toHaveAttribute(
+      "data-consent-token",
+      "test-consent",
     );
     expect(screen.getByTestId("browser-address")).toBeInTheDocument();
     expect(screen.queryByText("Take control")).toBeNull();

--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/pane-endpoints.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/pane-endpoints.test.ts
@@ -5,6 +5,7 @@ import { shortHash } from "../state-token";
 import { parsePaneCommand, paneCommandToAction } from "../pane-command";
 import type { BrowserCommand, BrowserCommandOutcome } from "../../protocol";
 import { INITIAL_SESSION_VIEWPORT } from "../../../../../shared/browser-viewport";
+import { decodeStateSnapshot } from "../../../../../shared/browser-pane-wire";
 
 /**
  * The three endpoints a person's browser needs, and the rule that a person's
@@ -20,6 +21,12 @@ function makeHandler(
     authority?: "shared" | "lease";
     submit?: (c: BrowserCommand) => Promise<BrowserCommandOutcome>;
     stateSnapshot?: () => Promise<unknown>;
+    webmcpToolsSnapshot?: (tabId?: string) => {
+      revision: number;
+      hash: string;
+      count: number;
+      supported: boolean;
+    };
     requestViewport?: (size: {
       width: number;
       height: number;
@@ -46,6 +53,7 @@ function makeHandler(
     driver: {
       health: async () => ({ ok: true as const }),
       sessionViewportState: () => INITIAL_SESSION_VIEWPORT,
+      webmcpToolsSnapshot: over.webmcpToolsSnapshot,
       ...(over.stateSnapshot
         ? { stateSnapshot: over.stateSnapshot as never }
         : {}),
@@ -89,6 +97,21 @@ const snapshot = () => ({
 });
 
 describe("GET /v1/state", () => {
+  it("carries the active tab's cached tool signal through state decoding", async () => {
+    const webmcp = { revision: 4, hash: "pizza", count: 7 };
+    const read = vi.fn(() => ({ ...webmcp, supported: true }));
+    const { handler } = makeHandler({
+      stateSnapshot: async () => snapshot(),
+      webmcpToolsSnapshot: read,
+    });
+    const res = await handler.handle(
+      req({ method: "GET", path: "/v1/state", body: "" }),
+    );
+    expect(read).toHaveBeenCalledWith("t1");
+    expect(decodeStateSnapshot(decodeStateSnapshot(res.body))?.webmcp).toEqual(
+      webmcp,
+    );
+  });
   it("answers with the whole browser, and who is driving", async () => {
     const { handler } = makeHandler({ stateSnapshot: async () => snapshot() });
     const res = await handler.handle(

--- a/mcpjam-inspector/server/services/browserd/daemon/request-handler.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/request-handler.ts
@@ -719,12 +719,14 @@ export class BrowserdRequestHandler {
       };
     }
     const snapshot = await this.driver.stateSnapshot();
+    const webmcp = this.webmcpSnapshot(snapshot.activeTabId ?? undefined);
     const lease = this.lease.state();
     return {
       status: 200,
       body: {
         bootId: this.bootId,
         ...snapshot,
+        ...(webmcp ? { webmcp } : {}),
         control:
           lease.state === "free"
             ? { kind: "agent" }

--- a/mcpjam-inspector/shared/browser-pane-wire.ts
+++ b/mcpjam-inspector/shared/browser-pane-wire.ts
@@ -107,7 +107,21 @@ export function decodeStateSnapshot(raw: unknown): BrowserStateSnapshot | null {
     .filter((tab): tab is BrowserTabState => tab !== null);
   const activeTabId =
     typeof body.activeTabId === "string" ? body.activeTabId : null;
+  const webmcp = body.webmcp as BrowserStateSnapshot["webmcp"];
   return {
+    ...(webmcp &&
+    typeof webmcp.revision === "number" &&
+    typeof webmcp.hash === "string" &&
+    typeof webmcp.count === "number"
+      ? {
+          webmcp: {
+            revision: webmcp.revision,
+            hash: webmcp.hash,
+            count: webmcp.count,
+            ...(typeof webmcp.url === "string" ? { url: webmcp.url } : {}),
+          },
+        }
+      : {}),
     seq: typeof body.seq === "number" ? body.seq : 0,
     tabs,
     // An active id naming a tab that is not in the list reads as "no tab is on

--- a/mcpjam-inspector/shared/browser-session-state.ts
+++ b/mcpjam-inspector/shared/browser-session-state.ts
@@ -173,6 +173,8 @@ export const EMPTY_BROWSER_SESSION_STATE: BrowserSessionState = {
  * assessment with "live" every time one arrived.
  */
 export interface BrowserStateSnapshot {
+  /** Cached page-tool change signal for viewers without a frame stream. */
+  webmcp?: { revision: number; hash: string; count: number; url?: string };
   seq: number;
   tabs: BrowserTabState[];
   activeTabId: string | null;


### PR DESCRIPTION
Electron could load a WebMCP page and discover its tools while leaving the native browser pane blank. Pass the device consent token through to native viewport placement so Electron can display the page.

The Playground tools rail could also stay on “No browser running yet” because native Electron has no frame stream to deliver tool-change notifications. Include the active tab’s cached WebMCP change signal in browser-state responses and feed it into the existing shared tool-change store. This reuses the same catalog and refresh logic as streamed browsers without starting a video stream or polling tool definitions.

Validation:
- 102 targeted tests passed across native WebMCP rendering, native browser placement, the local browser pane, the browser-tools hook, and daemon pane endpoints.
- Client typecheck and import guards passed.
- Regression coverage checks consent forwarding, signal decoding, and native tool updates without a frame socket.
- Packaged Electron visual verification remains pending.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consent-gated native rendering and browser-state wire format; scope is bounded to optional `webmcp` and client-side tool-store updates, with regression tests.
> 
> **Overview**
> Fixes two native-Electron gaps: **blank panes** and a **stale Playground tools rail**.
> 
> **Consent for native placement** — `WebmcpInspectorTab` now passes the device `consentToken` into `ElectronNativeBody` (WebMCP inspector and the same pattern elsewhere), so Electron can authorize viewport placement instead of leaving the pane empty while tools still discover.
> 
> **Live page tools without a frame socket** — `GET /v1/state` attaches the active tab’s cached WebMCP change signal (`revision` / `hash` / `count`) via the daemon’s existing `webmcpToolsSnapshot`. Shared types and `decodeStateSnapshot` understand optional `webmcp` on `BrowserStateSnapshot`. On the local native path, `LocalBrowserBody`’s shell `readState` pushes that signal into `noteWebmcpStats` on each poll, reusing the same store as streamed browsers.
> 
> Tests cover consent forwarding, state decoding, and native tool updates with no WebSocket.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97cf41508ef8c87a88ba219681c7dbffc1a36da7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->