### PR TITLE
Fix comparison browser setup, lease handoffs, and consent notifications

### DIFF
--- a/mcpjam-inspector/client/src/components/browser/ComparisonBrowser.tsx
+++ b/mcpjam-inspector/client/src/components/browser/ComparisonBrowser.tsx
@@ -44,6 +44,8 @@ export function ComparisonBrowser({
   );
   const showNames = clients.some((client) => client.clientCount > 1);
   const selected = clients.find((client) => client.sessionId === selectedId);
+  // Local setup must be reachable before Chromium can produce a snapshot.
+  const localClient = selected ?? clients[0];
   const engine = useBrowserEngine(projectId);
   const mint = useMintConversationBrowserToken();
   const mintRef = useRef(mint);
@@ -142,8 +144,8 @@ export function ComparisonBrowser({
           result.reason === "lease_held"
             ? "Someone else has control of this browser."
             : result.reason === "no_session"
-            ? "This browser is no longer running."
-            : "The browser could not complete that action. Try again.",
+              ? "This browser is no longer running."
+              : "The browser could not complete that action. Try again.",
         );
         return;
       }
@@ -176,8 +178,8 @@ export function ComparisonBrowser({
               title: views[client.sessionId]?.stale
                 ? "Reconnecting…"
                 : snapshot
-                ? "No open tabs"
-                : "Connecting…",
+                  ? "No open tabs"
+                  : "Connecting…",
               loading: !snapshot,
             },
           ];
@@ -191,7 +193,7 @@ export function ComparisonBrowser({
             clientName: showNames ? client.name : undefined,
             clientLogo: showNames ? client.logo : undefined,
             unavailable: !tab.id,
-          } satisfies BrowserDisplayTab & { sessionId: string; tabId: string }),
+          }) satisfies BrowserDisplayTab & { sessionId: string; tabId: string },
       );
     });
   const selectedView = selectedId ? views[selectedId] : undefined;
@@ -274,33 +276,36 @@ export function ComparisonBrowser({
               location="playground_browser"
             />
           </div>
+        ) : localClient?.engine === "local" ? (
+          <LocalBrowserBody
+            key={localClient.sessionId}
+            projectId={projectId}
+            sessionId={localClient.sessionId}
+            consentGranted={engine.consent.granted}
+            consentToken={engine.consent.token}
+            active={active}
+            onSessionReady={() =>
+              useBrowserComparisonStore
+                .getState()
+                .noteBrowsing(localClient.sessionId)
+            }
+          />
         ) : selected && selectedView?.snapshot ? (
-          selected.engine === "local" ? (
-            <LocalBrowserBody
-              key={selected.sessionId}
-              projectId={projectId}
-              sessionId={selected.sessionId}
-              consentGranted={engine.consent.granted}
-              consentToken={engine.consent.token}
-              active={active}
-            />
-          ) : (
-            <HostedBrowserBody
-              key={selected.sessionId}
-              projectId={projectId}
-              sessionId={selected.sessionId}
-              mintToken={mintSelected}
-              active={active}
-            />
-          )
+          <HostedBrowserBody
+            key={selected.sessionId}
+            projectId={projectId}
+            sessionId={selected.sessionId}
+            mintToken={mintSelected}
+            active={active}
+          />
         ) : (
           <p role="status" className="p-4 text-sm text-muted-foreground">
             {selected
               ? selected.engine === "local" && !engine.consent.granted
                 ? "Allow local browser access in Browser settings to view this client."
                 : showNames
-                ? `Connecting to ${selected.name}’s browser…`
-                : "Connecting to browser…"
+                  ? `Connecting to ${selected.name}’s browser…`
+                  : "Connecting to browser…"
               : "Waiting for a client to browse…"}
           </p>
         )}

