### PR TITLE
fix(browser panel): mint one token per lifetime, and stop polling when the browser is gone

### DIFF
--- a/.changeset/browser-panel-token-reuse.md
+++ b/.changeset/browser-panel-token-reuse.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Stop the Browser Panel from minting a browser token on every request, and stop its keepalive and lease heartbeat from silently retrying forever once the browser is gone. A computer released or auto-paused under an open panel now says so instead of logging one uncaught server error per minute for as long as the tab stays open.

--- a/mcpjam-inspector/client/src/components/computer/BrowserPanel.tsx
+++ b/mcpjam-inspector/client/src/components/computer/BrowserPanel.tsx
@@ -36,6 +36,41 @@ import { BROWSER_SESSION_ID_HEADER } from "@/shared/browser-session-header";
 const LEASE_HEARTBEAT_MS = 30_000;
 /** Keepalive cadence while merely watching. */
 const KEEPALIVE_MS = 60_000;
+/** Re-mint this long before a token actually lapses, to cover clock skew. */
+const TOKEN_EXPIRY_BUFFER_MS = 5_000;
+
+/**
+ * The backend's code for "there is no browser to attach to" — one was never
+ * reserved, or it was released or auto-paused under an open panel.
+ *
+ * Expected and user-actionable, not a fault, so the polling loops below must
+ * STOP on it. They used to swallow every failure with `.catch(() => {})`,
+ * which combined badly with minting a token per request: a single released
+ * computer logged one uncaught server error per minute per open tab, for as
+ * long as the tab stayed open, while the panel showed nothing at all.
+ *
+ * Kept in sync with `browserUnavailable` in mcpjam-backend
+ * `convex/projectComputers.ts`.
+ */
+const BROWSER_UNAVAILABLE = "browser_unavailable";
+
+/**
+ * The message to show when a mint failed because there is no browser, or
+ * `null` when this is some other (possibly transient) failure.
+ *
+ * Reads the `ConvexError` payload rather than `.message`, because Convex masks
+ * the message to "Server Error" in production — the payload is the only part
+ * that survives the boundary.
+ */
+function browserUnavailableMessage(error: unknown): string | null {
+  const data = (error as { data?: unknown })?.data;
+  if (!data || typeof data !== "object") return null;
+  if ((data as { kind?: unknown }).kind !== BROWSER_UNAVAILABLE) return null;
+  const message = (data as { message?: unknown }).message;
+  return typeof message === "string" && message.length > 0
+    ? message
+    : "No browser is running on this computer yet.";
+}
 
 type LeaseState =
   | { state: "free" }
