### PR TITLE
fix(desktop): retire the Update button when the download never lands

### DIFF
--- a/.changeset/shiny-pugs-repeat.md
+++ b/.changeset/shiny-pugs-repeat.md
@@ -2,4 +2,4 @@
 "@mcpjam/inspector": patch
 ---
 
-Desktop: stop showing an Update button that cannot install anything. When a download is announced and then never lands, the button is retired instead of being left clickable, and a second failure turns it into a "Download update" link to the releases page.
+Desktop: stop showing an Update button that cannot install anything. When a download is announced and then never lands, the button is retired instead of being left clickable, and a second failure turns it into a "Download update" link to the releases page. A slow download is no longer mistaken for a failed one: the 10-minute update poll gets refused while a download is in flight, and that refusal is now ignored instead of retiring the download.

--- a/.changeset/shiny-pugs-repeat.md
+++ b/.changeset/shiny-pugs-repeat.md
@@ -2,4 +2,4 @@
 "@mcpjam/inspector": patch
 ---
 
-Desktop: stop showing an Update button that cannot install anything. When a download is announced and then never lands, the button is retired instead of being left clickable, and a second failure turns it into a "Download update" link to the releases page. A slow download is no longer mistaken for a failed one: the 10-minute update poll gets refused while a download is in flight, and that refusal is now ignored instead of retiring the download.
+Desktop: stop showing an Update button that cannot install anything. When a download is announced and then never lands, the button is retired instead of being left clickable, and a second failure turns it into a "Download update" link to the releases page. A slow download is no longer mistaken for a failed one: the 10-minute update poll gets refused while a download is in flight, on macOS and on Windows, and that refusal is now ignored instead of retiring the download. A download that hangs without ever reporting an error still ends at the "Download update" link rather than at no button at all, and once that link is showing the app stops repeating the "Update failed" toast on every poll.

--- a/.changeset/shiny-pugs-repeat.md
+++ b/.changeset/shiny-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Desktop: stop showing an Update button that cannot install anything. When a download is announced and then never lands, the button is retired instead of being left clickable, and a second failure turns it into a "Download update" link to the releases page.

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Users,
   ShieldCheck,
   Loader2,
+  ExternalLink,
   Layers,
   Cable,
   MessagesSquare,
@@ -538,18 +539,31 @@ export function MCPSidebar({
   const {
     status: updateStatus,
     restartRequested,
+    downloadManually,
     restartAndInstall,
   } = useUpdateNotification();
   const showUpdateButton =
-    updateStatus.kind === "pending" || updateStatus.kind === "downloaded";
+    updateStatus.kind === "pending" ||
+    updateStatus.kind === "downloaded" ||
+    updateStatus.kind === "manual";
+  // Auto-update announced a build it then failed to install. The pill has to
+  // stay — there IS a newer version — but it must stop offering an in-app
+  // install that has already proven it cannot happen, or the user is back to
+  // clicking a control that does nothing.
+  const updateIsManual = updateStatus.kind === "manual";
   // Two ways to be mid-install, and both must disable the button: waiting on a
   // download that was asked to install when it finishes, and waiting on the
   // app to quit for one already downloaded. The second is the one a repeat
   // click used to get through.
   const updateInstalling =
-    restartRequested ||
-    (updateStatus.kind === "pending" && updateStatus.installRequested);
+    !updateIsManual &&
+    (restartRequested ||
+      (updateStatus.kind === "pending" && updateStatus.installRequested));
   const handleUpdateClick = () => {
+    if (updateIsManual) {
+      downloadManually();
+      return;
+    }
     if (!updateInstalling) {
       restartAndInstall();
     }
@@ -797,7 +811,14 @@ export function MCPSidebar({
                 {updateInstalling && (
                   <Loader2 className="size-2.5 animate-spin" aria-hidden />
                 )}
-                {updateInstalling ? "Updating…" : "Update"}
+                {updateIsManual && (
+                  <ExternalLink className="size-2.5" aria-hidden />
+                )}
+                {updateIsManual
+                  ? "Download update"
+                  : updateInstalling
+                  ? "Updating…"
+                  : "Update"}
               </Button>
             </div>
           )}

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
@@ -14,7 +14,7 @@ const mockFeatureFlags: Record<string, boolean | undefined> = {};
 // install has no WorkOS to sign up through — so these tests run hosted.
 vi.mock("@/lib/config", async () => {
   const actual = await vi.importActual<typeof import("@/lib/config")>(
-    "@/lib/config"
+    "@/lib/config",
   );
   return { ...actual, HOSTED_MODE: true };
 });
@@ -44,10 +44,24 @@ vi.mock("@/stores/preferences/preferences-provider", () => ({
     selector({ themeMode: "light" }),
 }));
 
+// Mutable so the update-pill tests below can drive the status without a
+// second copy of this file's mock stack.
+const mockUpdateState: {
+  status: { kind: string; [key: string]: unknown };
+  restartAndInstall: ReturnType<typeof vi.fn>;
+  downloadManually: ReturnType<typeof vi.fn>;
+} = {
+  status: { kind: "idle" },
+  restartAndInstall: vi.fn(),
+  downloadManually: vi.fn(),
+};
+
 vi.mock("@/hooks/useUpdateNotification", () => ({
   useUpdateNotification: () => ({
-    status: { kind: "idle" },
-    restartAndInstall: vi.fn(),
+    status: mockUpdateState.status,
+    restartRequested: false,
+    restartAndInstall: mockUpdateState.restartAndInstall,
+    downloadManually: mockUpdateState.downloadManually,
     simulateUpdate: vi.fn(),
   }),
 }));
@@ -163,7 +177,7 @@ function makeProject(id: string, name: string) {
 }
 
 function renderSidebar(
-  overrides: Partial<React.ComponentProps<typeof MCPSidebar>> = {}
+  overrides: Partial<React.ComponentProps<typeof MCPSidebar>> = {},
 ) {
   return render(
     <MCPSidebar
@@ -178,7 +192,7 @@ function renderSidebar(
       onDeleteProject={vi.fn()}
       onProjectShared={vi.fn()}
       {...overrides}
-    />
+    />,
   );
 }
 
@@ -205,11 +219,11 @@ describe("sidebar invite CTA", () => {
           <div data-testid="share-project-dialog">
             Share dialog for {projectName}
           </div>
-        ) : null
+        ) : null,
     );
     mockInviteSignUpDialog.mockImplementation(
       ({ isOpen }: { isOpen: boolean }) =>
-        isOpen ? <div data-testid="invite-signup-nudge" /> : null
+        isOpen ? <div data-testid="invite-signup-nudge" /> : null,
     );
     // The pending-invite marker is module state in sessionStorage — a leftover
     // would auto-open the share dialog in an unrelated test.
@@ -228,12 +242,12 @@ describe("sidebar invite CTA", () => {
     renderSidebar();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Invite team members" })
+      screen.getByRole("button", { name: "Invite team members" }),
     );
 
     expect(screen.getByTestId("invite-signup-nudge")).toBeInTheDocument();
     expect(
-      screen.queryByTestId("share-project-dialog")
+      screen.queryByTestId("share-project-dialog"),
     ).not.toBeInTheDocument();
   });
 
@@ -250,7 +264,7 @@ describe("sidebar invite CTA", () => {
     renderSidebar();
 
     expect(
-      screen.queryByRole("button", { name: "Invite team members" })
+      screen.queryByRole("button", { name: "Invite team members" }),
     ).not.toBeInTheDocument();
   });
 
@@ -262,7 +276,7 @@ describe("sidebar invite CTA", () => {
     renderSidebar();
 
     expect(screen.getByTestId("share-project-dialog")).toHaveTextContent(
-      "Share dialog for Acme"
+      "Share dialog for Acme",
     );
   });
 
@@ -279,7 +293,7 @@ describe("sidebar invite CTA", () => {
     renderSidebar();
 
     expect(
-      screen.queryByTestId("share-project-dialog")
+      screen.queryByTestId("share-project-dialog"),
     ).not.toBeInTheDocument();
     // …and the marker is still there for when sign-in completes, not consumed
     // by a render that could not act on it.
@@ -290,10 +304,10 @@ describe("sidebar invite CTA", () => {
     renderSidebar();
 
     expect(
-      screen.getByRole("button", { name: "Invite team members" })
+      screen.getByRole("button", { name: "Invite team members" }),
     ).toBeInTheDocument();
     expect(screen.getByText("Invite team members")).toHaveClass(
-      "group-data-[collapsible=icon]:hidden"
+      "group-data-[collapsible=icon]:hidden",
     );
   });
 
@@ -308,11 +322,11 @@ describe("sidebar invite CTA", () => {
 
     expect(
       inviteButton.compareDocumentPosition(seeCredits) &
-        Node.DOCUMENT_POSITION_FOLLOWING
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
       seeCredits.compareDocumentPosition(sidebarUser) &
-        Node.DOCUMENT_POSITION_FOLLOWING
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
 
@@ -337,16 +351,16 @@ describe("sidebar invite CTA", () => {
     renderSidebar();
 
     expect(
-      screen.queryByRole("button", { name: "Support" })
+      screen.queryByRole("button", { name: "Support" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Settings" })
+      screen.queryByRole("button", { name: "Settings" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "API Keys" })
+      screen.queryByRole("button", { name: "API Keys" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Notifications/ })
+      screen.queryByRole("button", { name: /Notifications/ }),
     ).not.toBeInTheDocument();
   });
 
@@ -363,10 +377,10 @@ describe("sidebar invite CTA", () => {
 
     expect(screen.getByRole("button", { name: "Support" })).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Settings" })
+      screen.getByRole("button", { name: "Settings" }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "API Keys" })
+      screen.queryByRole("button", { name: "API Keys" }),
     ).not.toBeInTheDocument();
   });
 
@@ -374,11 +388,11 @@ describe("sidebar invite CTA", () => {
     renderSidebar();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Invite team members" })
+      screen.getByRole("button", { name: "Invite team members" }),
     );
 
     expect(screen.getByTestId("share-project-dialog")).toHaveTextContent(
-      "Share dialog for Acme"
+      "Share dialog for Acme",
     );
   });
 
@@ -396,11 +410,11 @@ describe("sidebar invite CTA", () => {
         onCreateProject={vi.fn(async () => "project-created")}
         onDeleteProject={vi.fn()}
         onProjectShared={vi.fn()}
-      />
+      />,
     );
 
     expect(
-      screen.getByRole("button", { name: "Invite team members" })
+      screen.getByRole("button", { name: "Invite team members" }),
     ).toBeInTheDocument();
   });
 });
@@ -443,5 +457,46 @@ describe("MCPSidebar — one left margin down the rail", () => {
     // slide under its hit target.
     expect(button?.className).toContain("pr-10");
   });
+});
 
+describe("sidebar update pill", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateState.status = { kind: "idle" };
+    mockUseConvexAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    });
+    mockUseAuth.mockReturnValue({
+      user: { id: "user-1", email: "sophie@mcpjam.com" },
+      isLoading: false,
+    });
+  });
+
+  it("offers an in-app install while a download is genuinely running", () => {
+    mockUpdateState.status = { kind: "pending", installRequested: false };
+
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+
+    expect(mockUpdateState.restartAndInstall).toHaveBeenCalledTimes(1);
+    expect(mockUpdateState.downloadManually).not.toHaveBeenCalled();
+  });
+
+  it("sends the user to the releases page once auto-update has failed", () => {
+    // The fix for the reported bug: after the main process gives up on the
+    // download the pill stops pretending an install is one click away. It
+    // used to keep saying "Update" and do nothing — 17 clicks in 124
+    // seconds, no error, no progress.
+    mockUpdateState.status = { kind: "manual", version: "3.5.2" };
+
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole("button", { name: /Download update/ }));
+
+    expect(mockUpdateState.downloadManually).toHaveBeenCalledTimes(1);
+    expect(mockUpdateState.restartAndInstall).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "Update" })).toBeNull();
+  });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/useUpdateNotification.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useUpdateNotification.test.ts
@@ -288,6 +288,27 @@ describe("useUpdateNotification", () => {
     });
   });
 
