### PR TITLE
docs: remove Codex from MCP Apps rendering list

### DIFF
--- a/docs/inspector/compatibility.mdx
+++ b/docs/inspector/compatibility.mdx
@@ -4,7 +4,7 @@ description: "Check whether your MCP server works on each AI host — conformanc
 icon: "boxes"
 ---
 
-The Compatibility destination answers one question: **does my server work on this host?** It evaluates your connected server against a catalog of real AI hosts (Claude, ChatGPT, Cursor, Copilot, Codex, and others) and surfaces blockers, degraded experiences, and protocol gaps — without requiring you to deploy to each host first.
+The Compatibility destination answers one question: **does my server work on this host?** It evaluates your connected server against a catalog of real AI hosts (Claude, ChatGPT, Cursor, Copilot, and others) and surfaces blockers, degraded experiences, and protocol gaps — without requiring you to deploy to each host first.
 
 ## How to open it
 
@@ -55,7 +55,7 @@ For hosts that render MCP Apps widgets, a **Run live** button appears next to th
 
 Live rendering requires:
 - A connected server with at least one widget tool.
-- The host to support MCP Apps rendering (Claude, ChatGPT, Cursor, Copilot, Codex all do).
+- The host to support MCP Apps rendering (Claude, ChatGPT, Cursor, Copilot all do).
 
 ## Test in host
 


### PR DESCRIPTION
## What does this PR do?
This PR resolves audit item #1 by removing mentions of "Codex" from the list of AI hosts that support MCP Apps rendering in the Inspector Compatibility documentation. 
As confirmed by the team, Codex does not render MCP Apps natively in either its CLI or Desktop environments, so removing it prevents any inconsistencies with our marketing page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes Codex from the list of AI hosts that support MCP Apps rendering in the Inspector Compatibility docs. Codex doesn't render MCP Apps natively, so the old docs were inaccurate and could mislead users.

<sup>Written for commit 0ff7c86b88ab02dd0f267b150fa82a269e8ea17f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

