### PR TITLE
fix(clipboard): stop toasting a copy that never happened (BB-215)

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/clipboard.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/clipboard.test.ts
@@ -3,7 +3,8 @@
  * caller branches straight into a success or failure toast — so the boolean has
  * to describe what actually reached the clipboard, including in the deprecated
  * `execCommand` fallback, which reports failure by returning false rather than
- * by throwing.
+ * by throwing, and reports success for a copy that never happened when the
+ * selection never took.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -85,5 +86,54 @@ describe("copyToClipboard", () => {
     await expect(copyToClipboard("text")).resolves.toBe(false);
     // A throw must not strand the scratch textarea in the document either.
     expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("reports FAILURE when the fallback selection does not take", async () => {
+    stubClipboard(vi.fn().mockRejectedValue(new Error("denied")));
+    const execCommand = stubExecCommand(() => true);
+    // A Radix dialog's focus trap pulls focus off the scratch textarea before
+    // the copy runs, which collapses the selection `select()` just made.
+    vi.spyOn(HTMLTextAreaElement.prototype, "select").mockImplementation(
+      () => {},
+    );
+
+    // Regression (BB-215): execCommand answered `true` for this copy, so the
+    // share modal toasted "Link copied" over an untouched clipboard.
+    await expect(copyToClipboard("text")).resolves.toBe(false);
+    expect(execCommand).not.toHaveBeenCalled();
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("still copies multi-line text with CRLF newlines", async () => {
+    stubClipboard(vi.fn().mockRejectedValue(new Error("denied")));
+    stubExecCommand(() => true);
+
+    // A textarea normalizes CRLF to LF, so its selection is shorter than the
+    // string handed in — measuring against the input would reject a good copy.
+    await expect(copyToClipboard("line one\r\nline two")).resolves.toBe(true);
+  });
+
+  it("puts the scratch textarea inside the open dialog", async () => {
+    stubClipboard(vi.fn().mockRejectedValue(new Error("denied")));
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    const trigger = document.createElement("button");
+    dialog.appendChild(trigger);
+    document.body.appendChild(dialog);
+    trigger.focus();
+
+    let host: Element | null = null;
+    stubExecCommand(() => {
+      host = document.querySelector("textarea")?.parentElement ?? null;
+      return true;
+    });
+
+    const copied = await copyToClipboard("text");
+    // Removed before asserting so a failure can't strand it in the next test.
+    dialog.remove();
+
+    expect(copied).toBe(true);
+    // On <body> the dialog's focus trap would steal the selection back.
+    expect(host).toBe(dialog);
   });
 });

--- a/mcpjam-inspector/client/src/lib/clipboard.ts
+++ b/mcpjam-inspector/client/src/lib/clipboard.ts
@@ -1,4 +1,15 @@
 /**
+ * A Radix dialog traps focus, so a scratch textarea parked on <body> gets
+ * refocused away before the copy runs. Keep it inside the open dialog.
+ */
+function fallbackCopyHost(): Element {
+  return (
+    document.activeElement?.closest('[role="dialog"],[role="alertdialog"]') ??
+    document.body
+  );
+}
+
+/**
  * Copy text to clipboard with fallback for older browsers.
  * Returns true if copy succeeded, false otherwise.
  */
@@ -13,8 +24,21 @@ export async function copyToClipboard(text: string): Promise<boolean> {
       textarea.value = text;
       textarea.style.position = "fixed";
       textarea.style.opacity = "0";
-      document.body.appendChild(textarea);
+      fallbackCopyHost().appendChild(textarea);
       textarea.select();
+      // execCommand("copy") reports success even when the selection never took
+      // and nothing reached the clipboard, so the selection is what has to be
+      // checked. Measured against the textarea's own value, which normalizes
+      // CRLF to LF and so is shorter than `text` for multi-line Windows input.
+      if (
+        textarea.selectionStart !== 0 ||
+        textarea.selectionEnd !== textarea.value.length
+      ) {
+        console.warn(
+          "Clipboard copy failed: fallback selection did not take, nothing was copied",
+        );
+        return false;
+      }
       // execCommand REPORTS failure by returning false rather than throwing, so
       // the result has to be forwarded — swallowing it makes every caller show a
       // success toast for a copy that never happened.


### PR DESCRIPTION
Fixes BB-215.

## What broke

Open a User Testing study, click **Share**, click **Copy link**. A green "Link copied" toast appears and nothing is written to the clipboard.

The chain, all inside `client/src/lib/clipboard.ts`:

1. `navigator.clipboard.writeText()` gets the correct URL and rejects with `NotAllowedError: Write permission denied`.
2. The `catch` runs the `execCommand` fallback, which appends its scratch `<textarea>` to `document.body` — outside the Radix dialog.
3. The dialog's `FocusScope` sees focus leave the scope the moment `select()` runs and pulls it back synchronously, collapsing the selection.
4. `document.execCommand("copy")` returns `true` anyway, so `copyToClipboard` forwards a success and `ShareSection.handleCopyLink` toasts "Link copied".

The file already guarded against the neighbouring mistake — its comment says that swallowing the result would make every caller show a success toast for a copy that never happened, and the code forwards the result faithfully. The problem was one layer deeper: the source itself lies.

Not specific to the share modal. Every caller of `copyToClipboard` that runs inside a dialog had the same false positive — `ScenarioShareEmptyPanel`, `UrlElicitationConsent`, `error-card`, the `json-editor` copy buttons.

## The fix

1. **Append the textarea to the open dialog** (`document.activeElement?.closest('[role="dialog"],[role="alertdialog"]')`) instead of `<body>`, so the focus trap leaves the selection alone and the copy actually works. `alertdialog` is in the selector because `ShareSection` mounts an `AlertDialog` for link rotation.
2. **Verify the selection before trusting `execCommand`.** If it does not span the textarea, return `false` and don't run the copy. This makes the failure honest even where the fallback still can't work.

One deviation from the fix suggested on the ticket: the check measures against `textarea.value.length`, not `text.length`. A textarea normalizes CRLF to LF, so comparing against the input string would return `false` for every multi-line copy containing `\r\n` — trading a false positive for a false negative in the callers that copy JSON, commands and traces. Verified in jsdom: `"a\r\nb"` is 4 characters, and the textarea's value is 3.

## Tests

Three added to `clipboard.test.ts`. The first two fail against the previous implementation:

- `reports FAILURE when the fallback selection does not take` — stubs `select()` to a no-op while `execCommand` returns `true`, which is exactly the shape of the bug.
- `puts the scratch textarea inside the open dialog`.
- `still copies multi-line text with CRLF newlines` — covers the `textarea.value` measurement.

## Out of scope

`NetworkAccessError.tsx` has its own inline fallback with the same `if (document.execCommand("copy"))` shape. It doesn't route through `copyToClipboard`, so this change doesn't reach it. It renders as a full-page error rather than inside a dialog, so the selection does take there and the BB-215 symptom doesn't apply — left alone rather than widened into this PR.

## Verification

Run on the merged tree (branch is up to date with `main` at `ab2a7b730`), exit codes captured to a file rather than read through a pipe:

| Check | Result |
| --- | --- |
| `npm run docs:check-tokens` | exit 0 |
| `npm run typecheck` | exit 0 |
| `npm run typecheck:client -w @mcpjam/inspector` | exit 0 (incl. the tier-b and browser-viewer import guards) |
| `vitest run --project client` | `1304 passed \| 3 skipped`, 0 assertion failures |
| `npm run build:inspector` | exit 0 |
| `client/src/lib/__tests__/clipboard.test.ts` | 7/7 |

Both new regression tests were confirmed to **fail** against the pre-fix `clipboard.ts` and pass after it, so they are testing the bug rather than the implementation.

Two failures showed up locally that this branch does not cause:

- The root `npm test` exits 1 on Windows in server-side suites (`routes/web/*`, the `utils/harness/local/*` sandbox and supervisor family, `ws-native-fallback`) plus the `verify` scripts of `discord-app`, `surface-core` and `slack-app` on CRLF format checks. Nothing under `server/` or `cli/` imports `lib/clipboard` — this diff is two client files — and the merge-base `ab2a7b730` is green on `test.yml` in CI. Left untouched rather than reformatting packages this change has no business in.
- `ScenarioChatPage.test.tsx > prompts the recipient when the server does require authorization` timed out in the full client run and passes in isolation (exit 0). It asserts on an "Authorize again" button, and `ScenarioChatPage` calls `navigator.clipboard.writeText` directly without going through `copyToClipboard`.

E2E not run locally: the diff touches neither routing, app boot, nor the OAuth debugger.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes BB-215: the share modal's "Copy link" toasted success while leaving the clipboard untouched. Inside a Radix dialog, the `execCommand` fallback parked its scratch textarea on `<body>`, the focus trap collapsed the selection, and `execCommand` still returned `true`.

The fallback now appends the textarea to the open dialog so the selection takes, and verifies the selection spans the textarea before trusting `execCommand`'s return value. Callers now get `false` instead of a false positive.

**Bug Fixes**
- The fallback reported success when nothing was copied; it now returns `false` and logs a warning.
- The selection check measures against `textarea.value` (normalizes CRLF to LF), so multi-line copies with Windows newlines still pass.
- Added regression tests for selection failure, dialog hosting, and CRLF multi-line text; the first two fail against the pre-fix code.

<sup>Written for commit ab0c63911ec7686e7443ddfd4e06022fef61ae7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