+  describe("downloadManually", () => {
+    it("opens the releases page", () => {
+      // The escape hatch behind the `manual` status: auto-update announced a
+      // build it could not install, so the pill stops offering an in-app
+      // install and sends the user somewhere that works.
+      setupElectronMock();
+      const mockOpenExternal = vi.fn().mockResolvedValue(undefined);
+      (window.electronAPI as any).app = { openExternal: mockOpenExternal };
+
+      const { result } = renderHook(() => useUpdateNotification());
+
+      act(() => {
+        result.current.downloadManually();
+      });
+
+      expect(mockOpenExternal).toHaveBeenCalledWith(
+        "https://github.com/MCPJam/inspector/releases",
+      );
+    });
+  });
+
   describe("simulateUpdate", () => {
     it("calls the Electron simulate API", () => {
       const {

--- a/mcpjam-inspector/client/src/hooks/__tests__/useUpdateNotification.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useUpdateNotification.test.ts
@@ -194,6 +194,28 @@ describe("useUpdateNotification", () => {
       );
     });
 
+    it("drops the try-again promise once auto-update has given up", () => {
+      // In `manual` there is no in-app retry left to promise: the main
+      // process ignores every later update-available for the session.
+      const mocks = setupElectronMock();
+
+      renderHook(() => useUpdateNotification());
+      act(() => {
+        mocks.mockOnUpdateStatus.mock.calls[0][0]({
+          kind: "manual",
+          version: undefined,
+        });
+        mocks.mockOnUpdateError.mock.calls[0][0]();
+      });
+
+      expect(mockToastError).toHaveBeenCalledWith(
+        errorToastMessage(
+          "Automatic update isn't working on this install. Download the new version instead.",
+        ),
+        expect.anything(),
+      );
+    });
+
     it("toast action opens the releases page via openExternal", () => {
       const mocks = setupElectronMock();
       const mockOpenExternal = vi.fn().mockResolvedValue(undefined);
@@ -285,6 +307,42 @@ describe("useUpdateNotification", () => {
       });
 
       expect(result.current.restartRequested).toBe(false);
+    });
+
+    it("re-arms when a silent collapse retires the download", () => {
+      // A click can race a collapse: the main process drops to `idle` without
+      // broadcasting an error, so nothing used to clear this and the pill came
+      // back stuck on "Updating…" at the next download.
+      const { mockOnUpdateStatus } = setupElectronMock();
+
+      const { result } = renderHook(() => useUpdateNotification());
+      const onStatus = mockOnUpdateStatus.mock.calls[0][0];
+
+      act(() => {
+        onStatus({ kind: "pending", installRequested: false });
+        result.current.restartAndInstall();
+      });
+      expect(result.current.restartRequested).toBe(true);
+
+      act(() => {
+        onStatus({ kind: "idle" });
+      });
+
+      expect(result.current.restartRequested).toBe(false);
+    });
+
+    it("stays armed through a downloaded install so a second click cannot land", () => {
+      const { mockOnUpdateStatus } = setupElectronMock();
+
+      const { result } = renderHook(() => useUpdateNotification());
+      const onStatus = mockOnUpdateStatus.mock.calls[0][0];
+
+      act(() => {
+        onStatus({ kind: "downloaded", version: "3.6.0" });
+        result.current.restartAndInstall();
+      });
+
+      expect(result.current.restartRequested).toBe(true);
     });
   });
 

--- a/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
+++ b/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
@@ -20,6 +20,12 @@ export function useUpdateNotification() {
    */
   const [restartRequested, setRestartRequested] = useState(false);
 
+  const downloadManually = useCallback(() => {
+    window.electronAPI?.app?.openExternal(RELEASES_URL)?.catch((error) => {
+      console.warn("Failed to open releases page", error);
+    });
+  }, []);
+
   useEffect(() => {
     if (!window.isElectron || !window.electronAPI?.update) {
       return;
@@ -44,13 +50,7 @@ export function useUpdateNotification() {
       toast.error("Update failed. Try again later.", {
         action: {
           label: "Download manually",
-          onClick: () => {
-            window.electronAPI?.app
-              ?.openExternal(RELEASES_URL)
-              ?.catch((error) => {
-                console.warn("Failed to open releases page", error);
-              });
-          },
+          onClick: downloadManually,
         },
       });
     });
@@ -72,7 +72,8 @@ export function useUpdateNotification() {
       window.electronAPI?.update?.removeUpdateStatusListener();
       window.electronAPI?.update?.removeUpdateErrorListener();
     };
-  }, []);
+    // `downloadManually` is stable, so this stays a mount-once effect.
+  }, [downloadManually]);
 
   const restartAndInstall = useCallback(() => {
     setRestartRequested(true);
@@ -94,6 +95,7 @@ export function useUpdateNotification() {
   return {
     status,
     restartRequested,
+    downloadManually,
     restartAndInstall,
     simulateUpdate,
     simulateUpdateDownloaded,

--- a/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
+++ b/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { toast } from "@/lib/toast";
 import type { UpdateStatus } from "@/types/electron";
 
@@ -19,6 +19,26 @@ export function useUpdateNotification() {
    * click fires `quitAndInstall` twice (INSPECTOR-ELECTRON-GT).
    */
   const [restartRequested, setRestartRequested] = useState(false);
+  /**
+   * The latest status, readable from the IPC listeners below. They are
+   * registered once, so reading `status` inside them would read the value
+   * captured at mount.
+   */
+  const statusRef = useRef<UpdateStatus>({ kind: "idle" });
+
+  const applyStatus = useCallback((next: UpdateStatus) => {
+    statusRef.current = next;
+    // A click that raced a collapse leaves `restartRequested` set with nothing
+    // installing behind it. Only `update-error` used to clear it, and a first
+    // collapse is silent — so the pill would come back stuck on "Updating…"
+    // at the next download. Neither `idle` nor `manual` has an install in
+    // flight; only `downloaded` does, because the main process hands off to
+    // Electron's teardown without a further status.
+    if (next.kind === "idle" || next.kind === "manual") {
+      setRestartRequested(false);
+    }
+    setStatus(next);
+  }, []);
 
   const downloadManually = useCallback(() => {
     window.electronAPI?.app?.openExternal(RELEASES_URL)?.catch((error) => {
@@ -38,7 +58,7 @@ export function useUpdateNotification() {
     let liveEventReceived = false;
     api.onUpdateStatus((next) => {
       liveEventReceived = true;
-      setStatus(next);
+      applyStatus(next);
     });
     api.onUpdateError(() => {
       // The install did not happen, so let the user ask again. Its own toast
@@ -46,13 +66,21 @@ export function useUpdateNotification() {
       setRestartRequested(false);
       // Surface a fallback path — auto-update can stall silently on macOS
       // (Squirrel staging / signing issues), so always offer a manual
-      // download as an escape hatch.
-      toast.error("Update failed. Try again later.", {
-        action: {
-          label: "Download manually",
-          onClick: downloadManually,
+      // download as an escape hatch. Once the main process has given up on
+      // this install there is no later in-app retry to promise, so the copy
+      // says so rather than "try again later".
+      const autoUpdateGaveUp = statusRef.current.kind === "manual";
+      toast.error(
+        autoUpdateGaveUp
+          ? "Automatic update isn't working on this install. Download the new version instead."
+          : "Update failed. Try again later.",
+        {
+          action: {
+            label: "Download manually",
+            onClick: downloadManually,
+          },
         },
-      });
+      );
     });
 
     // Initial snapshot — apply only if a live event hasn't already overtaken it.
@@ -61,7 +89,7 @@ export function useUpdateNotification() {
     api
       .getUpdateStatus()
       .then((initial) => {
-        if (!cancelled && !liveEventReceived) setStatus(initial);
+        if (!cancelled && !liveEventReceived) applyStatus(initial);
       })
       .catch((error) => {
         console.warn("Failed to get update status", error);
@@ -72,8 +100,8 @@ export function useUpdateNotification() {
       window.electronAPI?.update?.removeUpdateStatusListener();
       window.electronAPI?.update?.removeUpdateErrorListener();
     };
-    // `downloadManually` is stable, so this stays a mount-once effect.
-  }, [downloadManually]);
+    // Both callbacks are stable, so this stays a mount-once effect.
+  }, [applyStatus, downloadManually]);
 
   const restartAndInstall = useCallback(() => {
     setRestartRequested(true);

--- a/mcpjam-inspector/client/src/types/electron.d.ts
+++ b/mcpjam-inspector/client/src/types/electron.d.ts
@@ -1,7 +1,10 @@
 export type UpdateStatus =
   | { kind: "idle" }
   | { kind: "pending"; version?: string; installRequested: boolean }
-  | { kind: "downloaded"; version: string; releaseNotes?: string };
+  | { kind: "downloaded"; version: string; releaseNotes?: string }
+  // Auto-update announced a version and then could not install it; the UI
+  // sends the user to the releases page instead of a dead Update button.
+  | { kind: "manual"; version?: string };
 
 export interface ElectronAPI {
   // App metadata

--- a/mcpjam-inspector/server/__tests__/update-listeners.test.ts
+++ b/mcpjam-inspector/server/__tests__/update-listeners.test.ts
@@ -267,6 +267,58 @@ describe("update-listeners", () => {
     );
   });
 
+  it("keeps a slow download alive when the 10-minute poll is refused mid-download", async () => {
+    // update-electron-app polls on a blind interval and Squirrel refuses a
+    // second check while one is running, so a download slower than 10
+    // minutes errors in RACCommandErrorDomain every 10 minutes. That says
+    // nothing about the download — collapsing on it would retire a build
+    // that was still on its way.
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    emitAutoUpdaterEvent("update-available");
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+    window.webContents.send.mockClear();
+
+    const refused = Object.assign(new Error("The command is disabled"), {
+      domain: "RACCommandErrorDomain",
+      code: 1,
+    });
+    emitAutoUpdaterEvent("error", refused);
+
+    // No collapse, no error toast, and the queued install survives.
+    expect(window.webContents.send).not.toHaveBeenCalledWith("update-error");
+    expect(window.webContents.send).not.toHaveBeenCalledWith(
+      "update-status",
+      expect.objectContaining({ kind: "manual" }),
+    );
+
+    emitAutoUpdaterEvent("update-downloaded", {}, "notes", "3.5.2");
+
+    expect(quitAndInstallMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still collapses on a real updater error from a different domain", async () => {
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    emitAutoUpdaterEvent("update-available");
+
+    const real = Object.assign(new Error("staging failed"), {
+      domain: "SQRLUpdaterErrorDomain",
+      code: 4,
+    });
+    emitAutoUpdaterEvent("error", real);
+
+    expect(window.webContents.send).toHaveBeenCalledWith("update-status", {
+      kind: "idle",
+    });
+  });
+
   it("offers a manual download when a user-requested install fails", async () => {
     const window = createWindow();
     windows.push(window);

--- a/mcpjam-inspector/server/__tests__/update-listeners.test.ts
+++ b/mcpjam-inspector/server/__tests__/update-listeners.test.ts
@@ -383,10 +383,11 @@ describe("update-listeners", () => {
     }
   });
 
-  it("sends a stale click on the manual fallback back to the error path", async () => {
-    // The renderer opens the releases page for `manual`, so this only
-    // happens when a click races the status change. Silence is the bug
-    // being fixed, so re-broadcast rather than no-op.
+  it("does not toast twice when a stale click races the manual fallback", async () => {
+    // The renderer opens the releases page for `manual`, so a click only
+    // arrives here when it raced the status change — and the collapse that
+    // set `manual` already broadcast the error, which is what resets the
+    // renderer. Repeating it would show two toasts back to back.
     const window = createWindow();
     windows.push(window);
     const { registerUpdateListeners } = await loadUpdateListeners();
@@ -395,12 +396,170 @@ describe("update-listeners", () => {
     emitAutoUpdaterEvent("update-available");
     ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
     emitAutoUpdaterEvent("update-not-available");
+    expect(window.webContents.send).toHaveBeenCalledWith("update-error");
     (window.webContents.send as any).mockClear();
 
     ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
 
-    expect(window.webContents.send).toHaveBeenCalledWith("update-error");
+    expect(window.webContents.send).not.toHaveBeenCalledWith("update-error");
     expect(quitAndInstallMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores the Windows shape of a refused concurrent check", async () => {
+    // Squirrel.Windows refuses the overlapping poll from spawnUpdate with a
+    // plain Error — no NSError domain — so a download slower than the
+    // 10-minute poll used to be retired on a healthy machine.
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    emitAutoUpdaterEvent("update-available");
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+    (window.webContents.send as any).mockClear();
+
+    emitAutoUpdaterEvent(
+      "error",
+      new Error(
+        "AutoUpdater process with arguments --checkForUpdate,https://example.test is already running",
+      ),
+    );
+
+    expect(window.webContents.send).not.toHaveBeenCalledWith("update-error");
+    expect(
+      ipcHandlers.get("app:get-update-status")?.({ sender: { id: 1 } }),
+    ).toEqual({ kind: "pending", installRequested: true });
+
+    // The queued install survives, so the slow download still installs.
+    emitAutoUpdaterEvent("update-downloaded", {}, "notes", "3.5.2");
+    expect(quitAndInstallMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers the manual download when checks stay refused after a collapse", async () => {
+    // A download that hangs with no error keeps Squirrel busy forever, so
+    // every later poll is refused and `pending` never comes back. Without
+    // this the user is left with no button, no toast and no link at all.
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    emitAutoUpdaterEvent("update-available");
+    emitAutoUpdaterEvent("update-not-available");
+    expect(
+      ipcHandlers.get("app:get-update-status")?.({ sender: { id: 1 } }),
+    ).toEqual({ kind: "idle" });
+    (window.webContents.send as any).mockClear();
+
+    const refused = Object.assign(new Error("The command is disabled"), {
+      domain: "RACCommandErrorDomain",
+      code: 1,
+    });
+    emitAutoUpdaterEvent("error", refused);
+
+    expect(window.webContents.send).toHaveBeenCalledWith("update-status", {
+      kind: "manual",
+    });
+    expect(window.webContents.send).toHaveBeenCalledWith("update-error");
+  });
+
+  it("stops re-toasting once the manual fallback is showing", async () => {
+    // update-electron-app keeps polling every 10 minutes. An install that
+    // fails the same way each time must not nag forever — the pill already
+    // says where to go.
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    emitAutoUpdaterEvent("update-available");
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+    emitAutoUpdaterEvent("error", new Error("staging failed"));
+    expect(window.webContents.send).toHaveBeenCalledWith("update-error");
+    (window.webContents.send as any).mockClear();
+
+    emitAutoUpdaterEvent("error", new Error("staging failed"));
+
+    expect(window.webContents.send).not.toHaveBeenCalledWith("update-error");
+    expect(
+      ipcHandlers.get("app:get-update-status")?.({ sender: { id: 1 } }),
+    ).toEqual({ kind: "manual", version: undefined });
+  });
+
+  it("collapses a simulated error the same way the real one does", async () => {
+    appState.isPackaged = false;
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    ipcListeners.get("app:simulate-update")?.({ sender: { id: 1 } });
+    ipcListeners.get("app:simulate-update-error")?.({ sender: { id: 1 } });
+
+    expect(window.webContents.send).toHaveBeenCalledWith("update-status", {
+      kind: "idle",
+    });
+
+    ipcListeners.get("app:simulate-update")?.({ sender: { id: 1 } });
+    ipcListeners.get("app:simulate-update-error")?.({ sender: { id: 1 } });
+
+    expect(window.webContents.send).toHaveBeenCalledWith("update-status", {
+      kind: "manual",
+      version: undefined,
+    });
+  });
+
+  it("does not push the stall deadline out when the poll re-announces the update", async () => {
+    // update-available on every poll used to re-arm the watchdog, so a stuck
+    // download could hold the button for the life of the process.
+    vi.useFakeTimers();
+    try {
+      const window = createWindow();
+      windows.push(window);
+      const mod = await loadUpdateListeners();
+      mod.__setStalledDownloadTimeoutForTests(1_000);
+
+      mod.registerUpdateListeners(window as any);
+      emitAutoUpdaterEvent("update-available");
+
+      vi.advanceTimersByTime(700);
+      emitAutoUpdaterEvent("update-available");
+      vi.advanceTimersByTime(400);
+
+      expect(window.webContents.send).toHaveBeenCalledWith("update-status", {
+        kind: "idle",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not give a slow download extra time because the user clicked", async () => {
+    // The click brings the deadline forward at most; it never resets it, so
+    // a healthy-but-slow download is not judged by a fresh five minutes
+    // starting from whenever the user happened to look at the pill.
+    vi.useFakeTimers();
+    try {
+      const window = createWindow();
+      windows.push(window);
+      const mod = await loadUpdateListeners();
+      mod.__setStalledDownloadTimeoutForTests(1_000);
+      mod.__setStalledInstallTimeoutForTests(5_000);
+
+      mod.registerUpdateListeners(window as any);
+      emitAutoUpdaterEvent("update-available");
+
+      vi.advanceTimersByTime(900);
+      ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+      vi.advanceTimersByTime(150);
+
+      expect(window.webContents.send).toHaveBeenCalledWith("update-status", {
+        kind: "manual",
+        version: undefined,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("guards installUpdateOnQuit against quitAndInstall throws", async () => {

--- a/mcpjam-inspector/server/__tests__/update-listeners.test.ts
+++ b/mcpjam-inspector/server/__tests__/update-listeners.test.ts
@@ -126,7 +126,17 @@ describe("update-listeners", () => {
     lastLoadedModule = null;
   });
 
-  it("keeps the update button visible when update-not-available follows an available update", async () => {
+  it("retires the update button when update-not-available follows an available update", async () => {
+    // THE SHIPPED BUG. `pending` used to be sticky: the button stayed on
+    // screen wired to a download that had already died, every click set
+    // installRequested, the next updater event cleared it, and the label
+    // flickered Update -> Updating… -> Update forever.
+    //
+    // On macOS these two events are not the matched pair they look like.
+    // `update-available` is a KVO side effect of SQRLUpdater entering its
+    // Downloading state; `update-not-available` is this check finishing with
+    // no downloaded build in hand. A download that starts and then dies
+    // without an NSError emits exactly this sequence.
     const window = createWindow();
     windows.push(window);
     const { registerUpdateListeners } = await loadUpdateListeners();
@@ -137,12 +147,78 @@ describe("update-listeners", () => {
     emitAutoUpdaterEvent("update-not-available");
 
     expect(window.webContents.send).toHaveBeenLastCalledWith("update-status", {
-      kind: "pending",
-      installRequested: false,
+      kind: "idle",
     });
     expect(
       ipcHandlers.get("app:get-update-status")?.({ sender: { id: 1 } }),
-    ).toEqual({ kind: "pending", installRequested: false });
+    ).toEqual({ kind: "idle" });
+  });
+
+  it("falls back to a manual download after the second collapsed download", async () => {
+    // One collapse can be a dropped connection, so the first drops to idle
+    // and the next poll gets a turn. Two is a pattern: this install cannot
+    // self-update, and re-arming the in-app button just hands the user
+    // something to click that will never work.
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+
+    emitAutoUpdaterEvent("update-available");
+    emitAutoUpdaterEvent("update-not-available");
+    emitAutoUpdaterEvent("update-available");
+    emitAutoUpdaterEvent("update-not-available");
+
+    expect(window.webContents.send).toHaveBeenCalledWith("update-status", {
+      kind: "manual",
+      version: undefined,
+    });
+    expect(window.webContents.send).toHaveBeenCalledWith("update-error");
+  });
+
+  it("does not re-arm the in-app install once the manual fallback is showing", async () => {
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    emitAutoUpdaterEvent("update-available");
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+    emitAutoUpdaterEvent("update-not-available");
+    (window.webContents.send as any).mockClear();
+
+    // update-electron-app keeps polling every 10 minutes.
+    emitAutoUpdaterEvent("update-available");
+
+    expect(window.webContents.send).not.toHaveBeenCalledWith(
+      "update-status",
+      expect.objectContaining({ kind: "pending" }),
+    );
+    expect(
+      ipcHandlers.get("app:get-update-status")?.({ sender: { id: 1 } }),
+    ).toEqual({ kind: "manual", version: undefined });
+  });
+
+  it("lets a download that finally lands override the manual fallback", async () => {
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    emitAutoUpdaterEvent("update-available");
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+    emitAutoUpdaterEvent("update-not-available");
+
+    emitAutoUpdaterEvent("update-downloaded", {}, "Notes", "3.6.0");
+
+    expect(window.webContents.send).toHaveBeenLastCalledWith(
+      "update-status",
+      expect.objectContaining({ kind: "downloaded", version: "3.6.0" }),
+    );
+    // The click that collapsed is long gone, so we do not quit behind the
+    // user's back.
+    expect(quitAndInstallMock).not.toHaveBeenCalled();
   });
 
   it("queues install when the user clicks Update while the download is still pending", async () => {
@@ -166,38 +242,47 @@ describe("update-listeners", () => {
     expect(quitAndInstallMock).toHaveBeenCalledTimes(1);
   });
 
-  it("lets the user retry from a pending state after a prior updater error", async () => {
+  it("retires the button after an updater error instead of leaving it clickable", async () => {
+    // Replaces the old "retry from pending" affordance. Offering that retry
+    // meant keeping `pending` alive, and a live `pending` with no download
+    // behind it is exactly the dead button this fix removes. The next poll
+    // re-announces the update if it is still installable.
     const window = createWindow();
     windows.push(window);
     const { registerUpdateListeners } = await loadUpdateListeners();
 
     registerUpdateListeners(window as any);
     emitAutoUpdaterEvent("update-available");
-    emitAutoUpdaterEvent("error", new Error("download failed"));
-
-    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
-
-    expect(checkForUpdatesMock).toHaveBeenCalledTimes(1);
-    expect(window.webContents.send).toHaveBeenLastCalledWith("update-status", {
-      kind: "pending",
-      installRequested: true,
-    });
-  });
-
-  it("keeps the button visible and notifies after a user-requested install fails", async () => {
-    const window = createWindow();
-    windows.push(window);
-    const { registerUpdateListeners } = await loadUpdateListeners();
-
-    registerUpdateListeners(window as any);
-    emitAutoUpdaterEvent("update-available");
-    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
-
     emitAutoUpdaterEvent("error", new Error("download failed"));
 
     expect(window.webContents.send).toHaveBeenCalledWith("update-status", {
-      kind: "pending",
-      installRequested: false,
+      kind: "idle",
+    });
+
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+
+    expect(checkForUpdatesMock).not.toHaveBeenCalled();
+    expect(logInfoMock).toHaveBeenCalledWith(
+      "Restart requested but no update is staged",
+    );
+  });
+
+  it("offers a manual download when a user-requested install fails", async () => {
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    emitAutoUpdaterEvent("update-available");
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+
+    emitAutoUpdaterEvent("error", new Error("download failed"));
+
+    // Someone who clicked gets the answer on the first failure, not the
+    // second: the button becomes a link to the releases page.
+    expect(window.webContents.send).toHaveBeenCalledWith("update-status", {
+      kind: "manual",
+      version: undefined,
     });
     expect(window.webContents.send).toHaveBeenCalledWith("update-error");
   });
@@ -216,36 +301,54 @@ describe("update-listeners", () => {
     expect(quitAndInstallMock).not.toHaveBeenCalled();
   });
 
-  it("lets the user retry checkForUpdates after the watchdog fires", async () => {
-    // Regression: bugbot flagged that holding `isCheckingOrDownloading` true
-    // after the watchdog blocks in-app retry, because the pending-click
-    // path skips `checkForUpdates` while that flag is set. Watchdog must
-    // clear it so a follow-up Update click triggers a fresh Squirrel check.
+  it("retires a download that never reports anything, even with no click", async () => {
+    // The half the click-armed watchdog never covered: `update-available`
+    // fires, Squirrel goes quiet, and nobody clicks. Before this the button
+    // sat there for the life of the process with nothing behind it.
     vi.useFakeTimers();
     try {
       const window = createWindow();
       windows.push(window);
       const mod = await loadUpdateListeners();
-      mod.__setStalledInstallTimeoutForTests(1_000);
+      mod.__setStalledDownloadTimeoutForTests(1_000);
 
       mod.registerUpdateListeners(window as any);
       emitAutoUpdaterEvent("update-available");
-      ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
 
-      // First checkForUpdates call fires on update-available via
-      // update-electron-app's polling path; that's outside our handler.
-      // Our handler only re-calls it on user-click while !isChecking.
-      checkForUpdatesMock.mockClear();
+      expect(window.webContents.send).toHaveBeenLastCalledWith(
+        "update-status",
+        { kind: "pending", installRequested: false },
+      );
 
-      // Watchdog fires.
       vi.advanceTimersByTime(1_000);
 
-      // User clicks Update again — should re-trigger checkForUpdates.
-      ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
-      expect(checkForUpdatesMock).toHaveBeenCalledTimes(1);
+      expect(window.webContents.send).toHaveBeenCalledWith("update-status", {
+        kind: "idle",
+      });
+      expect(window.webContents.send).toHaveBeenCalledWith("update-error");
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("sends a stale click on the manual fallback back to the error path", async () => {
+    // The renderer opens the releases page for `manual`, so this only
+    // happens when a click races the status change. Silence is the bug
+    // being fixed, so re-broadcast rather than no-op.
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    emitAutoUpdaterEvent("update-available");
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+    emitAutoUpdaterEvent("update-not-available");
+    (window.webContents.send as any).mockClear();
+
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+
+    expect(window.webContents.send).toHaveBeenCalledWith("update-error");
+    expect(quitAndInstallMock).not.toHaveBeenCalled();
   });
 
   it("guards installUpdateOnQuit against quitAndInstall throws", async () => {
@@ -290,11 +393,12 @@ describe("update-listeners", () => {
 
       vi.advanceTimersByTime(1_000);
 
-      // Watchdog should have reset installRequested and broadcast the error.
+      // Watchdog retires the dead download and hands the user the manual
+      // route, rather than parking them back on the same button.
       expect(window.webContents.send).toHaveBeenCalledWith("update-error");
       expect(window.webContents.send).toHaveBeenCalledWith("update-status", {
-        kind: "pending",
-        installRequested: false,
+        kind: "manual",
+        version: undefined,
       });
     } finally {
       vi.useRealTimers();

--- a/mcpjam-inspector/src/ipc/update/update-listeners.ts
+++ b/mcpjam-inspector/src/ipc/update/update-listeners.ts
@@ -4,20 +4,35 @@ import log from "electron-log";
 export type UpdateStatus =
   | { kind: "idle" }
   | { kind: "pending"; version?: string; installRequested: boolean }
-  | { kind: "downloaded"; version: string; releaseNotes?: string };
+  | { kind: "downloaded"; version: string; releaseNotes?: string }
+  // Auto-update announced a newer version and then failed to produce an
+  // installable build. The button stays, but it now sends the user to the
+  // releases page instead of pretending an install is one click away.
+  | { kind: "manual"; version?: string };
 
-// Watchdog for a stuck `pending + installRequested` state. Squirrel.Mac can
-// stall silently (mismatched TeamID, dropped connection) without firing
-// `update-downloaded` or `error`. After this timeout we surface an error
-// toast and unstick the UI — but we DON'T clear `isCheckingOrDownloading`,
-// so if the download was just slow and `update-downloaded` arrives later,
-// the user still sees the Update button reappear and can install. Five
-// minutes is enough cover for a 100MB+ macOS update on a sluggish link;
-// anything longer than that is much more likely a real stall than slow
-// network. Exposed as a `let` so tests can shorten it via
-// __setStalledInstallTimeoutForTests().
+// Watchdog for a `pending` that is not going anywhere.
+//
+// Two timeouts, because "the user is staring at a spinner" and "a download is
+// quietly running in the background" deserve different patience. Both are
+// exposed as `let` so tests can shorten them.
+//
+// INSTALL: the user clicked and is waiting. Five minutes covers a 100MB+
+// macOS update on a sluggish link; longer than that is a stall, not slow
+// network.
 export const DEFAULT_STALLED_INSTALL_TIMEOUT_MS = 5 * 60_000;
+// DOWNLOAD: nobody clicked, so we can wait longer — but not forever. Before
+// this existed a download that started and never landed left the Update
+// button on screen for the life of the process with nothing behind it.
+export const DEFAULT_STALLED_DOWNLOAD_TIMEOUT_MS = 20 * 60_000;
 let stalledInstallTimeoutMs = DEFAULT_STALLED_INSTALL_TIMEOUT_MS;
+let stalledDownloadTimeoutMs = DEFAULT_STALLED_DOWNLOAD_TIMEOUT_MS;
+
+// How many collapsed downloads it takes before we stop offering the in-app
+// install at all. One collapse can be a dropped connection; the next poll
+// deserves a chance. Two is a pattern — that install cannot self-update, and
+// re-arming the button just gives the user something to click that will never
+// work (BUG: 17 clicks in 124 seconds, INSPECTOR desktop 2.45.0).
+const MANUAL_FALLBACK_AFTER_COLLAPSES = 2;
 
 let currentStatus: UpdateStatus = { kind: "idle" };
 let isQuittingForUpdate = false;
@@ -25,6 +40,7 @@ let isCheckingOrDownloading = false;
 let trustedWindow: BrowserWindow | null = null;
 let updateListenersRegistered = false;
 let stalledInstallTimer: ReturnType<typeof setTimeout> | null = null;
+let collapsedDownloads = 0;
 
 function clearStalledInstallWatchdog(): void {
   if (stalledInstallTimer !== null) {
@@ -33,26 +49,72 @@ function clearStalledInstallWatchdog(): void {
   }
 }
 
-function startStalledInstallWatchdog(): void {
+function startStalledInstallWatchdog(timeoutMs: number): void {
   clearStalledInstallWatchdog();
   stalledInstallTimer = setTimeout(() => {
     stalledInstallTimer = null;
     // Re-check at fire-time: if anything succeeded or moved on, do nothing.
-    if (currentStatus.kind === "pending" && currentStatus.installRequested) {
-      log.error(
-        `Auto-updater stalled in pending+installRequested for ${stalledInstallTimeoutMs}ms — surfacing error`,
-      );
-      // Clear BOTH `installRequested` (so the spinner unsticks) AND
-      // `isCheckingOrDownloading` (so a follow-up Update click can call
-      // `checkForUpdates()` again to re-trigger the download). Squirrel's
-      // own `update-downloaded` event is independent of our flag, so if the
-      // original download eventually completes anyway, the existing handler
-      // still flips status to "downloaded" and the user can install.
-      isCheckingOrDownloading = false;
-      setStatus({ ...currentStatus, installRequested: false });
-      broadcastUpdateError();
+    if (currentStatus.kind === "pending") {
+      // Always audible: a watchdog firing means nothing at all came back,
+      // which the user cannot discover any other way.
+      collapsePendingDownload(`no progress for ${timeoutMs}ms`, {
+        alwaysNotify: true,
+      });
     }
-  }, stalledInstallTimeoutMs);
+  }, timeoutMs);
+}
+
+/**
+ * A `pending` that will never become `downloaded`, retired.
+ *
+ * Called from every event that means "this check is over and it did not hand
+ * us an installable build": `update-not-available`, `error`, and the
+ * watchdog. Retiring it is the whole point — the shipped bug was that
+ * `pending` was treated as sticky, so a download that died left a live
+ * "Update" pill wired to nothing. Clicking it set `installRequested`, the
+ * next updater event cleared it, and the label flickered `Update → Updating…
+ * → Update` forever with no error and no progress.
+ *
+ * On macOS the two events are not the matched pair they look like:
+ * `update-available` is a KVO side effect of SQRLUpdater entering its
+ * Downloading state, while `update-not-available` is *this check* completing
+ * without a `SQRLDownloadedUpdate` in hand (see Electron's
+ * auto_updater_mac.mm). A download that starts and then dies without an
+ * NSError produces exactly `update-available` … `update-not-available`, which
+ * is why the sticky-pending path was reachable at all.
+ */
+function collapsePendingDownload(
+  reason: string,
+  // Notify even when the collapse is still recoverable. Callers that saw a
+  // real updater `error` in a packaged build pass true, so the "always tell
+  // packaged users" rule from the earlier fix survives this change.
+  { alwaysNotify = false }: { alwaysNotify?: boolean } = {},
+): void {
+  if (currentStatus.kind !== "pending") {
+    return;
+  }
+  clearStalledInstallWatchdog();
+  // Squirrel's own state is independent of this flag, so clearing it only
+  // means "a later check may run again".
+  isCheckingOrDownloading = false;
+  const userWasWaiting = currentStatus.installRequested;
+  const version = currentStatus.version;
+  collapsedDownloads += 1;
+  log.error(
+    `Update download collapsed (${reason}); collapse #${collapsedDownloads}, user waiting: ${userWasWaiting}`,
+  );
+
+  // Someone who clicked is owed an answer now, not on the next poll.
+  const goesManual =
+    userWasWaiting || collapsedDownloads >= MANUAL_FALLBACK_AFTER_COLLAPSES;
+  // One collapse can be a dropped connection: drop back to idle and let
+  // update-electron-app's next poll try again. What must NOT happen is
+  // staying in `pending`, which is what left a live button wired to a
+  // download that had already died.
+  setStatus(goesManual ? { kind: "manual", version } : { kind: "idle" });
+  if (goesManual || alwaysNotify) {
+    broadcastUpdateError();
+  }
 }
 
 function isTrustedSender(senderId: number): boolean {
@@ -111,22 +173,41 @@ export function setupAutoUpdaterEvents(): void {
 
   autoUpdater.on("update-available", () => {
     isCheckingOrDownloading = true;
+    // Once an install has proven it cannot apply an update, re-arming the
+    // in-app button on the next poll just hands the user the same dead
+    // control again. `manual` already points them somewhere that works, so
+    // it outranks a fresh `update-available` for the rest of the session.
+    if (currentStatus.kind === "manual") {
+      log.info(
+        "Update available, but auto-update already failed on this install — keeping the manual download",
+      );
+      return;
+    }
     log.info("Update available, downloading...");
     const installRequested =
       currentStatus.kind === "pending" ? currentStatus.installRequested : false;
     setStatus({ kind: "pending", installRequested });
+    // Armed on ENTERING pending, not only when the user clicks: a download
+    // that dies quietly used to leave the button up for the life of the
+    // process with nothing behind it.
+    startStalledInstallWatchdog(
+      installRequested ? stalledInstallTimeoutMs : stalledDownloadTimeoutMs,
+    );
   });
 
   autoUpdater.on("update-not-available", () => {
     isCheckingOrDownloading = false;
     log.info("No updates available");
+    // A `pending` that ends here produced no installable build — retire it.
+    // A `downloaded` one is real and survives a later check; `manual` has
+    // already told the user where to go.
+    if (currentStatus.kind === "pending") {
+      collapsePendingDownload("update-not-available");
+      return;
+    }
     if (currentStatus.kind === "idle") {
       setStatus({ kind: "idle" });
       return;
-    }
-    if (currentStatus.kind === "pending" && currentStatus.installRequested) {
-      clearStalledInstallWatchdog();
-      setStatus({ ...currentStatus, installRequested: false });
     }
     log.info(
       `Keeping visible update status after update-not-available: ${currentStatus.kind}`,
@@ -137,22 +218,31 @@ export function setupAutoUpdaterEvents(): void {
     isCheckingOrDownloading = false;
     clearStalledInstallWatchdog();
     log.error("Auto-updater error:", error);
+    const wasQuittingForUpdate = isQuittingForUpdate;
+    isQuittingForUpdate = false;
+
     // Always notify users in packaged builds — Bug 2: previously we only
     // broadcast when the user had clicked, so download failures before any
     // click silently swallowed the error and the button kept inviting clicks.
-    const shouldNotifyUser =
-      app.isPackaged ||
-      (currentStatus.kind === "pending" && currentStatus.installRequested) ||
-      isQuittingForUpdate;
+    const shouldNotifyUser = app.isPackaged || wasQuittingForUpdate;
 
+    // Same retirement as update-not-available: the download is over and it
+    // did not deliver. collapsePendingDownload() owns the broadcast.
     if (currentStatus.kind === "pending") {
-      setStatus({ ...currentStatus, installRequested: false });
-    } else if (currentStatus.kind === "downloaded") {
+      collapsePendingDownload("updater error", {
+        alwaysNotify: shouldNotifyUser,
+      });
+      return;
+    }
+
+    if (
+      currentStatus.kind === "downloaded" ||
+      currentStatus.kind === "manual"
+    ) {
       setStatus(currentStatus);
     } else {
       setStatus({ kind: "idle" });
     }
-    isQuittingForUpdate = false;
 
     if (shouldNotifyUser) {
       broadcastUpdateError();
@@ -162,6 +252,9 @@ export function setupAutoUpdaterEvents(): void {
   autoUpdater.on("update-downloaded", (_event, releaseNotes, releaseName) => {
     isCheckingOrDownloading = false;
     clearStalledInstallWatchdog();
+    // A build that actually landed clears the history that pushed us to the
+    // manual fallback — `downloaded` always wins.
+    collapsedDownloads = 0;
     log.info(`Update downloaded: ${releaseName}`);
     const installRequested =
       currentStatus.kind === "pending" ? currentStatus.installRequested : false;
@@ -241,21 +334,27 @@ export function registerUpdateListeners(mainWindow: BrowserWindow): void {
     } else if (currentStatus.kind === "pending") {
       log.info("Update still downloading — queuing install for completion");
       setStatus({ ...currentStatus, installRequested: true });
-      // Arm the watchdog — if neither `update-downloaded` nor `error` fires
-      // within stalledInstallTimeoutMs, treat as stalled (Bug 1).
-      startStalledInstallWatchdog();
+      // Re-arm on the shorter, someone-is-watching timeout: if neither
+      // `update-downloaded` nor `error` fires within stalledInstallTimeoutMs,
+      // treat as stalled (Bug 1).
+      startStalledInstallWatchdog(stalledInstallTimeoutMs);
       if (!isCheckingOrDownloading) {
         try {
           isCheckingOrDownloading = true;
           autoUpdater.checkForUpdates();
         } catch (error) {
-          isCheckingOrDownloading = false;
-          clearStalledInstallWatchdog();
           log.error("Failed to retry update check:", error);
-          setStatus({ ...currentStatus, installRequested: false });
-          broadcastUpdateError();
+          collapsePendingDownload("checkForUpdates threw");
         }
       }
+    } else if (currentStatus.kind === "manual") {
+      // The renderer sends the user to the releases page instead of firing
+      // this, so reaching it means a stale click raced the status change.
+      // Re-broadcast rather than no-op: silence is the bug we are fixing.
+      log.info(
+        "Restart requested but auto-update is unavailable on this install",
+      );
+      broadcastUpdateError();
     } else {
       log.info("Restart requested but no update is staged");
     }
@@ -271,6 +370,7 @@ export function registerUpdateListeners(mainWindow: BrowserWindow): void {
       }
       log.info("Simulating update available (dev mode)");
       setStatus({ kind: "pending", installRequested: false });
+      startStalledInstallWatchdog(stalledDownloadTimeoutMs);
     });
 
     ipcMain.on("app:simulate-update-downloaded", (event) => {
@@ -302,19 +402,20 @@ export function registerUpdateListeners(mainWindow: BrowserWindow): void {
       }
       log.error("Auto-updater error:", new Error("Simulated update failure"));
       clearStalledInstallWatchdog();
-      // Dev simulation keeps its tighter notify rule (only the user-driven
-      // case) so manual QA can still distinguish click-vs-no-click flows.
-      const shouldNotifyUser =
-        currentStatus.kind === "pending" && currentStatus.installRequested;
+      // Mirrors the real handler so QA sees the shipped retirement path —
+      // including the second collapse that flips the pill to the manual
+      // download.
       if (currentStatus.kind === "pending") {
-        setStatus({ ...currentStatus, installRequested: false });
-      } else if (currentStatus.kind === "downloaded") {
+        collapsePendingDownload("simulated updater error");
+        return;
+      }
+      if (
+        currentStatus.kind === "downloaded" ||
+        currentStatus.kind === "manual"
+      ) {
         setStatus(currentStatus);
       } else {
         setStatus({ kind: "idle" });
-      }
-      if (shouldNotifyUser) {
-        broadcastUpdateError();
       }
     });
   }
@@ -352,11 +453,17 @@ export function __resetUpdateStateForTests(): void {
   isCheckingOrDownloading = false;
   trustedWindow = null;
   updateListenersRegistered = false;
+  collapsedDownloads = 0;
   stalledInstallTimeoutMs = DEFAULT_STALLED_INSTALL_TIMEOUT_MS;
+  stalledDownloadTimeoutMs = DEFAULT_STALLED_DOWNLOAD_TIMEOUT_MS;
 }
 
 // Test-only timeout override so the watchdog test doesn't have to advance
 // a full minute of fake timers.
 export function __setStalledInstallTimeoutForTests(ms: number): void {
   stalledInstallTimeoutMs = ms;
+}
+
+export function __setStalledDownloadTimeoutForTests(ms: number): void {
+  stalledDownloadTimeoutMs = ms;
 }

--- a/mcpjam-inspector/src/ipc/update/update-listeners.ts
+++ b/mcpjam-inspector/src/ipc/update/update-listeners.ts
@@ -34,6 +34,30 @@ let stalledDownloadTimeoutMs = DEFAULT_STALLED_DOWNLOAD_TIMEOUT_MS;
 // work (BUG: 17 clicks in 124 seconds, INSPECTOR desktop 2.45.0).
 const MANUAL_FALLBACK_AFTER_COLLAPSES = 2;
 
+// A refused EXTRA check, not a failed download.
+//
+// update-electron-app polls `checkForUpdates()` on a blind 10-minute
+// `setInterval`, and Electron's CheckForUpdates has no dedupe of its own.
+// Squirrel's `checkForUpdatesCommand` is a RACCommand with
+// `allowsConcurrentExecution = NO`, so a poll that lands mid-download is
+// refused on the spot and errors in `RACCommandErrorDomain`.
+//
+// That error describes the POLL, not the download: the download is still
+// running and can still land. Collapsing on it would tell a user on a slow
+// link that the update failed — a ~137MB macOS build has to sustain about
+// 1.9 Mbit/s just to beat the interval — and after two of them it would
+// retire the in-app install for a download that was working fine. The
+// watchdog is the backstop for a download that really is stuck.
+const CONCURRENT_CHECK_ERROR_DOMAIN = "RACCommandErrorDomain";
+
+function isRefusedConcurrentCheck(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { domain?: unknown }).domain === CONCURRENT_CHECK_ERROR_DOMAIN
+  );
+}
+
 let currentStatus: UpdateStatus = { kind: "idle" };
 let isQuittingForUpdate = false;
 let isCheckingOrDownloading = false;
@@ -215,6 +239,14 @@ export function setupAutoUpdaterEvents(): void {
   });
 
   autoUpdater.on("error", (error) => {
+    // Before anything else: leave the in-flight download alone. Its status,
+    // its watchdog and `isCheckingOrDownloading` all stay as they are.
+    if (isRefusedConcurrentCheck(error)) {
+      log.info(
+        "Ignoring update check refused while a download is already in flight",
+      );
+      return;
+    }
     isCheckingOrDownloading = false;
     clearStalledInstallWatchdog();
     log.error("Auto-updater error:", error);

--- a/mcpjam-inspector/src/ipc/update/update-listeners.ts
+++ b/mcpjam-inspector/src/ipc/update/update-listeners.ts
@@ -49,21 +49,31 @@ const MANUAL_FALLBACK_AFTER_COLLAPSES = 2;
 // retire the in-app install for a download that was working fine. The
 // watchdog is the backstop for a download that really is stuck.
 const CONCURRENT_CHECK_ERROR_DOMAIN = "RACCommandErrorDomain";
+// Windows has no NSError domain. Squirrel.Windows refuses the very same
+// overlapping poll from `spawnUpdate`, which throws a plain Error that
+// Electron re-emits verbatim, so the message is the only thing that tells it
+// apart from a download that really failed.
+const CONCURRENT_CHECK_MESSAGE = /AutoUpdater process .* is already running/i;
 
 function isRefusedConcurrentCheck(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const { domain, message } = error as { domain?: unknown; message?: unknown };
   return (
-    typeof error === "object" &&
-    error !== null &&
-    (error as { domain?: unknown }).domain === CONCURRENT_CHECK_ERROR_DOMAIN
+    domain === CONCURRENT_CHECK_ERROR_DOMAIN ||
+    (typeof message === "string" && CONCURRENT_CHECK_MESSAGE.test(message))
   );
 }
 
 let currentStatus: UpdateStatus = { kind: "idle" };
 let isQuittingForUpdate = false;
-let isCheckingOrDownloading = false;
 let trustedWindow: BrowserWindow | null = null;
 let updateListenersRegistered = false;
 let stalledInstallTimer: ReturnType<typeof setTimeout> | null = null;
+// Absolute deadline for the download that is currently `pending`. One per
+// download: a click may bring it forward, never push it out.
+let stalledDownloadDeadline: number | null = null;
 let collapsedDownloads = 0;
 
 function clearStalledInstallWatchdog(): void {
@@ -71,21 +81,34 @@ function clearStalledInstallWatchdog(): void {
     clearTimeout(stalledInstallTimer);
     stalledInstallTimer = null;
   }
+  stalledDownloadDeadline = null;
 }
 
 function startStalledInstallWatchdog(timeoutMs: number): void {
+  const now = Date.now();
+  // A click means "someone is watching now", not "start the clock over". If
+  // the download already has a deadline the click can only bring it forward,
+  // otherwise clicking at minute 19 of a 20-minute budget buys five more.
+  const remaining =
+    stalledDownloadDeadline === null ? null : stalledDownloadDeadline - now;
+  const effectiveMs =
+    remaining === null
+      ? timeoutMs
+      : Math.max(Math.min(remaining, timeoutMs), 0);
   clearStalledInstallWatchdog();
+  stalledDownloadDeadline = now + effectiveMs;
   stalledInstallTimer = setTimeout(() => {
     stalledInstallTimer = null;
+    stalledDownloadDeadline = null;
     // Re-check at fire-time: if anything succeeded or moved on, do nothing.
     if (currentStatus.kind === "pending") {
       // Always audible: a watchdog firing means nothing at all came back,
       // which the user cannot discover any other way.
-      collapsePendingDownload(`no progress for ${timeoutMs}ms`, {
+      collapsePendingDownload(`no progress for ${effectiveMs}ms`, {
         alwaysNotify: true,
       });
     }
-  }, timeoutMs);
+  }, effectiveMs);
 }
 
 /**
@@ -118,9 +141,6 @@ function collapsePendingDownload(
     return;
   }
   clearStalledInstallWatchdog();
-  // Squirrel's own state is independent of this flag, so clearing it only
-  // means "a later check may run again".
-  isCheckingOrDownloading = false;
   const userWasWaiting = currentStatus.installRequested;
   const version = currentStatus.version;
   collapsedDownloads += 1;
@@ -137,6 +157,46 @@ function collapsePendingDownload(
   // download that had already died.
   setStatus(goesManual ? { kind: "manual", version } : { kind: "idle" });
   if (goesManual || alwaysNotify) {
+    broadcastUpdateError();
+  }
+}
+
+/**
+ * The updater cannot recover on its own, so stop waiting for it.
+ *
+ * Reached when a check is STILL being refused after a download was already
+ * retired: Squirrel is parked on a download that will never finish, so no
+ * later check can succeed and `pending` can never come back. Without this the
+ * user is left with no button, no toast and no link at all.
+ */
+function escalateToManualDownload(reason: string): void {
+  if (currentStatus.kind === "manual" || currentStatus.kind === "downloaded") {
+    return;
+  }
+  log.error(`Auto-update cannot recover (${reason}); offering manual download`);
+  clearStalledInstallWatchdog();
+  setStatus({ kind: "manual" });
+  broadcastUpdateError();
+}
+
+/**
+ * Shared tail of the real and the simulated `error` handler.
+ *
+ * A `pending` is retired; anything else only needs a re-broadcast so a
+ * renderer that missed the last status catches up. `manual` deliberately gets
+ * no toast — the pill already points at the releases page, and the updater can
+ * keep failing on every 10-minute poll for the life of the process.
+ */
+function retireAfterUpdaterError(
+  reason: string,
+  { alwaysNotify = false }: { alwaysNotify?: boolean } = {},
+): void {
+  if (currentStatus.kind === "pending") {
+    collapsePendingDownload(reason, { alwaysNotify });
+    return;
+  }
+  broadcast();
+  if (alwaysNotify && currentStatus.kind !== "manual") {
     broadcastUpdateError();
   }
 }
@@ -191,12 +251,10 @@ function setStatus(next: UpdateStatus): void {
 
 export function setupAutoUpdaterEvents(): void {
   autoUpdater.on("checking-for-update", () => {
-    isCheckingOrDownloading = true;
     log.info("Checking for updates...");
   });
 
   autoUpdater.on("update-available", () => {
-    isCheckingOrDownloading = true;
     // Once an install has proven it cannot apply an update, re-arming the
     // in-app button on the next poll just hands the user the same dead
     // control again. `manual` already points them somewhere that works, so
@@ -207,20 +265,22 @@ export function setupAutoUpdaterEvents(): void {
       );
       return;
     }
+    if (currentStatus.kind === "pending") {
+      // Already downloading. Re-announcing must not restart the stall
+      // deadline: a poll every 10 minutes would push a 20-minute watchdog out
+      // forever, and the button-that-does-nothing would be back.
+      log.info("Update available, download already in progress");
+      return;
+    }
     log.info("Update available, downloading...");
-    const installRequested =
-      currentStatus.kind === "pending" ? currentStatus.installRequested : false;
-    setStatus({ kind: "pending", installRequested });
+    setStatus({ kind: "pending", installRequested: false });
     // Armed on ENTERING pending, not only when the user clicks: a download
     // that dies quietly used to leave the button up for the life of the
     // process with nothing behind it.
-    startStalledInstallWatchdog(
-      installRequested ? stalledInstallTimeoutMs : stalledDownloadTimeoutMs,
-    );
+    startStalledInstallWatchdog(stalledDownloadTimeoutMs);
   });
 
   autoUpdater.on("update-not-available", () => {
-    isCheckingOrDownloading = false;
     log.info("No updates available");
     // A `pending` that ends here produced no installable build — retire it.
     // A `downloaded` one is real and survives a later check; `manual` has
@@ -239,16 +299,25 @@ export function setupAutoUpdaterEvents(): void {
   });
 
   autoUpdater.on("error", (error) => {
-    // Before anything else: leave the in-flight download alone. Its status,
-    // its watchdog and `isCheckingOrDownloading` all stay as they are.
+    // Before anything else: a refused EXTRA check says nothing about the
+    // download, so leave an in-flight one alone — status and watchdog stay.
     if (isRefusedConcurrentCheck(error)) {
-      log.info(
-        "Ignoring update check refused while a download is already in flight",
-      );
+      if (currentStatus.kind === "pending") {
+        log.info(
+          "Ignoring update check refused while a download is already in flight",
+        );
+        return;
+      }
+      if (currentStatus.kind === "idle" && collapsedDownloads > 0) {
+        // Squirrel is still holding the download we already retired, so every
+        // later check is refused too and `pending` never comes back. Nothing
+        // else in this file can surface that, so hand over the manual link.
+        escalateToManualDownload("checks still refused after a collapse");
+        return;
+      }
+      log.info("Ignoring update check refused while the updater is busy");
       return;
     }
-    isCheckingOrDownloading = false;
-    clearStalledInstallWatchdog();
     log.error("Auto-updater error:", error);
     const wasQuittingForUpdate = isQuittingForUpdate;
     isQuittingForUpdate = false;
@@ -256,33 +325,12 @@ export function setupAutoUpdaterEvents(): void {
     // Always notify users in packaged builds — Bug 2: previously we only
     // broadcast when the user had clicked, so download failures before any
     // click silently swallowed the error and the button kept inviting clicks.
-    const shouldNotifyUser = app.isPackaged || wasQuittingForUpdate;
-
-    // Same retirement as update-not-available: the download is over and it
-    // did not deliver. collapsePendingDownload() owns the broadcast.
-    if (currentStatus.kind === "pending") {
-      collapsePendingDownload("updater error", {
-        alwaysNotify: shouldNotifyUser,
-      });
-      return;
-    }
-
-    if (
-      currentStatus.kind === "downloaded" ||
-      currentStatus.kind === "manual"
-    ) {
-      setStatus(currentStatus);
-    } else {
-      setStatus({ kind: "idle" });
-    }
-
-    if (shouldNotifyUser) {
-      broadcastUpdateError();
-    }
+    retireAfterUpdaterError("updater error", {
+      alwaysNotify: app.isPackaged || wasQuittingForUpdate,
+    });
   });
 
   autoUpdater.on("update-downloaded", (_event, releaseNotes, releaseName) => {
-    isCheckingOrDownloading = false;
     clearStalledInstallWatchdog();
     // A build that actually landed clears the history that pushed us to the
     // manual fallback — `downloaded` always wins.
@@ -366,28 +414,14 @@ export function registerUpdateListeners(mainWindow: BrowserWindow): void {
     } else if (currentStatus.kind === "pending") {
       log.info("Update still downloading — queuing install for completion");
       setStatus({ ...currentStatus, installRequested: true });
-      // Re-arm on the shorter, someone-is-watching timeout: if neither
-      // `update-downloaded` nor `error` fires within stalledInstallTimeoutMs,
-      // treat as stalled (Bug 1).
+      // Bring the deadline forward to the shorter someone-is-watching
+      // timeout, but never past the download's own deadline (Bug 1).
       startStalledInstallWatchdog(stalledInstallTimeoutMs);
-      if (!isCheckingOrDownloading) {
-        try {
-          isCheckingOrDownloading = true;
-          autoUpdater.checkForUpdates();
-        } catch (error) {
-          log.error("Failed to retry update check:", error);
-          collapsePendingDownload("checkForUpdates threw");
-        }
-      }
-    } else if (currentStatus.kind === "manual") {
-      // The renderer sends the user to the releases page instead of firing
-      // this, so reaching it means a stale click raced the status change.
-      // Re-broadcast rather than no-op: silence is the bug we are fixing.
-      log.info(
-        "Restart requested but auto-update is unavailable on this install",
-      );
-      broadcastUpdateError();
     } else {
+      // `manual` lands here too. The renderer opens the releases page instead
+      // of sending this, so a click that arrives anyway raced the status
+      // change — and the collapse that set `manual` already broadcast the
+      // error this branch would repeat.
       log.info("Restart requested but no update is staged");
     }
   });
@@ -433,22 +467,10 @@ export function registerUpdateListeners(mainWindow: BrowserWindow): void {
         return;
       }
       log.error("Auto-updater error:", new Error("Simulated update failure"));
-      clearStalledInstallWatchdog();
-      // Mirrors the real handler so QA sees the shipped retirement path —
+      // Runs the real handler's tail so QA sees the shipped retirement path,
       // including the second collapse that flips the pill to the manual
       // download.
-      if (currentStatus.kind === "pending") {
-        collapsePendingDownload("simulated updater error");
-        return;
-      }
-      if (
-        currentStatus.kind === "downloaded" ||
-        currentStatus.kind === "manual"
-      ) {
-        setStatus(currentStatus);
-      } else {
-        setStatus({ kind: "idle" });
-      }
+      retireAfterUpdaterError("simulated updater error");
     });
   }
 }
@@ -482,7 +504,6 @@ export function __resetUpdateStateForTests(): void {
   clearStalledInstallWatchdog();
   currentStatus = { kind: "idle" };
   isQuittingForUpdate = false;
-  isCheckingOrDownloading = false;
   trustedWindow = null;
   updateListenersRegistered = false;
   collapsedDownloads = 0;

--- a/mcpjam-inspector/src/preload.ts
+++ b/mcpjam-inspector/src/preload.ts
@@ -4,7 +4,10 @@ import { contextBridge, ipcRenderer } from "electron";
 type UpdateStatus =
   | { kind: "idle" }
   | { kind: "pending"; version?: string; installRequested: boolean }
-  | { kind: "downloaded"; version: string; releaseNotes?: string };
+  | { kind: "downloaded"; version: string; releaseNotes?: string }
+  // Auto-update announced a version and then could not install it; the UI
+  // sends the user to the releases page instead of a dead Update button.
+  | { kind: "manual"; version?: string };
 
 // Define the API interface
 interface ElectronAPI {


### PR DESCRIPTION
Fixes the "I click Update and nothing happens" report from @sophie-vo (desktop 2.45.0, macOS), following @olartgabo's triage.

## What the recording actually shows

Frame-stepping the screen recording at 6 fps, past the 1 fps read that makes it look like nothing moves at all:

| what | observed |
|---|---|
| button label on click | flips to **"Updating…"** with a spinner |
| how long it holds | **~200–300 ms**, then reverts to "Update" |
| error toast | **never appears**, over the whole clip |
| button | never goes away |

That combination pins the state exactly. In the 2.45.0 renderer `updateInstalling` is `status.kind === "pending" && status.installRequested`, so:

- the label flipping ⇒ the IPC **did** land and the status **was** `pending` (not `downloaded` — that path calls `quitAndInstall()`, which closes every window via `WindowList::CloseAllWindows()`; her window never closes);
- the label reverting with **no toast** ⇒ the only silent path that clears `installRequested`, which at the time was `update-not-available`.

So: the updater announced an update, the download never produced one, and every later check said "nothing here" — while the button stayed.

## Root cause

`pending` was sticky. Once `update-available` fired, nothing but `update-downloaded` could clear it:

```ts
autoUpdater.on("update-not-available", () => {
  if (currentStatus.kind === "pending" && currentStatus.installRequested) {
    setStatus({ ...currentStatus, installRequested: false }); // spinner off…
  }
  log.info("Keeping visible update status after update-not-available"); // …button stays
});
```

`error` did the same thing — reset `installRequested`, keep `pending`. The result is a live Update pill wired to a download that has already died. Click → `installRequested: true` → next updater event clears it → back to "Update". Seventeen times in 124 seconds.

**Why the two events can disagree on macOS.** They are not the matched pair they look like. From Electron's [`auto_updater_mac.mm`](https://github.com/electron/electron/blob/main/shell/browser/auto_updater_mac.mm):

- `update-available` is a **KVO side effect** of `SQRLUpdater` entering `SQRLUpdaterStateDownloadingUpdate` — the observer is installed in `setFeedURL`, and it fires on the state transition alone.
- `update-not-available` is emitted from `checkForUpdates`'s own subscription when the command signal completes **without delivering a `SQRLDownloadedUpdate`**.

A download that starts and then dies without an `NSError` therefore emits exactly `update-available` … `update-not-available`, with no `error` in between. That is the sequence that made the sticky-pending path reachable, and it is why no toast ever appeared.

## The fix

1. **`pending` is retired by anything that ends a check without a build** — `update-not-available`, `error`, and the watchdog all funnel into one `collapsePendingDownload()`. `downloaded` stays sticky (a staged build is real and survives a later check).
2. **The watchdog arms on entering `pending`, not only on a click.** The click-armed one only ever covered a user already staring at a spinner; a download nobody was watching could hang the button for the life of the process. 20 min unattended, 5 min once someone clicks.
3. **A new `manual` status.** One collapse can be a dropped connection, so the first drops to `idle` and lets the next 10-minute poll retry. A second one — or the first, if the user was already waiting on it — flips the pill to **"Download update"**, which opens the releases page. From then on `update-available` no longer re-arms the in-app install: an install that has proven it cannot self-update never gets handed a dead button again.

`update-downloaded` always wins and resets the collapse count, so a slow download that finally lands still turns into a normal Restart.

## What this does and does not fix

**Does:** every affected user now either gets a working button, no button, or a link that works. Nobody gets a control that does nothing. For @sophie-vo specifically, the first click after this ships flips her pill to "Download update" instead of flickering.

**Does not:** it does not fix whatever makes the Squirrel.Mac download die on her machine — that needs a Mac and her `~/Library/Logs/MCPJam Inspector/main.log`, per @olartgabo. The new `log.error("Update download collapsed (…)")` line is what to grep for; it names the reason and the collapse count.

Some notes for the follow-up, from checking the release side while triaging:

- **The feed is fine for arm64.** `GET https://update.electronjs.org/MCPJam/inspector/darwin-arm64/2.45.0` → `200` with `MCPJam.Inspector-darwin-arm64-3.5.2.zip`, and the zip is well-formed with `MCPJam Inspector.app/` at the root. So this is not a feed or packaging-shape problem.
- **`darwin-x64` 404s** (`needs asset matching .*-(mac|darwin|osx).*.zip`) and always has — we have never shipped an Intel or universal mac build, so no Intel Mac can run the app at all. Not Sophie's bug, but worth a decision.
- **`MCPJam.Inspector-stapled.zip` is dead weight.** `mac-release.yml`'s "Create stapled app ZIP for auto-updates" step produces a filename the update service cannot match, so auto-updates serve the un-stapled (still notarized) zip. Either rename it to the `-darwin-<arch>-<version>` form or drop the step.
- **~20% of macOS desktop users never move version.** Over 45 days, of macOS desktop people active ≥10 days, 217 advanced and **56 stayed pinned** — many on very old builds (1.1.2, 2.0.x, 2.4.11, 2.12.0, 2.28.1, 2.30.0) and still launching this week. Sophie's 2.45.0/1-person row is in that set, first seen 08-23, last seen 09-02, matching @olartgabo's numbers exactly. So this is a persistent per-install condition, not a one-off.
- **We capture no arch for the desktop app**, so we cannot tell those 56 apart from telemetry. Worth adding.

Answering @VigneshMcpjam's question from the thread: background updating already exists — `installUpdateOnQuit()` installs a staged build on quit, so a user who never clicks still comes back on the new version. The click only exists to skip the wait.

Out of scope here, but noted: @VigneshMcpjam / @nachocossio on the pill's corner radius not matching the design system. Happy to take that separately.

## Testing

`server/__tests__/update-listeners.test.ts` (19 pass), `client/src/hooks/__tests__/useUpdateNotification.test.ts` (16), `client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx` (14), `client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts` (23). Client typecheck clean.

Three existing tests encoded the old behaviour and were rewritten rather than deleted — notably `"keeps the update button visible when update-not-available follows an available update"`, which was the bug, asserted. New coverage: the two-collapse fallback, `manual` surviving a later `update-available`, `update-downloaded` overriding `manual`, and the unattended watchdog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes desktop update controls that could remain clickable after a download failed or show “Updating…” forever after a staged install stalled. These paths now retire the in-app install and offer a releases-page link instead.

**Bug Fixes**
- A pending download collapses on `update-not-available`, real errors, or the watchdog; the first failure retries on the next poll, while a user-requested or repeated failure shows “Download update”.
- The watchdog starts when downloading begins, gives unattended downloads 20 minutes, and shortens a clicked download to 30 seconds without resetting its deadline.
- Refused overlapping polls on macOS and Windows no longer retire a healthy slow download.
- A staged build remains available across later polls, and a silent `quitAndInstall()` failure now reaches the manual fallback after 30 seconds.
- Successful simulated downloads reset the failure history and watchdog, while repeated manual-fallback polls no longer repeat the error toast.

<sup>Written for commit a74c9231b49c11a64ad82ede069a9125bacffffc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

