### PR TITLE
Fix localhost address fallback in the local browser proxy

### DIFF
--- a/mcpjam-inspector/server/services/browserd/local/__tests__/egress-proxy.test.ts
+++ b/mcpjam-inspector/server/services/browserd/local/__tests__/egress-proxy.test.ts
@@ -1,4 +1,4 @@
-import { it, expect } from "vitest";
+import { it, expect, vi } from "vitest";
 import { createServer, request } from "node:http";
 import { startLocalBrowserProxy } from "../egress-proxy.js";
 import { createLocalBrowserSecurityPolicy } from "../security-policy.js";
@@ -51,3 +51,148 @@ it("forwards authenticated localhost development requests but denies the control
     await new Promise<void>((resolve) => site.close(() => resolve()));
   }
 });
+
+// Force DNS ordering rather than depending on the runner's localhost resolver.
+it.each(["127.0.0.1", "::1"])(
+  "falls back to an HTTP server bound only to %s without replaying the request",
+  async (host) => {
+    let calls = 0;
+    let receivedHost: string | undefined;
+    let body = "";
+    const site = createServer((req, res) => {
+      calls++;
+      receivedHost = req.headers.host;
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => res.end("ok"));
+    });
+    await new Promise<void>((resolve) => site.listen(0, host, resolve));
+    const port = (site.address() as import("node:net").AddressInfo).port;
+    const addresses =
+      host === "127.0.0.1"
+        ? [
+            { address: "::1", family: 6 },
+            { address: host, family: 4 },
+          ]
+        : [
+            { address: "127.0.0.1", family: 4 },
+            { address: host, family: 6 },
+          ];
+    const lookup = vi.fn().mockResolvedValue(addresses);
+    const policy = createLocalBrowserSecurityPolicy({
+      controllerUrls: [],
+      lookup,
+    });
+    const proxy = await startLocalBrowserProxy(policy);
+    try {
+      const result = await new Promise<string>((resolve, reject) => {
+        const req = request(
+          proxy.proxy.server,
+          {
+            method: "POST",
+            path: `http://localhost:${port}/submit`,
+            headers: {
+              "Proxy-Authorization": `Basic ${Buffer.from(
+                `${proxy.proxy.username}:${proxy.proxy.password}`,
+              ).toString("base64")}`,
+            },
+          },
+          (res) => {
+            let data = "";
+            res.on("data", (chunk) => {
+              data += chunk;
+            });
+            res.on("end", () => resolve(`${res.statusCode}:${data}`));
+          },
+        );
+        req.on("error", reject);
+        req.end("one submission");
+      });
+      expect(result).toBe("200:ok");
+      expect(calls).toBe(1);
+      expect(body).toBe("one submission");
+      expect(receivedHost).toBe(`localhost:${port}`);
+      expect(lookup).toHaveBeenCalledExactlyOnceWith("localhost", {
+        all: true,
+        verbatim: true,
+      });
+    } finally {
+      await proxy.close();
+      policy.dispose?.();
+      await new Promise<void>((resolve) => site.close(() => resolve()));
+    }
+  },
+);
+
+it.each(["CONNECT", "upgrade"])(
+  "falls back to IPv4 for %s tunnels",
+  async (mode) => {
+    const site = createServer();
+    site.on("upgrade", (req, socket) => {
+      expect(req.headers.host).toMatch(/^localhost:/);
+      expect(req.headers).not.toHaveProperty("proxy-authorization");
+      socket.end(
+        "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\nhello",
+      );
+    });
+    site.on("request", (_req, res) => res.end("hello"));
+    await new Promise<void>((resolve) => site.listen(0, "127.0.0.1", resolve));
+    const port = (site.address() as import("node:net").AddressInfo).port;
+    const lookup = vi.fn().mockResolvedValue([
+      { address: "::1", family: 6 },
+      { address: "127.0.0.1", family: 4 },
+    ]);
+    const policy = createLocalBrowserSecurityPolicy({
+      controllerUrls: [],
+      lookup,
+    });
+    const proxy = await startLocalBrowserProxy(policy);
+    try {
+      const result = await new Promise<string>((resolve, reject) => {
+        const req = request(proxy.proxy.server, {
+          method: mode === "CONNECT" ? "CONNECT" : "GET",
+          path:
+            mode === "CONNECT"
+              ? `localhost:${port}`
+              : `http://localhost:${port}/ws`,
+          headers: {
+            "Proxy-Authorization": `Basic ${Buffer.from(
+              `${proxy.proxy.username}:${proxy.proxy.password}`,
+            ).toString("base64")}`,
+            ...(mode === "upgrade"
+              ? { Connection: "Upgrade", Upgrade: "websocket" }
+              : {}),
+          },
+        });
+        req.on("error", reject);
+        req.on("response", (res) =>
+          reject(new Error(`Unexpected response ${res.statusCode}`)),
+        );
+        req.on(
+          mode === "CONNECT" ? "connect" : "upgrade",
+          (res, socket, head) => {
+            expect(res.statusCode).toBe(mode === "CONNECT" ? 200 : 101);
+            let data = head.toString();
+            socket.on("data", (chunk: Buffer) => {
+              data += chunk;
+            });
+            socket.on("error", reject);
+            socket.on("end", () => resolve(data));
+            if (mode === "CONNECT")
+              socket.write(
+                `GET / HTTP/1.1\r\nHost: localhost:${port}\r\nConnection: close\r\n\r\n`,
+              );
+          },
+        );
+        req.end();
+      });
+      expect(result).toContain("hello");
+      expect(lookup).toHaveBeenCalledOnce();
+    } finally {
+      await proxy.close();
+      policy.dispose?.();
+      await new Promise<void>((resolve) => site.close(() => resolve()));
+    }
+  },
+);

