### PR TITLE
Simplify GitHub check OAuth setup

### DIFF
--- a/docs/github-checks.mdx
+++ b/docs/github-checks.mdx
@@ -239,23 +239,19 @@ request. When MCPJam detects a Bearer challenge during the health probe, it
 marks the server as requiring authorization and looks for a project-shared OAuth
 connection to use.
 
-To run checks against such a server:
+MCPJam derives the OAuth connection from the repository's selected suite. When
+that suite has one authorized project-shared OAuth connection, there is nothing
+else connected-repository settings need you to choose.
 
-1. Go to **Settings → Integrations → GitHub** and find the repository in
-   **Connected repositories**.
-2. Under **Server authentication**, select the project-shared OAuth connection
-   that is authorized for the PR server.
-3. If no authorized connection appears in the list, click **Authorize or
-   reconnect** to go to the project's Servers page and complete the OAuth flow
-   there first.
+Settings shows a small action only when attention is needed: **Authorize** for
+a suite connection with no saved project authorization, **Reconnect** after a
+check reports that authorization no longer works, or a picker when the suite
+contains more than one eligible OAuth connection. These actions open the
+project's existing Servers page and OAuth flow.
 
-When no OAuth source is selected and the PR server requires login, the check
-reports **Action required** and skips execution. Selecting an authorized source
-lets the check proceed normally.
-
-The selector only shows connections that belong to the same project as the
-connected repository. Connections that have not been authorized yet appear in
-the list but are disabled — authorize them on the Servers page first.
+When the required authorization is missing or rejected, the GitHub check
+reports **Action required** and skips execution. Personal and unrelated project
+connections are never selected automatically.
 
 ## Per-repository switches
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
@@ -9,7 +9,6 @@ const {
   mockConnectRepo,
   mockSetRepoForkCredentials,
   mockSetRepoPrServerOAuth,
-  mockPrServerOAuthSources,
   mockConnectVerifiedRepo,
   mockListInstallationRepos,
   mockNavigate,
@@ -17,7 +16,8 @@ const {
 } = vi.hoisted(() => ({
   mockAvailability: {
     value: undefined as
-      { state: "enabled" | "disabled"; canManage?: boolean } | undefined,
+      | { state: "enabled" | "disabled"; canManage?: boolean }
+      | undefined,
   },
   mockRepos: { value: undefined as any[] | undefined },
   // The org's installations, on a live query. What the listing below is a
@@ -32,7 +32,6 @@ const {
   mockSetRepoPrServerOAuth: vi.fn(async (_args?: unknown) => ({
     changed: true,
   })),
-  mockPrServerOAuthSources: { value: [] as any[] },
   mockConnectRepo: vi.fn(async () => ({ configId: "cfg-legacy" })),
   // Loosely typed for the same reason as the settings-route suite: these stand
   // in for Convex actions whose arguments are hand-mirrored, and a narrow
@@ -43,20 +42,22 @@ const {
   // `repositoryId` is REQUIRED by the contract and is what the picker is keyed
   // on: two connected accounts can each have a `widgets`, so a name is not a
   // selector. `installationRef` says which installation the entry came from.
-  mockListInstallationRepos: vi.fn(async (): Promise<unknown[]> => [
-    {
-      repositoryId: 101,
-      fullName: "mcpjam/inspector",
-      installationRef: "bind-1",
-      accountLogin: "mcpjam",
-    },
-    {
-      repositoryId: 102,
-      fullName: "mcpjam/backend",
-      installationRef: "bind-1",
-      accountLogin: "mcpjam",
-    },
-  ]),
+  mockListInstallationRepos: vi.fn(
+    async (): Promise<unknown[]> => [
+      {
+        repositoryId: 101,
+        fullName: "mcpjam/inspector",
+        installationRef: "bind-1",
+        accountLogin: "mcpjam",
+      },
+      {
+        repositoryId: 102,
+        fullName: "mcpjam/backend",
+        installationRef: "bind-1",
+        accountLogin: "mcpjam",
+      },
+    ],
+  ),
   mockNavigate: vi.fn(),
   mockToast: { error: vi.fn(), success: vi.fn() },
 }));
@@ -66,7 +67,6 @@ vi.mock("@/hooks/useGithubChecksSettings", () => ({
     availability: mockAvailability.value,
     repos: mockRepos.value,
     bindings: mockBindings.value,
-    prServerOAuthSources: mockPrServerOAuthSources.value,
     connectRepo: mockConnectRepo,
     setRepoForkCredentials: mockSetRepoForkCredentials,
     setRepoPrServerOAuth: mockSetRepoPrServerOAuth,
@@ -89,6 +89,10 @@ const CONNECTED_HERE = {
   enabled: true,
   suiteId: "suite-1",
   projectId: "proj-1",
+  prServerOAuth: {
+    status: "not_configured" as const,
+    sources: [],
+  },
 };
 const CONNECTED_ELSEWHERE = {
   _id: "cfg-2",
@@ -100,7 +104,8 @@ const CONNECTED_ELSEWHERE = {
 function renderSection(
   opts: {
     availability?:
-      { state: "enabled" | "disabled"; canManage?: boolean } | undefined;
+      | { state: "enabled" | "disabled"; canManage?: boolean }
+      | undefined;
     repos?: any[] | undefined;
   } = {},
 ) {
@@ -371,7 +376,7 @@ describe("SuiteGithubChecksSection repository identity", () => {
     renderSection({ repos: [] });
     await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
     expect(
-      await screen.findByText(/No repositories available to connect\./)
+      await screen.findByText(/No repositories available to connect\./),
     ).toBeInTheDocument();
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /Connect/ })).toBeDisabled(),
@@ -502,23 +507,35 @@ it("the suite section edits the same repository credential policy", async () => 
   });
 });
 
-it("the suite section selects an authorized OAuth source", async () => {
-  mockPrServerOAuthSources.value = [
-    {
-      serverId: "server-oauth",
-      projectId: "proj-1",
-      name: "Test OAuth server",
-      authorized: true,
-    },
-  ];
+it("the suite section asks only when several OAuth sources need a choice", async () => {
   renderSection({
     availability: { state: "enabled", canManage: true },
-    repos: [{ ...CONNECTED_HERE, connectionStatus: "verified" }],
+    repos: [
+      {
+        ...CONNECTED_HERE,
+        connectionStatus: "verified",
+        prServerOAuth: {
+          status: "selection_required",
+          sources: [
+            {
+              serverId: "server-oauth",
+              name: "Test OAuth server",
+              authorized: true,
+            },
+            {
+              serverId: "server-other",
+              name: "Other OAuth server",
+              authorized: true,
+            },
+          ],
+        },
+      },
+    ],
   });
 
   await chooseOption(
     userEvent.setup(),
-    `Server authentication for ${CONNECTED_HERE.repoFullName}`,
+    `Server authorization for ${CONNECTED_HERE.repoFullName}`,
     "Test OAuth server",
   );
 
@@ -544,14 +561,16 @@ it("keeps each repository OAuth selector busy independently", async () => {
           resolveSecond = resolve;
         }),
     );
-  mockPrServerOAuthSources.value = [
-    {
-      serverId: "server-oauth",
-      projectId: "proj-1",
-      name: "Test OAuth server",
-      authorized: true,
-    },
-  ];
+  const oauthResolution = {
+    status: "selection_required" as const,
+    sources: [
+      {
+        serverId: "server-oauth",
+        name: "Test OAuth server",
+        authorized: true,
+      },
+    ],
+  };
   const second = {
     ...CONNECTED_HERE,
     _id: "cfg-2",
@@ -560,10 +579,13 @@ it("keeps each repository OAuth selector busy independently", async () => {
   const user = userEvent.setup();
   renderSection({
     availability: { state: "enabled", canManage: true },
-    repos: [CONNECTED_HERE, second],
+    repos: [
+      { ...CONNECTED_HERE, prServerOAuth: oauthResolution },
+      { ...second, prServerOAuth: oauthResolution },
+    ],
   });
-  const firstLabel = `Server authentication for ${CONNECTED_HERE.repoFullName}`;
-  const secondLabel = `Server authentication for ${second.repoFullName}`;
+  const firstLabel = `Server authorization for ${CONNECTED_HERE.repoFullName}`;
+  const secondLabel = `Server authorization for ${second.repoFullName}`;
 
   await chooseOption(user, firstLabel, "Test OAuth server");
   await chooseOption(user, secondLabel, "Test OAuth server");
@@ -584,21 +606,27 @@ it("does not toast when an OAuth write fails after the suite section is gone", a
         rejectWrite = reject;
       }),
   );
-  mockPrServerOAuthSources.value = [
-    {
-      serverId: "server-oauth",
-      projectId: "proj-1",
-      name: "Test OAuth server",
-      authorized: true,
-    },
-  ];
   const { unmount } = renderSection({
     availability: { state: "enabled", canManage: true },
-    repos: [CONNECTED_HERE],
+    repos: [
+      {
+        ...CONNECTED_HERE,
+        prServerOAuth: {
+          status: "selection_required",
+          sources: [
+            {
+              serverId: "server-oauth",
+              name: "Test OAuth server",
+              authorized: true,
+            },
+          ],
+        },
+      },
+    ],
   });
   await chooseOption(
     userEvent.setup(),
-    `Server authentication for ${CONNECTED_HERE.repoFullName}`,
+    `Server authorization for ${CONNECTED_HERE.repoFullName}`,
     "Test OAuth server",
   );
   unmount();

--- a/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
@@ -1,4 +1,5 @@
 import { GithubForkCredentialsToggle } from "@/components/settings/github-fork-credentials-toggle";
+import { GithubPrServerOAuthControl } from "@/components/settings/github-pr-server-oauth-control";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Github, Plus } from "lucide-react";
 import { toast } from "@/lib/toast";
@@ -66,7 +67,6 @@ export function SuiteGithubChecksSection({
     availability,
     repos,
     bindings,
-    prServerOAuthSources,
     connectVerifiedRepo,
     setRepoForkCredentials,
     setRepoPrServerOAuth,
@@ -274,68 +274,33 @@ export function SuiteGithubChecksSection({
                 canManage={availability?.canManage === true}
                 onChange={setRepoForkCredentials}
               />
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="text-xs text-muted-foreground">
-                  Server authentication
-                </span>
-                <Select
-                  value={row.prServerOAuthSourceServerId ?? "none"}
-                  disabled={
-                    pendingOAuth.has(row._id) ||
-                    availability?.canManage !== true
-                  }
-                  onValueChange={(value) => {
-                    if (pendingOAuth.has(row._id)) return;
-                    setPendingOAuth((current) => new Set(current).add(row._id));
-                    void setRepoPrServerOAuth({
-                      configId: row._id,
-                      sourceServerId: value === "none" ? null : value,
+              <GithubPrServerOAuthControl
+                row={row}
+                canManage={availability?.canManage === true}
+                pending={pendingOAuth.has(row._id)}
+                onChange={(sourceServerId) => {
+                  if (pendingOAuth.has(row._id)) return;
+                  setPendingOAuth((current) => new Set(current).add(row._id));
+                  void setRepoPrServerOAuth({
+                    configId: row._id,
+                    sourceServerId,
+                  })
+                    .catch((error) => {
+                      if (mountedRef.current) {
+                        toast.error(githubChecksWriteErrorMessage(error));
+                      }
                     })
-                      .catch((error) => {
-                        if (mountedRef.current) {
-                          toast.error(githubChecksWriteErrorMessage(error));
-                        }
-                      })
-                      .finally(() => {
-                        if (!mountedRef.current) return;
-                        setPendingOAuth((current) => {
-                          const next = new Set(current);
-                          next.delete(row._id);
-                          return next;
-                        });
+                    .finally(() => {
+                      if (!mountedRef.current) return;
+                      setPendingOAuth((current) => {
+                        const next = new Set(current);
+                        next.delete(row._id);
+                        return next;
                       });
-                  }}
-                >
-                  <SelectTrigger
-                    className="w-60"
-                    aria-label={`Server authentication for ${row.repoFullName}`}
-                  >
-                    <SelectValue placeholder="No saved authorization" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">No saved authorization</SelectItem>
-                    {(prServerOAuthSources ?? [])
-                      .filter((source) => source.projectId === row.projectId)
-                      .map((source) => (
-                        <SelectItem
-                          key={source.serverId}
-                          value={source.serverId}
-                          disabled={!source.authorized}
-                        >
-                          {source.name}
-                          {source.authorized ? "" : " — authorize first"}
-                        </SelectItem>
-                      ))}
-                  </SelectContent>
-                </Select>
-                <Button
-                  variant="link"
-                  size="sm"
-                  onClick={() => appNavigate(`/p/${row.projectId}/servers`)}
-                >
-                  Authorize or reconnect
-                </Button>
-              </div>
+                    });
+                }}
+                onManage={() => appNavigate(`/p/${row.projectId}/servers`)}
+              />
             </div>
           ))}
         </div>

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -1,4 +1,5 @@
 import { GithubForkCredentialsToggle } from "./github-fork-credentials-toggle";
+import { GithubPrServerOAuthControl } from "./github-pr-server-oauth-control";
 import {
   useCallback,
   useEffect,
@@ -264,7 +265,6 @@ export function GithubChecksRoute({
     availability,
     repos,
     suites,
-    prServerOAuthSources,
     bindings,
     connectVerifiedRepo,
     setRepoEnabled,
@@ -1126,51 +1126,15 @@ export function GithubChecksRoute({
                 canManage={canManage}
                 onChange={setRepoForkCredentials}
               />
-              <div className="flex flex-wrap items-center gap-3 border-t border-border/40 pt-3">
-                <div className="min-w-52">
-                  <p className="text-sm font-medium">Server authentication</p>
-                  <p className="text-xs text-muted-foreground">
-                    Reuse one project-shared test OAuth connection when this
-                    repository&apos;s PR server requires login.
-                  </p>
-                </div>
-                <Select
-                  value={row.prServerOAuthSourceServerId ?? "none"}
-                  disabled={pendingOAuth.has(row._id) || !canManage}
-                  onValueChange={(value) =>
-                    void handlePrServerOAuthChange(row, value)
-                  }
-                >
-                  <SelectTrigger
-                    className="w-64"
-                    aria-label={`Server authentication for ${row.repoFullName}`}
-                  >
-                    <SelectValue placeholder="No saved authorization" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">No saved authorization</SelectItem>
-                    {(prServerOAuthSources ?? [])
-                      .filter((source) => source.projectId === row.projectId)
-                      .map((source) => (
-                        <SelectItem
-                          key={source.serverId}
-                          value={source.serverId}
-                          disabled={!source.authorized}
-                        >
-                          {source.name}
-                          {source.authorized ? "" : " — authorize first"}
-                        </SelectItem>
-                      ))}
-                  </SelectContent>
-                </Select>
-                <Button
-                  variant="link"
-                  size="sm"
-                  onClick={() => appNavigate(`/p/${row.projectId}/servers`)}
-                >
-                  Authorize or reconnect
-                </Button>
-              </div>
+              <GithubPrServerOAuthControl
+                row={row}
+                canManage={canManage}
+                pending={pendingOAuth.has(row._id)}
+                onChange={(sourceServerId) =>
+                  void handlePrServerOAuthChange(row, sourceServerId)
+                }
+                onManage={() => appNavigate(`/p/${row.projectId}/servers`)}
+              />
             </div>
           ))
         )}

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -2014,6 +2014,17 @@ it("hides server authorization when the suite connection is ready", () => {
 
   expect(screen.queryByText("Server authentication")).not.toBeInTheDocument();
   expect(screen.queryByText("Authorize or reconnect")).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("combobox", {
+      name: `Server authorization for ${ROW.repoFullName}`,
+    }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "Authorize" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "Reconnect" }),
+  ).not.toBeInTheDocument();
 });
 
 it("shows Authorize only when the suite OAuth connection needs it", () => {

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -25,7 +25,6 @@ const {
   mockConnectVerifiedRepo,
   mockListInstallationRepos,
   mockBindings,
-  mockPrServerOAuthSources,
   mockStartInstallation,
   mockStartDirectClaim,
   mockUnbindInstallation,
@@ -62,16 +61,17 @@ const {
   mockConnectVerifiedRepo: vi.fn(async (_args?: Record<string, unknown>) => ({
     configId: "cfg-new",
   })),
-  mockListInstallationRepos: vi.fn(async (): Promise<unknown[]> => [
-    {
-      repositoryId: 2,
-      fullName: "mcpjam/other-repo",
-      installationRef: "bind-1",
-      accountLogin: "mcpjam",
-    },
-  ]),
+  mockListInstallationRepos: vi.fn(
+    async (): Promise<unknown[]> => [
+      {
+        repositoryId: 2,
+        fullName: "mcpjam/other-repo",
+        installationRef: "bind-1",
+        accountLogin: "mcpjam",
+      },
+    ],
+  ),
   mockBindings: { value: undefined as unknown[] | undefined },
-  mockPrServerOAuthSources: { value: [] as unknown[] },
   mockStartInstallation: vi.fn(async () => ({
     installUrl: "https://github.com/apps/mcpjam/installations/new?state=abc",
   })),
@@ -98,7 +98,6 @@ vi.mock("@/hooks/useGithubChecksSettings", () => ({
     repos: mockRepos.value,
     suites: mockSuites.value,
     bindings: mockBindings.value,
-    prServerOAuthSources: mockPrServerOAuthSources.value,
     connectRepo: mockConnectRepo,
     connectVerifiedRepo: mockConnectVerifiedRepo,
     setRepoEnabled: mockSetRepoEnabled,
@@ -170,6 +169,10 @@ const ROW = {
   // Backend-DERIVED. The page never computes this, and in particular never
   // infers it from a missing visibility badge.
   connectionStatus: "verified" as const,
+  prServerOAuth: {
+    status: "not_configured" as const,
+    sources: [],
+  },
   createdAt: 1,
   updatedAt: 1,
 };
@@ -330,7 +333,7 @@ describe("GithubChecksRoute availability gate", () => {
     expect(screen.getByText("mcpjam/mcp-check-fixture")).toBeInTheDocument();
     expect(screen.getByText("mcpjam.yaml")).toBeVisible();
     expect(
-      screen.getByRole("link", { name: "Read the recipe docs" })
+      screen.getByRole("link", { name: "Read the recipe docs" }),
     ).toHaveAttribute("href", "https://docs.mcpjam.com/github-checks");
   });
 
@@ -398,10 +401,7 @@ describe("GithubChecksRoute availability gate", () => {
 
     const pairs: Array<[string, string]> = [
       ["Checks", "Enable checks for mcpjam/mcp-check-fixture"],
-      [
-        "Conformance",
-        "Enable conformance check for mcpjam/mcp-check-fixture",
-      ],
+      ["Conformance", "Enable conformance check for mcpjam/mcp-check-fixture"],
       [
         "Comments",
         "Post feedback comments on pull requests for mcpjam/mcp-check-fixture",
@@ -1279,13 +1279,19 @@ describe("GithubChecksRoute organization switching", () => {
   });
 
   it("drops an OAuth failure that arrives after the organization changed", async () => {
-    mockRepos.value = [ROW];
-    mockPrServerOAuthSources.value = [
+    mockRepos.value = [
       {
-        serverId: "server-oauth",
-        projectId: ROW.projectId,
-        name: "Test OAuth server",
-        authorized: true,
+        ...ROW,
+        prServerOAuth: {
+          status: "selection_required",
+          sources: [
+            {
+              serverId: "server-oauth",
+              name: "Test OAuth server",
+              authorized: true,
+            },
+          ],
+        },
       },
     ];
     mockListInstallationRepos.mockResolvedValue([]);
@@ -1300,7 +1306,7 @@ describe("GithubChecksRoute organization switching", () => {
     const { rerender } = render(routeTree("org-1"));
     await chooseOption(
       userEvent.setup(),
-      `Server authentication for ${ROW.repoFullName}`,
+      `Server authorization for ${ROW.repoFullName}`,
       "Test OAuth server",
     );
     rerender(routeTree("org-2"));
@@ -1820,7 +1826,7 @@ describe("GithubChecksRoute connection status", () => {
     renderRoute();
     await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
     expect(
-      await screen.findByText(/No repositories available\./)
+      await screen.findByText(/No repositories available\./),
     ).toBeInTheDocument();
     await waitFor(() => expect(connectButton()).toBeDisabled());
     expect(mockConnectVerifiedRepo).not.toHaveBeenCalled();
@@ -1864,34 +1870,34 @@ describe("GithubChecksRoute permissions", () => {
     renderRoute();
 
     expect(
-      await screen.findByRole("button", { name: /Connect a GitHub account/ })
+      await screen.findByRole("button", { name: /Connect a GitHub account/ }),
     ).toBeDisabled();
     expect(
-      screen.getByRole("button", { name: /Disconnect mcpjam$/ })
+      screen.getByRole("button", { name: /Disconnect mcpjam$/ }),
     ).toBeDisabled();
     expect(
       screen.getByRole("switch", {
         name: /Enable checks for mcpjam\/mcp-check-fixture/,
-      })
+      }),
     ).toBeDisabled();
     expect(
       screen.getByRole("button", {
         name: /Disconnect mcpjam\/mcp-check-fixture/,
-      })
+      }),
     ).toBeDisabled();
     // The row's suite picker is a write too — `setRepoSuite` — and is the one
     // control on this page that had no `disabled` of its own to extend.
     expect(
       screen.getByRole("combobox", {
         name: /Suite for mcpjam\/mcp-check-fixture/,
-      })
+      }),
     ).toBeDisabled();
     // Nothing to fill in either, when the Connect it feeds is dead.
     expect(screen.getByRole("combobox", { name: "Repository" })).toBeDisabled();
 
     // The greyed page has to explain itself, or it reads as broken.
     expect(
-      screen.getByText(/only an organization owner or admin can change it/i)
+      screen.getByText(/only an organization owner or admin can change it/i),
     ).toBeInTheDocument();
   });
 
@@ -1900,15 +1906,15 @@ describe("GithubChecksRoute permissions", () => {
     renderRoute();
 
     expect(
-      await screen.findByRole("button", { name: /Connect a GitHub account/ })
+      await screen.findByRole("button", { name: /Connect a GitHub account/ }),
     ).toBeEnabled();
     expect(
       screen.getByRole("switch", {
         name: /Enable checks for mcpjam\/mcp-check-fixture/,
-      })
+      }),
     ).toBeEnabled();
     expect(
-      screen.queryByText(/only an organization owner or admin can change it/i)
+      screen.queryByText(/only an organization owner or admin can change it/i),
     ).not.toBeInTheDocument();
   });
 
@@ -1922,11 +1928,11 @@ describe("GithubChecksRoute permissions", () => {
 
     // Closed: the role is not known yet, so the page may not act on it.
     expect(
-      await screen.findByRole("button", { name: /Connect a GitHub account/ })
+      await screen.findByRole("button", { name: /Connect a GitHub account/ }),
     ).toBeDisabled();
     // Silent: we do not yet know the notice applies, so it must not flash.
     expect(
-      screen.queryByText(/only an organization owner or admin can change it/i)
+      screen.queryByText(/only an organization owner or admin can change it/i),
     ).not.toBeInTheDocument();
   });
 });
@@ -1949,25 +1955,36 @@ it("Settings opts in only the selected repository", async () => {
   });
 });
 
-it("Settings selects an authorized project-shared OAuth source", async () => {
+it("Settings asks only when several suite OAuth sources need a choice", async () => {
   mockMyRole.value = "admin";
   mockOrgsLoading.value = false;
   mockAuthLoading.value = false;
   mockAvailability.value = { state: "enabled" };
-  mockRepos.value = [ROW];
-  mockPrServerOAuthSources.value = [
+  mockRepos.value = [
     {
-      serverId: "server-oauth",
-      projectId: ROW.projectId,
-      name: "Test OAuth server",
-      authorized: true,
+      ...ROW,
+      prServerOAuth: {
+        status: "selection_required",
+        sources: [
+          {
+            serverId: "server-oauth",
+            name: "Test OAuth server",
+            authorized: true,
+          },
+          {
+            serverId: "server-other",
+            name: "Other OAuth server",
+            authorized: true,
+          },
+        ],
+      },
     },
   ];
   renderRoute();
 
   await chooseOption(
     userEvent.setup(),
-    `Server authentication for ${ROW.repoFullName}`,
+    `Server authorization for ${ROW.repoFullName}`,
     "Test OAuth server",
   );
 
@@ -1975,4 +1992,74 @@ it("Settings selects an authorized project-shared OAuth source", async () => {
     configId: ROW._id,
     sourceServerId: "server-oauth",
   });
+});
+
+it("hides server authorization when the suite connection is ready", () => {
+  mockMyRole.value = "admin";
+  mockOrgsLoading.value = false;
+  mockAuthLoading.value = false;
+  mockAvailability.value = { state: "enabled" };
+  mockRepos.value = [
+    {
+      ...ROW,
+      prServerOAuth: {
+        status: "ready",
+        sourceServerId: "server-oauth",
+        sourceName: "Test OAuth server",
+        sources: [],
+      },
+    },
+  ];
+  renderRoute();
+
+  expect(screen.queryByText("Server authentication")).not.toBeInTheDocument();
+  expect(screen.queryByText("Authorize or reconnect")).not.toBeInTheDocument();
+});
+
+it("shows Authorize only when the suite OAuth connection needs it", () => {
+  mockMyRole.value = "admin";
+  mockOrgsLoading.value = false;
+  mockAuthLoading.value = false;
+  mockAvailability.value = { state: "enabled" };
+  mockRepos.value = [
+    {
+      ...ROW,
+      prServerOAuth: {
+        status: "authorization_required",
+        sourceServerId: "server-oauth",
+        sourceName: "Test OAuth server",
+        sources: [],
+      },
+    },
+  ];
+  renderRoute();
+
+  expect(
+    screen.getByText("Authorize Test OAuth server for PR checks."),
+  ).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Authorize" })).toBeInTheDocument();
+});
+
+it("shows Reconnect after runtime authorization is rejected", () => {
+  mockMyRole.value = "admin";
+  mockOrgsLoading.value = false;
+  mockAuthLoading.value = false;
+  mockAvailability.value = { state: "enabled" };
+  mockRepos.value = [
+    {
+      ...ROW,
+      prServerOAuth: {
+        status: "reauthorization_required",
+        sourceServerId: "server-oauth",
+        sourceName: "Test OAuth server",
+        sources: [],
+      },
+    },
+  ];
+  renderRoute();
+
+  expect(
+    screen.getByText("Reconnect Test OAuth server for PR checks."),
+  ).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Reconnect" })).toBeInTheDocument();
 });

--- a/mcpjam-inspector/client/src/components/settings/github-pr-server-oauth-control.tsx
+++ b/mcpjam-inspector/client/src/components/settings/github-pr-server-oauth-control.tsx
@@ -1,0 +1,86 @@
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
+import type { GithubCheckRepoConfigRow } from "@/hooks/useGithubChecksSettings";
+
+export function GithubPrServerOAuthControl({
+  row,
+  canManage,
+  pending,
+  onChange,
+  onManage,
+}: {
+  row: GithubCheckRepoConfigRow;
+  canManage: boolean;
+  pending: boolean;
+  onChange: (sourceServerId: string) => void;
+  onManage: () => void;
+}) {
+  const resolution = row.prServerOAuth;
+  if (resolution.status === "not_configured" || resolution.status === "ready") {
+    return null;
+  }
+
+  if (
+    resolution.status === "authorization_required" ||
+    resolution.status === "reauthorization_required"
+  ) {
+    const reconnect = resolution.status === "reauthorization_required";
+    return (
+      <div className="flex flex-wrap items-center gap-2 border-t border-border/40 pt-3 text-sm">
+        <span className="text-muted-foreground">
+          {reconnect ? "Reconnect" : "Authorize"}{" "}
+          {resolution.sourceName ?? "this suite connection"} for PR checks.
+        </span>
+        <Button
+          variant="link"
+          size="sm"
+          disabled={!canManage}
+          onClick={onManage}
+        >
+          {reconnect ? "Reconnect" : "Authorize"}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-2 border-t border-border/40 pt-3">
+      <span className="text-sm text-muted-foreground">
+        Choose which suite authorization PR checks should use.
+      </span>
+      <Select
+        value={resolution.sourceServerId}
+        disabled={pending || !canManage}
+        onValueChange={onChange}
+      >
+        <SelectTrigger
+          className="w-60"
+          aria-label={`Server authorization for ${row.repoFullName}`}
+        >
+          <SelectValue placeholder="Choose authorization" />
+        </SelectTrigger>
+        <SelectContent>
+          {resolution.sources.map((source) => (
+            <SelectItem
+              key={source.serverId}
+              value={source.serverId}
+              disabled={!source.authorized}
+            >
+              {source.name}
+              {source.authorized ? "" : " — authorize first"}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button variant="link" size="sm" disabled={!canManage} onClick={onManage}>
+        Manage authorizations
+      </Button>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
@@ -195,6 +195,21 @@ export type GithubCheckRepoConfigRow = {
   allowSuiteCredentialsInForks?: boolean;
   prServerOAuthSourceServerId?: string;
   prServerOAuthPolicyRevision?: number;
+  prServerOAuth: {
+    status:
+      | "not_configured"
+      | "ready"
+      | "authorization_required"
+      | "reauthorization_required"
+      | "selection_required";
+    sourceServerId?: string;
+    sourceName?: string;
+    sources: Array<{
+      serverId: string;
+      name: string;
+      authorized: boolean;
+    }>;
+  };
   conformanceSuiteKinds?: Array<"protocol" | "apps" | "tasks" | "oauth">;
   /**
    * ABSENT IS `on`, NOT `off`. See {@link GithubCheckFeedbackComments}: an
@@ -245,19 +260,11 @@ export type SuiteOption = {
   projectId?: string;
 };
 
-export type PrServerOAuthSource = {
-  serverId: string;
-  projectId: string;
-  name: string;
-  authorized: boolean;
-};
-
 const AVAILABILITY_QUERY =
   "github/checkRepoConfigs:getGithubChecksSettingsAvailability";
 const LIST_QUERY = "github/checkRepoConfigs:listForOrganization";
 const SUITES_QUERY = "testSuites:getTestSuitesOverview";
 const BINDINGS_QUERY = "github/appInstallLink:listBindingsForOrganization";
-const OAUTH_SOURCES_QUERY = "github/checkRepoConfigs:listPrServerOAuthSources";
 
 // The availability message and the rest of this surface's error copy live in
 // `@/lib/github-checks-errors`, which has no React and no Convex client in it.
@@ -321,11 +328,6 @@ export function useGithubChecksSettings(
   const suites: SuiteOption[] | undefined = suiteOverview
     ?.map((entry) => entry.suite)
     .filter((suite): suite is SuiteOption => Boolean(suite?._id));
-
-  const prServerOAuthSources = useQuery(
-    OAUTH_SOURCES_QUERY as any,
-    canQuery ? ({ organizationId } as any) : "skip",
-  ) as PrServerOAuthSource[] | undefined;
 
   // The SERVER-VERIFIED connect, and the only connect path this app uses. It is
   // an action because proving the selected organization-owned installation can
@@ -537,7 +539,6 @@ export function useGithubChecksSettings(
     isEnabled,
     repos,
     suites,
-    prServerOAuthSources,
     bindings,
     connectVerifiedRepo,
     setRepoEnabled,

--- a/mcpjam-inspector/server/services/webmcp-inspector/__tests__/playwright-provider.integration.test.ts
+++ b/mcpjam-inspector/server/services/webmcp-inspector/__tests__/playwright-provider.integration.test.ts
@@ -21,10 +21,10 @@ import { chromium } from "playwright";
 
 // Every test and every hook here launches, drives, and disposes a real
 // Chromium, which the 30s defaults do not cover on a loaded CI runner — the
-// shard has failed on both a test and an `afterEach` overrunning them. Set
-// once for the file rather than per case, so a test added later inherits the
-// headroom instead of being flaky until someone notices.
-vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+// shard has failed on both a test and an `afterEach` overrunning them. Browser
+// teardown can take longer than a test while Chromium drains navigation work,
+// so give hooks separate headroom.
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 120_000 });
 import { isChromiumInstalled } from "../../../utils/browser-rendering-setup";
 import { startWebMcpSession, WebMcpSessionRegistry } from "../session-registry";
 import { localBrowserdWebMcpProvider } from "../local-browserd-provider";


### PR DESCRIPTION
The GitHub repository settings no longer show the large server-authentication selector when the suite already identifies a usable OAuth connection. They now stay quiet when no action is needed and show a compact Authorize, Reconnect, or choice control only when necessary.

This depends on [backend #1324](https://github.com/MCPJam/mcpjam-backend/pull/1324) and keeps authorization in the existing project Servers flow. Deploy the backend first.

Validation:
- client typecheck and renderer guards
- 128 focused settings, suite, and hook tests

Inspector has no applicable ESLint configuration for these client files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
GitHub checks connection settings no longer show the large server-authentication selector for every repository. Settings now stay quiet when the repository's suite has one usable OAuth connection, and show a compact Authorize, Reconnect, or choice control only when something needs attention.

- Adds a shared `GithubPrServerOAuthControl` component that renders nothing when the suite connection is ready or unconfigured, an action button when authorization or reauthorization is needed, or a picker when several OAuth sources are eligible.
- Removes the client-side `prServerOAuthSources` query; the suite resolution now carries the eligible OAuth sources.
- Updates the GitHub checks docs to describe the new flow.

**Migration**

- Deploy [backend #1324](https://github.com/MCPJam/mcpjam-backend/pull/1324) first; the client expects the new `prServerOAuth` field on each repo row.

<sup>Written for commit ff14ccef989a8adfa721ea27cdac2e6b92fa307a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

