### PR TITLE
Fix Electron browser views lingering over other screens

### DIFF
--- a/mcpjam-inspector/client/src/components/browser/ElectronNativeBody.tsx
+++ b/mcpjam-inspector/client/src/components/browser/ElectronNativeBody.tsx
@@ -120,7 +120,7 @@ export function ElectronNativeBody({
   const bootIdRef = useRef<string | null>(null);
   bootIdRef.current = session?.bootId ?? null;
   /**
-   * The browser this pane last asked to have ON SCREEN.
+   * The browser this pane last asked to have ON SCREEN, including pending IPC.
    *
    * Tracked separately from `bootIdRef` because a view that is parented into
    * the window can only be taken out BY NAME, and by the time the pane knows
@@ -130,6 +130,7 @@ export function ElectronNativeBody({
    * next, and nothing short of an unmount removes it.
    */
   const shownRef = useRef<string | null>(null);
+  const requestRevision = useRef(0);
   const takeoverRef = useRef(chrome === "none");
   takeoverRef.current = chrome === "none";
   const holderRef = useRef(holder);
@@ -144,6 +145,7 @@ export function ElectronNativeBody({
   const push = useCallback(() => {
     const api = window.electronAPI?.agentBrowser;
     if (!api) return;
+    const revision = ++requestRevision.current;
     const bootId = bootIdRef.current;
     // A browser we are no longer looking at comes out FIRST, and by its own
     // name — this is the only moment its id is still known.
@@ -168,6 +170,8 @@ export function ElectronNativeBody({
     // does — and it is applied in the MAIN process, which is the side that
     // actually knows it.
     const rect = element?.getBoundingClientRect();
+    // Remember pending placement too: teardown may run before IPC responds.
+    if (visible) shownRef.current = bootId;
     if (visible && rect && rect.width > 0 && rect.height > 0) {
       onViewportSizeRef.current?.({ width: rect.width, height: rect.height });
     }
@@ -190,9 +194,8 @@ export function ElectronNativeBody({
           : {}),
       })
       .then((result) => {
-        // What is PARENTED, not what was asked for: a refused ask leaves
-        // nothing in the window, and remembering it would send a pointless
-        // hide for a view that is not there.
+        if (requestRevision.current !== revision) return;
+        // Once the latest ask settles, remember only what was parented.
         shownRef.current = result.shown ? bootId : null;
         setPlaced(
           result.reason
@@ -201,6 +204,7 @@ export function ElectronNativeBody({
         );
       })
       .catch(() => {
+        if (requestRevision.current !== revision) return;
         shownRef.current = null;
         // A channel that is not there, or a main process mid-teardown. The
         // pane says nothing rather than showing an error over a browser that
@@ -263,6 +267,7 @@ export function ElectronNativeBody({
    */
   useEffect(() => {
     return () => {
+      ++requestRevision.current;
       const api = window.electronAPI?.agentBrowser;
       // Whatever is actually in the window — which is not necessarily the
       // session this render knows about, and is the only thing worth hiding.

--- a/mcpjam-inspector/client/src/components/browser/__tests__/ElectronNativeBody.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/ElectronNativeBody.test.tsx
@@ -75,6 +75,42 @@ const lastAsk = async () => {
 };
 
 describe("the native Electron browser pane", () => {
+  it("hides pending placement when the session disappears before IPC replies", async () => {
+    let finishShow!: (result: typeof answer) => void;
+    window.electronAPI!.agentBrowser!.setViewport = async (request) => {
+      asked.push(request);
+      if (request.visible) {
+        return new Promise<typeof answer>((resolve) => {
+          finishShow = resolve;
+        });
+      }
+      return { shown: false, inputAllowed: false };
+    };
+    const view = renderBody();
+    await lastAsk();
+    view.rerender(
+      <ElectronNativeBody
+        session={null}
+        holder="rail-1"
+        control="agent"
+        holding={false}
+        consentGranted
+      />,
+    );
+    await waitFor(() =>
+      expect(asked).toContainEqual(
+        expect.objectContaining({ bootId: "boot-1", visible: false }),
+      ),
+    );
+    finishShow({ shown: true, inputAllowed: false });
+    await waitFor(() =>
+      expect(screen.getByTestId("rail-browser-native-slot")).toHaveAttribute(
+        "data-shown",
+        "false",
+      ),
+    );
+  });
+
   it("asks for the view at the slot it measured", async () => {
     renderBody();
     expect(await lastAsk()).toEqual({

--- a/mcpjam-inspector/src/ipc/agent-browser/agent-browser-listeners.test.ts
+++ b/mcpjam-inspector/src/ipc/agent-browser/agent-browser-listeners.test.ts
@@ -215,6 +215,36 @@ describe("agent-browser:capability", () => {
 });
 
 describe("agent-browser:set-viewport", () => {
+  it("does not reattach a view when an older show finishes after hide", async () => {
+    const surface = createContextSurface({ authority: "shared" });
+    const view = fakeView();
+    surface.registerTab(view);
+    let finishShow!: (valid: boolean) => void;
+    const verifyConsent = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            finishShow = resolve;
+          }),
+      )
+      .mockResolvedValue(true);
+    const api = install({
+      surfaces: new Map([["boot-1", surface]]),
+      verifyConsent,
+    });
+    const show = api.setViewport({
+      bootId: "boot-1",
+      visible: true,
+      bounds: BOUNDS,
+    });
+    await api.setViewport({ bootId: "boot-1", visible: false });
+    finishShow(true);
+    await show;
+    expect(surface.isShown()).toBe(false);
+    expect(window_.children).not.toContain(view);
+  });
+
   const withSurface = (holder = "rail-1") => {
     const surface = createContextSurface();
     const view = fakeView();

--- a/mcpjam-inspector/src/ipc/agent-browser/agent-browser-listeners.ts
+++ b/mcpjam-inspector/src/ipc/agent-browser/agent-browser-listeners.ts
@@ -154,6 +154,7 @@ export function registerAgentBrowserListeners(
   deps: AgentBrowserDeps = {},
 ): void {
   const consentWatches = new Map<string, ReturnType<typeof setInterval>>();
+  const latestViewport = new WeakMap<ContextSurface, object>();
   const verifyConsent = deps.verifyConsent ?? verifyLocalBrowserConsent;
   const surfaceFor = deps.surfaceFor ?? contextSurfaceFor;
   const ipc = deps.ipc ?? ipcMain;
@@ -234,7 +235,15 @@ export function registerAgentBrowserListeners(
       // frames, not to show an error over a browser that is simply not there.
       if (!surface) return refused("unknown");
 
-      if (!(await verifyConsent(request.consentToken))) {
+      // Consent checks can finish out of order. A pane's teardown must
+      // supersede an earlier show, or that show resurrects the native view.
+      const revision = {};
+      latestViewport.set(surface, revision);
+      const valid = await verifyConsent(request.consentToken);
+      if (latestViewport.get(surface) !== revision) {
+        return { shown: surface.isShown(), inputAllowed: surface.inputAllowed() };
+      }
+      if (!valid) {
         surface.hide();
         return refused("consent");
       }


### PR DESCRIPTION
Leaving a browser pane could leave its native Electron view floating over other screens. A pending show request could finish its asynchronous consent check after the newer hide request and reattach the view.

Make the latest viewport request authoritative per native surface, so superseded requests cannot change placement. Track pending placement in the shared native browser component so session removal still sends a hide before IPC responds, and ignore stale replies after a newer request or unmount.

Validation:
- Reproduced the out-of-order show/hide failure in a regression test before fixing it.
- All 40 native browser component and Electron IPC tests pass, including pending-placement cleanup coverage.
- Client typecheck and import guards pass; git diff --check passes.
- Packaged Electron visual verification remains pending.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering of native view attach/detach and consent-gated IPC; mistakes could hide views incorrectly or briefly show them after teardown, but scope is narrow and covered by new tests.
> 
> **Overview**
> Fixes native **Electron** browser views that could stay painted over the app when the user left the pane or switched projects before an in-flight **show** finished.
> 
> On the renderer, **`ElectronNativeBody`** now tracks a **request revision** so older **`setViewport`** replies are ignored, records **pending** placement in **`shownRef`** before IPC returns (so a hide still knows which **`bootId`** to clear), and bumps revision on unmount. On the main process, **`agent-browser:set-viewport`** stores the latest request per surface and **skips applying** a show after **`verifyConsent`** if a newer call (e.g. hide) arrived in the meantime.
> 
> Regression tests cover session teardown before show completes (client) and hide-before-consent-resolves (IPC).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ebbece909464105fa7a96791b2527248df4a75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where a stale Electron show request could reattach a native browser view after it was hidden, leaving it floating over other screens.

The latest viewport request is now authoritative per native surface, and the client tracks pending placement so session teardown still sends a hide before IPC responds.

- Client and main process both ignore viewport replies superseded by a newer request or unmount.
- Remembers pending placement on show so teardown hides the view even if the IPC response hasn't arrived.
- Regression tests cover out-of-order show/hide in the client and the IPC listener.

<sup>Written for commit 81ebbece909464105fa7a96791b2527248df4a75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