--- a/mcpjam-inspector/server/services/browserd/local/__tests__/security-policy.test.ts
+++ b/mcpjam-inspector/server/services/browserd/local/__tests__/security-policy.test.ts
@@ -59,10 +59,12 @@ describe("local Browser destination policy", () => {
       lookup,
     });
     await expect(p.resolveDestination("rebind.test", 62344)).rejects.toThrow();
-    await expect(p.resolveDestination("dev.test", 3000)).resolves.toEqual({
-      address: "127.0.0.1",
-      family: 4,
-    });
+    await expect(p.resolveDestination("dev.test", 3000)).resolves.toEqual([
+      {
+        address: "127.0.0.1",
+        family: 4,
+      },
+    ]);
   });
   it("recognizes IPv4-mapped loopback", () =>
     expect(isMachineAddress("::ffff:7f00:1")).toBe(true));
@@ -159,4 +161,26 @@ it("reports bounded reason counts once without retaining destination content", (
     networkRefused: 1,
     destinationRefused: 0,
   });
+});
+
+it("validates every fallback address before returning the pinned DNS answer", async () => {
+  const addresses = [
+    { address: "203.0.113.1", family: 4 },
+    { address: "::1", family: 6 },
+  ];
+  const lookup = vi.fn().mockResolvedValue(addresses);
+  const policy = createLocalBrowserSecurityPolicy({
+    controllerUrls: ["http://localhost:62346"],
+    lookup,
+  });
+  try {
+    await expect(
+      policy.resolveDestination("alias.test", 62346),
+    ).rejects.toThrow(/browser_policy_refused/);
+    await expect(
+      policy.resolveDestination("alias.test", 3000),
+    ).resolves.toEqual(addresses);
+  } finally {
+    policy.dispose?.();
+  }
 });

--- a/mcpjam-inspector/server/services/browserd/local/egress-proxy.ts
+++ b/mcpjam-inspector/server/services/browserd/local/egress-proxy.ts
@@ -1,11 +1,27 @@
 /** Local browser egress only. No TLS interception, body capture, or direct fallback. */
 import { createServer, request, type IncomingMessage } from "node:http";
-import { connect, type Socket } from "node:net";
+import { connect, type LookupFunction, type Socket } from "node:net";
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import {
   registerBrowserController,
   type LocalBrowserSecurityPolicy,
 } from "./security-policy.js";
