### PR TITLE
Add first-visit local browser onboarding to Playground

### DIFF
--- a/.changeset/local-browser-playground-onboarding.md
+++ b/.changeset/local-browser-playground-onboarding.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Offer local browser setup on first Playground visit and resolve browser tools without requiring a saved default client.

--- a/mcpjam-inspector/client/src/components/browser/LocalBrowserConsentGate.tsx
+++ b/mcpjam-inspector/client/src/components/browser/LocalBrowserConsentGate.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@mcpjam/design-system/dialog";
+import { useEffect, useRef, useState } from "react";
 import { Globe } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { track } from "@/lib/analytics";
@@ -10,12 +17,28 @@ export function LocalBrowserConsentGate({
   onAllow,
   onUseCloud,
   location = "computer_tab_local",
+  variant = "card",
+  onOpenClientSettings,
+  onDismiss,
+  setupOnly = false,
 }: {
   onAllow: () => Promise<boolean> | boolean;
   onUseCloud?: () => void;
-  location?: "computer_tab_local" | "playground_browser" | "browser_settings";
+  location?:
+    | "computer_tab_local"
+    | "playground_browser"
+    | "playground_onboarding"
+    | "playground_tools"
+    | "browser_settings";
+  /** `inline` fits a list row (the Tools rail); `card` fills a pane. */
+  variant?: "card" | "inline" | "onboarding";
+  onDismiss?: () => void;
+  setupOnly?: boolean;
+  /** Opens the client's Browser settings, where Allow can be undone. */
+  onOpenClientSettings?: () => void;
 }) {
   const { user } = useAuth();
+  const submitting = useRef(false);
   const [granting, setGranting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -33,6 +56,8 @@ export function LocalBrowserConsentGate({
   }, [cloudOffered, location]);
 
   const handleAllow = async () => {
+    if (submitting.current) return;
+    submitting.current = true;
     setGranting(true);
     setError(null);
     try {
@@ -53,6 +78,7 @@ export function LocalBrowserConsentGate({
         outcome: "failed",
       });
     } finally {
+      submitting.current = false;
       setGranting(false);
     }
   };
@@ -63,6 +89,111 @@ export function LocalBrowserConsentGate({
   };
 
   if (HOSTED_MODE) return null;
+  if (variant === "onboarding") {
+    const dismiss = () => {
+      if (submitting.current) return;
+      track("local_browser_consent_denied", { location, reason: "not_now" });
+      onDismiss?.();
+    };
+    return (
+      <Dialog
+        open
+        onOpenChange={(open) => {
+          if (!open) dismiss();
+        }}
+      >
+        <DialogContent
+          showCloseButton={!granting}
+          onInteractOutside={(event) => event.preventDefault()}
+          onEscapeKeyDown={(event) => {
+            if (submitting.current) event.preventDefault();
+          }}
+          className="max-h-[calc(100dvh-2rem)] max-w-[calc(100vw-2rem)] overflow-y-auto sm:max-w-lg"
+        >
+          <Globe className="size-8 text-primary" aria-hidden />
+          <DialogTitle>
+            {setupOnly
+              ? "Finish enabling browser tools"
+              : "Let agents use your browser?"}
+          </DialogTitle>
+          <DialogDescription>
+            {setupOnly
+              ? "Browser permission is saved. Finish setup to enable browser tools for your clients. "
+              : "Allow agents to navigate, click, type, and read pages in a browser on this machine. "}
+            Page content may be sent to your model.
+          </DialogDescription>
+          <p className="text-sm text-muted-foreground">
+            {user
+              ? "Enables browser tools for clients in projects you manage. Clients you’ve explicitly disabled stay disabled."
+              : "Enables browser tools for your local clients on this device."}{" "}
+            You can change this in the Browser tab or client Browser settings.
+          </p>
+          {error ? (
+            <p
+              role="alert"
+              className="text-sm text-destructive"
+              data-testid="consent-error"
+            >
+              {error}
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button variant="outline" disabled={granting} onClick={dismiss}>
+              Not now
+            </Button>
+            <Button disabled={granting} onClick={() => void handleAllow()}>
+              {granting
+                ? "Enabling browser…"
+                : error
+                ? "Retry setup"
+                : setupOnly
+                ? "Finish setup"
+                : "Allow browser access"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+  if (variant === "inline") {
+    return (
+      <div
+        data-testid="local-browser-consent-inline"
+        className="space-y-2 px-3"
+      >
+        <p className="text-xs leading-snug text-muted-foreground">
+          Allow agents to navigate, click, type, and read pages on this machine.
+          Page content may be sent to your model.
+        </p>
+        <Button
+          size="sm"
+          onClick={() => void handleAllow()}
+          disabled={granting}
+        >
+          {granting ? "Allowing…" : "Allow"}
+        </Button>
+        {error ? (
+          <p className="text-xs text-destructive" data-testid="consent-error">
+            {error}
+          </p>
+        ) : null}
+        {onOpenClientSettings ? (
+          <p className="text-xs leading-snug text-muted-foreground">
+            {user ? "Enables every client you manage. " : null}
+            To turn it off, open{" "}
+            <Button
+              variant="link"
+              className="h-auto p-0 text-xs"
+              onClick={onOpenClientSettings}
+            >
+              client Browser settings
+            </Button>
+            .
+          </p>
+        ) : null}
+      </div>
+    );
+  }
   return (
     <div
       data-testid="local-browser-consent-gate"
@@ -76,7 +207,7 @@ export function LocalBrowserConsentGate({
         Allow agents to navigate, click, type, and read pages on this machine.
         Page content may be sent to your model.{" "}
         {user
-          ? "This enables local Browser for all clients in projects you manage, including shared clients. You can remove it in each client's Connect settings."
+          ? "You can remove it in each client's Connect settings."
           : "This enables Browser for your local clients across WebMCP, Playground, and tabs on this device."}
       </p>
       {user && (

--- a/mcpjam-inspector/client/src/components/browser/LocalBrowserOnboarding.tsx
+++ b/mcpjam-inspector/client/src/components/browser/LocalBrowserOnboarding.tsx
@@ -1,0 +1,39 @@
+import { useBrowserEngine } from "@/hooks/useBrowserEngine";
+import { useLocalBrowserEnabled } from "@/hooks/useComputersEnabled";
+import { useLocalBrowserOnboarding } from "@/hooks/useLocalBrowserOnboarding";
+import { HOSTED_MODE } from "@/lib/config";
+import { LocalBrowserConsentGate } from "./LocalBrowserConsentGate";
+
+/** Mounted once at the Playground root, independent of the active chat/client. */
+export function LocalBrowserOnboarding({
+  projectId,
+  authReady,
+}: {
+  projectId: string | null;
+  authReady: boolean;
+}) {
+  const enabled = useLocalBrowserEnabled();
+  const engine = useBrowserEngine(projectId);
+  const onboarding = useLocalBrowserOnboarding();
+  if (
+    HOSTED_MODE ||
+    !authReady ||
+    !enabled ||
+    !engine.resolved ||
+    !engine.localAvailable ||
+    engine.environmentMode ||
+    engine.selectedEngine !== "local" ||
+    !onboarding.undecided
+  )
+    return null;
+
+  return (
+    <LocalBrowserConsentGate
+      variant="onboarding"
+      location="playground_onboarding"
+      setupOnly={!!engine.consent.token}
+      onAllow={engine.consent.grant}
+      onDismiss={onboarding.dismiss}
+    />
+  );
+}

--- a/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserConsentGate.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserConsentGate.test.tsx
@@ -38,13 +38,11 @@ describe("LocalBrowserConsentGate", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Page content may be sent to your model/),
-    ).toHaveTextContent(
-      "all clients in projects you manage, including shared clients",
-    );
-    expect(
-      screen.getByText(/each client's Connect settings/),
+      screen.getByText(
+        /Allow agents to navigate, click, type, and read pages on this machine\. Page content may be sent to your model\. You can remove it in each client's Connect settings\./,
+      ),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/projects you manage/)).toBeNull();
     expect(onAllow).not.toHaveBeenCalled();
   });
 

--- a/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserOnboarding.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserOnboarding.test.tsx
@@ -1,0 +1,217 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { beforeEach, expect, it, vi } from "vitest";
+import { LocalBrowserOnboarding } from "../LocalBrowserOnboarding";
+import {
+  localBrowserOnboardingDecision,
+  clearStoredLocalBrowserConsent,
+} from "@/lib/local-browser-consent";
+
+const state = vi.hoisted(() => ({
+  hosted: false,
+  enabled: true,
+  available: true,
+  resolved: true,
+  environment: false,
+  guest: false,
+  engine: "local",
+  request: vi.fn(),
+}));
+vi.mock("@/lib/config", () => ({
+  get HOSTED_MODE() {
+    return state.hosted;
+  },
+}));
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+vi.mock("@/lib/session-token", () => ({ authFetch: state.request }));
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: state.guest ? null : { id: "member" } }),
+}));
+vi.mock("@/hooks/useComputersEnabled", () => ({
+  useLocalBrowserEnabled: () => state.enabled,
+}));
+vi.mock("@/hooks/useBrowserEngine", async () => {
+  const { useLocalBrowserConsent } = await import(
+    "@/hooks/useLocalBrowserConsent"
+  );
+  return {
+    useBrowserEngine: () => ({
+      resolved: state.resolved,
+      localAvailable: state.available,
+      environmentMode: state.environment,
+      selectedEngine: state.engine,
+      consent: useLocalBrowserConsent(),
+    }),
+  };
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  Object.assign(state, {
+    hosted: false,
+    enabled: true,
+    available: true,
+    resolved: true,
+    environment: false,
+    guest: false,
+    engine: "local",
+  });
+  state.request
+    .mockReset()
+    .mockImplementation(async (url: string) =>
+      Response.json(
+        url.endsWith("/grant")
+          ? { token: "device-consent-test-token", grantedAt: "now" }
+          : url.endsWith("/verify")
+          ? { valid: true }
+          : { enabledProjects: 1, skippedProjects: 0 },
+      ),
+    );
+});
+
+it("shows a centered decision over an existing conversation without requiring a client or server", () => {
+  render(
+    <>
+      <p>Existing conversation</p>
+      <LocalBrowserOnboarding projectId={null} authReady />
+    </>,
+  );
+  expect(
+    screen.getByRole("dialog", { name: "Let agents use your browser?" }),
+  ).toBeInTheDocument();
+  expect(screen.getByText("Existing conversation")).toBeInTheDocument();
+  expect(state.request).not.toHaveBeenCalled();
+});
+
+it.each(["Not now", "Close", "Escape"])(
+  "remembers %s across remounts without granting permission",
+  (action) => {
+    const view = render(
+      <LocalBrowserOnboarding projectId="project" authReady />,
+    );
+    if (action === "Escape")
+      fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    else fireEvent.click(screen.getByRole("button", { name: action }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(localBrowserOnboardingDecision()).toBe("dismissed");
+    view.unmount();
+    render(<LocalBrowserOnboarding projectId="another-project" authReady />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(state.request).not.toHaveBeenCalled();
+  },
+);
+
+it("finishes permission and client setup before closing, and never starts the browser", async () => {
+  let finish!: (value: Response) => void;
+  state.request.mockImplementation(async (url: string) =>
+    url.endsWith("/grant")
+      ? Response.json({ token: "device-consent-test-token", grantedAt: "now" })
+      : new Promise<Response>((resolve) => {
+          finish = resolve;
+        }),
+  );
+  render(<LocalBrowserOnboarding projectId={null} authReady />);
+  fireEvent.click(screen.getByRole("button", { name: "Allow browser access" }));
+  await waitFor(() => expect(state.request).toHaveBeenCalledTimes(2));
+  expect(
+    screen.getByRole("button", { name: "Enabling browser…" }),
+  ).toBeDisabled();
+  fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+  expect(screen.getByRole("dialog")).toBeInTheDocument();
+  expect(localBrowserOnboardingDecision()).toBeNull();
+  await act(async () =>
+    finish(Response.json({ enabledProjects: 1, skippedProjects: 0 })),
+  );
+  expect(screen.queryByRole("dialog")).toBeNull();
+  expect(localBrowserOnboardingDecision()).toBe("completed");
+  expect(state.request.mock.calls.map(([url]) => url)).toEqual([
+    "/api/mcp/computers/local-browser/consent/grant",
+    "/api/mcp/computers/local-browser/enable-clients",
+  ]);
+  act(() => clearStoredLocalBrowserConsent());
+  expect(screen.queryByRole("dialog")).toBeNull();
+});
+
+it("keeps partial failures visible and retries with saved permission", async () => {
+  state.request
+    .mockResolvedValueOnce(
+      Response.json({ token: "device-consent-test-token", grantedAt: "now" }),
+    )
+    .mockResolvedValueOnce(new Response("failed", { status: 503 }));
+  render(<LocalBrowserOnboarding projectId="project" authReady />);
+  fireEvent.click(screen.getByRole("button", { name: "Allow browser access" }));
+  expect(await screen.findByRole("alert")).toHaveTextContent(
+    "clients could not be enabled",
+  );
+  expect(localBrowserOnboardingDecision()).toBeNull();
+  fireEvent.click(screen.getByRole("button", { name: "Retry setup" }));
+  await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  expect(
+    state.request.mock.calls.filter(([url]) => url.endsWith("/grant")),
+  ).toHaveLength(1);
+  expect(
+    state.request.mock.calls.some(([url]) => url.endsWith("/verify")),
+  ).toBe(true);
+});
+
+it("offers existing authorized users setup once, without silently changing settings", () => {
+  localStorage.setItem(
+    "mcp-local-browser-consent-v1",
+    JSON.stringify({ token: "device-consent-test-token", grantedAt: "now" }),
+  );
+  render(<LocalBrowserOnboarding projectId="project" authReady />);
+  expect(
+    screen.getByRole("dialog", { name: "Finish enabling browser tools" }),
+  ).toBeInTheDocument();
+  expect(state.request).not.toHaveBeenCalled();
+});
+
+it.each([
+  "hosted",
+  "disabled",
+  "unavailable",
+  "loading",
+  "environment",
+  "cloud",
+  "auth",
+])("does not prompt when %s", (condition) => {
+  if (condition === "hosted") state.hosted = true;
+  if (condition === "disabled") state.enabled = false;
+  if (condition === "unavailable") state.available = false;
+  if (condition === "loading") state.resolved = false;
+  if (condition === "environment") state.environment = true;
+  if (condition === "cloud") state.engine = "cloud";
+  render(
+    <LocalBrowserOnboarding
+      projectId="project"
+      authReady={condition !== "auth"}
+    />,
+  );
+  expect(screen.queryByRole("dialog")).toBeNull();
+  expect(state.request).not.toHaveBeenCalled();
+});
+
+it("syncs dismissal from another tab", () => {
+  render(<LocalBrowserOnboarding projectId="project" authReady />);
+  act(() => {
+    localStorage.setItem("mcp-local-browser-onboarding-v1", "dismissed");
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: "mcp-local-browser-onboarding-v1" }),
+    );
+  });
+  expect(screen.queryByRole("dialog")).toBeNull();
+});
+
+it("explains device scope for guests", () => {
+  state.guest = true;
+  render(<LocalBrowserOnboarding projectId={null} authReady />);
+  expect(
+    screen.getByText(/your local clients on this device/),
+  ).toBeInTheDocument();
+  expect(screen.queryByText(/projects you manage/)).toBeNull();
+});

--- a/mcpjam-inspector/client/src/components/playground/BrowserToolsSection.tsx
+++ b/mcpjam-inspector/client/src/components/playground/BrowserToolsSection.tsx
@@ -20,6 +20,10 @@ import { Badge } from "@mcpjam/design-system/badge";
 import type { BrowserPageToolsResponse } from "@/shared/browser-page-tools";
 import type { SerializedModelRequestTool } from "@/shared/model-request-payload";
 import { cn } from "@/lib/utils";
+import { useAppNavigate } from "@/lib/app-navigation";
+import type { BrowserLocalConsentPrompt } from "@/hooks/useBrowserTools";
+import { Button } from "@mcpjam/design-system/button";
+import { buildHostFocusTabPath } from "@/components/hosts/host-verify-deep-link";
 import { ToolSourceHeader } from "./ToolSourceHeader";
 import {
   catalogBrowserPaneTools,
@@ -32,6 +36,11 @@ interface BrowserToolsSectionProps {
   searchQuery: string;
   selectedKey?: string | null;
   onSelect?: (key: string) => void;
+  /**
+   * Set while this device hasn't allowed local Browser. The browser verbs
+   * aren't offered until it has, so WebMCP asks for it in their place.
+   */
+  localConsent?: BrowserLocalConsentPrompt | null;
 }
 
 function pageNotice(response: BrowserPageToolsResponse): string {
@@ -73,7 +82,11 @@ function ToolRow({
     return <div className={className}>{children}</div>;
   }
   return (
-    <button type="button" onClick={() => onSelect(tool.key)} className={className}>
+    <button
+      type="button"
+      onClick={() => onSelect(tool.key)}
+      className={className}
+    >
       {children}
     </button>
   );
@@ -85,7 +98,9 @@ export function BrowserToolsSection({
   searchQuery,
   selectedKey = null,
   onSelect,
+  localConsent = null,
 }: BrowserToolsSectionProps) {
+  const navigate = useAppNavigate();
   const query = searchQuery.trim().toLowerCase();
   const catalog = useMemo(
     () => catalogBrowserPaneTools({ tools, page }),
@@ -97,7 +112,9 @@ export function BrowserToolsSection({
   const filteredPageTools = useMemo(() => {
     if (!query) return pageItems;
     return pageItems.filter((tool) =>
-      `${tool.title} ${tool.callName} ${tool.description ?? ""} ${tool.originHost ?? ""}`
+      `${tool.title} ${tool.callName} ${tool.description ?? ""} ${
+        tool.originHost ?? ""
+      }`
         .toLowerCase()
         .includes(query),
     );
@@ -109,19 +126,46 @@ export function BrowserToolsSection({
     );
   }, [browserItems, query]);
 
-  if (tools.length === 0) return null;
+  if (tools.length === 0 && !localConsent) return null;
   if (query && filteredTools.length === 0 && filteredPageTools.length === 0) {
     return null;
   }
 
   const showPage = !query || filteredPageTools.length > 0;
-  const showBrowser = !query || filteredTools.length > 0;
+  const showBrowser =
+    browserItems.length > 0 && (!query || filteredTools.length > 0);
 
   return (
     <div data-testid="browser-tools-section">
       {showPage ? (
-        <ToolSourceHeader title="WebMCP">
-          {page === null ? (
+        <ToolSourceHeader title={localConsent ? "Browser" : "WebMCP"}>
+          {localConsent ? (
+            <p className="px-3 text-xs leading-snug text-muted-foreground">
+              {localConsent.disabledForClient ? (
+                "Browser tools are disabled for this client."
+              ) : (
+                <>
+                  Enable browser access from the Browser tab on the right pane
+                  or{" "}
+                  <Button
+                    variant="link"
+                    className="h-auto p-0 text-xs"
+                    onClick={() =>
+                      navigate(
+                        buildHostFocusTabPath(
+                          localConsent.settingsHostId,
+                          "browser",
+                        ),
+                      )
+                    }
+                  >
+                    Browser settings
+                  </Button>
+                  .
+                </>
+              )}
+            </p>
+          ) : page === null ? (
             <p className="px-3 text-xs text-muted-foreground">
               Reading the page…
             </p>
@@ -134,10 +178,10 @@ export function BrowserToolsSection({
               {query
                 ? "No page tools match your search."
                 : page.webmcpSupported
-                  ? `This page offers no WebMCP tools${
-                      page.url ? ` (${page.url})` : ""
-                    }.`
-                  : "This page doesn't use WebMCP."}
+                ? `This page offers no WebMCP tools${
+                    page.url ? ` (${page.url})` : ""
+                  }.`
+                : "This page doesn't use WebMCP."}
             </p>
           ) : (
             <div className="space-y-0.5">

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
@@ -130,7 +130,7 @@ function RightRailTabbed({
   // harmless (the engine hooks no-op without a shared project) and deliberate.
   const engine = useComputerEngine(projectId);
   const browserEngine = useBrowserEngine(projectId);
-  const browserToolIds = useBrowserToolIds(hostConfig, browserEngine.selectedEngine);
+  const browserToolIds = useBrowserToolIds(hostConfig, browserEngine.selectedEngine, { projectId, hostId });
   // The BODY follows `selectedEngine` (consent-blind), mirroring the Computer
   // tab's face choice: someone who picked "This machine" but hasn't authorized
   // it yet must see the local body's pointer, not a cloud terminal they didn't

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
@@ -1,3 +1,4 @@
+import { LocalBrowserOnboarding } from "@/components/browser/LocalBrowserOnboarding";
 import { useActiveChatSessionStore } from "@/stores/active-chat-session-store";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useConvexAuth } from "convex/react";
@@ -159,8 +160,8 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
     hostId: previewedHostId,
   });
   const effectiveHostConfig = previewedHostId
-    ? (previewedHost?.config ?? null)
-    : (props.activeHost ?? null);
+    ? previewedHost?.config ?? null
+    : props.activeHost ?? null;
   const activeMcpProfile = effectiveHostConfig?.mcpProfile;
 
   // Host-derived widget runtime values. The preferences store is the
@@ -291,7 +292,11 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
   const projectScope = props.sharedProjectId ?? props.activeProjectId ?? null;
   const browsersEnabled = useBrowserEnabledState();
   const browserEngine = useBrowserEngine(projectScope);
-  const browserToolIds = useBrowserToolIds(effectiveHostConfig, browserEngine.selectedEngine);
+  const browserToolIds = useBrowserToolIds(
+    effectiveHostConfig,
+    browserEngine.selectedEngine,
+    { projectId: projectScope, hostId: previewedHostId },
+  );
   // Polled only on the local engine, where the question means something: on
   // hosted this route describes a machine that is not the one running the
   // browser.
@@ -415,6 +420,13 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
                     dropdown in the global header) and re-snapshots its
                     persisted config into the chip stores when it changes.
                     Renders nothing. */}
+                    <LocalBrowserOnboarding
+                      projectId={projectScope}
+                      authReady={
+                        !props.isWorkOsAuthLoading &&
+                        (!props.isSignedInWithWorkOs || isConvexAuthenticated)
+                      }
+                    />
                     <PlaygroundPreviewedClientSync
                       projectId={
                         props.sharedProjectId ?? props.activeProjectId ?? null

--- a/mcpjam-inspector/client/src/components/playground/__tests__/BrowserToolsSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/BrowserToolsSection.test.tsx
@@ -16,6 +16,16 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { BrowserToolsSection } from "../BrowserToolsSection";
 import type { SerializedModelRequestTool } from "@/shared/model-request-payload";
 
+const navigate = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/app-navigation", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/app-navigation")>()),
+  useAppNavigate: () => navigate,
+}));
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: { id: "member" } }),
+}));
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
 const TOOLS: SerializedModelRequestTool[] = [
   {
     name: "browser_navigate",
@@ -151,7 +161,9 @@ describe("BrowserToolsSection", () => {
   it("says the model calls them by name, not through a generic verb", () => {
     renderSection();
     expect(
-      screen.getByText(/Available to the model on its next step, by these names/),
+      screen.getByText(
+        /Available to the model on its next step, by these names/,
+      ),
     ).toBeInTheDocument();
     // THE INSTRUCTION ITSELF, not the whole pane. `browser_webmcp_invoke` is a
     // browser verb and belongs in the verb list above; the claim here is that
@@ -255,6 +267,35 @@ describe("BrowserToolsSection", () => {
     }
   });
 
+  it("asks for local Browser permission in WebMCP instead of saying none is running", async () => {
+    const onAllow = vi.fn(async () => true);
+    renderSection({
+      tools: [],
+      page: { ok: false, error: "no_browser_session" },
+      localConsent: { onAllow, settingsHostId: "host_1" },
+    });
+    expect(screen.queryByText(/No browser running yet/)).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /^browser$/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Allow" })).toBeNull();
+    expect(
+      screen.getByText(/Enable browser access from the Browser tab on the right pane/),
+    ).toBeInTheDocument();
+    expect(onAllow).not.toHaveBeenCalled();
+  });
+
+  it("links to Browser settings from the enable-access notice", () => {
+    navigate.mockClear();
+    renderSection({
+      tools: [],
+      page: { ok: false, error: "no_browser_session" },
+      localConsent: { onAllow: async () => true, settingsHostId: "host_1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Browser settings" }));
+    expect(navigate).toHaveBeenCalledWith("/hosts/host_1?hostTab=browser");
+  });
+
   it("stays quiet while the first read is in flight", () => {
     // `null` is "still asking". Flashing "no browser running" at a browser
     // that is starting is the wrong answer, briefly, every single time.
@@ -290,5 +331,20 @@ describe("BrowserToolsSection", () => {
     renderSection({ searchQuery: "zzz-nothing" });
     expect(screen.queryByTestId("browser-tools-section")).toBeNull();
   });
+});
 
+it("explains an explicit client opt-out without another permission prompt", () => {
+  renderSection({
+    tools: [],
+    page: null,
+    localConsent: {
+      onAllow: async () => true,
+      settingsHostId: "host_1",
+      disabledForClient: true,
+    },
+  });
+  expect(
+    screen.getByText("Browser tools are disabled for this client."),
+  ).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: "Allow" })).toBeNull();
 });

--- a/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundTab.test.tsx
@@ -1,4 +1,9 @@
-vi.mock("@workos-inc/authkit-react", () => ({ useAuth: () => ({ user: { id: "member" } }) }));
+vi.mock("@/components/browser/LocalBrowserOnboarding", () => ({
+  LocalBrowserOnboarding: () => null,
+}));
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: { id: "member" } }),
+}));
 import { useActiveChatSessionStore } from "@/stores/active-chat-session-store";
 import { useBrowserWorkspaceStore } from "@/stores/browser-workspace-store";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -9,7 +14,10 @@ import { act, render, screen } from "@testing-library/react";
 // `loadingState` branch that decides whether the branded first-run loading
 // screen shows, so neutralize everything else and drive `loadingState`.
 
-vi.mock("@/hooks/useComputersEnabled", () => ({ useBrowserWorkspaceEnabledState: () => true, useBrowserEnabledState: () => true }));
+vi.mock("@/hooks/useComputersEnabled", () => ({
+  useBrowserWorkspaceEnabledState: () => true,
+  useBrowserEnabledState: () => true,
+}));
 const mockLoadingScreen = vi.hoisted(() => vi.fn());
 const mockLoadingState = vi.hoisted(() => ({
   current: { kind: "skeleton" } as { kind: string },
@@ -30,6 +38,7 @@ vi.mock("@/components/ui-playground/hooks/use-playground-state", () => ({
 vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: false }),
+  useQuery: () => undefined,
 }));
 vi.mock("@/stores/preferences/preferences-provider", () => ({
   usePreferencesStore: (selector: (s: Record<string, unknown>) => unknown) =>
@@ -125,19 +134,32 @@ const baseProps: ComponentProps<typeof PlaygroundTab> = {
 
 describe("PlaygroundTab loading branch", () => {
   beforeEach(() => {
-    useActiveChatSessionStore.setState({ sessionId: null, restoredSession: null, restorationPending: false });
+    useActiveChatSessionStore.setState({
+      sessionId: null,
+      restoredSession: null,
+      restorationPending: false,
+    });
     useBrowserWorkspaceStore.setState({ conversations: {} });
     mockLoadingScreen.mockClear();
     mockLoadingState.current = { kind: "skeleton" };
   });
 
   it("does not close a persisted panel while conversation metadata is restoring", () => {
-    useActiveChatSessionStore.setState({ sessionId: "wire", restorationPending: true });
+    useActiveChatSessionStore.setState({
+      sessionId: "wire",
+      restorationPending: true,
+    });
     useBrowserWorkspaceStore.getState().openBrowser("wire");
     render(<PlaygroundTab {...baseProps} />);
-    expect(useBrowserWorkspaceStore.getState().conversations.wire.open).toBe(true);
-    act(() => useActiveChatSessionStore.getState().setRestorationPending(false));
-    expect(useBrowserWorkspaceStore.getState().conversations.wire.open).toBe(false);
+    expect(useBrowserWorkspaceStore.getState().conversations.wire.open).toBe(
+      true,
+    );
+    act(() =>
+      useActiveChatSessionStore.getState().setRestorationPending(false),
+    );
+    expect(useBrowserWorkspaceStore.getState().conversations.wire.open).toBe(
+      false,
+    );
   });
   it("shows the branded 'Setting things up...' screen during the first-run skeleton", () => {
     mockLoadingState.current = { kind: "skeleton" };

--- a/mcpjam-inspector/client/src/components/playground/panes/MultiServerToolsPane.tsx
+++ b/mcpjam-inspector/client/src/components/playground/panes/MultiServerToolsPane.tsx
@@ -407,7 +407,9 @@ function FlatToolList({
   // state must account for both, or it reports the wrong reason for a list
   // that is not actually empty.
   const hasBuiltin =
-    builtinTools.length > 0 || (browserTools?.tools.length ?? 0) > 0;
+    builtinTools.length > 0 ||
+    (browserTools?.tools.length ?? 0) > 0 ||
+    Boolean(browserTools?.localConsent);
   const uniqueServerIds = [...new Set(entries.map((entry) => entry.serverId))];
   const showServerBadge = uniqueServerIds.length > 1;
   const serversChip =
@@ -451,6 +453,7 @@ function FlatToolList({
                 searchQuery={searchQuery}
                 selectedKey={selectedBrowserKey}
                 onSelect={onSelectBrowser}
+                localConsent={browserTools.localConsent}
               />
             ) : null}
             {entries.length > 0 ? (

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -940,6 +940,7 @@ export function PlaygroundMain({
   const effectiveBuiltInToolIds = useBrowserToolIds(
     previewedHostId ? previewedHost?.config : projectDefaultHostConfig,
     playgroundBrowserEngine.engine,
+    { projectId: convexProjectId, hostId: previewedHostId },
   );
   // A newly selected host is unknown for one render while its config loads.
   // Fail closed in that gap: it may resolve to Codex or Claude Code, whose

--- a/mcpjam-inspector/client/src/components/ui-playground/ToolList.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/ToolList.tsx
@@ -176,7 +176,12 @@ export function ToolList({
     ).length;
   }, [browserTools, searchQuery]);
 
+  // Local Browser permission is a row of its own: until it is granted the
+  // browser's tools are withheld, and the section is where Allow lives.
+  const browserConsentShown =
+    browserTools?.localConsent && !searchQuery.trim() ? 1 : 0;
   const totalShown =
+    browserConsentShown +
     filteredToolNames.length +
     filteredAppEntries.length +
     filteredBuiltinCount +
@@ -192,7 +197,8 @@ export function ToolList({
     toolNames.length === 0 &&
     appEntries.length === 0 &&
     builtinTools.length === 0 &&
-    (browserTools?.tools.length ?? 0) === 0;
+    (browserTools?.tools.length ?? 0) === 0 &&
+    !browserTools?.localConsent;
 
   return (
     <div className="h-full flex flex-col">
@@ -247,6 +253,7 @@ export function ToolList({
                 searchQuery={searchQuery}
                 selectedKey={selectedBrowserKey}
                 onSelect={onSelectBrowser}
+                localConsent={browserTools.localConsent}
               />
             ) : null}
             {filteredToolNames.length > 0 || filteredAppEntries.length > 0 ? (

--- a/mcpjam-inspector/client/src/hooks/__tests__/useBrowserToolIds.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useBrowserToolIds.test.tsx
@@ -4,6 +4,15 @@ const state = vi.hoisted(() => ({
   hosted: false,
   user: null as null | { id: string },
   request: vi.fn(),
+  setting: undefined as { enabled: boolean | null } | undefined,
+  queries: vi.fn(),
+}));
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: !!state.user }),
+  useQuery: (name: unknown, args: unknown) => {
+    state.queries(name, args);
+    return state.setting;
+  },
 }));
 vi.mock("@/lib/config", () => ({
   get HOSTED_MODE() {
@@ -22,6 +31,8 @@ beforeEach(() => {
   localStorage.clear();
   state.hosted = false;
   state.user = null;
+  state.setting = undefined;
+  state.queries.mockClear();
   state.request
     .mockReset()
     .mockImplementation(async (url: string) =>
@@ -87,4 +98,42 @@ it("preserves an explicit client opt-out for guests", () => {
   expect(
     renderHook(() => useBrowserToolIds(config, "local")).result.current,
   ).toEqual([]);
+});
+
+it("reads the project setting without any saved/default client and updates reactively", () => {
+  state.user = { id: "member" };
+  state.setting = { enabled: true };
+  const scope = { projectId: "proj_1" };
+  const view = renderHook(() => useBrowserToolIds(null, "local", scope));
+  expect(view.result.current).toEqual(["browser"]);
+  expect(state.queries).toHaveBeenCalledWith(
+    "hosts:getLocalBrowserSettings",
+    scope,
+  );
+  state.setting = { enabled: false };
+  view.rerender();
+  expect(view.result.current).toEqual([]);
+});
+
+it("waits for the named client's setting and respects an opt-out before its DTO loads", () => {
+  state.user = { id: "member" };
+  const scope = { projectId: "proj_1", hostId: "host_1" };
+  const view = renderHook(() => useBrowserToolIds(null, "local", scope));
+  expect(view.result.current).toBeUndefined();
+  state.setting = { enabled: false };
+  view.rerender();
+  expect(view.result.current).toEqual([]);
+  expect(state.queries).toHaveBeenCalledWith(
+    "hosts:getLocalBrowserSettings",
+    scope,
+  );
+});
+
+it("skips local settings for hosted engines and invalid project scopes", () => {
+  state.user = { id: "member" };
+  renderHook(() => useBrowserToolIds(null, "cloud", { projectId: "proj_1" }));
+  renderHook(() => useBrowserToolIds(null, "local", { projectId: "none" }));
+  expect(state.queries.mock.calls.every(([, args]) => args === "skip")).toBe(
+    true,
+  );
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/useBrowserTools.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useBrowserTools.test.tsx
@@ -1,4 +1,6 @@
-vi.mock("@workos-inc/authkit-react", () => ({ useAuth: () => ({ user: { id: "member" } }) }));
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: { id: "member" } }),
+}));
 /**
  * `useBrowserTools` — which host the Tools panel's Browser section believes it
  * is describing, and when it asks the server anything at all.
@@ -13,8 +15,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 
 const state = vi.hoisted(() => ({
-  explicitHost: null as { config?: { builtInToolIds?: string[]; localBrowserEnabled?: boolean } } | null,
-  projectDefault: null as { builtInToolIds?: string[]; localBrowserEnabled?: boolean } | null,
+  setting: undefined as { enabled: boolean | null } | undefined,
+  explicitHost: null as {
+    config?: { builtInToolIds?: string[]; localBrowserEnabled?: boolean };
+  } | null,
+  projectDefault: null as {
+    builtInToolIds?: string[];
+    localBrowserEnabled?: boolean;
+  } | null,
   selectedEngine: "cloud" as "cloud" | "local",
   consentToken: null as string | null,
   definitions: [{ name: "browser_navigate", description: "Open a URL." }],
@@ -34,6 +42,15 @@ vi.mock("convex/react", () => ({
   // argument object is the whole difference between a quiet render and a
   // server-side throw.
   useQuery: (_name: unknown, args: unknown) => {
+    if (_name === "hosts:getLocalBrowserSettings")
+      return (
+        state.setting ?? {
+          enabled:
+            state.explicitHost?.config?.localBrowserEnabled ??
+            state.projectDefault?.localBrowserEnabled ??
+            null,
+        }
+      );
     state.projectDefaultQueryArgs.push(args);
     return state.projectDefault ?? undefined;
   },
@@ -79,32 +96,32 @@ vi.mock("@/lib/browser-page-tools/client", () => ({
     state.definitionCalls.push(engine);
     return state.definitions;
   }),
-  fetchHostedPageTools: vi.fn(async (_tokens: unknown, _signal: unknown, tabId?: string) => {
-    state.pageCalls.push("hosted");
-    state.pageTabIds.push(tabId);
-    return {
-      ok: true,
-      url: "https://webmcp.dev/",
-      webmcpSupported: true,
-      tools: [],
-    };
-  }),
-  fetchLocalPageTools: vi.fn(async (args: {
-    tabId?: string;
-    sessionId?: string;
-    holder?: string;
-  }) => {
-    state.pageCalls.push("local");
-    state.pageTabIds.push(args?.tabId);
-    state.pageSessionIds.push(args?.sessionId);
-    state.pageHolders.push(args?.holder);
-    return {
-      ok: true,
-      url: "http://localhost/",
-      webmcpSupported: false,
-      tools: [],
-    };
-  }),
+  fetchHostedPageTools: vi.fn(
+    async (_tokens: unknown, _signal: unknown, tabId?: string) => {
+      state.pageCalls.push("hosted");
+      state.pageTabIds.push(tabId);
+      return {
+        ok: true,
+        url: "https://webmcp.dev/",
+        webmcpSupported: true,
+        tools: [],
+      };
+    },
+  ),
+  fetchLocalPageTools: vi.fn(
+    async (args: { tabId?: string; sessionId?: string; holder?: string }) => {
+      state.pageCalls.push("local");
+      state.pageTabIds.push(args?.tabId);
+      state.pageSessionIds.push(args?.sessionId);
+      state.pageHolders.push(args?.holder);
+      return {
+        ok: true,
+        url: "http://localhost/",
+        webmcpSupported: false,
+        tools: [],
+      };
+    },
+  ),
   fetchHostedPageToolInvoke: vi.fn(async () => ({
     ok: true,
     output: {},
@@ -132,6 +149,7 @@ beforeEach(() => {
   state.selectedEngine = "cloud";
   state.consentToken = null;
   state.definitionCalls = [];
+  state.setting = undefined;
   state.pageCalls = [];
   state.pageTabIds = [];
   state.pageSessionIds = [];
@@ -153,7 +171,9 @@ describe("useBrowserTools — which host it describes", () => {
     state.selectedEngine = "local";
     state.consentToken = "saved-device-consent";
     state.projectDefault = { ...WITHOUT_BROWSER, localBrowserEnabled: true };
-    const { result } = renderHook(() => useBrowserTools({ projectId: "proj_1", hostId: null }));
+    const { result } = renderHook(() =>
+      useBrowserTools({ projectId: "proj_1", hostId: null }),
+    );
     await waitFor(() => expect(result.current.tools).toHaveLength(1));
     expect(result.current.attached).toBe(true);
     expect(state.definitionCalls).toEqual(["local"]);
@@ -162,8 +182,12 @@ describe("useBrowserTools — which host it describes", () => {
   it("stops exposing tools when this client's local override is disabled", async () => {
     state.selectedEngine = "local";
     state.consentToken = "saved-device-consent";
-    state.explicitHost = { config: { ...WITH_BROWSER, localBrowserEnabled: false } };
-    const { result } = renderHook(() => useBrowserTools({ projectId: "proj_1", hostId: "host_1" }));
+    state.explicitHost = {
+      config: { ...WITH_BROWSER, localBrowserEnabled: false },
+    };
+    const { result } = renderHook(() =>
+      useBrowserTools({ projectId: "proj_1", hostId: "host_1" }),
+    );
     expect(result.current.attached).toBe(false);
     expect(state.definitionCalls).toEqual([]);
     expect(state.pageCalls).toEqual([]);
@@ -315,9 +339,7 @@ describe("useBrowserTools — the read follows the tab the signal came from", ()
       { webmcp: { revision: 7, hash: "h7", count: 1 }, tabs: { active: "t2" } },
       "boot-1",
     );
-    await waitFor(() =>
-      expect(state.pageCalls.length).toBeGreaterThan(before),
-    );
+    await waitFor(() => expect(state.pageCalls.length).toBeGreaterThan(before));
     expect(state.pageTabIds.at(-1)).toBe("t2");
     expect(result.current.attached).toBe(true);
   });
@@ -356,4 +378,17 @@ describe("useBrowserTools — what it sends to Convex", () => {
       }),
     );
   });
+});
+
+it("lists tools after Allow in a project with no saved client configuration", async () => {
+  state.selectedEngine = "local";
+  state.consentToken = "saved-device-consent";
+  state.projectDefault = null;
+  state.explicitHost = null;
+  state.setting = { enabled: true };
+  const { result } = renderHook(() =>
+    useBrowserTools({ projectId: "proj_1", hostId: null }),
+  );
+  await waitFor(() => expect(result.current.tools).toHaveLength(1));
+  expect(result.current.attached).toBe(true);
 });

--- a/mcpjam-inspector/client/src/hooks/useBrowserToolIds.ts
+++ b/mcpjam-inspector/client/src/hooks/useBrowserToolIds.ts
@@ -1,3 +1,5 @@
+import { useConvexAuth, useQuery } from "convex/react";
+import { shouldQueryProjectId } from "./useProjects";
 import { useMemo } from "react";
 import { HOSTED_MODE } from "@/lib/config";
 import { resolveLocalBrowserTools } from "@/shared/local-browser-settings";
@@ -8,21 +10,40 @@ import { useLocalBrowserConsent } from "./useLocalBrowserConsent";
 export function useBrowserToolIds(
   config: HostConfigDtoV2 | null | undefined,
   engine: "local" | "cloud",
+  scope?: { projectId: string | null; hostId?: string | null },
 ) {
   const { user } = useAuth();
   const consent = useLocalBrowserConsent();
+  const { isAuthenticated } = useConvexAuth();
+  // This preference exists even when the project has no default host config.
+  // Include the named host so its explicit opt-out wins while its DTO loads.
+  const querySettings =
+    !HOSTED_MODE &&
+    engine === "local" &&
+    isAuthenticated &&
+    !!user &&
+    shouldQueryProjectId(scope?.projectId);
+  const settings = useQuery(
+    "hosts:getLocalBrowserSettings" as never,
+    querySettings
+      ? ({
+          projectId: scope!.projectId,
+          ...(scope?.hostId ? { hostId: scope.hostId } : {}),
+        } as never)
+      : "skip",
+  ) as { enabled: boolean | null } | undefined;
   // Guest clients have no shared project setting to update. Their explicit
   // device grant supplies the local default, including views in other tabs.
   const enabled =
-    config?.localBrowserEnabled ??
+    (querySettings ? settings?.enabled : config?.localBrowserEnabled) ??
     (!user && consent.granted ? true : undefined);
   return useMemo(
     () =>
       resolveLocalBrowserTools(
-        config?.builtInToolIds,
+        querySettings && !settings ? undefined : config?.builtInToolIds,
         enabled,
         !HOSTED_MODE && engine === "local",
       ),
-    [config?.builtInToolIds, enabled, engine],
+    [config?.builtInToolIds, enabled, engine, querySettings, settings],
   );
 }

--- a/mcpjam-inspector/client/src/hooks/useBrowserTools.ts
+++ b/mcpjam-inspector/client/src/hooks/useBrowserTools.ts
@@ -63,6 +63,17 @@ const LEASE_HELD_RETRIES = 3;
  */
 const DEFINITIONS_CACHE = new Map<string, SerializedModelRequestTool[]>();
 
+/**
+ * Explains missing local access in the tool list and links to client settings.
+ * Initial permission discovery belongs to the Playground onboarding dialog.
+ */
+export interface BrowserLocalConsentPrompt {
+  onAllow: () => Promise<boolean>;
+  disabledForClient?: boolean;
+  /** The saved client whose Browser tab turns it back off; null → clients list. */
+  settingsHostId: string | null;
+}
+
 export interface BrowserToolsState {
   /** True when the previewed host actually attaches the browser capability. */
   attached: boolean;
@@ -92,6 +103,8 @@ export interface BrowserToolsState {
     frameId?: string;
     input: Record<string, unknown>;
   }) => Promise<BrowserPageToolInvokeResponse>;
+  /** Local permission or client enablement is missing; show a settings link. */
+  localConsent?: BrowserLocalConsentPrompt | null;
 }
 
 export function useBrowserTools(args: {
@@ -146,10 +159,12 @@ export function useBrowserTools(args: {
   // this list say someone else has the browser, while the model can still
   // call the tools after the next hand-back.
   const paneHolder = usePaneHolderId();
-  const toolIds = useBrowserToolIds(hostConfig, engineState.selectedEngine);
-  const attached = (toolIds ?? []).includes(
-    BROWSER_BUILT_IN_TOOL_ID,
+  const toolIds = useBrowserToolIds(
+    hostConfig,
+    engineState.selectedEngine,
+    args,
   );
+  const attached = (toolIds ?? []).includes(BROWSER_BUILT_IN_TOOL_ID);
   // The BODY-side engine choice, exactly as the Browser pane resolves it, so
   // the pane and the tool list cannot describe two different browsers.
   const engine: "hosted" | "local" =
@@ -395,9 +410,20 @@ export function useBrowserTools(args: {
   const available =
     engine !== "local" ||
     (engineState.localAvailable && engineState.consent.granted);
+  const localConsent: BrowserLocalConsentPrompt | null =
+    engine === "local" &&
+    engineState.localAvailable &&
+    (!engineState.consent.granted || !attached)
+      ? {
+          disabledForClient: engineState.consent.granted && !attached,
+          onAllow: engineState.consent.grant,
+          settingsHostId: host?.hostId ?? null,
+        }
+      : null;
   return {
     attached,
     engine,
+    localConsent,
     tools: available ? tools : [],
     page: available
       ? page

--- a/mcpjam-inspector/client/src/hooks/useLocalBrowserConsent.ts
+++ b/mcpjam-inspector/client/src/hooks/useLocalBrowserConsent.ts
@@ -18,6 +18,7 @@ import { useCallback, useSyncExternalStore } from "react";
 import { HOSTED_MODE } from "@/lib/config";
 import {
   clearStoredLocalBrowserConsent,
+  rememberLocalBrowserOnboarding,
   loadStoredLocalBrowserConsent,
   enableLocalBrowserForAllClients,
   localBrowserSetupPending,
@@ -73,6 +74,7 @@ export function useLocalBrowserConsent(): LocalBrowserConsent {
     // it is also SCOPED to the token being forgotten, so on the server side a
     // delayed revoke can't sever a capability a newer grant rotated in.
     const stored = loadStoredLocalBrowserConsent()?.token ?? null;
+    rememberLocalBrowserOnboarding("dismissed");
     clearStoredLocalBrowserConsent();
     await revokeLocalBrowserConsentOnServer(stored);
   }, []);

--- a/mcpjam-inspector/client/src/hooks/useLocalBrowserOnboarding.ts
+++ b/mcpjam-inspector/client/src/hooks/useLocalBrowserOnboarding.ts
@@ -1,0 +1,22 @@
+import { useCallback, useState, useSyncExternalStore } from "react";
+import {
+  localBrowserOnboardingDecision,
+  rememberLocalBrowserOnboarding,
+  subscribeLocalBrowserConsent,
+} from "@/lib/local-browser-consent";
+
+/** Discovery is remembered separately from the device's permission capability. */
+export function useLocalBrowserOnboarding() {
+  const decision = useSyncExternalStore(
+    subscribeLocalBrowserConsent,
+    localBrowserOnboardingDecision,
+    () => null,
+  );
+  // Storage can be blocked: dismissal should still work for this mount.
+  const [dismissedHere, setDismissedHere] = useState(false);
+  const dismiss = useCallback(() => {
+    setDismissedHere(true);
+    rememberLocalBrowserOnboarding("dismissed");
+  }, []);
+  return { undecided: !decision && !dismissedHere, dismiss };
+}

--- a/mcpjam-inspector/client/src/lib/local-browser-consent.ts
+++ b/mcpjam-inspector/client/src/lib/local-browser-consent.ts
@@ -27,6 +27,29 @@ import { authFetch } from "@/lib/session-token";
 const STORAGE_KEY = "mcp-local-browser-consent-v1";
 const EVENT_NAME = "local-browser-consent-changed";
 const SETUP_KEY = "mcp-local-browser-setup-pending-v1";
+const ONBOARDING_KEY = "mcp-local-browser-onboarding-v1";
+export type LocalBrowserOnboardingDecision = "dismissed" | "completed" | null;
+
+export function localBrowserOnboardingDecision(): LocalBrowserOnboardingDecision {
+  try {
+    const value = localStorage.getItem(ONBOARDING_KEY);
+    return value === "dismissed" || value === "completed" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function rememberLocalBrowserOnboarding(
+  decision: Exclude<LocalBrowserOnboardingDecision, null>,
+): boolean {
+  try {
+    localStorage.setItem(ONBOARDING_KEY, decision);
+    window.dispatchEvent(new CustomEvent(EVENT_NAME));
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export function localBrowserSetupPending(): boolean {
   try {
@@ -105,6 +128,7 @@ export function subscribeLocalBrowserConsent(callback: () => void): () => void {
     if (
       event.key === STORAGE_KEY ||
       event.key === SETUP_KEY ||
+      event.key === ONBOARDING_KEY ||
       event.key === null
     )
       callback();
@@ -241,6 +265,7 @@ export function enableLocalBrowserForAllClients(): Promise<boolean> {
     // A revoke or grant in another tab wins over this delayed completion.
     if (loadStoredLocalBrowserConsent()?.token !== token) return false;
     setSetupPending(false);
+    rememberLocalBrowserOnboarding("completed");
     return true;
   })().finally(() => {
     setupInFlight = null;


### PR DESCRIPTION
## Purpose and behavior

Local users can reach Playground with an authorized browser but no visible browser tools. This adds a centered first-visit setup dialog, including over restored conversations, without requiring a saved client or a connected MCP server. Allow grants device access and enables eligible clients; Not now, Escape, and Close remember dismissal. Later setup remains available from the Browser tab and client Browser settings.

Setup failures stay visible with an explicit retry. Existing device permission is reused, client opt-outs are preserved, and successful setup is remembered across tabs. The tool list, Browser controls, and chat now read the project browser setting independently of a default client configuration, so a missing default config no longer hides enabled browser tools. The left pane links to settings instead of showing a duplicate Allow prompt.

## Validation

- 120 targeted client tests passed on this branch after rebasing onto main, covering onboarding, consent, tool resolution, browser engine selection, and Playground rendering.
- Desktop, narrow-screen, dark-mode, backdrop dismissal, and keyboard focus checked with an isolated browser preview using the real dialog and compiled source styles.
- Client TypeScript and renderer import guards checked.

## Rollout

Local Inspector only, under the existing local-browser rollout and runtime-availability gates. Hosted users and cloud/environment conversations do not receive this prompt. Uses existing backend APIs; no database migration or backend runtime deployment is required. Includes a patch changeset. Onboarding dismissal/completion is recorded separately from device consent; authorized installations without that record receive a one-time finish-setup prompt.

Related issue: reported local Playground browser-discovery mismatch; no tracked issue supplied. Separate local browser-control layout work is excluded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local browser consent, client enablement, and Convex-backed project settings that gate which tools the model sees; mistakes could hide or expose browser tools incorrectly, but changes are local-inspector gated with existing APIs.
> 
> **Overview**
> Adds **first-visit local browser onboarding** in Playground via `LocalBrowserOnboarding` at the tab root: a modal consent flow (including over restored chats) that does not require a selected client or MCP server. **Allow** runs device grant plus client enablement and blocks dismiss until setup finishes; **Not now** / close paths persist a separate onboarding decision from device consent, with a one-time **finish setup** path when permission already exists.
> 
> **`LocalBrowserConsentGate`** gains `onboarding`, `inline`, and `card` variants, richer analytics locations, and submit guarding during grant.
> 
> **Browser tool visibility** no longer depends on a saved default host DTO: `useBrowserToolIds` takes `{ projectId, hostId }` and reads `hosts:getLocalBrowserSettings` so tools can appear when the project setting is on but no default client config exists. The Tools rail surfaces **`localConsent`** as guidance (Browser tab / settings link, or client opt-out copy) instead of a second Allow button or misleading “no browser running” WebMCP state.
> 
> Playground call sites (`PlaygroundTab`, right rail, `PlaygroundMain`, tool panes) pass the new scope; tests cover onboarding, consent UI, and tool resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20ba3a1367f1feec98c44aba046fe6dedc9d737d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a first-visit setup dialog so local Playground users with an authorized browser but no visible tools can enable them without a saved client or connected MCP server.

**New Features**
- Allow grants device access and enables eligible clients; Not now, Escape, and Close remember dismissal across tabs.
- Users with saved device permission who never finished setup get a one-time Finish setup prompt; failures stay visible with retry and client opt-outs are preserved.
- Browser tool visibility now reads the project setting independently of a default client config, so a missing default config no longer hides enabled tools; the Tools pane links to Browser settings instead of showing a second Allow prompt.

**Rollout**
- Local Inspector only, under existing local-browser and runtime-availability gates; hosted users and cloud conversations are unaffected.
- Uses existing backend APIs with no database migration or backend deployment; includes a patch changeset.

<sup>Written for commit 20ba3a1367f1feec98c44aba046fe6dedc9d737d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

