### PR TITLE
clarify Codex Desktop supports rendering

### DIFF
--- a/docs/inspector/compatibility.mdx
+++ b/docs/inspector/compatibility.mdx
@@ -4,7 +4,7 @@ description: "Check whether your MCP server works on each AI host — conformanc
 icon: "boxes"
 ---
 
-The Compatibility destination answers one question: **does my server work on this host?** It evaluates your connected server against a catalog of real AI hosts (Claude, ChatGPT, Cursor, Copilot, Codex, and others) and surfaces blockers, degraded experiences, and protocol gaps — without requiring you to deploy to each host first.
+The Compatibility destination answers one question: **does my server work on this host?** It evaluates your connected server against a catalog of real AI hosts (Claude, ChatGPT, Cursor, Copilot, Codex Desktop, and others) and surfaces blockers, degraded experiences, and protocol gaps — without requiring you to deploy to each host first.
 
 ## How to open it
 
@@ -55,7 +55,7 @@ For hosts that render MCP Apps widgets, a **Run live** button appears next to th
 
 Live rendering requires:
 - A connected server with at least one widget tool.
-- The host to support MCP Apps rendering (Claude, ChatGPT, Cursor, Copilot, Codex all do).
+- The host to support MCP Apps rendering (Claude, ChatGPT, Cursor, Copilot, Codex Desktop all do).
 
 ## Test in host
 

--- a/docs/inspector/host-compat.mdx
+++ b/docs/inspector/host-compat.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Host Compatibility"
-description: "See which hosts your MCP server will work in — Claude, ChatGPT, Cursor, Copilot, Codex CLI — the moment you connect"
+description: "See which hosts your MCP server will work in — Claude, ChatGPT, Cursor, Copilot, Codex Desktop — the moment you connect"
 icon: "circle-check"
 ---
 
@@ -40,8 +40,8 @@ The report is computed from data already on the client at connect time — no ex
 
 The most common source of findings. The report checks whether each host can render the widget bridges your server's tools declare:
 
-- **MCP Apps** (`_meta.ui.resourceUri`) — rendered by Claude, ChatGPT, Cursor, and Copilot. Not rendered by Codex CLI (a CLI with no widget surface).
-- **OpenAI Apps** (`openai/outputTemplate`) — rendered by ChatGPT and Copilot via the `window.openai` shim. Not rendered by Claude, Cursor, or Codex CLI.
+- **MCP Apps** (`_meta.ui.resourceUri`) — rendered by Claude, ChatGPT, Cursor, Copilot, and Codex Desktop.
+- **OpenAI Apps** (`openai/outputTemplate`) — rendered by ChatGPT, Copilot, and Codex Desktop via the `window.openai` shim. Not rendered by Claude or Cursor.
 - **Dual-bridge** (both keys declared) — renderable wherever either bridge is supported.
 
 When a host can't render a widget, the verdict is **Degraded** (the tool falls back to its plain-text result). If the tool is declared app-only (`_meta.ui.visibility` excludes `"model"`), there is no text fallback and the verdict is **Blocked**.

--- a/docs/inspector/host-compat.mdx
+++ b/docs/inspector/host-compat.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Host Compatibility"
-description: "See which hosts your MCP server will work in — Claude, ChatGPT, Cursor, Copilot, Codex — the moment you connect"
+description: "See which hosts your MCP server will work in — Claude, ChatGPT, Cursor, Copilot, Codex CLI — the moment you connect"
 icon: "circle-check"
 ---
 
@@ -40,8 +40,8 @@ The report is computed from data already on the client at connect time — no ex
 
 The most common source of findings. The report checks whether each host can render the widget bridges your server's tools declare:
 
-- **MCP Apps** (`_meta.ui.resourceUri`) — rendered by Claude, ChatGPT, Cursor, and Copilot. Not rendered by Codex (a CLI with no widget surface).
-- **OpenAI Apps** (`openai/outputTemplate`) — rendered by ChatGPT and Copilot via the `window.openai` shim. Not rendered by Claude, Cursor, or Codex.
+- **MCP Apps** (`_meta.ui.resourceUri`) — rendered by Claude, ChatGPT, Cursor, and Copilot. Not rendered by Codex CLI (a CLI with no widget surface).
+- **OpenAI Apps** (`openai/outputTemplate`) — rendered by ChatGPT and Copilot via the `window.openai` shim. Not rendered by Claude, Cursor, or Codex CLI.
 - **Dual-bridge** (both keys declared) — renderable wherever either bridge is supported.
 
 When a host can't render a widget, the verdict is **Degraded** (the tool falls back to its plain-text result). If the tool is declared app-only (`_meta.ui.visibility` excludes `"model"`), there is no text fallback and the verdict is **Blocked**.

--- a/docs/inspector/playground.mdx
+++ b/docs/inspector/playground.mdx
@@ -253,7 +253,7 @@ Widgets can request mode changes from their own code; users can exit PiP or Full
 
 All widgets — whether they declare `openai/outputTemplate` (ChatGPT Apps), `_meta.ui.resourceUri` (MCP Apps), or both — render through a single unified renderer. The `window.openai` compatibility shim is always injected, so both `window.openai.*` calls and `ui/*` JSON-RPC messages work regardless of which metadata the tool declares.
 
-Widget rendering is gated on the active Client's `clientCapabilities`. Hosts that advertise the MCP UI extension (Claude, ChatGPT, MCPJam, Copilot, Cursor) render widgets as normal. Hosts that strip the extension — such as Codex, an elicitation-only CLI — show the plain tool result row instead. Per-server capability overrides are honored.
+Widget rendering is gated on the active Client's `clientCapabilities`. Hosts that advertise the MCP UI extension (Claude, ChatGPT, MCPJam, Copilot, Cursor, Codex) render widgets as normal. Hosts that strip the extension show the plain tool result row instead. Per-server capability overrides are honored.
 
 ## Per-Widget Debugging
 

--- a/sdk/src/host-compat/catalog.generated.ts
+++ b/sdk/src/host-compat/catalog.generated.ts
@@ -2773,7 +2773,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
     },
     codex: {
       id: "codex",
-      label: "Codex Desktop",
+      label: "Codex",
       provenance: "probe",
       rendersMcpApps: true,
       supportedProtocolVersions: ["2025-03-26", "2025-06-18", "2025-11-25"],

--- a/sdk/src/host-compat/catalog.generated.ts
+++ b/sdk/src/host-compat/catalog.generated.ts
@@ -2773,7 +2773,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
     },
     codex: {
       id: "codex",
-      label: "Codex",
+      label: "Codex Desktop",
       provenance: "probe",
       rendersMcpApps: true,
       supportedProtocolVersions: ["2025-03-26", "2025-06-18", "2025-11-25"],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies the inspector docs to correctly describe Codex Desktop as a widget-rendering host instead of a CLI with no widget surface.

- Documents in `host-compat.mdx` that Codex Desktop renders MCP Apps and OpenAI Apps via the `window.openai` shim; only Claude and Cursor lack OpenAI Apps support.
- Removes Codex from the "strips the MCP UI extension" example in `playground.mdx`, since its preset advertises the extension.

<sup>Written for commit 728973d9477bd2b5885eaf21b0ce2085ee62a349. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