+
+// Let Node try both address families, but only from the DNS answer already
+// checked by the policy. Never resolve again during connection fallback.
+function pinnedAddressOptions(
+  addresses: Array<{ address: string; family: number }>,
+) {
+  const lookup: LookupFunction = (_hostname, options, callback) => {
+    if (options.all) callback(null, addresses);
+    else callback(null, addresses[0].address, addresses[0].family);
+  };
+  return {
+    lookup,
+    autoSelectFamily: true,
+    autoSelectFamilyAttemptTimeout: 250,
+  };
+}
 
 export async function startLocalBrowserProxy(
   policy: LocalBrowserSecurityPolicy,
@@ -45,7 +61,7 @@ export async function startLocalBrowserProxy(
           !policy.allowsRequest(target.href)
         )
           throw new Error("denied");
-        const address = await policy.resolveDestination(
+        const addresses = await policy.resolveDestination(
           target.hostname,
           Number(target.port || 80),
         );
@@ -58,8 +74,8 @@ export async function startLocalBrowserProxy(
         delete headers["proxy-connection"];
         const upstream = request(
           {
-            hostname: address.address,
-            family: address.family,
+            hostname: target.hostname.replace(/^\[|\]$/g, ""),
+            ...pinnedAddressOptions(addresses),
             port: target.port || 80,
             path: target.pathname + target.search,
             method: req.method,
@@ -120,14 +136,14 @@ export async function startLocalBrowserProxy(
         !policy.allowsRequest(target.href)
       )
         throw new Error("denied");
-      const destination = await policy.resolveDestination(
+      const addresses = await policy.resolveDestination(
         target.hostname,
         Number(target.port || (upgrade ? 80 : 443)),
       );
       if (closed || downstream.destroyed) throw new Error("closed");
       const upstream = connect({
-        host: destination.address,
-        family: destination.family,
+        host: target.hostname.replace(/^\[|\]$/g, ""),
+        ...pinnedAddressOptions(addresses),
         port: Number(target.port || (upgrade ? 80 : 443)),
       });
       track(upstream);

--- a/mcpjam-inspector/server/services/browserd/local/security-policy.ts
+++ b/mcpjam-inspector/server/services/browserd/local/security-policy.ts
@@ -82,7 +82,7 @@ export interface LocalBrowserSecurityPolicy {
   resolveDestination(
     hostname: string,
     port: number,
-  ): Promise<{ address: string; family: number }>;
+  ): Promise<Array<{ address: string; family: number }>>;
   assertActive(): Promise<void>;
   isActive(): boolean;
   dispose?(): void;
@@ -248,7 +248,7 @@ export function createLocalBrowserSecurityPolicy(
       )
         throw destinationError();
       await assertActive();
-      return addresses[0];
+      return addresses;
     },
   };
   return policy;


### PR DESCRIPTION
Developers pasting `http://localhost:4173` into the local browser could get a blank page when DNS returned `::1` first but their dev server listened only on `127.0.0.1`. The proxy selected one DNS address and returned an empty 502 when that connection failed.

Return all policy-validated addresses and use Node’s address-family fallback with a lookup pinned to that validated answer for HTTP, CONNECT, and WebSocket upgrades. This preserves the original URL and Host header, performs no second DNS resolution, and retains rejection when any address points to an Inspector controller. Fallback happens before HTTP delivery, so POST bodies are not replayed.

Validation:
- 30 targeted proxy and security-policy tests passed, including IPv6-to-IPv4 and IPv4-to-IPv6 fallback, one-time POST delivery, CONNECT and WebSocket tunnels, and controller-address rejection.
- `git diff --check` passed.
- Server-wide TypeScript check was attempted; it reports unrelated diagnostics elsewhere (including missing jsdom declarations and unused declarations), with no diagnostics in the changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local browser egress networking and destination policy validation; behavior is constrained to pre-validated DNS answers but incorrect pinning could still affect proxy security or connectivity.
> 
> **Overview**
> Fixes blank pages / **502** when `localhost` resolves to **`::1` first** but the dev server only listens on **`127.0.0.1`** (and the symmetric case).
> 
> **`resolveDestination`** now returns the **full policy-checked address list** (not just the first record) and **rejects** if **any** resolved address would hit a blocked controller port. The egress proxy connects with the **original hostname** and Node **`autoSelectFamily`**, using a **pinned lookup** that only returns those validated addresses—**no second DNS lookup** during fallback.
> 
> Applies to plain **HTTP**, **`CONNECT`**, and **WebSocket upgrade** tunnels. Tests cover cross-family fallback, **single POST delivery** (no replay), tunnel paths, and multi-address policy validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 489ab6b9f3023027d3601a9a1853ddb86e1ca757. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the local browser proxy so pasting `http://localhost:4173` no longer shows a blank page when DNS returns `::1` first but the dev server only listens on `127.0.0.1`.

- The security policy now returns every validated address instead of just the first one.
- HTTP, CONNECT, and WebSocket upgrades fall back across address families using a lookup pinned to the policy's DNS answer.
- The original URL and Host header are preserved, with no second DNS resolution.
- Fallback happens before HTTP delivery, so POST bodies are not replayed.
- Any address pointing to an Inspector controller still rejects the request.

<sup>Written for commit 489ab6b9f3023027d3601a9a1853ddb86e1ca757. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

