### PR TITLE
Skip the project-default query for a non-Convex project id

### DIFF
--- a/.changeset/skip-project-default-for-sentinel-project-id.md
+++ b/.changeset/skip-project-default-for-sentinel-project-id.md
@@ -1,0 +1,12 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Stop asking the backend for a project default host config under a project id
+that is not a Convex row. The Playground passes `sharedProjectId ??
+activeProjectId`, so a guest with no cloud project reached
+`hostConfigsV2:getProjectDefault` with the string sentinel `"none"` — truthy,
+and rejected by `v.id("projects")` before the handler runs, where nothing
+client-side could catch it. All four call sites now gate on
+`shouldQueryProjectId`, the guard the rest of the Convex-reading hooks already
+use.

--- a/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Loader2, RotateCcw, Save, Settings2 } from "lucide-react";
 import { useMutation, useQuery } from "convex/react";
+import { shouldQueryProjectId } from "@/hooks/useProjects";
 import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { ClientConfigEditor } from "@/components/client-config/ClientConfigEditor";
@@ -66,7 +67,12 @@ export function SuiteExecutionConfigEditor({
   // (e.g. unscoped guest suites).
   const projectDefaultDto = useQuery(
     "hostConfigsV2:getProjectDefault" as any,
-    canQuery && projectId ? ({ projectId } as any) : "skip"
+    // `shouldQueryProjectId`, not a bare truthiness check — an unscoped guest
+    // suite carries a sentinel or local id, and `v.id("projects")` throws on
+    // it before the handler runs.
+    canQuery && shouldQueryProjectId(projectId)
+      ? ({ projectId } as any)
+      : "skip"
   ) as HostConfigDtoV2 | null | undefined;
 
   const setSuiteConfig = useMutation(

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -182,7 +182,7 @@ import {
 } from "@/lib/previewed-client-storage";
 import { useProjectServers } from "@/hooks/useViews";
 import { useServerActionsOptional } from "@/state/server-actions-context";
-import { useProjectMembers } from "@/hooks/useProjects";
+import { shouldQueryProjectId, useProjectMembers } from "@/hooks/useProjects";
 import { buildProjectOwnerProfileByUserId } from "@/components/chat-v2/history/project-thread-owner-avatar";
 import { buildSenderAvatarResolver } from "@/components/chat-v2/shared/sender-avatar";
 import { useHostedOrgModelConfig } from "@/hooks/use-hosted-org-model-config";
@@ -924,9 +924,13 @@ export function PlaygroundMain({
     isAuthenticated: isConvexAuthenticated,
     hostId: previewedHostId,
   });
+  // `shouldQueryProjectId`, not a bare truthiness check — the same guard the
+  // rest of the Convex-reading hooks use. `convexProjectId` is a shared project
+  // id today, but a local/placeholder id reaching `v.id("projects")` throws
+  // before the handler and cannot be caught downstream.
   const projectDefaultHostConfig = useQuery(
     "hostConfigsV2:getProjectDefault" as never,
-    isConvexAuthenticated && convexProjectId
+    isConvexAuthenticated && shouldQueryProjectId(convexProjectId)
       ? ({ projectId: convexProjectId } as never)
       : "skip",
   ) as HostConfigDtoV2 | null | undefined;

--- a/mcpjam-inspector/client/src/hooks/__tests__/useBrowserTools.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useBrowserTools.test.tsx
@@ -22,11 +22,20 @@ const state = vi.hoisted(() => ({
   pageTabIds: [] as Array<string | undefined>,
   pageSessionIds: [] as Array<string | undefined>,
   pageHolders: [] as Array<string | undefined>,
+  projectDefaultQueryArgs: [] as unknown[],
 }));
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
-  useQuery: () => state.projectDefault ?? undefined,
+  // Records what the hook ASKS FOR, not just what it gets back. The
+  // project-default query is the one place this hook hands a caller-supplied
+  // project scope to a `v.id("projects")` validator, and "skip" vs. an
+  // argument object is the whole difference between a quiet render and a
+  // server-side throw.
+  useQuery: (_name: unknown, args: unknown) => {
+    state.projectDefaultQueryArgs.push(args);
+    return state.projectDefault ?? undefined;
+  },
   useAction: () => vi.fn(),
 }));
 
