### PR TITLE
Add patch changeset for comparison browser fixes

### DIFF
--- a/.changeset/friendly-browsers-recover.md
+++ b/.changeset/friendly-browsers-recover.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Fix comparison browser controls leaving browser access blocked before the next chat turn. Make Chromium installation and recovery available before a comparison browser starts, and notify consent subscribers once when clearing browser permission.


### PR DESCRIPTION
Add an `@mcpjam/inspector` patch changeset for the comparison browser handoff, Chromium setup, and consent notification fixes merged in #4944.

Validation: `npx changeset status` confirms only an Inspector patch bump; `git diff --check` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only; no application code changes in this PR.
> 
> **Overview**
> Adds a **patch changeset** for `@mcpjam/inspector` so the next release picks up fixes already merged in #4944.
> 
> The changeset notes three Inspector behaviors: comparison browser controls no longer leave access blocked until the next chat turn, Chromium install/recovery is available before a comparison browser starts, and consent subscribers get a single notification when browser permission is cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49bb91a1bfd0c4967637bfda84d4688a3fbb680d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a patch changeset for `@mcpjam/inspector` documenting comparison browser bug fixes.

- Comparison browser controls no longer leave browser access blocked before the next chat turn.
- Chromium installation and recovery now complete before a comparison browser starts.
- Consent subscribers are notified exactly once when clearing browser permission.

<sup>Written for commit 49bb91a1bfd0c4967637bfda84d4688a3fbb680d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

