### PR TITLE
docs: tag @chelojimenez in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ First off, thank you for considering contributing to MCPJam Inspector! It's peop
 
 1. You can find things to work on in our [issues tab](https://github.com/MCPJam/inspector/issues).
 2. Look for issues labelled `good first issue` and `very easy`. These are great starter tasks that are low commitment.
-3. Once you find an issue you like to work on, comment on the issue and tag @matteo8p. Then assign yourself the issue. This helps avoid multiple contributors working on the same issue.
+3. Once you find an issue you like to work on, comment on the issue and tag @chelojimenez. Then assign yourself the issue. This helps avoid multiple contributors working on the same issue.
 
 ## Getting Started
 


### PR DESCRIPTION
- Contributing guide told new contributors to tag @matteo8p when claiming an issue.
- Now it says to tag @chelojimenez (Marcelo) instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the contributing guide so new contributors tag `@chelojimenez` instead of `@matteo8p` when claiming an issue.

<sup>Written for commit 4d550d2c8ff62c70e1400e26ea818473552d43ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