@@ -78,34 +113,82 @@ export function BrowserPanel({
   const visibleRef = useRef(true);
   /** Bumped whenever this panel changes which browser it is looking at. */
   const panelGeneration = useRef(0);
+  /** The live browser token, reused until it is nearly expired. */
+  const tokenCache = useRef<{
+    key: string;
+    token: string;
+    expiresAt: number;
+  } | null>(null);
 
-  /** Every call mints its own token: they last ~60s, so caching one across a
-   *  panel's lifetime would just produce expiry failures. */
-  /** A bare token for the stream socket, which cannot send an auth header. */
-  const mintStreamToken = useCallback(async () => {
-    const { token } = sessionId
+  /**
+   * Which browser the cached token is for. A token minted for one conversation
+   * must never be handed to another, so the identity is part of the cache key
+   * rather than something a separate effect has to remember to invalidate.
+   */
+  const tokenKey = sessionId
+    ? `session:${projectId}:${sessionId}`
+    : `project:${projectId}`;
+
+  /**
+   * Mint once per token lifetime, not once per request.
+   *
+   * Every call used to mint: the keepalive, the lease heartbeat, each lease
+   * action, every refresh. Tokens last ~60s, so almost all of that was a round
+   * trip to Convex to re-obtain a token still sitting in memory — and when
+   * there was no browser to mint for, it was also an uncaught server error per
+   * call rather than per token.
+   */
+  const getToken = useCallback(async (): Promise<string> => {
+    const cached = tokenCache.current;
+    if (
+      cached &&
+      cached.key === tokenKey &&
+      cached.expiresAt - TOKEN_EXPIRY_BUFFER_MS > Date.now()
+    ) {
+      return cached.token;
+    }
+    const minted = sessionId
       ? await mintConversationBrowserToken({
           projectId,
           conversationId: sessionId,
         })
       : await mintBrowserToken({ projectId });
-    return token;
-  }, [mintBrowserToken, mintConversationBrowserToken, projectId, sessionId]);
+    tokenCache.current = {
+      key: tokenKey,
+      token: minted.token,
+      expiresAt: minted.expiresAt,
+    };
+    return minted.token;
+  }, [
+    mintBrowserToken,
+    mintConversationBrowserToken,
+    projectId,
+    sessionId,
+    tokenKey,
+  ]);
+
+  /** A bare token for the stream socket, which cannot send an auth header. */
+  const mintStreamToken = useCallback(() => getToken(), [getToken]);
 
   const authorized = useCallback(
     async (path: string, init: RequestInit = {}): Promise<Response> => {
-      const { token } = sessionId
-        ? await mintConversationBrowserToken({
-            projectId,
-            conversationId: sessionId,
-          })
-        : await mintBrowserToken({ projectId });
-      const headers = new Headers(init.headers);
-      headers.set("authorization", `Bearer ${token}`);
-      if (init.body) headers.set("content-type", "application/json");
-      return fetch(`/api/web/computers/browser${path}`, { ...init, headers });
+      const send = async (token: string) => {
+        const headers = new Headers(init.headers);
+        headers.set("authorization", `Bearer ${token}`);
+        if (init.body) headers.set("content-type", "application/json");
+        return fetch(`/api/web/computers/browser${path}`, { ...init, headers });
+      };
+
+      const response = await send(await getToken());
+      // Caching a token means one can now lapse in flight, which minting per
+      // request made impossible. Drop it and mint once more — but only once,
+      // so a genuinely rejected token cannot become a retry loop. `init.body`
+      // is always a string here, so replaying the request is safe.
+      if (response.status !== 401) return response;
+      tokenCache.current = null;
+      return send(await getToken());
     },
-    [mintBrowserToken, mintConversationBrowserToken, projectId, sessionId],
+    [getToken],
   );
 
   const exportProfile = useCallback(async () => {
@@ -126,6 +209,23 @@ export function BrowserPanel({
       ...(savedFrom ? { savedFrom } : {}),
     };
   }, [authorized]);
+
+  /**
+   * A polling tick failed. Transient failures are ignored as before — the next
+   * tick can still succeed. "There is no browser" is not transient: stop, and
+   * say so, rather than logging a server error every tick until the tab closes.
+   *
+   * Clearing `session` and `holding` tears down both intervals through their
+   * own effect cleanups, so there is no timer to cancel here.
+   */
+  const handlePollFailure = useCallback((cause: unknown) => {
+    const message = browserUnavailableMessage(cause);
+    if (!message) return;
+    tokenCache.current = null;
+    setSession(null);
+    setHolding(false);
+    setError(message);
+  }, []);
 
   const refresh = useCallback(async () => {
     // Captured before the await. Clearing state on a switch is not enough on
@@ -158,7 +258,10 @@ export function BrowserPanel({
       setError(null);
     } catch (cause) {
       if (stale()) return;
-      setError(cause instanceof Error ? cause.message : String(cause));
+      setError(
+        browserUnavailableMessage(cause) ??
+          (cause instanceof Error ? cause.message : String(cause)),
+      );
     }
   }, [authorized, ensure, markBrowserSessionActive, projectId, sessionId]);
 
@@ -186,6 +289,7 @@ export function BrowserPanel({
     // Anything still in flight against the previous conversation's browser
     // must not land on this one.
     panelGeneration.current += 1;
+    tokenCache.current = null;
     setSession(null);
     setHolding(false);
     setBusy(false);
@@ -210,10 +314,12 @@ export function BrowserPanel({
     if (!session) return;
     const timer = setInterval(() => {
       if (!visibleRef.current) return;
-      void authorized("/keepalive", { method: "POST" }).catch(() => {});
+      void authorized("/keepalive", { method: "POST" }).catch(
+        handlePollFailure,
+      );
     }, KEEPALIVE_MS);
     return () => clearInterval(timer);
-  }, [authorized, session]);
+  }, [authorized, handlePollFailure, session]);
 
   // Heartbeat while holding. Stopping (closing the tab, losing the network)
   // parks the lease rather than freeing it, so the agent stays stopped.
@@ -223,10 +329,10 @@ export function BrowserPanel({
       void authorized("/lease", {
         method: "POST",
         body: JSON.stringify({ action: "heartbeat" }),
-      }).catch(() => {});
+      }).catch(handlePollFailure);
     }, LEASE_HEARTBEAT_MS);
     return () => clearInterval(timer);
-  }, [authorized, holding]);
+  }, [authorized, handlePollFailure, holding]);
 
   const changeLease = useCallback(
     async (action: "acquire" | "resume") => {

--- a/mcpjam-inspector/client/src/components/computer/__tests__/BrowserPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/BrowserPanel.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * The Browser Panel's token discipline.
+ *
+ * Both cases here are one incident (Sentry CONVEX-27Q). The panel minted a
+ * fresh token on every request, and its two polling loops swallowed every
+ * failure with `.catch(() => {})`. So a computer released or auto-paused under
+ * an open panel produced one uncaught server error per minute per open tab,
+ * for as long as the tab stayed open, while the panel itself showed nothing.
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { ConvexError } from "convex/values";
+
+const mintProject = vi.fn();
+const mintConversation = vi.fn();
+
+// Both must be referentially STABLE across renders. `useAction` is; a mock
+// that returns a fresh function each render rebuilds `getToken` → `authorized`
+// → `refresh`, and the effect keyed on `refresh` then re-fires forever.
+vi.mock("@/hooks/useProjectComputer", () => ({
+  useMintBrowserToken: () => mintProject,
+  useMintConversationBrowserToken: () => mintConversation,
+}));
+
+vi.mock("../BrowserStream", () => ({ BrowserStream: () => null }));
+vi.mock("@/components/browser/BrowserProfileSaveButton", () => ({
+  BrowserProfileSaveButton: () => null,
+}));
+
+const setBrowserLocation = vi.fn();
+const markBrowserSessionActive = vi.fn();
+const useActiveChatSessionStore = Object.assign(
+  (select: (s: unknown) => unknown) => select({ markBrowserSessionActive }),
+  { getState: () => ({ setBrowserLocation }) },
+);
+vi.mock("@/stores/active-chat-session-store", () => ({
+  get useActiveChatSessionStore() {
+    return useActiveChatSessionStore;
+  },
+}));
+
+import { BrowserPanel } from "../BrowserPanel";
+
+/** A live `/session` answer, so the panel settles into WATCHING. */
+function sessionOk() {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    json: async () => ({
+      sessionId: "s-1",
+      bootId: "b-1",
+      lease: { state: "free" },
+    }),
+  } as unknown as Response;
+}
+
+describe("BrowserPanel token discipline", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mintProject.mockReset();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => sessionOk()),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("reuses one token across requests instead of minting per request", async () => {
+    // Long-lived token so the keepalive tick lands well inside its lifetime.
+    mintProject.mockResolvedValue({
+      token: "tok",
+      expiresAt: Date.now() + 600_000,
+    });
+
+    render(<BrowserPanel projectId="p1" />);
+    await act(async () => {});
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    // Two requests went out — the initial /session and one /keepalive — and
+    // they shared a single mint. Before this, that was two round trips to
+    // Convex for a token already sitting in memory.
+    expect(
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(mintProject).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops polling and says so when the browser goes away", async () => {
+    // First mint succeeds so the panel reaches WATCHING; the computer is then
+    // released, so the re-mint after the token lapses reports it.
+    mintProject
+      .mockResolvedValueOnce({ token: "tok", expiresAt: Date.now() + 60_000 })
+      .mockRejectedValue(
+        new ConvexError({
+          kind: "browser_unavailable",
+          message:
+            "No active desktop computer for this project — reserve one first",
+        }),
+      );
+
+    render(<BrowserPanel projectId="p1" />);
+    await act(async () => {});
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(screen.getByText(/reserve one first/)).toBeTruthy();
+
+    const afterStop = mintProject.mock.calls.length;
+    // Five more minutes of wall clock. The loop is gone, so nothing else is
+    // attempted — this is the assertion that the error-per-minute stops.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300_000);
+    });
+    expect(mintProject).toHaveBeenCalledTimes(afterStop);
+  });
+});


