### PR TITLE
Add a labelled exit to the scenario preview surface

### DIFF
--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -920,18 +920,18 @@ export function ScenarioChatPage({
     }
   }, [session, shareableToken]);
 
+  const leaveScenario = useCallback(
+    (to: string) => {
+      clearScenarioSession();
+      navigateApp(to, { replace: true });
+      onExitScenarioChat?.();
+    },
+    [onExitScenarioChat],
+  );
+
   const handleOpenMcpJam = useCallback(() => {
-    clearScenarioSession();
-    // Route via the navigation API so React Router's `useLocation`
-    // (consumed by App's pathname-sync effect) sees the new pathname.
-    // A bare `window.history.replaceState` would leave `locationForRoute`
-    // stale on `/scenario/...`, and the sync effect would then redirect
-    // back to `/servers` before the hash-migration shim could pivot.
-    navigateApp("/scenarios", {
-      replace: isEmbeddedPreview() ? true : true,
-    });
-    onExitScenarioChat?.();
-  }, [onExitScenarioChat]);
+    leaveScenario("/scenarios");
+  }, [leaveScenario]);
 
   const handleSignIn = useCallback(() => {
     writeScenarioSignInReturnPath(window.location.pathname);

--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -29,7 +29,10 @@ import type {
   HostedAccessErrorDetail,
   HostedAccessRecoveryResult,
 } from "@/lib/hosted-runtime-context";
-import { navigateApp } from "@/lib/app-navigation";
+import {
+  buildUserTestingScenarioPath,
+  navigateApp,
+} from "@/lib/app-navigation";
 import {
   isEmbeddedPreview,
   syncScenarioBootstrapHash,
@@ -933,6 +936,17 @@ export function ScenarioChatPage({
     leaveScenario("/scenarios");
   }, [leaveScenario]);
 
+  const isPreviewSurface = session?.surface === "preview";
+  const previewScenarioId = session?.scenarioId ?? null;
+
+  const handleReturnToStudy = useCallback(() => {
+    leaveScenario(
+      previewScenarioId
+        ? buildUserTestingScenarioPath(previewScenarioId)
+        : "/scenarios",
+    );
+  }, [leaveScenario, previewScenarioId]);
+
   const handleSignIn = useCallback(() => {
     writeScenarioSignInReturnPath(window.location.pathname);
     signIn();
@@ -1229,6 +1243,17 @@ export function ScenarioChatPage({
                           />
                         </button>
                         <div className="flex flex-1 items-center justify-end gap-1.5">
+                          {sessionForCurrentLink && isPreviewSurface ? (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="text-muted-foreground"
+                              onClick={handleReturnToStudy}
+                              data-testid="scenario-preview-back-to-study"
+                            >
+                              Back to study
+                            </Button>
+                          ) : null}
                           {session && shareableToken ? (
                             <Button
                               variant="ghost"

--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -389,6 +389,14 @@ export function ScenarioChatPage({
    * resume for a scenario this visitor can no longer reach. Takes the scenario
    * id explicitly because the session it belongs to is being torn down in the
    * same breath.
+   *
+   * Every exit path that drops the session goes through here, because this is
+   * the one place that knows the embed rule: inside the same-origin Preview
+   * iframe, never touch sessionStorage — it belongs to the host tab, and
+   * clearing it would wipe the outer dashboard's own scenario session. The
+   * rule is only safe because the embed never runs the post-redeem URL strip
+   * (see `readCurrentSession` above): its URL keeps the share token, so
+   * skipping the clear leaves nothing stale behind and a reload re-redeems.
    */
   const clearCurrentSession = useCallback((scenarioId?: string | null) => {
     if (isEmbeddedPreview()) {
@@ -925,13 +933,11 @@ export function ScenarioChatPage({
 
   const leaveScenario = useCallback(
     (to: string) => {
-      if (!isEmbeddedPreview()) {
-        clearScenarioSession();
-      }
+      clearCurrentSession();
       navigateApp(to, { replace: true });
       onExitScenarioChat?.();
     },
-    [onExitScenarioChat],
+    [clearCurrentSession, onExitScenarioChat],
   );
 
   const handleOpenMcpJam = useCallback(() => {

--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -1153,7 +1153,9 @@ export function ScenarioChatPage({
           showConsent={introGate.showConsent}
           hasTasks={hasScenarioTasks}
           onAcceptConsent={introGate.acceptConsent}
-          onDeclineConsent={introGate.declineConsent}
+          onDeclineConsent={
+            isPreviewSurface ? handleReturnToStudy : introGate.declineConsent
+          }
           showAuthPanel={introGate.showAuthPanel}
           pendingOAuthServers={pendingOAuthServers}
           authorizeServer={authorizeServer}

--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -925,7 +925,9 @@ export function ScenarioChatPage({
 
   const leaveScenario = useCallback(
     (to: string) => {
-      clearScenarioSession();
+      if (!isEmbeddedPreview()) {
+        clearScenarioSession();
+      }
       navigateApp(to, { replace: true });
       onExitScenarioChat?.();
     },

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
@@ -2321,5 +2321,43 @@ describe("ScenarioChatPage", () => {
       ).not.toBeInTheDocument();
       expect(screen.getByRole("button", { name: "MCPJam" })).toBeInTheDocument();
     });
+
+    it("routes consent Leave back to the study on the preview surface", async () => {
+      writeSurfaceSession("preview");
+      window.history.replaceState({}, "", "/#surface-scenario");
+      const onExit = vi.fn();
+
+      render(<ScenarioChatPage onExitScenarioChat={onExit} />);
+
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Leave" }),
+      );
+
+      expect(onExit).toHaveBeenCalledTimes(1);
+      expect(readScenarioSession()).toBeNull();
+      expect(window.location.pathname).toBe("/user-testing/sbx_1");
+      expect(
+        screen.queryByTestId("scenario-recording-declined"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("keeps the terminal declined panel for a share-link tester who Leaves", async () => {
+      writeSurfaceSession("share_link");
+      window.history.replaceState({}, "", "/#surface-scenario");
+      const onExit = vi.fn();
+
+      render(<ScenarioChatPage onExitScenarioChat={onExit} />);
+
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Leave" }),
+      );
+
+      expect(
+        await screen.findByTestId("scenario-recording-declined"),
+      ).toBeInTheDocument();
+      expect(onExit).not.toHaveBeenCalled();
+      expect(readScenarioSession()?.scenarioId).toBe("sbx_1");
+      expect(window.location.pathname).toBe("/");
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
@@ -2359,5 +2359,53 @@ describe("ScenarioChatPage", () => {
       expect(readScenarioSession()?.scenarioId).toBe("sbx_1");
       expect(window.location.pathname).toBe("/");
     });
+
+    it("never clears the host tab's stored session when exiting from inside the embed", async () => {
+      mockIsEmbeddedPreview.mockReturnValue(true);
+      const outerSession = {
+        scenarioId: "sbx_outer",
+        accessVersion: 7,
+        payload: {
+          projectId: "ws_outer",
+          scenarioId: "sbx_outer",
+          name: "Outer Dashboard Scenario",
+          description: "Hosted scenario",
+          hostStyle: "chatgpt" as const,
+          mode: "invited_only" as const,
+          allowGuestAccess: false,
+          viewerIsProjectMember: true,
+          systemPrompt: "You are helpful.",
+          modelId: "openai/gpt-5-mini",
+          temperature: 0.4,
+          requireToolApproval: true,
+          servers: [],
+        },
+      };
+      writeScenarioSession(outerSession);
+      consentAlreadyGiven();
+      window.history.replaceState(
+        {},
+        "",
+        "/user-testing/demo/scenario-token?surface=preview",
+      );
+      const onExit = vi.fn();
+
+      render(
+        <ScenarioChatPage
+          pathToken="scenario-token"
+          onExitScenarioChat={onExit}
+        />,
+      );
+
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Back to study" }),
+      );
+
+      expect(onExit).toHaveBeenCalledTimes(1);
+      expect(readScenarioSession()).toMatchObject({
+        scenarioId: "sbx_outer",
+        accessVersion: 7,
+      });
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
@@ -2262,5 +2262,64 @@ describe("ScenarioChatPage", () => {
         }),
       );
     });
+
+    function writeSurfaceSession(surface: "preview" | "share_link") {
+      writeScenarioSession({
+        scenarioId: "sbx_1",
+        accessVersion: 1,
+        surface,
+        payload: {
+          projectId: "ws_1",
+          scenarioId: "sbx_1",
+          name: "Surface Scenario",
+          description: "",
+          hostStyle: "claude",
+          mode: "anyone_with_link",
+          allowGuestAccess: false,
+          viewerIsProjectMember: true,
+          systemPrompt: "You are helpful.",
+          modelId: "openai/gpt-5-mini",
+          temperature: 0.7,
+          requireToolApproval: false,
+          servers: [],
+        },
+      });
+    }
+
+    it("shows a labelled Back to study control after consent on the preview surface", async () => {
+      writeSurfaceSession("preview");
+      window.history.replaceState({}, "", "/#surface-scenario");
+      const onExit = vi.fn();
+
+      render(<ScenarioChatPage onExitScenarioChat={onExit} />);
+
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Continue" }),
+      );
+      expect(await screen.findByTestId("scenario-chat-tab")).toBeInTheDocument();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Back to study" }),
+      );
+
+      expect(onExit).toHaveBeenCalledTimes(1);
+      expect(readScenarioSession()).toBeNull();
+      expect(window.location.pathname).toBe("/user-testing/sbx_1");
+      expect(window.location.hash).toBe("");
+    });
+
+    it("keeps the header free of Back to study for a share-link tester", async () => {
+      writeSurfaceSession("share_link");
+      consentAlreadyGiven();
+      window.history.replaceState({}, "", "/#surface-scenario");
+
+      render(<ScenarioChatPage />);
+
+      expect(await screen.findByTestId("scenario-chat-tab")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Back to study" }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "MCPJam" })).toBeInTheDocument();
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
@@ -2239,4 +2239,28 @@ describe("ScenarioChatPage", () => {
       );
     });
   });
+
+  describe("preview surface", () => {
+    it("keeps surface=preview on the session after the URL collapses to /#slug", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/user-testing/demo/scenario-token?surface=preview",
+      );
+
+      render(<ScenarioChatPage pathToken="scenario-token" />);
+
+      expect(await screen.findByTestId("scenario-chat-tab")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(window.location.hash).toBe("#resolved-scenario");
+      });
+      expect(window.location.search).toBe("");
+      expect(readScenarioSession()?.surface).toBe("preview");
+      expect(mockChatTabV2).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          hostedContext: expect.objectContaining({ scenarioSurface: "preview" }),
+        }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Problem

After the recording notice on the scenario page is dismissed, the page exposes no labelled exit control. The only way out is the MCPJam logo in the header, which is a bare `<button>` wrapping an image with no text, title, or aria-label describing an action. The consent dialog's Leave button does not exit either: it swaps the chat for a terminal "You left this session" panel whose only control is Rejoin.

## Root cause

The page renders identically for both surfaces it serves.

The terminal panel behind Leave is correct for a share-link visitor. They arrived by pasted link, the tab has no history, `window.close()` does nothing for a window the script did not open, and there is nowhere to navigate to. Every exit decision on the page was calibrated for that visitor.

The preview surface is different. It is opened from inside the app via "Open preview", carries `?surface=preview` on the tester link, and has an obvious destination: the study detail page it came from. The page already knew which case it was in. `session.surface` is stamped at redeem time from that query parameter and persisted with the session, so it survives the post-redeem collapse of the URL to `/#<slug>`. Until this change it was read for exactly one thing, the `scenarioSurface` field of the hosted chat context, and drove no UI.

## What changed

Three commits, each independently revertable.

**`c17ff1455` refactor: pin preview surface survival and share the scenario exit path**
Adds a characterization test proving `session.surface === "preview"` survives redeem and the URL collapse, and is what the hosted context receives. Extracts the logo button's exit into a shared `leaveScenario(to)` callback that clears the stored session, navigates with `replace`, and fires `onExitScenarioChat` so `App` stops rendering the scenario branch. The logo now calls it with the same `/scenarios` target it always had. No behavior change.

**`32c0cf645` feat: add Back to study exit to the preview surface header**
Derives `isPreviewSurface` from `session.surface`. When true and the session belongs to the current link, renders a labelled "Back to study" ghost button in the header beside Copy link. It calls `leaveScenario` with `buildUserTestingScenarioPath(session.scenarioId)`, so the visitor lands on the study detail page. The logo button is unchanged.

**`16b4a2ca8` feat: route consent Leave back to the study on the preview surface**
On the preview surface, the consent dialog's Leave calls the same study-detail exit instead of `declineConsent`. Share-link visitors keep the terminal panel and Rejoin.

### Share-link behavior is unchanged

Every new branch is gated on `session.surface === "preview"`. That value is only ever `"preview"` when the redeem URL carried `?surface=preview`, and the only writer of that query is the "Open preview" link on the study detail page. A share link never carries it, so the session normalizes to `share_link` and every new branch is a no-op.

Pinned by tests:

- a share-link session renders no "Back to study" and the logo button is still present;
- a share-link visitor who clicks Leave still gets the terminal panel, storage is untouched, and the exit callback is not called;
- the pre-existing test "unmounts the chat on Leave, and re-asks on rejoin" is unmodified and passes.

## Address bar behavior, deliberately not fixed here

Read this before touching the hash handling on this page.

**Symptom.** On `/#<slug>`, selecting the fragment in the address bar, deleting it, and pressing Enter does not exit. The view stays and the URL visibly rewrites itself back to `/#<slug>`. This PR does not change that.

**Why.** Going from `/#<slug>` to `/` with no fragment is not a fragment navigation under the HTML spec, which only treats the change as same-document when the new URL has a fragment. The browser performs a full page load, so no `hashchange` fires. The page remounts. `App.tsx` decides to render the scenario branch from `sessionStorage` regardless of what the address bar says. `ScenarioChatPage` reaches its storage-recovery branch, restores the session, and calls `syncScenarioBootstrapHash`, which `replaceState`s the fragment back. The visible rewrite is the bootstrap, not a listener.

There is also a `hashchange` listener on the page that re-enforces the slug. It is not what produces the observed rewrite for this gesture, because the gesture never fires `hashchange`. It only matters for `/#<slug>` to `/#` or `/#other`, which are fragment navigations.

**What does not work.** A `hashchange` listener does not solve this, because the real gesture never fires the event. Unit tests that dispatch a synthetic `HashChangeEvent` will pass while the real gesture still fails. That exact mistake was made and reverted during this work. Any test for this behavior has to simulate the actual gesture: a full mount at `/` with storage seeded and no hash.

**The viable fix, implemented and then reverted.** In the recovery branch of `ScenarioChatPage`, a root-only rule: when not embedded, no path token, `pathname === "/"`, and the hash is empty, treat the mount as an exit instead of a recovery, clearing the session and navigating to the surface's destination. Root-only, because in-flight MCP OAuth markers written before their return-path fix ships land hashless on non-root paths such as `/<server-name>` and must still recover. Tests for it mounted the page for real at `/` with storage seeded and passed against the rule.

It was reverted because opening a preview then produced "Link Unavailable" and the regression was not diagnosed before the revert. The revert is pending diagnosis, not a verdict that the approach is wrong. "Link Unavailable" is the copy for the 404 path the page shows when it has neither a token nor a stored session, which is consistent with the rule clearing storage before `App` switched views, but that has not been confirmed.

**Its prerequisite.** The MCP OAuth return inside a session currently resolves to `/<server-name>` with no hash. `captureCurrentReturnPath` returns null for a root pathname, so the gate falls back to the server name, and the callback lands on a bare pathname that depends on the same recovery branch to restore the session. The root-only rule would not eject it, but a broader rule would, mid-authorization. `park/oauth-return-path-slug` changes that return path to `/#<slug>`, threads the scenario slug through `authorizeServer`'s options, and updates `resolveHostedOAuthReturnPath` to match. It needs to land before any recovery-branch rule ships. It is a separate branch pending its own PR.

**Why it matters.** Normal browser behavior is being overridden. Deleting everything after the `/` lands on the app root everywhere else in the app. On this surface it does not. The underlying cause is that the URL is not the source of truth here; `sessionStorage` is. The gate in `App.tsx` renders the scenario branch from stored state regardless of the address bar. As long as that holds, the URL and the rendered view can disagree, and this gesture is the most visible symptom. Any real fix has to reconcile the two, which is why the reverted rule targeted the recovery branch, the one place that decides whether a stored session becomes a rendered one, rather than adding another listener.

## Manual test

### Preview surface

1. Sign in, open a study, click Open preview. The tab lands on `/user-testing/<slug>/<token>?surface=preview`, the session loads, the URL collapses to `/#<slug>`, and the recording notice appears.
2. Click Continue. The chat is usable and the header shows "Back to study" beside Copy link.
3. Click Back to study. You land on the study detail page at `/p/<org>/user-testing/<scenarioId>`. Reload it and confirm you stay there.
4. Open preview again and click Leave on the notice. Same landing on the study detail, and no "You left this session" panel.
5. Open preview again, Continue, then reload at `/#<slug>`. The session recovers, the notice does not reappear, Back to study is still present.
6. Click the MCPJam logo. It exits to `/p/<org>/user-testing` as before.
7. Delete the fragment from the address bar and press Enter. Expected today: the page reloads, the session is still there, and the URL is back to `/#<slug>`. This is the known behavior described above, not a regression.

### Share-link visitor, private window

8. Copy the share link from the Share section and open it in a private window. The notice appears.
9. Click Continue. The header shows the client logo, the MCPJam logo, Copy link, What to try if the study has tasks, and no "Back to study".
10. Reopen the link fresh and click Leave. The "You left this session" panel appears with Rejoin. Click Rejoin and the notice returns.
11. Click the MCPJam logo. It exits as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a labelled "Back to study" exit to the scenario preview surface so preview visitors can return to the study detail page. Routes the consent dialog's Leave button to the same destination on that surface. Share-link visitors keep the existing terminal panel and logo exit. Also guards the exit so it never clears a host tab's stored session when running inside an embed.

**Behavior**
- Preview surface (`session.surface === "preview"`) shows a "Back to study" button beside Copy link after consent, and consent Leave navigates to the study detail page instead of showing the declined panel.
- Share-link sessions are unchanged: no Back to study button, Leave still shows the "You left this session" panel, and the logo button exits to `/scenarios`.
- The exit path skips clearing the stored session when embedded, so an author's resumable session in the host tab survives.
- The known address bar behavior (deleting the hash and pressing Enter does not exit) is not addressed here.
- Adds tests covering both preview and share-link exit paths, including the embedded case.

<sup>Written for commit 6f23cc51c040037b98efc570106a747479b5e52e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

