### PR TITLE
Add changesets

### DIFF
--- a/.changeset/restore-credentialed-mcp-connections.md
+++ b/.changeset/restore-credentialed-mcp-connections.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Restore bearer-authenticated and OAuth MCP server connections when the backend does not provide credential-origin bindings by temporarily reverting enforcement until backend support and the required backfill are deployed.


### PR DESCRIPTION
Adds an Inspector patch changeset for the rollback merged in #4933, documenting restored bearer and OAuth connections while backend credential-origin support and backfill are pending.

Validation: changeset status and git diff --check passed. Existing pending changesets make the combined Inspector release a minor bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata only; no runtime or security logic changes in this diff.
> 
> **Overview**
> This PR **only adds a patch changeset** for `@mcpjam/inspector`; it does not change application code.
> 
> The changeset records that **bearer-authenticated and OAuth MCP server connections are restored** when the backend lacks credential-origin bindings, by **temporarily rolling back enforcement** until backend support and a data backfill ship (behavior already merged in #4933).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca7a91ac16cae6dd62d68412864739f7e0133c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->