### PR TITLE
User Testing: create-flow validation, a refusal that does not redirect, a locked setup, and a Settings that uses the screen

### DIFF
--- a/mcpjam-inspector/client/src/components/UserTestingTab.tsx
+++ b/mcpjam-inspector/client/src/components/UserTestingTab.tsx
@@ -622,6 +622,10 @@ export function UserTestingTab({
     return (
       <UserTestingScenarioDetail
         scenario={scenario}
+        // From the LIST row: the detail query carries no activity counters,
+        // and this only gates an edit — a stale-by-one count cannot lose data
+        // in either direction.
+        sessionCount={scenarioRow?.sessionCount}
         editMode={editOpen}
         onBack={goOverview}
         onDeleted={goOverview}

--- a/mcpjam-inspector/client/src/components/UserTestingTab.tsx
+++ b/mcpjam-inspector/client/src/components/UserTestingTab.tsx
@@ -517,9 +517,16 @@ export function UserTestingTab({
             name,
             mode,
           });
-          navigate(buildUserTestingScenarioPath(result.scenarioId), {
-            replace: true,
-          });
+          // ONLY when this call created it. An idempotent hit means the
+          // creator asked for a new study and got none; walking them into the
+          // one that already exists answers a question they did not ask, and
+          // loses the draft they were holding. The create screen reports it
+          // and keeps them there.
+          if (result.created) {
+            navigate(buildUserTestingScenarioPath(result.scenarioId), {
+              replace: true,
+            });
+          }
           return { scenarioId: result.scenarioId, created: result.created };
         }}
         onApplyStudySurfaces={async (scenarioId, surfaces) => {

--- a/mcpjam-inspector/client/src/components/environment-composer/__tests__/environment-composer.test.tsx
+++ b/mcpjam-inspector/client/src/components/environment-composer/__tests__/environment-composer.test.tsx
@@ -2,7 +2,7 @@
  * Shared lego-strip slots: default swarm strip omits models; callers can
  * opt into a subset (evals create: servers, or clients + models).
  */
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useState } from "react";
 import {
@@ -14,6 +14,11 @@ const flagState = vi.hoisted(() => ({
   skills: false,
   computers: false,
   environments: true,
+}));
+const toastError = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/toast", () => ({
+  toast: { error: toastError, success: vi.fn() },
 }));
 
 vi.mock("@/hooks/useSkillsEnabled", () => ({
@@ -44,9 +49,32 @@ vi.mock("@/hooks/use-available-models", () => ({
 vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: true }),
 }));
+vi.mock("@/components/environment-composer/clients-pill", () => ({
+  ClientsPill: ({
+    testId,
+    disabled,
+  }: {
+    testId?: string;
+    disabled?: boolean;
+  }) => (
+    <button type="button" data-testid={testId} disabled={disabled}>
+      clients
+    </button>
+  ),
+}));
 vi.mock("@/components/hosts/ServerGroupPicker", () => ({
-  ServerGroupPicker: ({ triggerTestId }: { triggerTestId?: string }) => (
-    <div data-testid={triggerTestId ?? "server-group-picker"} />
+  ServerGroupPicker: ({
+    triggerTestId,
+    disabled,
+  }: {
+    triggerTestId?: string;
+    disabled?: boolean;
+  }) => (
+    <button
+      type="button"
+      data-testid={triggerTestId ?? "server-group-picker"}
+      disabled={disabled}
+    />
   ),
 }));
 vi.mock("@/components/project-environments/environment-picker", () => ({
@@ -67,10 +95,12 @@ function Harness({
   slots,
   environments = [],
   initialValue,
+  lockedSlots,
 }: {
   slots?: Parameters<typeof EnvironmentComposer>[0]["slots"];
   environments?: Parameters<typeof EnvironmentComposer>[0]["environments"];
   initialValue?: EnvironmentComposerState;
+  lockedSlots?: Parameters<typeof EnvironmentComposer>[0]["lockedSlots"];
 }) {
   const [value, setValue] = useState<EnvironmentComposerState>(
     () => initialValue ?? emptyComposerState(),
@@ -83,6 +113,7 @@ function Harness({
       onChange={setValue}
       testIdPrefix="strip"
       slots={slots}
+      lockedSlots={lockedSlots}
     />
   );
 }
@@ -184,5 +215,51 @@ describe("EnvironmentComposer slots", () => {
     );
 
     expect(screen.getByTestId("strip-models-picker")).toHaveTextContent("GPT-4");
+  });
+});
+
+/**
+ * A slot a surface refuses to let anyone change — User Testing locks the
+ * client and the servers once a study has results, because repointing it
+ * would leave those results answering a setup that no longer exists.
+ */
+describe("EnvironmentComposer locked slots", () => {
+  beforeEach(() => {
+    flagState.skills = false;
+    flagState.computers = false;
+    flagState.environments = true;
+    toastError.mockClear();
+  });
+
+  it("answers a press on a locked pill with its reason", () => {
+    // The whole point of the wrapper: a plain disabled control dispatches no
+    // click, so someone who does not know the rule presses it and gets
+    // silence.
+    render(
+      <Harness lockedSlots={{ clients: "This study already has sessions." }} />,
+    );
+
+    fireEvent.click(screen.getByTestId("strip-clients-picker"));
+
+    expect(toastError).toHaveBeenCalledWith("This study already has sessions.");
+    expect(screen.getByTestId("strip-clients-picker")).toBeDisabled();
+  });
+
+  it("locks each slot on its own", () => {
+    render(<Harness lockedSlots={{ servers: "Servers are fixed." }} />);
+
+    expect(screen.getByTestId("strip-servers-picker")).toBeDisabled();
+    // The client stays editable: one lock is not a reason to freeze the strip.
+    expect(screen.getByTestId("strip-clients-picker")).not.toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("strip-clients-picker"));
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("leaves an unlocked strip alone", () => {
+    render(<Harness />);
+
+    expect(screen.getByTestId("strip-clients-picker")).not.toBeDisabled();
+    expect(screen.getByTestId("strip-servers-picker")).not.toBeDisabled();
   });
 });

--- a/mcpjam-inspector/client/src/components/environment-composer/__tests__/environment-composer.test.tsx
+++ b/mcpjam-inspector/client/src/components/environment-composer/__tests__/environment-composer.test.tsx
@@ -78,8 +78,14 @@ vi.mock("@/components/hosts/ServerGroupPicker", () => ({
   ),
 }));
 vi.mock("@/components/project-environments/environment-picker", () => ({
-  EnvironmentPicker: ({ triggerTestId }: { triggerTestId?: string }) => (
-    <button type="button" data-testid={triggerTestId}>
+  EnvironmentPicker: ({
+    triggerTestId,
+    disabled,
+  }: {
+    triggerTestId?: string;
+    disabled?: boolean;
+  }) => (
+    <button type="button" data-testid={triggerTestId} disabled={disabled}>
       environments
     </button>
   ),
@@ -254,6 +260,47 @@ describe("EnvironmentComposer locked slots", () => {
 
     fireEvent.click(screen.getByTestId("strip-clients-picker"));
     expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("locks the environment picker too — it re-seeds the other two", () => {
+    // Caught in review: picking a saved environment reseeds `hostIds` and
+    // `serverAttachmentId`, so a lock that skipped this pill locked nothing.
+    render(
+      <Harness
+        environments={[]}
+        lockedSlots={{
+          clients: "This study already has sessions.",
+          servers: "This study already has sessions.",
+          environments: "This study already has sessions.",
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("strip-environments-picker")).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("strip-environments-picker"));
+
+    expect(toastError).toHaveBeenCalledWith("This study already has sessions.");
+  });
+
+  it("answers a locked pill from the keyboard as well as the mouse", () => {
+    render(<Harness lockedSlots={{ clients: "Locked." }} />);
+
+    const wrapper = screen.getByTestId("strip-clients-picker").parentElement!;
+    fireEvent.keyDown(wrapper, { key: "Enter" });
+
+    expect(toastError).toHaveBeenCalledWith("Locked.");
+  });
+
+  it("does not nest the wrapper inside or around another button", () => {
+    // `button > button` is invalid HTML and two interactive roles for a screen
+    // reader to reconcile. The wrapper carries the role on a span instead.
+    render(<Harness lockedSlots={{ clients: "Locked." }} />);
+
+    const wrapper = screen.getByTestId("strip-clients-picker").parentElement!;
+    expect(wrapper.tagName).toBe("SPAN");
+    expect(wrapper).toHaveAttribute("role", "button");
+    expect(wrapper.closest("button")).toBeNull();
   });
 
   it("leaves an unlocked strip alone", () => {

--- a/mcpjam-inspector/client/src/components/environment-composer/environment-composer.tsx
+++ b/mcpjam-inspector/client/src/components/environment-composer/environment-composer.tsx
@@ -51,12 +51,7 @@ import type { ProjectEnvironmentView } from "@/hooks/useProjectEnvironments";
 import { cn } from "@/lib/utils";
 
 export type ComposerSlot =
-  | "environments"
-  | "clients"
-  | "servers"
-  | "skills"
-  | "computers"
-  | "models";
+  "environments" | "clients" | "servers" | "skills" | "computers" | "models";
 
 /** Default strip: no models slot. Evals opt in via `slots`. */
 export const DEFAULT_COMPOSER_SLOTS: ComposerSlot[] = [
@@ -127,8 +122,14 @@ export function EnvironmentComposer({
    * point. A locked pill stays visible and stays reachable: pressing it says
    * why rather than doing nothing, which is what a plain greyed-out control
    * offers someone who does not already know the rule.
+   *
+   * `environments` is lockable for a reason found in review: picking a saved
+   * environment RE-SEEDS the client and the server group (see
+   * `handleEnvironmentsChange`), so a surface that locks those two and leaves
+   * this one open has not locked anything — the same change is one pill to the
+   * left.
    */
-  lockedSlots?: Partial<Record<"clients" | "servers", string>>;
+  lockedSlots?: Partial<Record<"clients" | "servers" | "environments", string>>;
   /**
    * Evaluate calls the saved-target picker Clients. Other surfaces keep
    * Environments so Swarms and the Environments page stay unchanged.
@@ -159,7 +160,7 @@ export function EnvironmentComposer({
   const { isAuthenticated } = useConvexAuth();
   const modelsOptedIn = slots.includes("models");
   const modelMatrix = useModelMatrixCapability(
-    modelsOptedIn ? projectId : null
+    modelsOptedIn ? projectId : null,
   );
   const modelsEnabled = modelsOptedIn && modelMatrix === true;
   const { hosts } = useHostList({
@@ -178,7 +179,7 @@ export function EnvironmentComposer({
 
   const liveEnvironments = useMemo(
     () => environments.filter((e) => !e.archivedAt),
-    [environments]
+    [environments],
   );
   /**
    * The selection cannot be round-tripped through a stack, so slot edits are
@@ -225,22 +226,36 @@ export function EnvironmentComposer({
    *
    * The child is genuinely `disabled`, so it dispatches no click of its own —
    * `pointer-events-none` hands the press to this wrapper instead, which is
-   * the only way to answer a click on a control that must not act. `button`,
-   * not a div: it is a thing you press and it responds, and a keyboard reaches
-   * it the same way a mouse does.
+   * the only way to answer a click on a control that must not act.
+   *
+   * NOT a `<button>`: every pill's own trigger already is one, and a button
+   * inside a button is invalid HTML (React says so, loudly) and two nested
+   * interactive roles for a screen reader to reconcile. A span carrying the
+   * role reaches the same place — pressed by mouse, reached by Tab, answered
+   * on Enter and Space — with one interactive element in the tree.
    */
   const renderLocked = (reason: string, pill: ReactNode) => (
-    <button
-      type="button"
+    <span
+      role="button"
+      tabIndex={0}
       aria-disabled
-      className="cursor-not-allowed rounded-lg [&>*]:pointer-events-none"
+      className="inline-flex cursor-not-allowed rounded-lg [&>*]:pointer-events-none"
       onClick={() => toast.error(reason)}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        // Space scrolls the page otherwise, which is the opposite of an answer.
+        event.preventDefault();
+        toast.error(reason);
+      }}
       title={reason}
     >
       {pill}
-    </button>
+    </span>
   );
-  const withLock = (slot: "clients" | "servers", pill: ReactNode) => {
+  const withLock = (
+    slot: "clients" | "servers" | "environments",
+    pill: ReactNode,
+  ) => {
     const reason = lockedSlots?.[slot];
     return reason ? renderLocked(reason, pill) : pill;
   };
@@ -254,7 +269,7 @@ export function EnvironmentComposer({
       ...new Set(
         hosts
           .filter((host) => selected.has(host.hostId) && host.modelId)
-          .map((host) => host.modelId)
+          .map((host) => host.modelId),
       ),
     ];
     return modelIds.length === 1 ? modelIds[0] : null;
@@ -274,7 +289,7 @@ export function EnvironmentComposer({
         stack: { ...value.stack, ...patch },
       });
     },
-    [onChange, value]
+    [onChange, value],
   );
 
   const handleEnvironmentsChange = useCallback(
@@ -343,15 +358,15 @@ export function EnvironmentComposer({
       const keptHosts = new Set(remaining.map((e) => e.hostId));
       const removedHosts = new Set(
         resolve(value.environmentIds.filter((id) => !ids.includes(id))).map(
-          (e) => e.hostId
-        )
+          (e) => e.hostId,
+        ),
       );
       onChange({
         environmentIds: ids,
         stack: {
           ...value.stack,
           hostIds: value.stack.hostIds.filter(
-            (hostId) => !removedHosts.has(hostId) || keptHosts.has(hostId)
+            (hostId) => !removedHosts.has(hostId) || keptHosts.has(hostId),
           ),
         },
         customized: true,
@@ -367,7 +382,7 @@ export function EnvironmentComposer({
       value.environmentIds,
       value.customized,
       value.stack,
-    ]
+    ],
   );
 
   return (
@@ -376,51 +391,56 @@ export function EnvironmentComposer({
         className="flex min-w-0 flex-wrap items-center gap-2"
         data-testid={testId("lego-strip")}
       >
-        {showEnvironmentsSlot ? (
-          <EnvironmentPicker
-            projectId={projectId}
-            value={
-              maxTargets === 1
-                ? (value.environmentIds[0] ?? null)
-                : value.environmentIds
-            }
-            onChange={(next: string | string[] | null) =>
-              handleEnvironmentsChange(
-                Array.isArray(next) ? next : next ? [next] : []
-              )
-            }
-            multi={maxTargets > 1}
-            max={maxTargets}
-            disabled={disabled}
-            emptyLabel={
-              environmentsVocabulary === "client"
-                ? maxTargets === 1
-                  ? "Select a client"
-                  : "No clients · pick some"
-                : maxTargets === 1
-                  ? "Select an environment"
-                  : "No environments · pick some"
-            }
-            headingLabel={
-              environmentsVocabulary === "client"
-                ? maxTargets > 1
-                  ? "Clients · run order"
-                  : "Clients"
-                : undefined
-            }
-            emptyProjectLabel={
-              environmentsVocabulary === "client"
-                ? "No clients in this project yet."
-                : undefined
-            }
-            triggerTestId={testId("environments-picker")}
-            triggerAriaLabel={
-              environmentsVocabulary === "client" ? "Clients" : "Environments"
-            }
-            inModal={inModal}
-            footerSlot={environmentPickerFooter}
-          />
-        ) : null}
+        {showEnvironmentsSlot
+          ? withLock(
+              "environments",
+              <EnvironmentPicker
+                projectId={projectId}
+                value={
+                  maxTargets === 1
+                    ? (value.environmentIds[0] ?? null)
+                    : value.environmentIds
+                }
+                onChange={(next: string | string[] | null) =>
+                  handleEnvironmentsChange(
+                    Array.isArray(next) ? next : next ? [next] : [],
+                  )
+                }
+                multi={maxTargets > 1}
+                max={maxTargets}
+                disabled={disabled || Boolean(lockedSlots?.environments)}
+                emptyLabel={
+                  environmentsVocabulary === "client"
+                    ? maxTargets === 1
+                      ? "Select a client"
+                      : "No clients · pick some"
+                    : maxTargets === 1
+                      ? "Select an environment"
+                      : "No environments · pick some"
+                }
+                headingLabel={
+                  environmentsVocabulary === "client"
+                    ? maxTargets > 1
+                      ? "Clients · run order"
+                      : "Clients"
+                    : undefined
+                }
+                emptyProjectLabel={
+                  environmentsVocabulary === "client"
+                    ? "No clients in this project yet."
+                    : undefined
+                }
+                triggerTestId={testId("environments-picker")}
+                triggerAriaLabel={
+                  environmentsVocabulary === "client"
+                    ? "Clients"
+                    : "Environments"
+                }
+                inModal={inModal}
+                footerSlot={environmentPickerFooter}
+              />,
+            )
+          : null}
         {showClientsSlot
           ? withLock(
               "clients",
@@ -468,7 +488,9 @@ export function EnvironmentComposer({
                 emptyTriggerLabel={emptyServerLabel}
                 infoText={serverInfoText}
                 triggerTestId={testId("servers-picker")}
-                onClearSelection={() => patchStack({ serverAttachmentId: null })}
+                onClearSelection={() =>
+                  patchStack({ serverAttachmentId: null })
+                }
                 inModal={inModal}
               />,
             )
@@ -512,10 +534,13 @@ export function EnvironmentComposer({
             ? "This selection pins plugin versions, which this strip can't carry — editing the stack would run without them. Change the environment selection instead."
             : stackEditBlock === "models"
               ? "This selection pins a model override, which this strip can't carry — editing the stack would run the client default instead. Change the environment selection instead."
-            : "These environments don't share one setup — they differ by client or by their server group, skills or image — so editing the stack would change what some of them run. Change the environment selection instead."}
+              : "These environments don't share one setup — they differ by client or by their server group, skills or image — so editing the stack would change what some of them run. Change the environment selection instead."}
         </p>
       ) : null}
-      {modelsEnabled && slots.includes("models") && showTargetCount && !disabled ? (
+      {modelsEnabled &&
+      slots.includes("models") &&
+      showTargetCount &&
+      !disabled ? (
         <p
           className="text-[11px] text-muted-foreground"
           data-testid={testId("target-count")}

--- a/mcpjam-inspector/client/src/components/environment-composer/environment-composer.tsx
+++ b/mcpjam-inspector/client/src/components/environment-composer/environment-composer.tsx
@@ -22,6 +22,7 @@
  */
 import { useCallback, useMemo, type ReactNode } from "react";
 import { useConvexAuth } from "convex/react";
+import { toast } from "@/lib/toast";
 import { EnvironmentPicker } from "@/components/project-environments/environment-picker";
 import { ServerGroupPicker } from "@/components/hosts/ServerGroupPicker";
 import { ClientsPill } from "@/components/environment-composer/clients-pill";
@@ -88,6 +89,7 @@ export function EnvironmentComposer({
   serverInfoText = "Optional shared server group for every client in this setup.",
   environmentsVocabulary = "environment",
   showTargetCount = true,
+  lockedSlots,
 }: {
   projectId: string;
   /** Selectable saved environments. Archived rows are filtered out here. */
@@ -117,6 +119,16 @@ export function EnvironmentComposer({
    */
   emptyServerLabel?: string;
   serverInfoText?: string;
+  /**
+   * Slots this surface refuses to let anyone change, each with the reason.
+   *
+   * Distinct from `disabled`, which is the strip being busy or unavailable —
+   * this is a standing rule about one control, and the reason is the whole
+   * point. A locked pill stays visible and stays reachable: pressing it says
+   * why rather than doing nothing, which is what a plain greyed-out control
+   * offers someone who does not already know the rule.
+   */
+  lockedSlots?: Partial<Record<"clients" | "servers", string>>;
   /**
    * Evaluate calls the saved-target picker Clients. Other surfaces keep
    * Environments so Swarms and the Environments page stay unchanged.
@@ -207,6 +219,31 @@ export function EnvironmentComposer({
     value.environmentIds,
   ]);
   const slotsDisabled = disabled || stackEditBlock !== null;
+
+  /**
+   * A locked pill, wrapped so the refusal is audible.
+   *
+   * The child is genuinely `disabled`, so it dispatches no click of its own —
+   * `pointer-events-none` hands the press to this wrapper instead, which is
+   * the only way to answer a click on a control that must not act. `button`,
+   * not a div: it is a thing you press and it responds, and a keyboard reaches
+   * it the same way a mouse does.
+   */
+  const renderLocked = (reason: string, pill: ReactNode) => (
+    <button
+      type="button"
+      aria-disabled
+      className="cursor-not-allowed rounded-lg [&>*]:pointer-events-none"
+      onClick={() => toast.error(reason)}
+      title={reason}
+    >
+      {pill}
+    </button>
+  );
+  const withLock = (slot: "clients" | "servers", pill: ReactNode) => {
+    const reason = lockedSlots?.[slot];
+    return reason ? renderLocked(reason, pill) : pill;
+  };
   const testId = (suffix: string) =>
     testIdPrefix ? `${testIdPrefix}-${suffix}` : undefined;
   const choiceCount = modelChoiceCount(value.stack.modelSelection);
@@ -384,18 +421,21 @@ export function EnvironmentComposer({
             footerSlot={environmentPickerFooter}
           />
         ) : null}
-        {showClientsSlot ? (
-          <ClientsPill
-            projectId={projectId}
-            value={value.stack.hostIds}
-            onChange={(hostIds) => patchStack({ hostIds })}
-            max={maxTargets}
-            disabled={slotsDisabled}
-            testId={testId("clients-picker")}
-            inModal={inModal}
-            budget={budget}
-          />
-        ) : null}
+        {showClientsSlot
+          ? withLock(
+              "clients",
+              <ClientsPill
+                projectId={projectId}
+                value={value.stack.hostIds}
+                onChange={(hostIds) => patchStack({ hostIds })}
+                max={maxTargets}
+                disabled={slotsDisabled || Boolean(lockedSlots?.clients)}
+                testId={testId("clients-picker")}
+                inModal={inModal}
+                budget={budget}
+              />,
+            )
+          : null}
         {modelsEnabled ? (
           <ModelsPill
             projectId={projectId}
@@ -415,19 +455,24 @@ export function EnvironmentComposer({
             clientDefaultLabel={inheritedClientDefaultLabel}
           />
         ) : null}
-        {showServersSlot ? (
-          <ServerGroupPicker
-            projectId={projectId}
-            value={value.stack.serverAttachmentId}
-            onChange={(serverAttachmentId) => patchStack({ serverAttachmentId })}
-            disabled={slotsDisabled}
-            emptyTriggerLabel={emptyServerLabel}
-            infoText={serverInfoText}
-            triggerTestId={testId("servers-picker")}
-            onClearSelection={() => patchStack({ serverAttachmentId: null })}
-            inModal={inModal}
-          />
-        ) : null}
+        {showServersSlot
+          ? withLock(
+              "servers",
+              <ServerGroupPicker
+                projectId={projectId}
+                value={value.stack.serverAttachmentId}
+                onChange={(serverAttachmentId) =>
+                  patchStack({ serverAttachmentId })
+                }
+                disabled={slotsDisabled || Boolean(lockedSlots?.servers)}
+                emptyTriggerLabel={emptyServerLabel}
+                infoText={serverInfoText}
+                triggerTestId={testId("servers-picker")}
+                onClearSelection={() => patchStack({ serverAttachmentId: null })}
+                inModal={inModal}
+              />,
+            )
+          : null}
         {showSkillsSlot ? (
           <SkillsPill
             projectId={projectId}

--- a/mcpjam-inspector/client/src/components/scenarios/ScenarioGradingSection.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/ScenarioGradingSection.tsx
@@ -149,11 +149,15 @@ export function ScenarioGradingSection({
   return (
     <section
       data-testid="scenario-grading-section"
-      className="space-y-4 border-t border-border/40 pt-4"
+      // No top rule any more: the settings page gives this its own card, and a
+      // divider inside one draws a line to nothing.
+      className="space-y-4"
     >
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-1">
-          <h3 className="text-sm font-medium">Grading</h3>
+          <h3 className="text-base font-medium tracking-tight text-foreground">
+            Grading
+          </h3>
           <p className="text-xs text-muted-foreground">
             Grade a sample of real tester sessions against checks after they go
             quiet. Verdicts appear on each session and in Insights.
@@ -179,9 +183,7 @@ export function ScenarioGradingSection({
           className="h-7 w-16 text-xs"
           inputMode="numeric"
           value={draft.samplingPercent}
-          onChange={(event) =>
-            update({ samplingPercent: event.target.value })
-          }
+          onChange={(event) => update({ samplingPercent: event.target.value })}
           aria-invalid={!samplingValid}
         />
         <span className="text-xs text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/scenarios/ScenarioGradingSection.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/ScenarioGradingSection.tsx
@@ -155,9 +155,12 @@ export function ScenarioGradingSection({
     >
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-1">
-          <h3 className="text-base font-medium tracking-tight text-foreground">
+          {/* `h2`, like every other Settings card: this one is their peer, and
+              an `h3` would file it under whichever card precedes it for anyone
+              navigating by heading. */}
+          <h2 className="text-base font-medium tracking-tight text-foreground">
             Grading
-          </h3>
+          </h2>
           <p className="text-xs text-muted-foreground">
             Grade a sample of real tester sessions against checks after they go
             quiet. Verdicts appear on each session and in Insights.

--- a/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioCreateFlow.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioCreateFlow.tsx
@@ -148,7 +148,7 @@ export function composedSetupHasServers(args: {
  * on naming a study and again on an empty client picker — "People block when
  * you're making them name things", "Here you don't have a default client
  * picked", "Don't put that in my way". So a client is preselected, the name is
- * suggested off it, and Continue is pressable the moment the screen settles.
+ * suggested off it, and Continue carries the screen the moment it settles.
  * A cleared name is not a wall either: Save falls back to the suggestion.
  *
  * **Step 2 is a LIST, not a wizard.** It authors the "what to try" checklist a
@@ -186,14 +186,18 @@ export function composedSetupHasServers(args: {
  * local state — Continue only moves the stepper — and the writes happen once,
  * at the end. Leaving from either step leaves nothing behind.
  *
- * **The environment is REQUIRED, and now says so.** A scenario is a link handed
- * to a person, and without an environment there is nothing behind that link —
- * the tester is the one who finds out. Continue has always been gated on a
- * target, but silently: a disabled button that never explains itself reads as
- * "I can create a scenario without an environment", which is how this was
- * reported. The gate names itself here (marked labels, plus the hint under the
- * strip), and `ScenarioShareSection` holds the other end — a scenario whose
- * environment stops resolving issues no tester link.
+ * **The environment is REQUIRED, and Continue says so ON PRESS.** A scenario is
+ * a link handed to a person, and without an environment there is nothing behind
+ * that link — the tester is the one who finds out. The button is therefore
+ * live, not disabled: pressing it is how someone asks "am I done?", and a
+ * button that cannot be pressed answers nothing. The press validates and names
+ * what is missing — no client, or a client with no servers — and only then
+ * moves the stepper. Nothing is nagged before the ask, which is the half a
+ * permanently-inert button got wrong: it read as "I can create a scenario
+ * without an environment", which is how this was reported. Marked labels still
+ * carry the requirement ahead of the press, and `ScenarioShareSection` holds
+ * the other end — a scenario whose environment stops resolving issues no
+ * tester link.
  */
 interface UserTestingScenarioCreateFlowProps {
   projectId: string;
@@ -394,6 +398,12 @@ export function UserTestingScenarioCreateFlow({
     hostsLoading,
   });
 
+  // The PUBLISH gate — step 2's Create study button. Step 1's Continue no
+  // longer reads it: it validates on press and names what is missing
+  // (`continueBlocker` below). Both ask the same questions; only Create is
+  // allowed to answer them by refusing the click, because past it there is
+  // a link in someone's hands.
+  //
   // Deliberately NOT gated on the name. A prefilled suggestion plus a
   // fallback means "empty" is a state the creator can pass through, not a
   // wall they have to satisfy first (BB-176).
@@ -416,6 +426,42 @@ export function UserTestingScenarioCreateFlow({
     hasTarget &&
     setupHasServers !== false &&
     !isSaving;
+
+  /**
+   * What Continue would refuse over, or `null` when it would carry.
+   *
+   * Read live rather than frozen at press time, so fixing the problem clears
+   * the message the moment it is fixed rather than leaving an error standing
+   * over a form that no longer has one.
+   */
+  const continueBlocker: "loading" | "client" | "servers" | null =
+    !environmentsSettled || hostsLoading
+      ? "loading"
+      : !hasTarget
+        ? "client"
+        : setupHasServers === false
+          ? "servers"
+          : null;
+  /**
+   * Whether Continue has been pressed on a setup it could not carry.
+   *
+   * The button itself is never disabled: pressing the thing that moves on is
+   * how someone asks whether they are done, and finding out THERE what is
+   * missing beats scanning a form for whatever keeps a grey button grey.
+   */
+  const [continueAttempted, setContinueAttempted] = useState(false);
+  const showClientError = continueAttempted && continueBlocker === "client";
+  const showServersError = continueAttempted && continueBlocker === "servers";
+
+  const handleContinue = () => {
+    setContinueAttempted(true);
+    // "loading" is not the creator's mistake and is never dressed as one — the
+    // loading line under the strip already says it. The press is still
+    // remembered, so an answer arriving a moment later lands on the right
+    // message instead of on silence.
+    if (continueBlocker) return;
+    setStep("tasks");
+  };
 
   const handleTargetChange = (next: EnvironmentComposerState) => {
     // A pick of their own settles the question the default was answering.
@@ -616,11 +662,6 @@ export function UserTestingScenarioCreateFlow({
                     setName(e.target.value);
                   }}
                 />
-                <p className="text-xs text-muted-foreground">
-                  Suggested from the client you picked — keep it or write your
-                  own. What you&apos;ll recognize this study by; renaming the
-                  environment later won&apos;t rename it.
-                </p>
               </div>
 
               <div className="space-y-2">
@@ -654,20 +695,26 @@ export function UserTestingScenarioCreateFlow({
                     None of these fit — build a new environment
                   </button>
                 ) : null}
-                {/* Why Continue is inert, said where the choice is made. Only
-                    once the list has SETTLED: before that the loading line
-                    below is the honest answer, and two hints would contradict
-                    each other. */}
-                {environmentsSettled && !hasTarget ? (
+                {/* Why Continue did not carry, said where the choice is made
+                    and only once it has been asked for. `role="alert"` because
+                    it arrives in response to a press: a sighted user watches it
+                    land, and a screen reader user is told.
+
+                    Flag-on and flag-off say the SAME thing. The composer shows
+                    client pills either way, so "a client" is what is missing on
+                    both; a saved environment is one way to supply it, not a
+                    second thing to ask for.
+
+                    Names the missing thing rather than the fix: two errors, one
+                    shape, so a creator reads which of the two required choices
+                    is outstanding and not a pair of instructions to follow. */}
+                {showClientError ? (
                   <p
-                    className="text-xs text-muted-foreground"
+                    className="text-xs text-destructive"
+                    role="alert"
                     data-testid="user-testing-create-environment-required"
                   >
-                    {environmentsEnabled
-                      ? "Required — pick a saved environment or compose one."
-                      : "Required — pick the client a tester will see. Its server group is optional, and covers every server you want them to reach."}{" "}
-                    A scenario without one has nothing for a tester to run, so
-                    it isn&apos;t created and no tester link is issued.
+                    No client picked
                   </p>
                 ) : null}
                 {!environmentsSettled ? (
@@ -681,16 +728,21 @@ export function UserTestingScenarioCreateFlow({
                 {/* The gate that would have saved a broken study: a setup with
                     no servers publishes fine and then refuses to open, and
                     neither the creator's nor the tester's error names the
-                    cause. Said here, where the fix is one click away. */}
-                {hasTarget && setupHasServers === false ? (
+                    cause. Said on press, directly under the server group that
+                    fixes it.
+
+                    One message for one problem — "this setup reaches no
+                    server". Whether that is because the client carries none of
+                    its own or because no group is attached is a distinction the
+                    creator cannot act on differently: the fix is the same
+                    control either way. */}
+                {showServersError ? (
                   <p
-                    className="text-xs text-amber-600 dark:text-amber-500"
+                    className="text-xs text-destructive"
+                    role="alert"
                     data-testid="user-testing-create-servers-required"
                   >
-                    This client has no servers of its own, so there would be
-                    nothing for a tester to reach — pick a server group above. A
-                    study with no servers is created but never opens, for you or
-                    a tester.
+                    No server picked
                   </p>
                 ) : null}
                 {computersEnabled ? (
@@ -831,9 +883,9 @@ export function UserTestingScenarioCreateFlow({
               <Button variant="ghost" onClick={onCancel} disabled={isSaving}>
                 Cancel
               </Button>
+              {/* Never disabled — see `handleContinue`. */}
               <Button
-                onClick={() => setStep("tasks")}
-                disabled={!canAdvance}
+                onClick={handleContinue}
                 data-testid="user-testing-create-continue"
               >
                 Continue

--- a/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioCreateFlow.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioCreateFlow.tsx
@@ -212,8 +212,12 @@ interface UserTestingScenarioCreateFlowProps {
    * The primary write path: publishes the environment, applying the name and
    * access mode in the same mutation so the scenario is never briefly live in
    * a mode nobody asked for. Resolves to the new scenario's id, plus whether
-   * this call actually created it (`false` ⇒ the environment was already
-   * published and the existing scenario is what opens).
+   * this call actually created it.
+   *
+   * `created: false` means the backend refused: publishing is idempotent per
+   * environment, so this setup already has a study and none was made. The
+   * caller must NOT navigate in that case — this screen reports it and the
+   * creator stays on their draft.
    */
   onCreateScenario: (draft: {
     environmentId: string;
@@ -527,43 +531,47 @@ export function UserTestingScenarioCreateFlow({
         mode: settingsFromScenarioAccessPreset(accessPreset).mode,
       });
 
-      // Only for a study this call actually created. Publishing is idempotent
-      // per environment, so on a collision the existing study keeps its own
-      // settings — silently rewriting its rating widget or replacing its task
-      // list would be this screen reconfiguring someone else's study.
+      // Nothing was created: this client and server already carry a study
+      // (publishing is idempotent per environment). This used to report it as
+      // a success and open that other study — which reads as "your study was
+      // created" while the screen fills with someone else's tasks, name and
+      // access. It is a refusal, so it stops here: the draft stays on screen,
+      // untouched and re-submittable once the setup changes.
+      if (!created) {
+        toast.error(
+          "This client and server already have a study. Change the setup, or open the existing study from User Testing.",
+        );
+        savingRef.current = false;
+        setIsSaving(false);
+        return;
+      }
+
+      // Past the refusal above, so this is always a study THIS call created —
+      // which is the only one whose ratings and task list are ours to write.
       let surfacesFailed = false;
-      if (created) {
-        try {
-          await onApplyStudySurfaces(scenarioId, {
-            perTurnFeedback: {
-              enabled: perTurnRatings,
-              style: ratingStyle,
-            },
-            tasks: { items: scenarioTasksFromDrafts(taskDrafts) },
-          });
-        } catch {
-          // The study exists; only its chatUi settings did not land. Say which
-          // half failed and where to fix it, rather than reporting a failed
-          // creation the user can see succeeded.
-          surfacesFailed = true;
-          toast.error(
-            "Study created, but its ratings and task list didn't save. Set them from the study's settings.",
-          );
-        }
+      try {
+        await onApplyStudySurfaces(scenarioId, {
+          perTurnFeedback: {
+            enabled: perTurnRatings,
+            style: ratingStyle,
+          },
+          tasks: { items: scenarioTasksFromDrafts(taskDrafts) },
+        });
+      } catch {
+        // The study exists; only its chatUi settings did not land. Say which
+        // half failed and where to fix it, rather than reporting a failed
+        // creation the user can see succeeded.
+        surfacesFailed = true;
+        toast.error(
+          "Study created, but its ratings and task list didn't save. Set them from the study's settings.",
+        );
       }
 
       // The error above already opens with "Study created" — pairing it with a
       // bare success toast makes the screen say two things about one outcome
       // and reads like one of them is stale.
       if (!surfacesFailed) {
-        toast.success(
-          created
-            ? "Study created"
-            : // Publishing is idempotent per environment, and composing makes a
-              // collision likelier: an identical setup resolves to the SAME row,
-              // whose scenario keeps its own name, access and tasks.
-              "This setup is already published — opening its study, with the name and access it already has",
-        );
+        toast.success("Study created");
       }
     } catch (err) {
       // Surface the backend's copy verbatim: publishing is project-admin

--- a/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioDetail.tsx
@@ -113,6 +113,15 @@ const TAB_OPTIONS: ReadonlyArray<{
   { value: "sessions", label: "Sessions" },
 ];
 
+/**
+ * One settings card. Two columns of them need a visible edge each — without
+ * one, sections side by side read as a single column with odd gaps.
+ */
+const SETTINGS_CARD =
+  "space-y-4 rounded-xl border border-border bg-card p-5 shadow-sm";
+const SETTINGS_CARD_TITLE =
+  "text-base font-medium tracking-tight text-foreground";
+
 export function UserTestingScenarioDetail({
   scenario,
   sessionCount,
@@ -611,143 +620,168 @@ export function UserTestingScenarioDetail({
           className="relative min-h-0 flex-1 overflow-hidden"
           data-testid="user-testing-edit-tab"
         >
-          {/* ONE COLUMN, 560px, left-aligned (BB-176). The split this
-              replaces gave settings half a screen and spent the other half on
-              a preview whose only job was to be looked at — so a form built
-              for a readable measure got squeezed, and every field wrapped.
-              A fixed measure with `max-w-full` also keeps it honest on a
-              narrow window, where a percentage panel just kept shrinking. */}
-          <div className="h-full overflow-y-auto px-8 py-4">
-            <div className="w-[560px] max-w-full space-y-8">
+          {/* TWO COLUMNS of cards on a wide screen, one below `xl`.
+              Reported: "too much white space… make better use of the full
+              screen". This was a 560px column pinned to the left edge of a
+              pane twice that wide — a readable measure, but the rest of the
+              screen was empty, and reaching the task list meant scrolling past
+              every switch.
+
+              The split is by WHAT A SECTION IS, not by what fits: the left
+              column is the study itself (what it says, where it runs, what it
+              asks people to try), the right is the rules it runs under (who
+              may open it, what gets rated, what gets graded). Each column
+              keeps a readable measure; neither stretches on an ultra-wide
+              monitor, because the whole grid is capped and centred.
+
+              Cards, not bare headings: side by side, sections with no
+              boundary read as one long column that happens to have gaps. */}
+          <div className="h-full overflow-y-auto px-6 py-6 sm:px-8">
+            <div className="mx-auto w-full max-w-[1400px] space-y-6">
               <h1 className="text-xl font-semibold tracking-tight text-foreground">
                 Settings
               </h1>
-
-              {/* Off the header row as of BB-202: a field that grows next to
+              <div className="grid grid-cols-1 items-start gap-6 xl:grid-cols-2">
+                <div className="min-w-0 space-y-6">
+                  {/* Off the header row as of BB-202: a field that grows next to
                   the title crowds the tabs. Still the only editor for it. */}
-              <section
-                className="space-y-4"
-                data-testid="user-testing-description-section"
-              >
-                <h2 className="text-lg font-medium tracking-tight text-foreground">
-                  Description
-                </h2>
-                <TextareaAutosize
-                  aria-label="Scenario description"
-                  data-testid="user-testing-description"
-                  value={descriptionDraft}
-                  onChange={(e) => setDescriptionDraft(e.target.value)}
-                  onFocus={() => {
-                    descriptionFocusedRef.current = true;
-                  }}
-                  onBlur={() => void persistDescription()}
-                  minRows={2}
-                  maxRows={8}
-                  maxLength={2000}
-                  placeholder="Add a description…"
-                  className="resize-none text-sm"
-                />
-              </section>
+                  <section
+                    className={SETTINGS_CARD}
+                    data-testid="user-testing-description-section"
+                  >
+                    <h2 className={SETTINGS_CARD_TITLE}>Description</h2>
+                    <TextareaAutosize
+                      aria-label="Scenario description"
+                      data-testid="user-testing-description"
+                      value={descriptionDraft}
+                      onChange={(e) => setDescriptionDraft(e.target.value)}
+                      onFocus={() => {
+                        descriptionFocusedRef.current = true;
+                      }}
+                      onBlur={() => void persistDescription()}
+                      minRows={2}
+                      maxRows={8}
+                      maxLength={2000}
+                      placeholder="Add a description…"
+                      className="resize-none text-sm"
+                    />
+                  </section>
 
-              {environmentError ? (
-                <div
-                  data-testid="user-testing-detail-environment-error"
-                  className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3"
-                >
-                  <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-500" />
-                  <div className="min-w-0 text-sm">
-                    <p className="font-medium text-foreground">
-                      {environmentError.code === "ENV_ARCHIVED"
-                        ? "This scenario's environment is archived — the share link no longer opens."
-                        : "This scenario's environment can't be loaded right now — the share link won't open."}
-                    </p>
-                    <p className="mt-0.5 text-xs text-muted-foreground">
-                      {environmentError.message} Its sessions are unaffected.
-                    </p>
-                  </div>
-                </div>
-              ) : null}
+                  {environmentError ? (
+                    <div
+                      data-testid="user-testing-detail-environment-error"
+                      className="flex items-start gap-2 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3"
+                    >
+                      <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-500" />
+                      <div className="min-w-0 text-sm">
+                        <p className="font-medium text-foreground">
+                          {environmentError.code === "ENV_ARCHIVED"
+                            ? "This scenario's environment is archived — the share link no longer opens."
+                            : "This scenario's environment can't be loaded right now — the share link won't open."}
+                        </p>
+                        <p className="mt-0.5 text-xs text-muted-foreground">
+                          {environmentError.message} Its sessions are
+                          unaffected.
+                        </p>
+                      </div>
+                    </div>
+                  ) : null}
 
-              {/* Where this scenario runs, edited in place. It used to hide
+                  {/* Where this scenario runs, edited in place. It used to hide
                     behind a footer "Edit setup" dialog; the setup IS the
                     setting, so it reads as one here. */}
-              {composerActive ? (
-                <section
-                  className="space-y-4"
-                  data-testid="user-testing-environment-section"
-                >
-                  <h2 className="text-lg font-medium tracking-tight text-foreground">
-                    Environment
-                  </h2>
-                  <div className="min-w-0">
-                    <EnvironmentComposer
-                      projectId={scenario.projectId}
-                      environments={liveNamedEnvironments}
-                      value={composer}
-                      onChange={handleComposerChange}
-                      maxTargets={1}
-                      disabled={isRebinding || !composerReady}
-                      lockedSlots={setupLockedReason}
-                      testIdPrefix="user-testing-detail"
-                      environmentPickerFooter={
-                        canPromoteEnvironment ? (
-                          // The row behind this setup is ad-hoc:
-                          // content-addressed, immutable, labeled by its
-                          // client rather than a name. Saving it (in place,
-                          // same id) turns it into a curated environment
-                          // other surfaces can pick.
-                          <button
-                            type="button"
-                            onClick={() => setNameEnvironmentOpen(true)}
-                            data-testid="user-testing-save-as-environment"
-                            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                          >
-                            <PenLine className="size-3.5 shrink-0" />
-                            Save as environment
-                          </button>
-                        ) : null
-                      }
-                    />
-                  </div>
-                </section>
-              ) : null}
+                  {composerActive ? (
+                    <section
+                      className={SETTINGS_CARD}
+                      data-testid="user-testing-environment-section"
+                    >
+                      <h2 className={SETTINGS_CARD_TITLE}>Environment</h2>
+                      <div className="min-w-0">
+                        <EnvironmentComposer
+                          projectId={scenario.projectId}
+                          environments={liveNamedEnvironments}
+                          value={composer}
+                          onChange={handleComposerChange}
+                          maxTargets={1}
+                          disabled={isRebinding || !composerReady}
+                          lockedSlots={setupLockedReason}
+                          testIdPrefix="user-testing-detail"
+                          environmentPickerFooter={
+                            canPromoteEnvironment ? (
+                              // The row behind this setup is ad-hoc:
+                              // content-addressed, immutable, labeled by its
+                              // client rather than a name. Saving it (in place,
+                              // same id) turns it into a curated environment
+                              // other surfaces can pick.
+                              <button
+                                type="button"
+                                onClick={() => setNameEnvironmentOpen(true)}
+                                data-testid="user-testing-save-as-environment"
+                                className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                              >
+                                <PenLine className="size-3.5 shrink-0" />
+                                Save as environment
+                              </button>
+                            ) : null
+                          }
+                        />
+                      </div>
+                    </section>
+                  ) : null}
 
-              <section className="space-y-4">
-                <h2 className="text-lg font-medium tracking-tight text-foreground">
-                  Sharing permissions
-                </h2>
-                <ScenarioShareSection scenario={scenario} />
-              </section>
-
-              <section className="space-y-4">
-                <h2 className="text-lg font-medium tracking-tight text-foreground">
-                  Ratings
-                </h2>
-                {/* Keyed per scenario: the toggle holds optimistic state
-                      across an await, and reusing one instance would let a
-                      write started on one scenario resolve into another's. */}
-                <ScenarioPerTurnFeedbackToggle
-                  key={scenario.scenarioId}
-                  scenario={scenario}
-                />
-              </section>
-
-              {/* Production scoring: grade sampled real sessions against
-                    deterministic checks. Its own section — grading config is
-                    a peer of sharing, not part of it. */}
-              <ScenarioGradingSection scenario={scenario} />
-
-              {/* The same "what to try" list create step 2 authors, keyed
+                  {/* The same "what to try" list create step 2 authors, keyed
                     per scenario for the reason the ratings toggle is: this
                     section holds an unsaved draft, and reusing one instance
                     across scenarios would carry one study's rows into
                     another's editor. */}
-              <ScenarioTasksSection
-                key={scenario.scenarioId}
-                scenario={scenario}
-              />
+                  <div className={SETTINGS_CARD}>
+                    <ScenarioTasksSection
+                      key={scenario.scenarioId}
+                      scenario={scenario}
+                    />
+                  </div>
+                </div>
 
-              <div className="flex flex-wrap items-center justify-end gap-2 border-t border-border/40 pt-4">
+                {/* The rules it runs under. */}
+                <div className="min-w-0 space-y-6">
+                  <section className={SETTINGS_CARD}>
+                    <h2 className={SETTINGS_CARD_TITLE}>Sharing permissions</h2>
+                    <ScenarioShareSection scenario={scenario} />
+                  </section>
+
+                  <section className={SETTINGS_CARD}>
+                    <h2 className={SETTINGS_CARD_TITLE}>Ratings</h2>
+                    {/* Keyed per scenario: the toggle holds optimistic state
+                        across an await, and reusing one instance would let a
+                        write started on one scenario resolve into another's. */}
+                    <ScenarioPerTurnFeedbackToggle
+                      key={scenario.scenarioId}
+                      scenario={scenario}
+                    />
+                  </section>
+
+                  {/* Production scoring: grade sampled real sessions against
+                      deterministic checks. Its own card — grading config is a
+                      peer of sharing, not part of it. */}
+                  <div className={SETTINGS_CARD}>
+                    <ScenarioGradingSection scenario={scenario} />
+                  </div>
+                </div>
+              </div>
+
+              {/* Full width, under both columns and visibly apart from them:
+                  the one control here that cannot be undone should not sit in
+                  a column where a mis-aimed click lives next to a switch. */}
+              <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-destructive/25 bg-destructive/5 px-5 py-4">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-foreground">
+                    Delete this study
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Removes the study, its share link and its sessions. This
+                    cannot be undone.
+                  </p>
+                </div>
                 <Button
                   variant="outline"
                   size="sm"

--- a/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioDetail.tsx
@@ -247,13 +247,12 @@ export function UserTestingScenarioDetail({
    * the existing sessions were an answer to.
    */
   const hasTesterSessions = (sessionCount ?? 0) > 0;
+  // One sentence, the same on both pills: the fact IS the reason, and someone
+  // who just pressed a control they cannot use wants to know why in the time
+  // a toast is on screen.
+  const SETUP_LOCKED = "This study already has sessions.";
   const setupLockedReason = hasTesterSessions
-    ? {
-        clients:
-          "This study already has sessions — changing its client would leave results that answered a different setup. Duplicate the study to test another client.",
-        servers:
-          "This study already has sessions — changing its servers would leave results that answered a different setup. Duplicate the study to test other servers.",
-      }
+    ? { clients: SETUP_LOCKED, servers: SETUP_LOCKED }
     : undefined;
   // Held closed until the NAMED list settles, like the create flow: the
   // resolver reuses a matching named environment, and resolving against an

--- a/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioDetail.tsx
@@ -88,6 +88,15 @@ import { ActionableFindings } from "@/components/shared/actionable-insights/acti
  */
 interface UserTestingScenarioDetailProps {
   scenario: ScenarioSettings;
+  /**
+   * Tester sessions recorded against this study, from the list row.
+   *
+   * `undefined` on a deployment that does not report the counter — which is
+   * "unknown", not "none". The setup stays editable there: refusing every edit
+   * on an unanswered question would take a working screen away from everyone
+   * to protect a case we cannot see.
+   */
+  sessionCount?: number;
   /** `/user-testing/:id/edit` — the study's settings, no detail tabs. */
   editMode?: boolean;
   onBack: () => void;
@@ -106,6 +115,7 @@ const TAB_OPTIONS: ReadonlyArray<{
 
 export function UserTestingScenarioDetail({
   scenario,
+  sessionCount,
   editMode = false,
   onBack,
   onDeleted,
@@ -211,6 +221,31 @@ export function UserTestingScenarioDetail({
   }, [environment?.environmentId, environment?.revision]);
 
   const composerActive = Boolean(scenario.environmentId && environment);
+
+  /**
+   * A study with results runs on a FIXED setup.
+   *
+   * Reported in review: nothing stopped someone from repointing a study at a
+   * different client or server after testers had already been through it —
+   * which leaves one set of sessions answered against Excalidraw and the next
+   * against GitHub, under one name, with nothing on screen saying the ground
+   * moved. Those results are no longer comparable, and no analysis over them
+   * is honest.
+   *
+   * So the two pills that change where it runs lock once the first tester
+   * session lands. Everything else about the study stays editable — the name,
+   * the access, the tasks, the ratings — because none of that rewrites what
+   * the existing sessions were an answer to.
+   */
+  const hasTesterSessions = (sessionCount ?? 0) > 0;
+  const setupLockedReason = hasTesterSessions
+    ? {
+        clients:
+          "This study already has sessions — changing its client would leave results that answered a different setup. Duplicate the study to test another client.",
+        servers:
+          "This study already has sessions — changing its servers would leave results that answered a different setup. Duplicate the study to test other servers.",
+      }
+    : undefined;
   // Held closed until the NAMED list settles, like the create flow: the
   // resolver reuses a matching named environment, and resolving against an
   // empty not-yet-loaded list would mint an unnamed twin of one that exists.
@@ -652,6 +687,7 @@ export function UserTestingScenarioDetail({
                       onChange={handleComposerChange}
                       maxTargets={1}
                       disabled={isRebinding || !composerReady}
+                      lockedSlots={setupLockedReason}
                       testIdPrefix="user-testing-detail"
                       environmentPickerFooter={
                         canPromoteEnvironment ? (

--- a/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioDetail.tsx
@@ -251,8 +251,16 @@ export function UserTestingScenarioDetail({
   // who just pressed a control they cannot use wants to know why in the time
   // a toast is on screen.
   const SETUP_LOCKED = "This study already has sessions.";
+  // The environment picker too, and not as belt-and-braces: picking a saved
+  // environment RE-SEEDS the client and the server group, so locking those two
+  // and leaving this one open locks nothing — the same change is one pill to
+  // the left (caught in review).
   const setupLockedReason = hasTesterSessions
-    ? { clients: SETUP_LOCKED, servers: SETUP_LOCKED }
+    ? {
+        clients: SETUP_LOCKED,
+        servers: SETUP_LOCKED,
+        environments: SETUP_LOCKED,
+      }
     : undefined;
   // Held closed until the NAMED list settles, like the create flow: the
   // resolver reuses a matching named environment, and resolving against an

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioCreateFlow.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioCreateFlow.test.tsx
@@ -364,7 +364,7 @@ describe("UserTestingScenarioCreateFlow", () => {
     );
   });
 
-  it("reports an already-published environment as such, not as a failure", async () => {
+  it("refuses a setup that already has a study, rather than calling it created", async () => {
     const onCreateScenario = vi
       .fn()
       .mockResolvedValue({ scenarioId: "cb-9", created: false });
@@ -376,11 +376,11 @@ describe("UserTestingScenarioCreateFlow", () => {
     createStudy();
 
     await waitFor(() => {
-      expect(toastSuccess).toHaveBeenCalledWith(
-        expect.stringMatching(/already published/i),
+      expect(toastError).toHaveBeenCalledWith(
+        expect.stringMatching(/already have a study/i),
       );
     });
-    expect(toastError).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
   });
 
   it("surfaces the backend's message verbatim when publishing is refused", async () => {
@@ -919,7 +919,7 @@ describe("UserTestingScenarioCreateFlow — composing a setup", () => {
     expect(onCreateScenario.mock.calls[0][0].environmentId).toBe("env-1");
   });
 
-  it("says an identical setup reopens the scenario it already has", async () => {
+  it("refuses an identical composed setup instead of opening the study it has", async () => {
     const alreadyPublished = vi
       .fn()
       .mockResolvedValue({ scenarioId: "cb-9", created: false });
@@ -932,11 +932,12 @@ describe("UserTestingScenarioCreateFlow — composing a setup", () => {
     });
     createStudy();
 
-    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
-    // The typed name is dropped by the idempotent publish — say so rather than
-    // claiming a scenario was created with it.
-    expect(toastSuccess.mock.calls[0][0]).toMatch(/already published/i);
-    expect(toastSuccess.mock.calls[0][0]).toMatch(/name and access/i);
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    // The typed name never reached a study, so the screen must not suggest one
+    // was made with it — and "Another go" stays in the field to be retried on a
+    // different setup.
+    expect(toastError.mock.calls[0][0]).toMatch(/already have a study/i);
+    expect(screen.getByTestId("user-testing-create-save")).toBeInTheDocument();
   });
 
   it("degrades to the saved-environment path on a backend without ad-hoc rows", async () => {
@@ -1157,8 +1158,8 @@ describe("UserTestingScenarioCreateFlow — create study (Production Redesign)",
   });
 
   it("leaves an already-published study's ratings and tasks alone", async () => {
-    // Publishing is idempotent per environment, so a collision opens someone
-    // else's study — rewriting its rating widget or replacing its task list
+    // Publishing is idempotent per environment, so the id that comes back is
+    // another study's — rewriting its rating widget or replacing its task list
     // from here would reconfigure it.
     const { onApplyStudySurfaces } = renderFlow(
       vi.fn().mockResolvedValue({ scenarioId: "cb-existing", created: false }),
@@ -1170,7 +1171,7 @@ describe("UserTestingScenarioCreateFlow — create study (Production Redesign)",
     createStudy();
 
     await waitFor(() => {
-      expect(toastSuccess).toHaveBeenCalled();
+      expect(toastError).toHaveBeenCalled();
     });
     expect(onApplyStudySurfaces).not.toHaveBeenCalled();
   });
@@ -1262,5 +1263,70 @@ describe("UserTestingScenarioCreateFlow — org share ceiling", () => {
         mode: "project_members",
       });
     });
+  });
+});
+
+/**
+ * Reported: "I create a second study with the same client and server and it
+ * replaces the first — I get 'already published' and it redirects me to the
+ * original." Publishing is idempotent per environment, so nothing was created;
+ * the screen used to call that a success and walk the creator into the other
+ * study. Until the backend can carry two studies on one setup, the honest
+ * answer is to refuse and stay put.
+ */
+describe("UserTestingScenarioCreateFlow — a setup that already has a study", () => {
+  const publishedAlready = () =>
+    vi.fn().mockResolvedValue({ scenarioId: "existing-1", created: false });
+
+  it("reports the refusal as an error, not as a created study", async () => {
+    const { onCreateScenario } = renderFlow(publishedAlready());
+
+    createStudy();
+
+    await waitFor(() => expect(onCreateScenario).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        expect.stringMatching(/already have a study/i),
+      ),
+    );
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("keeps the creator on their draft", async () => {
+    // Navigation is the caller's job and it is told `created: false`; what this
+    // screen owes is not disappearing out from under the draft.
+    const onCreateScenario = publishedAlready();
+    renderFlow(onCreateScenario);
+
+    createStudy();
+
+    await waitFor(() => expect(onCreateScenario).toHaveBeenCalled());
+    expect(screen.getByTestId("user-testing-create-save")).toBeInTheDocument();
+  });
+
+  it("does not write ratings or tasks onto the study that already exists", async () => {
+    // The draft on screen belongs to a study that was never created. Applying
+    // it would reconfigure someone else's live study.
+    const onApplyStudySurfaces = vi.fn().mockResolvedValue(undefined);
+    const onCreateScenario = publishedAlready();
+    renderFlow(onCreateScenario, vi.fn(), onApplyStudySurfaces);
+
+    createStudy();
+
+    await waitFor(() => expect(onCreateScenario).toHaveBeenCalled());
+    expect(onApplyStudySurfaces).not.toHaveBeenCalled();
+  });
+
+  it("lets them try again once the setup changes", async () => {
+    // The refusal releases the button; a stuck "Creating…" would make the
+    // screen a dead end.
+    const onCreateScenario = publishedAlready();
+    renderFlow(onCreateScenario);
+
+    createStudy();
+    await waitFor(() => expect(onCreateScenario).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTestId("user-testing-create-save"));
+    await waitFor(() => expect(onCreateScenario).toHaveBeenCalledTimes(2));
   });
 });

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioCreateFlow.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioCreateFlow.test.tsx
@@ -168,6 +168,11 @@ function goToTasks() {
   fireEvent.click(screen.getByTestId("user-testing-create-continue"));
 }
 
+/** Step 2 is on screen — the only proof that a Continue press actually carried. */
+function onTasksStep() {
+  return screen.queryByTestId("user-testing-create-save") !== null;
+}
+
 /** Step 1 → step 2 → publish, for the tests that are not about the stepper. */
 function createStudy() {
   goToTasks();
@@ -263,49 +268,69 @@ describe("UserTestingScenarioCreateFlow", () => {
     });
   });
 
-  it("cannot continue without an environment", () => {
-    // No clients to default to, so nothing answers the required field.
+  it("presses through to nothing without an environment, and says why", () => {
+    // No clients to default to, so nothing answers the required field. The
+    // button is live — it has to be pressed to find that out.
     hostListState.hosts = [];
     renderFlow();
-    expect(screen.getByTestId("user-testing-create-continue")).toBeDisabled();
+
+    goToTasks();
+
+    expect(onTasksStep()).toBe(false);
+    expect(
+      screen.getByTestId("user-testing-create-environment-required"),
+    ).toBeInTheDocument();
   });
 
   /**
-   * The gate above is old; SAYING so is the fix. It was reported as "I can
-   * create a scenario without an environment" precisely because the only sign
-   * was an inert button — so the requirement is stated on the field, and drops
-   * away once the field is satisfied rather than nagging under a valid form.
+   * The gate is old; SAYING so is the fix. It was reported as "I can create a
+   * scenario without an environment" precisely because the only sign was an
+   * inert button — so the press names what is missing, and the message drops
+   * away the moment the field is satisfied rather than standing over a form
+   * that no longer has a problem.
    */
-  it("says the environment is required, and stops saying it once one is picked", () => {
+  it("says the environment is required only once asked, and stops saying it once one is picked", () => {
     hostListState.hosts = [];
     renderFlow();
+
+    // Nothing is nagged before the ask. The marked label is what carries the
+    // requirement until then — an asterisk is what a scanning user reads as
+    // "required" before they try Continue.
+    expect(
+      screen.queryByTestId("user-testing-create-environment-required"),
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByText("(required)").length).toBeGreaterThan(0);
+
+    goToTasks();
 
     expect(
       screen.getByTestId("user-testing-create-environment-required"),
     ).toBeInTheDocument();
-    // Marked on the label too — an asterisk is what a scanning user reads as
-    // "required" before they try Continue.
-    expect(screen.getAllByText("(required)").length).toBeGreaterThan(0);
 
     fireEvent.change(screen.getByTestId("user-testing-create-environment"), {
       target: { value: "env-1" },
     });
 
+    // Cleared by the fix itself, with no second press needed.
     expect(
       screen.queryByTestId("user-testing-create-environment-required"),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByTestId("user-testing-create-continue"),
-    ).not.toBeDisabled();
+
+    goToTasks();
+    expect(onTasksStep()).toBe(true);
   });
 
-  it("waits for the environment list before claiming anything is missing", () => {
+  it("waits for the environment list before claiming anything is missing, even on a press", () => {
     // `undefined` is "we haven't looked yet" — the loading line is the honest
-    // answer there, and asserting a missing field would contradict it.
+    // answer there, and telling the creator they forgot something would be a
+    // claim about them rather than about the query.
     environmentsState.value = undefined;
     hostListState.hosts = [];
     renderFlow();
 
+    goToTasks();
+
+    expect(onTasksStep()).toBe(false);
     expect(
       screen.queryByTestId("user-testing-create-environment-required"),
     ).not.toBeInTheDocument();
@@ -514,30 +539,40 @@ describe("UserTestingScenarioCreateFlow — a setup with no servers", () => {
     expect(ask({ hostId: "host-unknown" })).toBeNull();
   });
 
-  it("refuses to publish, and says what is missing", () => {
+  it("refuses to carry a client with no servers, and says what is missing", () => {
     hostListState.hosts = [
       { hostId: "host-1", name: "Claude", serverCount: 0 },
     ];
     renderFlow();
 
+    // Silent until asked: a client picked FOR them is not something the
+    // creator did wrong until they try to move on with it.
+    expect(
+      screen.queryByTestId("user-testing-create-servers-required"),
+    ).not.toBeInTheDocument();
+
+    goToTasks();
+
+    expect(onTasksStep()).toBe(false);
     expect(
       screen.getByTestId("user-testing-create-servers-required"),
-    ).toHaveTextContent(/no servers of its own/i);
-    expect(screen.getByTestId("user-testing-create-continue")).toBeDisabled();
+    ).toHaveTextContent(/no server picked/i);
   });
 
   it("says nothing while the host list has not settled, and lets nothing through", () => {
     // An unknown answer must not render as a problem — but it must not open
     // the gate either. The server question answers `null` during the load
-    // window, and a fast creator could otherwise publish straight through it.
+    // window, and a fast creator could otherwise walk straight through it.
     hostListState.hosts = [];
     hostListState.isLoading = true;
     renderFlow();
 
+    goToTasks();
+
+    expect(onTasksStep()).toBe(false);
     expect(
       screen.queryByTestId("user-testing-create-servers-required"),
     ).not.toBeInTheDocument();
-    expect(screen.getByTestId("user-testing-create-continue")).toBeDisabled();
   });
 
   it("never lands the default on the broken client when a runnable one exists", () => {
@@ -552,12 +587,12 @@ describe("UserTestingScenarioCreateFlow — a setup with no servers", () => {
     expect(screen.getByTestId("user-testing-create-name")).toHaveValue(
       "Loaded",
     );
+    goToTasks();
+
+    expect(onTasksStep()).toBe(true);
     expect(
       screen.queryByTestId("user-testing-create-servers-required"),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByTestId("user-testing-create-continue"),
-    ).not.toBeDisabled();
   });
 
   it("blocks a picked client that cannot run, even in a mixed project", () => {
@@ -572,26 +607,28 @@ describe("UserTestingScenarioCreateFlow — a setup with no servers", () => {
     fireEvent.click(screen.getByTestId("user-testing-create-clients-picker"));
     fireEvent.click(screen.getByRole("checkbox", { name: /^empty$/i }));
 
+    goToTasks();
+
+    expect(onTasksStep()).toBe(false);
     expect(
       screen.getByTestId("user-testing-create-servers-required"),
     ).toBeInTheDocument();
-    expect(screen.getByTestId("user-testing-create-continue")).toBeDisabled();
   });
 });
 
 describe("UserTestingScenarioCreateFlow — defaults", () => {
-  it("preselects a client and suggests a name, so Continue is pressable on arrival", () => {
+  it("preselects a client and suggests a name, so Continue carries on arrival", () => {
     renderFlow();
 
     expect(screen.getByTestId("user-testing-create-name")).toHaveValue(
       "Claude",
     );
     expect(
-      screen.getByTestId("user-testing-create-continue"),
-    ).not.toBeDisabled();
-    expect(
       screen.queryByTestId("user-testing-create-environment-required"),
     ).not.toBeInTheDocument();
+
+    goToTasks();
+    expect(onTasksStep()).toBe(true);
   });
 
   it("waits for the host list to settle before deciding there is nothing to default to", () => {
@@ -601,7 +638,9 @@ describe("UserTestingScenarioCreateFlow — defaults", () => {
     hostListState.isLoading = true;
     const { onCreateScenario } = renderFlow();
 
-    expect(screen.getByTestId("user-testing-create-continue")).toBeDisabled();
+    goToTasks();
+
+    expect(onTasksStep()).toBe(false);
     expect(onCreateScenario).not.toHaveBeenCalled();
   });
 
@@ -643,9 +682,6 @@ describe("UserTestingScenarioCreateFlow — defaults", () => {
     fireEvent.change(screen.getByTestId("user-testing-create-name"), {
       target: { value: "" },
     });
-    expect(
-      screen.getByTestId("user-testing-create-continue"),
-    ).not.toBeDisabled();
 
     createStudy();
 
@@ -844,9 +880,6 @@ describe("UserTestingScenarioCreateFlow — composing a setup", () => {
     expect(screen.getByTestId("user-testing-create-name")).toHaveValue(
       "Cursor",
     );
-    expect(
-      screen.getByTestId("user-testing-create-continue"),
-    ).not.toBeDisabled();
 
     fireEvent.change(screen.getByTestId("user-testing-create-name"), {
       target: { value: "Round 2 with real users" },
@@ -993,9 +1026,11 @@ describe("UserTestingScenarioCreateFlow — without Project Environments", () =>
     hostListState.hosts = [];
     renderFlow();
 
+    goToTasks();
+
     expect(
       screen.getByTestId("user-testing-create-environment-required"),
-    ).toHaveTextContent(/pick the client a tester will see/i);
+    ).toHaveTextContent(/no client picked/i);
   });
 });
 

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioDetail.test.tsx
@@ -1157,20 +1157,45 @@ describe("UserTestingScenarioDetail — settings layout", () => {
     expect(previewPaneMock).not.toHaveBeenCalled();
   });
 
-  it("lays Settings out as a single fixed-measure column", () => {
+  it("lays Settings out in two columns that fill the pane", () => {
     const { container } = renderEdit();
 
     expect(screen.getByTestId("user-testing-edit-tab")).toBeInTheDocument();
-    // The 560px measure the frame specifies, not a percentage of a split pane
-    // that keeps shrinking as the window narrows.
-    expect(container.querySelector('[class*="w-[560px]"]')).not.toBeNull();
-    // A resizable split is what the fixed measure replaced. Asserted against
-    // the MOCK's own test id, not `[data-panel-group]`: the group is stubbed
-    // in this file, so the real attribute never appears in jsdom and that
-    // assertion could not fail even if the split came back.
+    // Reported as "too much white space": the 560px column this replaces sat
+    // pinned to the left of a pane twice its width. Two columns from `xl`,
+    // capped so an ultra-wide monitor does not stretch the measure.
+    expect(container.querySelector('[class*="w-[560px]"]')).toBeNull();
+    expect(container.querySelector('[class*="xl:grid-cols-2"]')).not.toBeNull();
+    expect(container.querySelector('[class*="max-w-[1400px]"]')).not.toBeNull();
+    // A resizable split is what the single column replaced, and it is not
+    // coming back. Asserted against the MOCK's own test id, not
+    // `[data-panel-group]`: the group is stubbed in this file, so the real
+    // attribute never appears in jsdom and that assertion could not fail even
+    // if the split came back.
     expect(
       screen.queryByTestId("stub-resizable-group"),
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps every settings section on the page after the split", () => {
+    // The redesign moved sections between columns; losing one to a bad JSX
+    // nesting is the failure mode a layout change actually has.
+    renderEdit();
+
+    expect(
+      screen.getByTestId("user-testing-description-section"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Sharing permissions" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Ratings" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("scenario-grading-section")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("user-testing-tasks-section"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("user-testing-delete")).toBeInTheDocument();
   });
 
   it("tags Open preview as preview traffic, not as a tester session", () => {

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioDetail.test.tsx
@@ -271,10 +271,11 @@ const scenario = {
 
 const detail = (
   over: Partial<ScenarioSettings> = {},
-  opts: { editMode?: boolean } = {},
+  opts: { editMode?: boolean; sessionCount?: number } = {},
 ) => (
   <UserTestingScenarioDetail
     scenario={{ ...scenario, ...over } as ScenarioSettings}
+    sessionCount={opts.sessionCount}
     editMode={opts.editMode}
     onBack={vi.fn()}
     onDeleted={vi.fn()}
@@ -283,11 +284,13 @@ const detail = (
 
 const renderDetail = (
   over: Partial<ScenarioSettings> = {},
-  opts: { editMode?: boolean } = {},
+  opts: { editMode?: boolean; sessionCount?: number } = {},
 ) => render(detail(over, opts));
 
-const renderEdit = (over: Partial<ScenarioSettings> = {}) =>
-  renderDetail(over, { editMode: true });
+const renderEdit = (
+  over: Partial<ScenarioSettings> = {},
+  opts: { sessionCount?: number } = {},
+) => renderDetail(over, { ...opts, editMode: true });
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -1234,5 +1237,67 @@ describe("UserTestingScenarioDetail — settings layout", () => {
     expect(
       screen.getByTestId("user-testing-settings-tasks"),
     ).toBeInTheDocument();
+  });
+});
+
+/**
+ * Raised in review: "we're letting them mess up their test configurations —
+ * one might be pointing to Excalidraw and the other to GitHub." Repointing a
+ * study that has already been run leaves one set of results answering a setup
+ * that no longer exists, under the same name, with nothing saying so.
+ */
+describe("UserTestingScenarioDetail — the setup of a study with results", () => {
+  const composerProps = () =>
+    composerMock.mock.calls[composerMock.mock.calls.length - 1][0] as {
+      lockedSlots?: Record<string, string>;
+    };
+
+  const withEnvironment = () => {
+    environmentState.row = {
+      environmentId: "env-1",
+      projectId: "p1",
+      origin: "named",
+      name: "Checkout flow",
+      hostId: "host-1",
+      revision: 1,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+  };
+
+  it("locks the client and the servers once a tester has been through it", () => {
+    withEnvironment();
+    renderEdit(
+      { environmentId: "env-1", environmentName: "Checkout flow" },
+      { sessionCount: 3 },
+    );
+
+    const locks = composerProps().lockedSlots;
+    // Each names ITS OWN control — someone who pressed the servers pill is
+    // asking about servers, and being told about clients is being answered
+    // about something else.
+    expect(locks?.clients).toMatch(/client/i);
+    expect(locks?.servers).toMatch(/servers/i);
+    expect(locks?.clients).toMatch(/already has sessions/i);
+  });
+
+  it("leaves a study nobody has run fully editable", () => {
+    withEnvironment();
+    renderEdit(
+      { environmentId: "env-1", environmentName: "Checkout flow" },
+      { sessionCount: 0 },
+    );
+
+    expect(composerProps().lockedSlots).toBeUndefined();
+  });
+
+  it("stays editable when the backend does not report the count", () => {
+    // `undefined` is "unknown", not "none". Refusing every edit on an
+    // unanswered question would take a working screen away from everyone to
+    // protect a case we cannot see.
+    withEnvironment();
+    renderEdit({ environmentId: "env-1", environmentName: "Checkout flow" });
+
+    expect(composerProps().lockedSlots).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioDetail.test.tsx
@@ -1298,9 +1298,12 @@ describe("UserTestingScenarioDetail — the setup of a study with results", () =
     );
 
     const locks = composerProps().lockedSlots;
-    // One sentence, and the same one on both: the fact is the reason.
+    // One sentence, and the same one on all three: the fact is the reason.
     expect(locks?.clients).toBe("This study already has sessions.");
     expect(locks?.servers).toBe("This study already has sessions.");
+    // The environment picker included — it re-seeds the other two, so leaving
+    // it open would have left the whole lock bypassable (caught in review).
+    expect(locks?.environments).toBe("This study already has sessions.");
   });
 
   it("leaves a study nobody has run fully editable", () => {

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioDetail.test.tsx
@@ -1298,12 +1298,9 @@ describe("UserTestingScenarioDetail — the setup of a study with results", () =
     );
 
     const locks = composerProps().lockedSlots;
-    // Each names ITS OWN control — someone who pressed the servers pill is
-    // asking about servers, and being told about clients is being answered
-    // about something else.
-    expect(locks?.clients).toMatch(/client/i);
-    expect(locks?.servers).toMatch(/servers/i);
-    expect(locks?.clients).toMatch(/already has sessions/i);
+    // One sentence, and the same one on both: the fact is the reason.
+    expect(locks?.clients).toBe("This study already has sessions.");
+    expect(locks?.servers).toBe("This study already has sessions.");
   });
 
   it("leaves a study nobody has run fully editable", () => {


### PR DESCRIPTION
Five fixes to User Testing's create and edit screens, from the review notes and from a bug report. One commit each, so any of them can be dropped on its own.

## 1. The helper paragraph under Study name is gone

`d25ced4` — It explained a suggestion the field already makes ("keep it or write your own") and a consequence nobody had asked about (renaming the environment later). Two sentences of prose above the control they described.

## 2. Continue is live, and says what is missing when pressed

`d25ced4` — It was disabled until the form was satisfied. That is how "I can create a scenario without an environment" got reported in the first place: a grey button explains nothing, so the requirement was invisible until someone guessed it.

Pressing the thing that moves on is how someone asks whether they are done, so it always answers:

| On pressing Continue | What happens |
|---|---|
| No client picked | **No client picked** — does not advance |
| No server (client brings none, no group attached) | **No server picked** — does not advance |
| Everything valid | Advances to step 2 |
| Still loading | Does not advance, and shows no error |

Both messages name the missing thing rather than giving an instruction, so they read as two unchecked boxes and not as two different orders. Nothing is nagged before the press, and a message clears the moment its cause does.

That last row is deliberate: a press while the environment or client lists are still in flight is not the creator's mistake, and the loading line under the strip is already saying so. Telling them they forgot something would be a claim about them rather than about the query.

## 3. A setup that already has a study is refused, not silently swapped

`0342ca9` — **The reported bug.** Create a study on Claude + Excalidraw, then create a second one on the same pair: publishing is idempotent per environment, so no study was created — and the screen called that a success and navigated to the study the setup already had. The creator landed in another study's name, access, ratings and tasks, with the draft they were holding gone, under a message saying it had worked.

Now it reads as the refusal it is: an error naming what to change, the draft untouched on screen, the button released so a changed setup can be submitted immediately. The tab navigates only when the call actually created something.

**This does not make two studies on one setup possible.** That needs the backend to carry more than one scenario per environment — `insertScenarioForEnvironment` enforces one, and `unpublishEnvironmentScenario` and the ad-hoc backing retirement both read through that invariant. The decision between "each study mints its own environment" and "many studies per environment" is still open; this only stops the screen from claiming otherwise in the meantime.

## 4. A study with results keeps the setup it was run on

`ae2c641` — From review note 4: nothing stopped someone repointing a study at another client or server after testers had been through it. One set of sessions then answered Excalidraw and the next answered GitHub, under one name, with nothing on screen saying the ground moved — and every reading of those results compares two different things.

The two pills that change where a study runs lock once its first tester session lands. Everything else stays editable: name, access, tasks, ratings. None of those rewrite what the recorded sessions were an answer to.

A locked pill still answers. `disabled` alone dispatches no click, so someone who does not know the rule presses it and gets silence; each pill is wrapped so the press lands and says why — naming the control that was pressed, since someone asking about servers is not asking about clients.

The count comes from the list row, and `undefined` there is **unknown**, not "none": a deployment that does not report it keeps the setup editable rather than freezing every study over a question nobody answered.

## 5. Settings uses the screen

`5d1b600` — From review note 5 ("too much white space"). It was a 560px column pinned to the left of a pane twice its width, everything in one flow, so the task list sat below every switch.

Two columns from `xl`, split by what a section **is**: the left is the study itself (what it says, where it runs, what it asks people to try), the right is the rules it runs under (who may open it, what gets rated, what gets graded). One column below that, same order, and the grid is capped and centred — filling the screen is not stretching a form until its lines stop being readable.

Sections become cards, because side by side with no boundary they read as one long column with odd gaps. Delete moves out of the column and under both, full width and visibly apart: the one control here that cannot be undone should not sit a mis-aimed click away from a switch.

## Tests

New coverage for each behaviour: the two press-time messages and the loading case; the refusal (error not success, draft kept, no write onto the other study's settings, button released); the setup lock (locked with sessions, open without, open when the count is unknown, a press answered, one lock not freezing the other); and that the redesign kept every section on the page, which is the failure mode a layout change actually has.

Three existing tests described the old behaviour of item 3 and were rewritten — they were not wrong, that behaviour was the bug.

`UserTestingScenarioCreateFlow` 57 passed, `UserTestingScenarioDetail` 52, `environment-composer` 80, `UserTestingTab` suites 24. `typecheck:client` clean.

Not verified in a browser: `/user-testing` is behind sign-in and the preview session is signed out. Item 5 is a visual change and deserves a look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes User Testing’s create and settings flows so validation is explicit, existing studies are not mistaken for new ones, and completed studies keep the setup they were tested on.

**Bug Fixes**

- Continue stays enabled and reports missing clients or servers only after a press, without showing errors while data loads.
- A setup that already has a study now shows an error, keeps the draft, releases the save action, and skips navigation and settings writes.
- Studies with recorded sessions lock the client, server, and environment pickers — a saved environment re-seeds the other two, so leaving it open would bypass the lock — while leaving other settings editable.
- Locked controls answer a press with a toast stating the fact ("This study already has sessions.") and nothing more, via a `role="button"` span rather than a nested button, so the answer works by mouse and keyboard with one interactive role.
- Settings now use a capped, centered two-column card layout, with Delete separated below both columns.
- Tests cover validation, duplicate-study refusal, setup locking, and layout completeness.

<sup>Written for commit 196fd8dbd6a8709b13b96f62d133be963c5e2033. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