### PR DESCRIPTION
The client half of `CONVEX-27Q`. Pairs with **MCPJam/mcpjam-backend#1323**, which must deploy first.

## What was wrong

`authorized()` minted a fresh browser token on **every** request — the keepalive, the lease heartbeat, each lease action, every refresh. Tokens last ~60s, so nearly all of that was a round trip to Convex for a token already sitting in memory.

Both polling loops then swallowed every failure with `.catch(() => {})`. Together those two facts turned a released or auto-paused computer into **one uncaught server error per minute per open tab, for as long as the tab stayed open**, while the panel itself displayed nothing. That is the whole of `CONVEX-27Q`'s escalation curve.

## What changed

- **One token per lifetime.** Cached per `(project, conversation)` until nearly expired, and dropped when the panel switches browsers. Caching means a token can now lapse in flight — which minting per request made impossible — so `authorized()` retries a 401 exactly *once* with a fresh token. Once, so a genuinely rejected token cannot become a retry loop.
- **The loops stop.** Both now recognize the backend's `browser_unavailable` code, tear themselves down through their existing effect cleanups, and show the message. Transient failures are still ignored, because the next tick can still succeed.
- **`refresh()` reads the payload too.** Convex masks plain error messages to `Server Error` in production, so the `ConvexError` payload is the only part that survives the boundary. Without this the user got an opaque string where the actionable sentence belongs.
- Removed the comment claiming a cached token "would just produce expiry failures" — it described the bug.

