### PR TITLE
fix: emit missing PiP widget sizing styles

### DIFF
--- a/mcpjam-inspector/client/src/__tests__/widget-styles.test.ts
+++ b/mcpjam-inspector/client/src/__tests__/widget-styles.test.ts
@@ -1,0 +1,24 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { compile } from "@tailwindcss/node";
+import { Scanner } from "@tailwindcss/oxide";
+import { expect, it } from "vitest";
+
+it("ships fullscreen and PiP styles from the widget package", async () => {
+  const stylesheet = path.resolve(__dirname, "../index.css");
+  const base = path.dirname(stylesheet);
+  const compiler = await compile(await readFile(stylesheet, "utf8"), {
+    base,
+    onDependency: () => {},
+  });
+  // Only use explicit external sources: classes found elsewhere in the app
+  // must not accidentally mask an unscanned widget package.
+  const scanner = new Scanner({ sources: compiler.sources });
+  const candidates = scanner.scan();
+  expect(scanner.files).toContain(
+    path.resolve(base, "../../../widget-react/src/mcp-apps-renderer.tsx"),
+  );
+  const css = compiler.build(candidates);
+  expect(css).toMatch(/\.z-40\s*\{\s*z-index:\s*40;/);
+  expect(css).toContain("max-width: min(90vw, 1200px)");
+});

--- a/mcpjam-inspector/client/src/index.css
+++ b/mcpjam-inspector/client/src/index.css
@@ -10,6 +10,8 @@
    read-only transcript relies on the inspector's existing global shadcn tokens
    for color values, so no package stylesheet import is needed here. */
 @source "../../../chat-ui/src/**/*.{ts,tsx}";
+/* Widget renderers are also aliased to source outside client/src. */
+@source "../../../widget-react/src/**/*.{ts,tsx}";
 
 @layer base {
   * {


### PR DESCRIPTION
PiP widgets use `max-w-[min(90vw,1200px)]`, but Tailwind does not scan `widget-react/src`, so that width limit is missing from the generated inspector CSS. Add the widget package as an explicit source so PiP sizing utilities are emitted.

Adds a regression test that scans the configured external sources and compiles CSS, checking that the renderer is included and that width and stacking utilities are generated. The test failed before the source entry and passes after it.

Validation: focused Vitest test, Prettier check, `git diff --check`, and `design:check` pass. `design:lint` could not run because the local `designmd` executable is unavailable.

This fixes the confirmed PiP CSS issue. The reported fullscreen chat bleed remains unresolved.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing PiP widget sizing styles by scanning `widget-react/src` for Tailwind so the width limit and stacking utilities are generated.

- Adds a regression test that compiles CSS and confirms the renderer is scanned and the needed utilities are present.
- The fullscreen chat bleed issue remains unresolved.

<sup>Written for commit 05ffb28a5ee1215eac53a38e1e98b90920c5b997. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