@@ -126,6 +135,7 @@ beforeEach(() => {
   state.pageTabIds = [];
   state.pageSessionIds = [];
   state.pageHolders = [];
+  state.projectDefaultQueryArgs = [];
   sessionStorage.clear();
   useBrowserPageToolsStore.setState({ live: {}, epoch: {} });
   useActiveChatSessionStore.setState({
@@ -289,5 +299,40 @@ describe("useBrowserTools — the read follows the tab the signal came from", ()
     );
     expect(state.pageTabIds.at(-1)).toBe("t2");
     expect(result.current.attached).toBe(true);
+  });
+});
+
+describe("useBrowserTools — what it sends to Convex", () => {
+  /**
+   * The Playground passes `sharedProjectId ?? activeProjectId`, so a guest with
+   * no cloud project reaches this hook with the string sentinel "none". It is
+   * truthy, so the old guard forwarded it to `hostConfigsV2:getProjectDefault`,
+   * whose `v.id("projects")` validator rejects it BEFORE the handler runs —
+   * unhandleable client-side, and the top Convex error in production
+   * (Sentry CONVEX-HQ, 636 users).
+   */
+  it.each(["none", "null", "undefined", "local_abc", "project_abc", "  "])(
+    "skips the project-default query for the non-Convex id %j",
+    async (projectId) => {
+      renderHook(() => useBrowserTools({ projectId, hostId: null }));
+
+      await waitFor(() =>
+        expect(state.projectDefaultQueryArgs.length).toBeGreaterThan(0),
+      );
+      expect(state.projectDefaultQueryArgs).not.toContainEqual({ projectId });
+      expect(new Set(state.projectDefaultQueryArgs)).toEqual(new Set(["skip"]));
+    },
+  );
+
+  it("still asks for a real Convex project id", async () => {
+    renderHook(() =>
+      useBrowserTools({ projectId: "v97cz533abc", hostId: null }),
+    );
+
+    await waitFor(() =>
+      expect(state.projectDefaultQueryArgs).toContainEqual({
+        projectId: "v97cz533abc",
+      }),
+    );
   });
 });

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -492,7 +492,11 @@ export function useAppState({
       ?.sharedProjectId;
   const activeProjectDefaultHostConfig = useQuery(
     "hostConfigsV2:getProjectDefault" as any,
-    isUserReady && activeSharedProjectId
+    // `shouldQueryProjectId`, not a bare truthiness check: the sentinel and
+    // local/placeholder ids this app uses for a project that is not a Convex
+    // row are all truthy, and `v.id("projects")` rejects them before the
+    // handler runs, where nothing downstream can catch it.
+    isUserReady && shouldQueryProjectId(activeSharedProjectId)
       ? { projectId: activeSharedProjectId as any }
       : "skip",
   ) as HostConfigDtoV2 | null | undefined;

--- a/mcpjam-inspector/client/src/hooks/useBrowserTools.ts
+++ b/mcpjam-inspector/client/src/hooks/useBrowserTools.ts
@@ -18,6 +18,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useConvexAuth, useQuery } from "convex/react";
 import { useBrowserEngine } from "@/hooks/useBrowserEngine";
+import { shouldQueryProjectId } from "@/hooks/useProjects";
 import { useHost } from "@/hooks/useClients";
 import { resolveEffectiveHost } from "@/lib/effective-client";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
@@ -114,9 +115,16 @@ export function useBrowserTools(args: {
   // that stopped at the explicit pick reported "no browser" for a project
   // whose DEFAULT host has one, which is the common case: the pane offered a
   // live browser while the Tools panel beside it said no server was connected.
+  // `shouldQueryProjectId`, not a bare truthiness check. This hook's
+  // `projectId` is the PLAYGROUND'S project scope, which falls back to the
+  // local `activeProjectId` when there is no cloud project (PlaygroundTab
+  // passes `sharedProjectId ?? activeProjectId`). That fallback is the string
+  // sentinel `"none"` for a guest, which is truthy and reached
+  // `v.id("projects")` — a validator that throws BEFORE the handler runs, so
+  // nothing downstream could catch it. Sentry CONVEX-HQ: 636 users.
   const projectDefaultHostConfig = useQuery(
     "hostConfigsV2:getProjectDefault" as never,
-    isAuthenticated && args.projectId
+    isAuthenticated && shouldQueryProjectId(args.projectId)
       ? ({ projectId: args.projectId } as never)
       : "skip",
   ) as HostConfigDtoV2 | null | undefined;


### PR DESCRIPTION
## What

`hostConfigsV2:getProjectDefault` is the **top Convex error in production**: 6,487 events across **636 users** since 2026-05-13 ([Sentry CONVEX-HQ](https://mcpjam-gh.sentry.io/issues/CONVEX-HQ)), every one of them

```
ArgumentValidationError: Value does not match validator.
Path: .projectId
Value: "none"
Validator: v.id("projects")
```

It is 176 of the ~290 `ArgumentValidationError`s prod saw in the last 7 days — the rest are an unrelated long tail of ≤16 each.

## Why it happens

`PlaygroundTab` passes its project scope down as `sharedProjectId ?? activeProjectId`, and `activeProjectId` is the string sentinel `"none"` for a guest with no cloud project. All four `getProjectDefault` call sites gated on bare truthiness — and `"none"` is truthy:

```
PlaygroundTab (sharedProjectId ?? activeProjectId → "none")
  └─ PlaygroundLeftRail → ToolsBody
       └─ useBrowserTools({ projectId: "none" })
            └─ useQuery("hostConfigsV2:getProjectDefault", { projectId: "none" })
                 └─ v.id("projects")  ✗ throws BEFORE the handler
```

Because an argument validator rejects *before* the handler runs, nothing client-side could catch it either — it is unhandleable by construction, which is why it has sat at the top of the error list for four months.

The Sentry events are tagged with guest identities (`api.mcpjam.com/guest|…`), which matches: a signed-in user has a real shared project and never hits the sentinel.

## The fix

Gate all four call sites on `shouldQueryProjectId` — the guard roughly 30 other Convex-reading call sites already use. It blocks the `"none"` / `"null"` / `"undefined"` sentinels plus UUID and `local_` / `project_` placeholder ids.

The other three sites read `sharedProjectId`, which should always be a real Convex id; they are changed for consistency and because a placeholder reaching them fails the same unhandleable way.

## Testing

`useBrowserTools.test.tsx` now records the args handed to `useQuery`, so it pins what the hook *asks for* rather than only what it gets back. Reverting the `useBrowserTools` guard alone fails 6 of the 7 new cases; with the guard they pass.

- `useBrowserTools.test.tsx` — 17 passed (10 existing + 7 new)
- `use-app-state` / `use-app-state.hosted` / `suite-execution-config-editor.computer` — 31 passed
- `client/src/components/ui-playground` — 325 passed
- `tsc --noEmit -p client/tsconfig.typecheck.json` — clean

Formatting: these files are already Prettier-dirty on `main` (the known v2/v3 config split), so only the touched lines were formatted — no drive-by reformatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UnZVFvHMoR9AwupxD4rQ5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow client-side query gating that preserves behavior for real Convex project ids while avoiding validator errors for guests and placeholders.
> 
> **Overview**
> Fixes a top production Convex error where guests without a cloud project still triggered `hostConfigsV2:getProjectDefault` with sentinel ids like `"none"` (truthy but invalid for `v.id("projects")`).
> 
> All **four** `getProjectDefault` call sites (`useBrowserTools`, `use-app-state`, `PlaygroundMain`, `SuiteExecutionConfigEditor`) now skip the query unless `shouldQueryProjectId` passes—the same guard other Convex hooks already use—so invalid/placeholder project ids never hit argument validation.
> 
> Tests in `useBrowserTools.test.tsx` assert the hook passes `"skip"` to `useQuery` for non-Convex ids and still queries with a real Convex project id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31c89f25b5d2f93d8fedad6054f94dffda2c86fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the Playground from sending a non-Convex project id to `hostConfigsV2:getProjectDefault`, the top Convex error in production. A guest with no cloud project fell back to the truthy string sentinel `"none"`, which the `v.id("projects")` validator rejected before the handler ran, so nothing client-side could catch it.

- All four call sites now gate on `shouldQueryProjectId`, the guard the other Convex-reading hooks already use.
- `useBrowserTools` tests now record the args handed to `useQuery`, so they pin what the hook asks for instead of only what it gets back.

<sup>Written for commit 31c89f25b5d2f93d8fedad6054f94dffda2c86fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

