### PR TITLE
perf(billing): subscribe to the bundled billing query

### DIFF
--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -913,12 +913,16 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     // Status, entitlements, both premiumness states and the plan catalog now
-    // ride on one bundled subscription.
-    const bundleCall = mockUseQuery.mock.calls.find(
+    // ride on one bundled subscription. Every one of its calls must be
+    // skipped, not just the first App happens to issue.
+    const bundleCalls = mockUseQuery.mock.calls.filter(
       ([name]) => name === "billing:getOrganizationBillingBundle",
     );
 
-    expect(bundleCall?.[1]).toBe("skip");
+    expect(bundleCalls.length).toBeGreaterThan(0);
+    for (const [, bundleArgs] of bundleCalls) {
+      expect(bundleArgs).toBe("skip");
+    }
   });
 
   it("skips billing queries while a project org id is still unvalidated", () => {
@@ -939,12 +943,16 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     // Status, entitlements, both premiumness states and the plan catalog now
-    // ride on one bundled subscription.
-    const bundleCall = mockUseQuery.mock.calls.find(
+    // ride on one bundled subscription. Every one of its calls must be
+    // skipped, not just the first App happens to issue.
+    const bundleCalls = mockUseQuery.mock.calls.filter(
       ([name]) => name === "billing:getOrganizationBillingBundle",
     );
 
-    expect(bundleCall?.[1]).toBe("skip");
+    expect(bundleCalls.length).toBeGreaterThan(0);
+    for (const [, bundleArgs] of bundleCalls) {
+      expect(bundleArgs).toBe("skip");
+    }
   });
 
   it("skips project billing and clears stale synced selection when the active project is missing", async () => {

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -912,19 +912,13 @@ describe("App hosted OAuth callback handling", () => {
 
     render(<App />);
 
-    const entitlementsCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getOrganizationEntitlements",
-    );
-    const orgPremiumnessCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getOrganizationPremiumness",
-    );
-    const wsPremiumnessCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getProjectPremiumness",
+    // Status, entitlements, both premiumness states and the plan catalog now
+    // ride on one bundled subscription.
+    const bundleCall = mockUseQuery.mock.calls.find(
+      ([name]) => name === "billing:getOrganizationBillingBundle",
     );
 
-    expect(entitlementsCall?.[1]).toBe("skip");
-    expect(orgPremiumnessCall?.[1]).toBe("skip");
-    expect(wsPremiumnessCall?.[1]).toBe("skip");
+    expect(bundleCall?.[1]).toBe("skip");
   });
 
   it("skips billing queries while a project org id is still unvalidated", () => {
@@ -944,19 +938,13 @@ describe("App hosted OAuth callback handling", () => {
 
     render(<App />);
 
-    const entitlementsCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getOrganizationEntitlements",
-    );
-    const orgPremiumnessCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getOrganizationPremiumness",
-    );
-    const wsPremiumnessCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getProjectPremiumness",
+    // Status, entitlements, both premiumness states and the plan catalog now
+    // ride on one bundled subscription.
+    const bundleCall = mockUseQuery.mock.calls.find(
+      ([name]) => name === "billing:getOrganizationBillingBundle",
     );
 
-    expect(entitlementsCall?.[1]).toBe("skip");
-    expect(orgPremiumnessCall?.[1]).toBe("skip");
-    expect(wsPremiumnessCall?.[1]).toBe("skip");
+    expect(bundleCall?.[1]).toBe("skip");
   });
 
   it("skips project billing and clears stale synced selection when the active project is missing", async () => {
@@ -991,11 +979,16 @@ describe("App hosted OAuth callback handling", () => {
 
     render(<App />);
 
-    const wsPremiumnessCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getProjectPremiumness",
+    // The bundle may still run for the organization, but it must not carry a
+    // projectId while the project's org is unvalidated.
+    const bundleCalls = mockUseQuery.mock.calls.filter(
+      ([name]) => name === "billing:getOrganizationBillingBundle",
     );
 
-    expect(wsPremiumnessCall?.[1]).toBe("skip");
+    expect(bundleCalls.length).toBeGreaterThan(0);
+    for (const [, bundleArgs] of bundleCalls) {
+      expect(bundleArgs === "skip" || !("projectId" in bundleArgs)).toBe(true);
+    }
     await waitFor(() => {
       expect(clearConvexActiveProjectSelection).toHaveBeenCalled();
     });
@@ -1051,11 +1044,16 @@ describe("App hosted OAuth callback handling", () => {
 
     render(<App />);
 
-    const wsPremiumnessCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getProjectPremiumness",
+    // The bundle may still run for the organization, but it must not carry a
+    // projectId while the project's org is unvalidated.
+    const bundleCalls = mockUseQuery.mock.calls.filter(
+      ([name]) => name === "billing:getOrganizationBillingBundle",
     );
 
-    expect(wsPremiumnessCall?.[1]).toBe("skip");
+    expect(bundleCalls.length).toBeGreaterThan(0);
+    for (const [, bundleArgs] of bundleCalls) {
+      expect(bundleArgs === "skip" || !("projectId" in bundleArgs)).toBe(true);
+    }
     await waitFor(() => {
       expect(clearConvexActiveProjectSelection).toHaveBeenCalled();
     });
@@ -1667,6 +1665,49 @@ describe("App hosted OAuth callback handling", () => {
       ...createAppStateMock(),
       activeOrganizationId: "org-1",
     }));
+    const orgThreeBillingStatus = {
+      organizationId: "org-3",
+      organizationName: "Org Three",
+      plan: "free",
+      effectivePlan: "free",
+      source: "free",
+      billingInterval: null,
+      billingConfigured: true,
+      subscriptionStatus: null,
+      canManageBilling: true,
+      isOwner: true,
+      hasCustomer: false,
+      stripeCurrentPeriodEnd: null,
+      stripePriceId: null,
+      trialStatus: "none",
+      trialPlan: null,
+      trialStartedAt: null,
+      trialEndsAt: null,
+      trialDaysRemaining: null,
+      decisionRequired: false,
+      trialDecision: null,
+    };
+    const orgThreePremiumness = {
+      plan: "free",
+      effectivePlan: "free",
+      billingInterval: null,
+      source: "free",
+      enforcementState: "active",
+      decisionRequired: false,
+      gates: [
+        {
+          gateKey: "maxProjects",
+          kind: "limit",
+          scope: "organization",
+          canAccess: true,
+          shouldShowUpsell: false,
+          upgradePlan: null,
+          reason: "within_limit",
+          currentValue: 1,
+          allowedValue: null,
+        },
+      ],
+    };
     mockUseQuery.mockImplementation((name: string, args?: any) => {
       if (name === "organizations:getMyOrganizations") {
         return [
@@ -1688,58 +1729,21 @@ describe("App hosted OAuth callback handling", () => {
           },
         ];
       }
-      if (
-        name === "billing:getOrganizationBillingStatus" &&
-        args?.organizationId === "org-3"
-      ) {
-        return {
-          organizationId: "org-3",
-          organizationName: "Org Three",
-          plan: "free",
-          effectivePlan: "free",
-          source: "free",
-          billingInterval: null,
-          billingConfigured: true,
-          subscriptionStatus: null,
-          canManageBilling: true,
-          isOwner: true,
-          hasCustomer: false,
-          stripeCurrentPeriodEnd: null,
-          stripePriceId: null,
-          trialStatus: "none",
-          trialPlan: null,
-          trialStartedAt: null,
-          trialEndsAt: null,
-          trialDaysRemaining: null,
-          decisionRequired: false,
-          trialDecision: null,
-        };
-      }
-      if (
-        name === "billing:getOrganizationPremiumness" &&
-        args?.organizationId === "org-3"
-      ) {
-        return {
-          plan: "free",
-          effectivePlan: "free",
-          billingInterval: null,
-          source: "free",
-          enforcementState: "active",
-          decisionRequired: false,
-          gates: [
-            {
-              gateKey: "maxProjects",
-              kind: "limit",
-              scope: "organization",
-              canAccess: true,
-              shouldShowUpsell: false,
-              upgradePlan: null,
-              reason: "within_limit",
-              currentValue: 1,
-              allowedValue: null,
-            },
-          ],
-        };
+      if (args?.organizationId === "org-3") {
+        // `useOrganizationBillingStatus` is still its own subscription; the
+        // rest of the billing reads arrive together in the bundle.
+        if (name === "billing:getOrganizationBillingStatus") {
+          return orgThreeBillingStatus;
+        }
+        if (name === "billing:getOrganizationBillingBundle") {
+          return {
+            billingStatus: orgThreeBillingStatus,
+            entitlements: undefined,
+            organizationPremiumness: orgThreePremiumness,
+            projectPremiumness: null,
+            planCatalog: undefined,
+          };
+        }
       }
 
       return undefined;
@@ -3948,25 +3952,31 @@ describe("App hosted OAuth callback handling", () => {
         ];
       }
 
-      if (name === "billing:getProjectPremiumness") {
+      if (name === "billing:getOrganizationBillingBundle") {
         return {
-          plan: "free",
-          enforcementState: "active",
-          effectivePlan: "free",
-          billingInterval: null,
-          source: "free",
-          decisionRequired: false,
-          gates: [
-            {
-              gateKey: "evals",
-              kind: "feature",
-              scope: "organization",
-              canAccess: false,
-              shouldShowUpsell: true,
-              upgradePlan: "team",
-              reason: "feature_not_included",
-            },
-          ],
+          billingStatus: undefined,
+          entitlements: undefined,
+          organizationPremiumness: undefined,
+          projectPremiumness: {
+            plan: "free",
+            enforcementState: "active",
+            effectivePlan: "free",
+            billingInterval: null,
+            source: "free",
+            decisionRequired: false,
+            gates: [
+              {
+                gateKey: "evals",
+                kind: "feature",
+                scope: "organization",
+                canAccess: false,
+                shouldShowUpsell: true,
+                upgradePlan: "team",
+                reason: "feature_not_included",
+              },
+            ],
+          },
+          planCatalog: undefined,
         };
       }
 
@@ -3975,11 +3985,11 @@ describe("App hosted OAuth callback handling", () => {
 
     render(<App />);
 
-    const wsPremiumnessCall = mockUseQuery.mock.calls.find(
-      ([name]) => name === "billing:getProjectPremiumness",
+    const bundleCall = mockUseQuery.mock.calls.find(
+      ([name]) => name === "billing:getOrganizationBillingBundle",
     );
 
-    expect(wsPremiumnessCall?.[1]).toEqual({
+    expect(bundleCall?.[1]).toEqual({
       organizationId: "org-1",
       projectId: "shared-ws-1",
     });

--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrganizationBilling.bundle.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrganizationBilling.bundle.test.tsx
@@ -1,0 +1,170 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `useOrganizationBilling` used to open five subscriptions per session, which
+// is what pushed prod into its concurrent-query cap. These tests pin the fact
+// that it now opens exactly one, and that the values it hands back (including
+// the loading flags gates depend on) are unchanged.
+
+const mockState = vi.hoisted(() => ({
+  isUserReady: true,
+  bundle: undefined as unknown,
+  queryCalls: [] as Array<{ name: string; args: unknown }>,
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: (name: string, args: unknown) => {
+    mockState.queryCalls.push({ name, args });
+    if (args === "skip") return undefined;
+    if (name === "billing:getOrganizationBillingBundle")
+      return mockState.bundle;
+    return undefined;
+  },
+  useMutation: () => vi.fn(),
+  useAction: () => vi.fn(),
+}));
+
+vi.mock("@/contexts/db-user-ready-context", () => ({
+  useDbUserReady: () => mockState.isUserReady,
+}));
+
+vi.mock("@/lib/seat-payment-stripe", () => ({
+  confirmSeatPaymentWithStripe: vi.fn(),
+}));
+
+import { useOrganizationBilling } from "../useOrganizationBilling";
+
+const LEGACY_QUERY_NAMES = [
+  "billing:getOrganizationBillingStatus",
+  "billing:getOrganizationEntitlements",
+  "billing:getOrganizationPremiumness",
+  "billing:getProjectPremiumness",
+  "billing:getPlanCatalog",
+];
+
+const premiumness = (plan: string) => ({
+  plan,
+  effectivePlan: plan,
+  billingInterval: null,
+  source: "free",
+  enforcementState: "active",
+  decisionRequired: false,
+  gates: [],
+});
+
+const fullBundle = {
+  billingStatus: { organizationId: "org-1", plan: "free" },
+  entitlements: { plan: "free", features: {}, limits: {} },
+  organizationPremiumness: premiumness("free"),
+  projectPremiumness: premiumness("team"),
+  planCatalog: { catalogVersion: "v1", plans: {} },
+};
+
+function bundleCalls() {
+  return mockState.queryCalls.filter(
+    (call) => call.name === "billing:getOrganizationBillingBundle",
+  );
+}
+
+describe("useOrganizationBilling bundled subscription", () => {
+  beforeEach(() => {
+    mockState.isUserReady = true;
+    mockState.bundle = undefined;
+    mockState.queryCalls = [];
+  });
+
+  it("opens one bundle subscription and maps every field from it", () => {
+    mockState.bundle = fullBundle;
+
+    const { result } = renderHook(() =>
+      useOrganizationBilling("org-1", { projectId: "project-1" }),
+    );
+
+    const calls = bundleCalls();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toEqual({
+      organizationId: "org-1",
+      projectId: "project-1",
+    });
+
+    for (const name of LEGACY_QUERY_NAMES) {
+      expect(mockState.queryCalls.some((call) => call.name === name)).toBe(
+        false,
+      );
+    }
+
+    expect(result.current.billingStatus).toBe(fullBundle.billingStatus);
+    expect(result.current.entitlements).toBe(fullBundle.entitlements);
+    expect(result.current.organizationPremiumness).toBe(
+      fullBundle.organizationPremiumness,
+    );
+    expect(result.current.projectPremiumness).toBe(
+      fullBundle.projectPremiumness,
+    );
+    expect(result.current.planCatalog).toBe(fullBundle.planCatalog);
+
+    expect(result.current.isLoadingBilling).toBe(false);
+    expect(result.current.isLoadingEntitlements).toBe(false);
+    expect(result.current.isLoadingOrganizationPremiumness).toBe(false);
+    expect(result.current.isLoadingProjectPremiumness).toBe(false);
+    expect(result.current.isLoadingPlanCatalog).toBe(false);
+  });
+
+  it("sends no projectId and reports undefined project premiumness without a project", () => {
+    mockState.bundle = { ...fullBundle, projectPremiumness: null };
+
+    const { result } = renderHook(() => useOrganizationBilling("org-1"));
+
+    expect(bundleCalls()[0].args).toEqual({ organizationId: "org-1" });
+    // The server says null for "not asked"; callers have always seen undefined.
+    expect(result.current.projectPremiumness).toBeUndefined();
+    expect(result.current.isLoadingProjectPremiumness).toBe(false);
+    expect(result.current.organizationPremiumness).toBe(
+      fullBundle.organizationPremiumness,
+    );
+  });
+
+  it("reports every surface as loading while the bundle is in flight", () => {
+    mockState.bundle = undefined;
+
+    const { result } = renderHook(() =>
+      useOrganizationBilling("org-1", { projectId: "project-1" }),
+    );
+
+    expect(result.current.isLoadingBilling).toBe(true);
+    expect(result.current.isLoadingEntitlements).toBe(true);
+    expect(result.current.isLoadingOrganizationPremiumness).toBe(true);
+    expect(result.current.isLoadingProjectPremiumness).toBe(true);
+    expect(result.current.isLoadingPlanCatalog).toBe(true);
+  });
+
+  it("skips the bundle until the users row exists, and still reads as loading", () => {
+    mockState.isUserReady = false;
+    mockState.bundle = fullBundle;
+
+    const { result } = renderHook(() =>
+      useOrganizationBilling("org-1", { projectId: "project-1" }),
+    );
+
+    expect(bundleCalls()[0].args).toBe("skip");
+    // Gates fail open when they read as settled, so the awaiting-user-row
+    // window must stay "loading".
+    expect(result.current.isLoadingBilling).toBe(true);
+    expect(result.current.isLoadingProjectPremiumness).toBe(true);
+  });
+
+  it("skips the bundle when the caller disables billing", () => {
+    mockState.bundle = fullBundle;
+
+    const { result } = renderHook(() =>
+      useOrganizationBilling("org-1", {
+        projectId: "project-1",
+        enabled: false,
+      }),
+    );
+
+    expect(bundleCalls()[0].args).toBe("skip");
+    expect(result.current.isLoadingBilling).toBe(false);
+    expect(result.current.isLoadingProjectPremiumness).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrganizationBilling.bundle.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrganizationBilling.bundle.test.tsx
@@ -87,6 +87,16 @@ describe("useOrganizationBilling bundled subscription", () => {
       projectId: "project-1",
     });
 
+    // Nothing else may hold a live subscription: the whole non-skipped set is
+    // this one call. Catches a regression that adds a sixth query back.
+    const liveCalls = mockState.queryCalls.filter(
+      (call) => call.args !== "skip",
+    );
+    expect(liveCalls.map((call) => call.name)).toEqual([
+      "billing:getOrganizationBillingBundle",
+    ]);
+
+    // And the five it replaced are gone entirely, skipped or not.
     for (const name of LEGACY_QUERY_NAMES) {
       expect(mockState.queryCalls.some((call) => call.name === name)).toBe(
         false,

--- a/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
@@ -50,9 +50,7 @@ export type PremiumnessGateKey =
   | "journeyRunsPerDay";
 
 export type BillingEnforcementState =
-  | "active"
-  | "disabled"
-  | "decision_required";
+  "active" | "disabled" | "decision_required";
 
 export interface GateDecision {
   gateKey: PremiumnessGateKey;
@@ -128,11 +126,7 @@ export interface OrganizationSeatPaymentIntent {
   role: "guest" | "member";
   source: string;
   status:
-    | "pending"
-    | "requires_action"
-    | "cleanup_pending"
-    | "failed"
-    | "canceled";
+    "pending" | "requires_action" | "cleanup_pending" | "failed" | "canceled";
   /**
    * The charge ended terminally and the invitee is still waiting. Only ever
    * true for charges raised automatically at signup — when an owner starts one
@@ -177,6 +171,18 @@ export interface PlanCatalog {
   currency: string;
   appOrigin?: string;
   plans: Record<OrganizationPlan, PlanCatalogEntry>;
+}
+
+// One envelope for the five stable billing reads. Bundled server-side because
+// every open page used to hold five separate subscriptions for them, which is
+// what pushed prod into its concurrent-query limit. `projectPremiumness` is
+// null when the caller sent no projectId.
+export interface OrganizationBillingBundle {
+  billingStatus: OrganizationBillingStatus;
+  entitlements: OrganizationEntitlements;
+  organizationPremiumness: PremiumnessState;
+  projectPremiumness: PremiumnessState | null;
+  planCatalog: PlanCatalog;
 }
 
 export interface OrganizationPlanChangeSnapshot {
@@ -237,20 +243,20 @@ export interface StartOrganizationPlanChangeOptions {
 
 export function useOrganizationBillingStatus(
   organizationId: string | null,
-  options?: UseOrganizationBillingStatusOptions
+  options?: UseOrganizationBillingStatusOptions,
 ): OrganizationBillingStatus | undefined {
   const isUserReady = useDbUserReady();
   const enabled = (options?.enabled ?? true) && isUserReady;
 
   return useQuery(
     "billing:getOrganizationBillingStatus" as any,
-    enabled && organizationId ? ({ organizationId } as any) : "skip"
+    enabled && organizationId ? ({ organizationId } as any) : "skip",
   ) as OrganizationBillingStatus | undefined;
 }
 
 export function useOrganizationBilling(
   organizationId: string | null,
-  options?: UseOrganizationBillingOptions
+  options?: UseOrganizationBillingOptions,
 ) {
   const projectId = options?.projectId ?? null;
   const isUserReady = useDbUserReady();
@@ -261,56 +267,57 @@ export function useOrganizationBilling(
   const shouldQuerySeatPaymentIntent =
     shouldQueryOrganization && options?.includeSeatPaymentIntent === true;
 
-  const billingStatus = useOrganizationBillingStatus(organizationId, {
-    enabled,
-  });
+  // One subscription instead of five. `useOrganizationBillingStatus` stays a
+  // separate export for callers that only want the status, so it is not reused
+  // here.
+  const bundle = useQuery(
+    "billing:getOrganizationBillingBundle" as any,
+    shouldQueryOrganization
+      ? ({
+          organizationId,
+          ...(shouldQueryProject ? { projectId } : {}),
+        } as any)
+      : "skip",
+  ) as OrganizationBillingBundle | undefined;
 
-  const entitlements = useQuery(
-    "billing:getOrganizationEntitlements" as any,
-    shouldQueryOrganization ? ({ organizationId } as any) : "skip"
-  ) as OrganizationEntitlements | undefined;
-
-  const organizationPremiumness = useQuery(
-    "billing:getOrganizationPremiumness" as any,
-    shouldQueryOrganization ? ({ organizationId } as any) : "skip"
-  ) as PremiumnessState | undefined;
-
-  const projectPremiumness = useQuery(
-    "billing:getProjectPremiumness" as any,
-    shouldQueryProject ? ({ organizationId, projectId } as any) : "skip"
-  ) as PremiumnessState | undefined;
-
-  const planCatalog = useQuery(
-    "billing:getPlanCatalog" as any,
-    shouldQueryOrganization ? ({ organizationId } as any) : "skip"
-  ) as PlanCatalog | undefined;
+  const billingStatus = bundle?.billingStatus;
+  const entitlements = bundle?.entitlements;
+  const organizationPremiumness = bundle?.organizationPremiumness;
+  // The bundle says null for "no projectId sent"; callers expect undefined,
+  // which is what the old "skip" subscription gave them. Gate it on
+  // shouldQueryProject too, so a bundle fetched without a project can never
+  // read as a settled project answer.
+  const projectPremiumness = shouldQueryProject
+    ? (bundle?.projectPremiumness ?? undefined)
+    : undefined;
+  const planCatalog = bundle?.planCatalog;
 
   const activeSeatPaymentIntent = useQuery(
     "billing:getActiveOrganizationSeatPaymentIntent" as any,
-    shouldQuerySeatPaymentIntent ? ({ organizationId } as any) : "skip"
+    shouldQuerySeatPaymentIntent ? ({ organizationId } as any) : "skip",
   ) as OrganizationSeatPaymentIntent | null | undefined;
 
   const startPlanChangeAction = useAction(
-    "billing:startOrganizationPlanChange" as any
+    "billing:startOrganizationPlanChange" as any,
   );
   const createPortal = useAction(
-    "billing:createOrganizationBillingPortalSession" as any
+    "billing:createOrganizationBillingPortalSession" as any,
   );
   const createCancellationPortal = useAction(
-    "billing:createOrganizationBillingPortalCancellationSession" as any
+    "billing:createOrganizationBillingPortalCancellationSession" as any,
   );
   const createIntervalChangePortal = useAction(
-    "billing:createOrganizationBillingPortalIntervalChangeSession" as any
+    "billing:createOrganizationBillingPortalIntervalChangeSession" as any,
   );
   const cancelScheduledBillingChangeAction = useAction(
-    "billing:cancelOrganizationScheduledBillingChange" as any
+    "billing:cancelOrganizationScheduledBillingChange" as any,
   );
   const selectFreeAfterTrialMutation = useMutation(
-    "billing:selectOrganizationFreePlanAfterTrial" as any
+    "billing:selectOrganizationFreePlanAfterTrial" as any,
   );
   const startSeatPaymentAction = useAction("billing:startSeatPayment" as any);
   const completeSeatPaymentAction = useAction(
-    "billing:completeSeatPayment" as any
+    "billing:completeSeatPayment" as any,
   );
   const cancelSeatPaymentAction = useAction("billing:cancelSeatPayment" as any);
   const retrySeatPaymentMutation = useMutation(
@@ -340,7 +347,7 @@ export function useOrganizationBilling(
       returnUrl: string,
       tier: "team" = "team",
       billingInterval: BillingInterval = "monthly",
-      options: StartOrganizationPlanChangeOptions = {}
+      options: StartOrganizationPlanChangeOptions = {},
     ): Promise<OrganizationPlanChangeResult> => {
       if (!organizationId) throw new Error("Organization is required");
       setIsStartingPlanChange(true);
@@ -365,7 +372,7 @@ export function useOrganizationBilling(
         setPendingPlanChangeTarget(null);
       }
     },
-    [organizationId, startPlanChangeAction]
+    [organizationId, startPlanChangeAction],
   );
 
   const openPortal = useCallback(
@@ -388,7 +395,7 @@ export function useOrganizationBilling(
         setIsOpeningPortal(false);
       }
     },
-    [createPortal, organizationId]
+    [createPortal, organizationId],
   );
 
   const openIntervalChangePortal = useCallback(
@@ -414,7 +421,7 @@ export function useOrganizationBilling(
         setIsOpeningPortal(false);
       }
     },
-    [createIntervalChangePortal, organizationId]
+    [createIntervalChangePortal, organizationId],
   );
 
   const openCancellationPortal = useCallback(
@@ -439,7 +446,7 @@ export function useOrganizationBilling(
         setIsOpeningPortal(false);
       }
     },
-    [createCancellationPortal, organizationId]
+    [createCancellationPortal, organizationId],
   );
 
   const cancelScheduledBillingChange = useCallback(async () => {
@@ -522,7 +529,7 @@ export function useOrganizationBilling(
             } catch (cancelError) {
               console.warn(
                 "[billing] Failed to cancel incomplete seat payment",
-                cancelError
+                cancelError,
               );
             }
             throw confirmError;
@@ -555,7 +562,7 @@ export function useOrganizationBilling(
         if (startResult.status === "failed") {
           if (startResult.reason === "missing_payment_method") {
             throw new Error(
-              "Stripe has no default payment method for this subscription. Add or select a card in Billing, then click Finish payment again."
+              "Stripe has no default payment method for this subscription. Add or select a card in Billing, then click Finish payment again.",
             );
           }
           throw new Error("Payment failed. The member was not added.");
@@ -577,7 +584,7 @@ export function useOrganizationBilling(
       completeSeatPaymentAction,
       organizationId,
       startSeatPaymentAction,
-    ]
+    ],
   );
 
   /**
@@ -662,7 +669,7 @@ export function useOrganizationBilling(
       activeSeatPaymentIntent?.stripeInvoiceId,
       cancelSeatPaymentAction,
       organizationId,
-    ]
+    ],
   );
 
   // The caller asked for billing and we're only waiting on the `users` row.
@@ -694,7 +701,8 @@ export function useOrganizationBilling(
     isLoadingOrganizationPremiumness,
     isLoadingProjectPremiumness,
     isLoadingPlanCatalog:
-      isAwaitingUserRow || (shouldQueryOrganization && planCatalog === undefined),
+      isAwaitingUserRow ||
+      (shouldQueryOrganization && planCatalog === undefined),
     isStartingPlanChange,
     pendingPlanChangeTarget,
     isOpeningPortal,


### PR DESCRIPTION
- Depends on MCPJam/mcpjam-backend#1320. Do not merge this until that one is live, or the hook will call a query that doesn't exist yet.
- Every open page used to hold five separate billing subscriptions. That fan-out is what pushed prod Convex over its 256-concurrent-query limit (Sentry CONVEX-27K). Now it holds one.
- Nothing changes for the 21 places that use the hook. Same fields, same loading flags, same values.
- The status hook stays separate on purpose. The sidebar, credits widget and project state only read the status, so bundling them would make them download four things they never look at.
- New test file pins that the hook opens exactly one query and never falls back to the old five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the five billing subscriptions `useOrganizationBilling` opened on every page with a single bundled query, fixing the fan-out that pushed prod Convex over its 256-concurrent-query limit (Sentry CONVEX-27K). Callers see the same fields, loading flags, and values.

`useOrganizationBillingStatus` stays a separate query because the sidebar, credits widget, and project state only read the status. The bundle reports null project premiumness when no projectId is sent; the hook maps that back to undefined so loading flags behave exactly as before.

Tests pin the bundle as the only live subscription and assert every App bundle call is skipped during the OAuth-sensitive windows.

**Dependencies**
- Requires `MCPJam/mcpjam-backend#1320` to be live; the hook calls `billing:getOrganizationBillingBundle`, which doesn't exist until then.

<sup>Written for commit b08222ea2f8a1b4ff5789ece8e04e58f59b754a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