--- a/mcpjam-inspector/client/src/components/browser/LocalBrowserBody.tsx
+++ b/mcpjam-inspector/client/src/components/browser/LocalBrowserBody.tsx
@@ -8,7 +8,14 @@ import {
   noteWebmcpStats,
   useBrowserPageToolsStore,
 } from "@/stores/browser-page-tools-store";
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { BrowserWorkspaceChrome } from "./BrowserWorkspaceChrome";
 import { Loader2 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
@@ -99,6 +106,7 @@ export function LocalBrowserBody({
   consentGranted,
   consentToken,
   active = true,
+  onSessionReady,
 }: {
   projectId: string | null;
   /** Durable logical session, when this pane belongs to a conversation. */
@@ -115,12 +123,19 @@ export function LocalBrowserBody({
    * idle reap, so a hidden pane must stop claiming somebody is watching.
    */
   active?: boolean;
+  /** Notify comparison chrome when a manual start or an existing session is found. */
+  onSessionReady?: () => void;
 }) {
   const workspaceEnabled = useBrowserWorkspaceEnabled();
   const comparisonWorkspace = useContext(BrowserWorkspaceChrome);
   const { grant: grantConsent } = useLocalBrowserConsent();
   const [status, setStatus] = useState<LocalBrowserStatus | null>(null);
   const [session, setSession] = useState<{ bootId: string } | null>(null);
+  const sessionReadyRef = useRef(onSessionReady);
+  sessionReadyRef.current = onSessionReady;
+  useEffect(() => {
+    if (session) sessionReadyRef.current?.();
+  }, [session]);
   const [lease, setLease] = useState<LocalBrowserLease>({ state: "free" });
   const [frame, setFrame] = useState<PaneFrame | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/mcpjam-inspector/client/src/components/browser/__tests__/ComparisonBrowser.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/ComparisonBrowser.test.tsx
@@ -26,8 +26,14 @@ const mocks = vi.hoisted(() => ({
   grant: vi.fn(async () => true),
   hosted: false,
 }));
-vi.mock("@/lib/config", () => ({ get HOSTED_MODE() { return mocks.hosted; } }));
-vi.mock("@workos-inc/authkit-react", () => ({ useAuth: () => ({ user: null }) }));
+vi.mock("@/lib/config", () => ({
+  get HOSTED_MODE() {
+    return mocks.hosted;
+  },
+}));
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: null }),
+}));
 vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 vi.mock("@/hooks/useBrowserEngine", () => ({
   useBrowserEngine: () => ({
@@ -119,6 +125,30 @@ beforeEach(() => {
 });
 
 describe("one combined browser strip", () => {
+  it("mounts local setup before the first browser session or snapshot exists", async () => {
+    register("a", 0);
+    store.setState((state) => ({
+      clients: { a: { ...state.clients.a, started: false } },
+      selected: {},
+    }));
+    mocks.read.mockResolvedValue(null);
+    mount();
+    expect(screen.getByTestId("local-body")).toHaveAttribute(
+      "data-session",
+      "a",
+    );
+    expect(mocks.transports).not.toHaveBeenCalled();
+  });
+
+  it("keeps local installation and recovery available when a started client has no snapshot", () => {
+    register("a", 0);
+    mocks.read.mockResolvedValue(null);
+    mount();
+    expect(screen.getByTestId("local-body")).toHaveAttribute(
+      "data-session",
+      "a",
+    );
+  });
   it("shows guests Allow before any client has started browsing", async () => {
     mocks.granted = false;
     mount();

--- a/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserBody.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserBody.test.tsx
@@ -1,4 +1,6 @@
-vi.mock("@workos-inc/authkit-react", () => ({ useAuth: () => ({ user: { id: "member" } }) }));
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: { id: "member" } }),
+}));
 import { releaseBrowserForChat } from "@/lib/browser-shell/chat-handoff";
 import { useBrowserPageToolsStore } from "@/stores/browser-page-tools-store";
 import { beforeAll } from "vitest";
@@ -251,6 +253,54 @@ function renderBody(over: Record<string, unknown> = {}) {
 }
 
 describe("the agent browser pane", () => {
+  it("offers Chromium installation before a comparison session exists", async () => {
+    api.status = {
+      ...api.status,
+      installed: false,
+      install: { status: "idle" },
+    } as typeof api.status;
+    render(
+      <BrowserWorkspaceChrome.Provider
+        value={{ holderId: "comparison-holder" }}
+      >
+        <LocalBrowserBody
+          projectId="proj-1"
+          sessionId="cursor-session"
+          consentGranted
+          consentToken="tok"
+        />
+      </BrowserWorkspaceChrome.Provider>,
+    );
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Install Chromium" }),
+    );
+    expect(api.installs).toBe(1);
+    expect(api.ensures).toEqual([]);
+  });
+
+  it("notifies comparison chrome when an existing session is discovered", async () => {
+    const ready = vi.fn();
+    api.lookup.mockResolvedValue({
+      bootId: "existing",
+      lease: { state: "free" },
+    });
+    render(
+      <BrowserWorkspaceChrome.Provider
+        value={{ holderId: "comparison-holder" }}
+      >
+        <LocalBrowserBody
+          projectId="proj-1"
+          sessionId="cursor-session"
+          consentGranted
+          consentToken="tok"
+          onSessionReady={ready}
+        />
+      </BrowserWorkspaceChrome.Provider>,
+    );
+    await waitFor(() => expect(ready).toHaveBeenCalledOnce());
+    expect(api.ensures).toEqual([]);
+  });
+
   it("only attaches to existing sessions when viewing a comparison client", async () => {
     render(
       <BrowserWorkspaceChrome.Provider

--- a/mcpjam-inspector/client/src/lib/browser-shell/__tests__/chat-handoff.test.tsx
+++ b/mcpjam-inspector/client/src/lib/browser-shell/__tests__/chat-handoff.test.tsx
@@ -1,6 +1,51 @@
 import { act, renderHook } from "@testing-library/react";
 import { expect, it, vi } from "vitest";
-import { releaseBrowserForChat, useBrowserChatHandoff } from "../chat-handoff";
+import {
+  releaseBrowserForChat,
+  useBrowserChatHandoff,
+  runBrowserCommandWithHandoff,
+} from "../chat-handoff";
+
+it("retains background commands across renderer mounts and panel closure", async () => {
+  const release = vi.fn(async () => {});
+  await runBrowserCommandWithHandoff({
+    projectId: "background",
+    sessionId: "b",
+    send: async () => {},
+    release,
+  });
+  const view = renderHook(() =>
+    useBrowserChatHandoff({
+      projectId: "background",
+      sessionId: "b",
+      holding: false,
+      release: async () => true,
+    }),
+  );
+  view.unmount();
+  await releaseBrowserForChat("background", "b");
+  await releaseBrowserForChat("background", "b");
+  expect(release).toHaveBeenCalledOnce();
+});
+
+it("shares concurrent background handoffs even when the command response is lost", async () => {
+  const release = vi.fn(async () => {});
+  await expect(
+    runBrowserCommandWithHandoff({
+      projectId: "lost-response",
+      sessionId: "b",
+      send: async () => {
+        throw new Error("offline");
+      },
+      release,
+    }),
+  ).rejects.toThrow("offline");
+  await Promise.all([
+    releaseBrowserForChat("lost-response", "b"),
+    releaseBrowserForChat("lost-response", "b"),
+  ]);
+  expect(release).toHaveBeenCalledOnce();
+});
 
 it("awaits handoff only for the matching conversation", async () => {
   let finish!: (ok: boolean) => void;

--- a/mcpjam-inspector/client/src/lib/browser-shell/__tests__/comparison-transport.test.ts
+++ b/mcpjam-inspector/client/src/lib/browser-shell/__tests__/comparison-transport.test.ts
@@ -1,18 +1,23 @@
-import { beforeEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { releaseBrowserForChat } from "../chat-handoff";
 import { createComparisonTransport } from "../comparison-transport";
 import type { BrowserComparisonClient } from "@/stores/browser-comparison-store";
 import * as local from "@/lib/local-browser/client";
 import * as hosted from "@/lib/hosted-browser/client";
 
-vi.mock("@/lib/local-browser/client", () => ({
+vi.mock("@/lib/local-browser/client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/local-browser/client")>()),
   fetchLocalBrowserSession: vi.fn(),
   fetchLocalBrowserState: vi.fn(),
   sendLocalPaneCommand: vi.fn(),
+  actOnLocalBrowserLease: vi.fn(),
 }));
-vi.mock("@/lib/hosted-browser/client", () => ({
+vi.mock("@/lib/hosted-browser/client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hosted-browser/client")>()),
   createBrowserTokenCache: vi.fn((mint) => ({ get: mint })),
   fetchHostedBrowserState: vi.fn(),
   sendHostedPaneCommand: vi.fn(),
+  actOnHostedBrowserLease: vi.fn(),
 }));
 const client: BrowserComparisonClient = {
   workspaceId: "workspace",
@@ -29,7 +34,18 @@ const options = {
   consentToken: "consent",
   mint: vi.fn(),
 };
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(local.actOnLocalBrowserLease).mockResolvedValue({
+    lease: { state: "free" },
+  });
+  vi.mocked(hosted.actOnHostedBrowserLease).mockResolvedValue({
+    took: true,
+    yours: false,
+    lease: { state: "free" },
+  });
+});
+afterEach(() => releaseBrowserForChat(client.projectId, client.sessionId));
 
 it("only looks up the child's local session and routes commands to its boot ID", async () => {
   vi.mocked(local.fetchLocalBrowserSession).mockResolvedValue({
@@ -55,6 +71,17 @@ it("only looks up the child's local session and routes commands to its boot ID",
     consentToken: "consent",
     command: { op: "close_tab", tabId: "tab" },
   });
+  await releaseBrowserForChat("project", "another-child");
+  expect(local.actOnLocalBrowserLease).not.toHaveBeenCalled();
+  await releaseBrowserForChat("project", "child");
+  expect(local.actOnLocalBrowserLease).toHaveBeenCalledWith(
+    {
+      bootId: "child-boot",
+      holder: "same-pane-holder",
+      action: "resume",
+    },
+    "consent",
+  );
 });
 it("does not create a browser when lookup is empty and discards an old boot ID", async () => {
   vi.mocked(local.fetchLocalBrowserSession)
@@ -81,4 +108,89 @@ it("keeps hosted credentials scoped to the supplied conversation mint", async ()
   expect(hosted.sendHostedPaneCommand).toHaveBeenCalledWith(expect.anything(), {
     command: { op: "create_tab" },
   });
+  await releaseBrowserForChat("project", "child");
+  expect(hosted.actOnHostedBrowserLease).toHaveBeenCalledWith(
+    expect.anything(),
+    { action: "resume" },
+  );
+});
+
+it("waits for a background command and releases its original boot after metadata changes", async () => {
+  let finish!: (result: { ok: true }) => void;
+  vi.mocked(local.sendLocalPaneCommand).mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        finish = resolve;
+      }),
+  );
+  vi.mocked(local.fetchLocalBrowserSession)
+    .mockResolvedValueOnce({ bootId: "original" } as never)
+    .mockResolvedValue({ bootId: "replacement" } as never);
+  const transport = createComparisonTransport(client, options);
+  await transport.readState();
+  const command = transport.sendCommand({
+    command: { op: "close_tab", tabId: "tab" },
+  });
+  const handoff = releaseBrowserForChat("project", "child");
+  await transport.readState();
+  expect(local.actOnLocalBrowserLease).not.toHaveBeenCalled();
+  finish({ ok: true });
+  await Promise.all([command, handoff]);
+  expect(local.actOnLocalBrowserLease).toHaveBeenCalledWith(
+    {
+      bootId: "original",
+      holder: "same-pane-holder",
+      action: "resume",
+    },
+    "consent",
+  );
+});
+
+it("retries a failed background handoff instead of sending chat while the lease is held", async () => {
+  vi.mocked(local.fetchLocalBrowserSession).mockResolvedValue({
+    bootId: "boot",
+  } as never);
+  vi.mocked(local.actOnLocalBrowserLease).mockRejectedValueOnce(
+    new Error("offline"),
+  );
+  const transport = createComparisonTransport(client, options);
+  await transport.readState();
+  await transport.sendCommand({ command: { op: "create_tab" } });
+  await expect(releaseBrowserForChat("project", "child")).rejects.toThrow(
+    "offline",
+  );
+  await releaseBrowserForChat("project", "child");
+  expect(local.actOnLocalBrowserLease).toHaveBeenCalledTimes(2);
+});
+
+it("does not treat a hosted resume as success while another holder retains the lease", async () => {
+  const transport = createComparisonTransport(
+    { ...client, engine: "cloud" },
+    options,
+  );
+  await transport.sendCommand({ command: { op: "create_tab" } });
+  vi.mocked(hosted.actOnHostedBrowserLease).mockResolvedValueOnce({
+    took: true,
+    yours: false,
+    lease: { state: "held", holder: "other" },
+  });
+  await expect(releaseBrowserForChat("project", "child")).rejects.toThrow(
+    "Couldn't return browser control",
+  );
+  await releaseBrowserForChat("project", "child");
+});
+
+it("forgets a handoff when the commanded local browser has closed", async () => {
+  vi.mocked(local.fetchLocalBrowserSession).mockResolvedValue({
+    bootId: "closed",
+  } as never);
+  const transport = createComparisonTransport(client, options);
+  await transport.readState();
+  await transport.sendCommand({ command: { op: "create_tab" } });
+  vi.mocked(local.actOnLocalBrowserLease).mockRejectedValue(
+    new local.LocalBrowserRequestError("No browser", 404),
+  );
+  await releaseBrowserForChat("project", "child");
+  await releaseBrowserForChat("project", "child");
+  expect(local.actOnLocalBrowserLease).toHaveBeenCalledOnce();
 });

--- a/mcpjam-inspector/client/src/lib/browser-shell/chat-handoff.ts
+++ b/mcpjam-inspector/client/src/lib/browser-shell/chat-handoff.ts
@@ -10,6 +10,56 @@ const holders = new Map<string, Holder>();
 const keyFor = (projectId: string | null, sessionId?: string | null) =>
   JSON.stringify([projectId, sessionId ?? null]);
 
+type CommandHandoff = {
+  settled: Promise<void>;
+  release: () => Promise<void>;
+  releaseInFlight?: Promise<void>;
+};
+// Tab-strip commands can hold a browser that has never had a mounted renderer.
+// Keep these separate from pane registrations, which may mount/unmount while a
+// command is still in flight and must not overwrite its pending handoff.
+const commandHandoffs = new Map<string, Set<CommandHandoff>>();
+
+export function runBrowserCommandWithHandoff<T>(args: {
+  projectId: string;
+  sessionId: string;
+  send: () => Promise<T>;
+  release: () => Promise<void>;
+}): Promise<T> {
+  const key = keyFor(args.projectId, args.sessionId);
+  const pending = Promise.resolve().then(args.send);
+  const handoff: CommandHandoff = {
+    // Even an error can follow acquisition (for example a stale page). A lost
+    // response is not evidence that the daemon did not acquire the lease.
+    settled: pending.then(
+      () => {},
+      () => {},
+    ),
+    release: args.release,
+  };
+  const entries = commandHandoffs.get(key) ?? new Set<CommandHandoff>();
+  entries.add(handoff);
+  commandHandoffs.set(key, entries);
+  return pending;
+}
+
+async function releaseCommandHandoffs(key: string): Promise<void> {
+  const entries = commandHandoffs.get(key);
+  if (!entries) return;
+  for (const handoff of entries) {
+    handoff.releaseInFlight ??= handoff.settled
+      .then(handoff.release)
+      .then(() => {
+        entries.delete(handoff);
+        if (!entries.size) commandHandoffs.delete(key);
+      })
+      .finally(() => {
+        handoff.releaseInFlight = undefined;
+      });
+    await handoff.releaseInFlight;
+  }
+}
+
 /** The holder survives closing the panel: the browser lease does too. */
 export function useBrowserChatHandoff({
   projectId,
@@ -48,6 +98,7 @@ export async function releaseBrowserForChat(
 ): Promise<void> {
   if (!projectId) return;
   const key = keyFor(projectId, sessionId);
+  if (commandHandoffs.has(key)) await releaseCommandHandoffs(key);
   const holder = holders.get(key);
   if (!holder) return;
   if (!holder.releaseInFlight && holder.holding) {

--- a/mcpjam-inspector/client/src/lib/browser-shell/comparison-transport.ts
+++ b/mcpjam-inspector/client/src/lib/browser-shell/comparison-transport.ts
@@ -3,14 +3,24 @@ import {
   createBrowserTokenCache,
   fetchHostedBrowserState,
   sendHostedPaneCommand,
+  actOnHostedBrowserLease,
+  HostedBrowserError,
   type MintBrowserToken,
 } from "@/lib/hosted-browser/client";
 import {
   fetchLocalBrowserSession,
   fetchLocalBrowserState,
   sendLocalPaneCommand,
+  actOnLocalBrowserLease,
+  LocalBrowserRequestError,
 } from "@/lib/local-browser/client";
 import type { BrowserSessionTransport } from "./use-browser-session";
+import { runBrowserCommandWithHandoff } from "./chat-handoff";
+
+const handoffFailed = () =>
+  new Error(
+    "Couldn't return browser control to the agent. Try sending your message again.",
+  );
 
 /** Metadata and explicit commands only: never ensure, watch, resize, or stream. */
 export function createComparisonTransport(
@@ -25,7 +35,28 @@ export function createComparisonTransport(
     const tokens = createBrowserTokenCache(options.mint);
     return {
       readState: () => fetchHostedBrowserState(tokens),
-      sendCommand: (command) => sendHostedPaneCommand(tokens, command),
+      sendCommand: (command) =>
+        runBrowserCommandWithHandoff({
+          projectId: client.projectId,
+          sessionId: client.sessionId,
+          send: () => sendHostedPaneCommand(tokens, command),
+          release: async () => {
+            try {
+              const result = await actOnHostedBrowserLease(tokens, {
+                action: "resume",
+              });
+              if (!result.took || result.lease.state !== "free")
+                throw handoffFailed();
+            } catch (error) {
+              if (
+                error instanceof HostedBrowserError &&
+                error.code === "no_browser_session"
+              )
+                return;
+              throw error;
+            }
+          },
+        }),
     };
   }
   let bootId: string | null = null;
@@ -45,14 +76,42 @@ export function createComparisonTransport(
           })
         : null;
     },
-    sendCommand: (args) =>
-      bootId
-        ? sendLocalPaneCommand({
+    sendCommand: (args) => {
+      // Capture the boot we command: a later metadata read may find a new one.
+      const commandBootId = bootId;
+      if (!commandBootId)
+        return Promise.resolve({ ok: false, reason: "no_session" });
+      return runBrowserCommandWithHandoff({
+        projectId: client.projectId,
+        sessionId: client.sessionId,
+        send: () =>
+          sendLocalPaneCommand({
             ...args,
-            bootId,
+            bootId: commandBootId,
             holder: options.holder,
             consentToken: options.consentToken,
-          })
-        : Promise.resolve({ ok: false, reason: "no_session" }),
+          }),
+        release: async () => {
+          try {
+            const result = await actOnLocalBrowserLease(
+              {
+                bootId: commandBootId,
+                holder: options.holder,
+                action: "resume",
+              },
+              options.consentToken,
+            );
+            if (result.lease.state !== "free") throw handoffFailed();
+          } catch (error) {
+            if (
+              error instanceof LocalBrowserRequestError &&
+              error.status === 404
+            )
+              return;
+            throw error;
+          }
+        },
+      });
+    },
   };
 }

--- a/mcpjam-inspector/client/src/lib/local-browser-consent.ts
+++ b/mcpjam-inspector/client/src/lib/local-browser-consent.ts
@@ -91,12 +91,13 @@ function persist(consent: StoredLocalBrowserConsent | null): boolean {
 }
 
 export function clearStoredLocalBrowserConsent(): void {
-  persist(null);
   try {
-    setSetupPending(false);
+    localStorage.removeItem(SETUP_KEY);
   } catch {
     /* Storage may be blocked. */
   }
+  // Subscribers must see the complete cleared state in one notification.
+  persist(null);
 }
 
 export function subscribeLocalBrowserConsent(callback: () => void): () => void {

--- a/mcpjam-inspector/client/src/lib/local-browser/__tests__/consent-recovery.test.ts
+++ b/mcpjam-inspector/client/src/lib/local-browser/__tests__/consent-recovery.test.ts
@@ -4,6 +4,7 @@ import {
   clearStoredLocalBrowserConsent,
   loadStoredLocalBrowserConsent,
   persistLocalBrowserConsent,
+  localBrowserSetupPending,
   subscribeLocalBrowserConsent,
 } from "@/lib/local-browser-consent";
 import { ensureLocalBrowser } from "../client";
@@ -29,20 +30,28 @@ beforeEach(() => {
 afterEach(() => clearStoredLocalBrowserConsent());
 
 describe("local browser consent recovery", () => {
-  it("clears the rejected grant and notifies the consent gate", async () => {
-    vi.mocked(authFetch).mockResolvedValue(refused());
-    const changed = vi.fn();
-    const unsubscribe = subscribeLocalBrowserConsent(changed);
-    try {
-      await expect(ensureLocalBrowser("project", oldToken)).rejects.toThrow(
-        "Browser permission is required. Allow Browser in the Browser panel.",
-      );
-      expect(loadStoredLocalBrowserConsent()).toBeNull();
-      expect(changed).toHaveBeenCalledOnce();
-    } finally {
-      unsubscribe();
-    }
-  });
+  it.each([false, true])(
+    "clears the rejected grant and notifies once (setup pending: %s)",
+    async (setupPending) => {
+      vi.mocked(authFetch).mockResolvedValue(refused());
+      if (setupPending)
+        localStorage.setItem("mcp-local-browser-setup-pending-v1", "true");
+      const changed = vi.fn(() => {
+        expect(loadStoredLocalBrowserConsent()).toBeNull();
+        expect(localBrowserSetupPending()).toBe(false);
+      });
+      const unsubscribe = subscribeLocalBrowserConsent(changed);
+      try {
+        await expect(ensureLocalBrowser("project", oldToken)).rejects.toThrow(
+          "Browser permission is required. Allow Browser in the Browser panel.",
+        );
+        expect(loadStoredLocalBrowserConsent()).toBeNull();
+        expect(changed).toHaveBeenCalledOnce();
+      } finally {
+        unsubscribe();
+      }
+    },
+  );
 
   it("preserves a newer grant when an old request is rejected", async () => {
     vi.mocked(authFetch).mockImplementation(async () => {


### PR DESCRIPTION
Comparison tab commands could acquire a browser lease without a mounted renderer to release it before the next chat turn. Retain those handoffs independently of the renderer, wait for pending commands, and retry failed releases.

Show local installation and recovery controls before a browser snapshot exists, so fresh Chromium installs can proceed in comparison mode. Clear consent and pending setup with one notification, fixing the failure in Inspector Tests 4/6.

Follow-up to #4941.

Validation:
- 91 focused client tests passed after rebasing onto main.
- Inspector shard 4/6 passed locally before rebase: 5,065 tests passed, 5 skipped.
- Client typecheck and design checks passed before rebase (existing design warnings only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes browser lease lifecycle and comparison rendering paths; mistakes could leave leases stuck or block chat, but scope is client-side browser UI with broad new tests.
> 
> **Overview**
> Fixes comparison-mode browser setup and lease handoff so tab-strip actions and chat turns don’t fight over control.
> 
> **Comparison UI:** For local engines, `ComparisonBrowser` now mounts `LocalBrowserBody` as soon as there’s a local client (selected or first in the lineup), not only after a transport snapshot exists. That exposes Chromium install/recovery and session attach before metadata polling can return tabs. `LocalBrowserBody` gains an optional `onSessionReady` hook so comparison chrome can call `noteBrowsing` when a session is found or started. Hosted rendering stays gated on a snapshot for the selected client.
> 
> **Lease handoffs:** Tab-strip commands in comparison mode can take a lease without a mounted pane. `runBrowserCommandWithHandoff` tracks those in-flight commands separately from pane `useBrowserChatHandoff` registrations; `releaseBrowserForChat` waits for them to settle, then resumes the lease (local `actOnLocalBrowserLease` / hosted `actOnHostedBrowserLease`), with retries, boot-id pinning, and 404/no-session treated as done. `createComparisonTransport` wraps every `sendCommand` in that path.
> 
> **Consent:** `clearStoredLocalBrowserConsent` removes the setup-pending flag before clearing stored consent so subscribers get one coherent “fully cleared” notification (covers Inspector test shard issues).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56d90efa8689db3aa7221480146218e994daaa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes comparison browser lease handoffs so tab-strip commands can't strand a browser lease when the renderer unmounts, and shows local installation and recovery controls before a Chromium snapshot exists. Also clears consent and setup-pending state in one notification instead of two.

**Bug Fixes**
- Track command handoffs independently of renderer mounts and wait for pending commands before releasing.
- Retry failed lease releases; treat a still-held lease or a closed browser as terminal.
- Mount local setup before any snapshot so fresh Chromium installs can proceed.

<sup>Written for commit a56d90efa8689db3aa7221480146218e994daaa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