## Tests

New `BrowserPanel.test.tsx` covers both behaviours, and **both cases fail against the previous implementation** (verified by running them against `main`'s version of the file). Related suites: 16 files / 158 tests pass. `tsc -p client/tsconfig.typecheck.json` clean.

One thing the tests surfaced worth knowing: the panel depends on the mint hooks being referentially stable. `useAction` is; a mock returning a fresh function per render rebuilds `getToken` → `authorized` → `refresh` and re-fires the effect forever. Noted in the test so the next person does not lose an hour to it.

## Merge order

Merge and deploy **mcpjam-backend#1323 first**. Until it is live this PR is a no-op rather than a regression: an unrecognized failure falls back to today's behaviour.

## Note on formatting

`BrowserPanel.tsx` does not pass `prettier@3 --check` on `main` today (one pre-existing long line at `savedFrom`). I deliberately left that line alone so the diff is only this change — running `--write` from the repo root also picks up prettier v2 and reformats unrelated lines the other way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RuCTeekLgN1uBXTSgNacZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authenticated browser API polling and token caching in a security-sensitive path; behavior depends on backend `browser_unavailable` errors being deployed first.
> 
> **Overview**
> Fixes **Browser Panel** behavior when a hosted computer is released or auto-paused while the tab stays open (client side of CONVEX-27Q).
> 
> **Token reuse:** `authorized()` and the stream no longer mint a fresh browser token on every `/session`, keepalive, and lease call. Tokens are cached per `(projectId, conversation)` until shortly before `expiresAt`, cleared on conversation switch, with a **single** 401 retry after invalidating the cache.
> 
> **Polling stops on “no browser”:** Keepalive and lease heartbeat failures that surface as Convex `browser_unavailable` (via error **payload**, not masked message) tear down session/holding state, show the backend message, and stop the intervals instead of silently retrying forever.
> 
> Adds **`BrowserPanel.test.tsx`** for one-mint-across-requests and stop-polling-when-gone; patch **changeset** for `@mcpjam/inspector`. Intended to deploy after the matching backend PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5ebc442535989abb9bf6f5ea519c3b5e3b1b8c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the browser panel from minting a fresh browser token on every request and from retrying forever once the browser is gone. A released or auto-paused computer under an open panel used to log one uncaught server error per minute per open tab; it now surfaces the backend's message and shuts down its polling loops.

- Caches one token per project and conversation, and retries a 401 exactly once with a fresh mint so a token lapsing in flight cannot become a retry loop.
- Reads the `ConvexError` payload in `refresh()` because Convex masks error messages to "Server Error" in production.
- Requires `mcpjam-backend#1323` to be deployed first; until then this is a no-op.
- New tests cover both behaviors and fail against the previous implementation.

<sup>Written for commit b5ebc442535989abb9bf6f5ea519c3b5e3b1b8c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

