### PR TITLE
Browser settings belong in the browser, not beside it

### DIFF
--- a/.changeset/plenty-panes-settle.md
+++ b/.changeset/plenty-panes-settle.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Move the Browser settings entry point into the browser pane itself. The pane's nav bar now carries a Browser settings button that opens the client's Browser tab, the compact runtime-controls menu links there too, and the duplicate button in the Playground right rail and browser panel header is gone. Consent copy is now shared across the dialog, the inline prompt, and onboarding so the three no longer drift.

--- a/mcpjam-inspector/client/src/components/browser/BrowserRuntimeControls.tsx
+++ b/mcpjam-inspector/client/src/components/browser/BrowserRuntimeControls.tsx
@@ -12,16 +12,22 @@ import { usePlaygroundChatHistoryBridge } from "@/components/playground/playgrou
 import { useActiveChatSessionStore } from "@/stores/active-chat-session-store";
 import { useBrowserReadinessStore } from "@/stores/browser-readiness-store";
 import { HOSTED_MODE } from "@/lib/config";
+import { useAppNavigate } from "@/lib/app-navigation";
+import { buildHostFocusTabPath } from "@/components/hosts/host-verify-deep-link";
 
 export function BrowserRuntimeControls({
   projectId,
   compact = false,
   settings = false,
+  hostId = null,
 }: {
   projectId: string | null;
   compact?: boolean;
   settings?: boolean;
+  /** When set with `compact`, links to this client's Browser settings tab. */
+  hostId?: string | null;
 }) {
+  const navigate = useAppNavigate();
   const engine = useBrowserEngine(
     projectId,
     settings ? "preference" : "conversation",
@@ -158,6 +164,18 @@ export function BrowserRuntimeControls({
         <p role="status" className="text-muted-foreground">
           {visibleReason}
         </p>
+      ) : null}
+      {compact && hostId ? (
+        <div className="border-t border-border pt-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-auto w-full justify-start px-1 py-1 text-xs font-normal text-muted-foreground"
+            onClick={() => navigate(buildHostFocusTabPath(hostId, "browser"))}
+          >
+            Browser settings
+          </Button>
+        </div>
       ) : null}
     </div>
   );

--- a/mcpjam-inspector/client/src/components/browser/BrowserSettingsButton.tsx
+++ b/mcpjam-inspector/client/src/components/browser/BrowserSettingsButton.tsx
@@ -1,0 +1,21 @@
+import { Globe } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { useAppNavigate } from "@/lib/app-navigation";
+import { buildHostFocusTabPath } from "@/components/hosts/host-verify-deep-link";
+
+/** Opens this client's Browser tab in host focus. */
+export function BrowserSettingsButton({ hostId }: { hostId: string }) {
+  const navigate = useAppNavigate();
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      aria-label="Browser settings"
+      title="Open client Browser settings"
+      data-testid="browser-settings-link"
+      onClick={() => navigate(buildHostFocusTabPath(hostId, "browser"))}
+    >
+      <Globe className="h-3.5 w-3.5" />
+    </Button>
+  );
+}

--- a/mcpjam-inspector/client/src/components/browser/HostedBrowserBody.tsx
+++ b/mcpjam-inspector/client/src/components/browser/HostedBrowserBody.tsx
@@ -30,6 +30,7 @@ import {
   labelFor,
 } from "@/components/browser/PaneControlBar";
 import { BrowserPanel } from "@/components/computer/BrowserPanel";
+import { BrowserSettingsButton } from "@/components/browser/BrowserSettingsButton";
 import { BrowserProfileSaveButton } from "@/components/browser/BrowserProfileSaveButton";
 import {
   createTierController,
@@ -127,6 +128,7 @@ export function HostedBrowserBody({
   projectId,
   sessionId,
   mintToken,
+  hostId = null,
   active = true,
 }: {
   projectId: string | null;
@@ -137,6 +139,8 @@ export function HostedBrowserBody({
     token: string;
     expiresAt: number;
   }>;
+  /** Client id for the Browser settings button in the nav bar. */
+  hostId?: string | null;
   /**
    * Is this pane the rail's visible tab?
    *
@@ -1348,21 +1352,24 @@ export function HostedBrowserBody({
       error={error ?? shell.error}
       {...(placeholder ? { placeholder } : {})}
       trailing={
-        <PaneSettingsMenu
-          statsOpen={statsOpen}
-          onToggleStats={onStatsToggle}
-          tier={tierPreference}
-          tiers={HOSTED_TIERS}
-          onTier={onTier}
-        >
-          {session && sessionId ? (
-            <BrowserProfileSaveButton
-              projectId={projectId ?? ""}
-              exportArchive={exportProfile}
-              disabled={busy}
-            />
-          ) : null}
-        </PaneSettingsMenu>
+        <>
+          {hostId ? <BrowserSettingsButton hostId={hostId} /> : null}
+          <PaneSettingsMenu
+            statsOpen={statsOpen}
+            onToggleStats={onStatsToggle}
+            tier={tierPreference}
+            tiers={HOSTED_TIERS}
+            onTier={onTier}
+          >
+            {session && sessionId ? (
+              <BrowserProfileSaveButton
+                projectId={projectId ?? ""}
+                exportArchive={exportProfile}
+                disabled={busy}
+              />
+            ) : null}
+          </PaneSettingsMenu>
+        </>
       }
     >
       <BrowserPaneSurface

--- a/mcpjam-inspector/client/src/components/browser/LocalBrowserBody.tsx
+++ b/mcpjam-inspector/client/src/components/browser/LocalBrowserBody.tsx
@@ -29,6 +29,7 @@ import {
 import { ElectronNativeBody } from "@/components/browser/ElectronNativeBody";
 import { BrowserShell } from "@/components/browser/BrowserShell";
 import { PaneSettingsMenu } from "@/components/browser/PaneControlBar";
+import { BrowserSettingsButton } from "@/components/browser/BrowserSettingsButton";
 import { BrowserProfileSaveButton } from "@/components/browser/BrowserProfileSaveButton";
 import { useBrowserSession } from "@/lib/browser-shell/use-browser-session";
 import {
@@ -105,6 +106,7 @@ export function LocalBrowserBody({
   sessionId,
   consentGranted,
   consentToken,
+  hostId = null,
   active = true,
   onSessionReady,
 }: {
@@ -113,6 +115,8 @@ export function LocalBrowserBody({
   sessionId?: string;
   consentGranted: boolean;
   consentToken: string | null;
+  /** Client id for the Browser settings button in the nav bar. */
+  hostId?: string | null;
   /**
    * Is this pane the rail's visible tab?
    *
@@ -1317,18 +1321,21 @@ export function LocalBrowserBody({
           // that has gone — replace the page area entirely. @see the prop.
           {...(placeholder ? { placeholder } : {})}
           trailing={
-            <PaneSettingsMenu
-              statsOpen={statsOpen}
-              onToggleStats={onStatsToggle}
-            >
-              {session && sessionId ? (
-                <BrowserProfileSaveButton
-                  projectId={projectId ?? ""}
-                  exportArchive={exportProfile}
-                  disabled={busy}
-                />
-              ) : null}
-            </PaneSettingsMenu>
+            <>
+              {hostId ? <BrowserSettingsButton hostId={hostId} /> : null}
+              <PaneSettingsMenu
+                statsOpen={statsOpen}
+                onToggleStats={onStatsToggle}
+              >
+                {session && sessionId ? (
+                  <BrowserProfileSaveButton
+                    projectId={projectId ?? ""}
+                    exportArchive={exportProfile}
+                    disabled={busy}
+                  />
+                ) : null}
+              </PaneSettingsMenu>
+            </>
           }
         >
           {native ? (

--- a/mcpjam-inspector/client/src/components/browser/LocalBrowserConsentGate.tsx
+++ b/mcpjam-inspector/client/src/components/browser/LocalBrowserConsentGate.tsx
@@ -10,7 +10,48 @@ import { Globe } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { track } from "@/lib/analytics";
 import { HOSTED_MODE } from "@/lib/config";
+import { routePaths, useAppNavigate } from "@/lib/app-navigation";
 import { useAuth } from "@workos-inc/authkit-react";
+
+/** Shared consent copy — one description across card, inline, and onboarding. */
+function LocalBrowserConsentDescription({
+  guest,
+  onOpenBrowserSettings,
+  linkClassName = "text-sm",
+}: {
+  guest: boolean;
+  onOpenBrowserSettings?: () => void;
+  linkClassName?: string;
+}) {
+  const navigate = useAppNavigate();
+  const openSettings =
+    onOpenBrowserSettings ?? (() => navigate(routePaths.hosts));
+
+  if (guest) {
+    return (
+      <>
+        Allow agents to navigate, click, type, and read pages on this machine.
+        Page content may be sent to your model. This enables Browser for your
+        local clients across WebMCP, Playground, and tabs on this device.
+      </>
+    );
+  }
+
+  return (
+    <>
+      Allow agents to navigate, click, type, and read pages on this machine.
+      Page content may be sent to your model. You can remove it in each{" "}
+      <Button
+        variant="link"
+        className={`h-auto p-0 ${linkClassName}`}
+        onClick={openSettings}
+      >
+        Browser settings
+      </Button>
+      .
+    </>
+  );
+}
 
 /** Explicit device consent and shared local-client setup. */
 export function LocalBrowserConsentGate({
@@ -116,18 +157,23 @@ export function LocalBrowserConsentGate({
               ? "Finish enabling browser tools"
               : "Let agents use your browser?"}
           </DialogTitle>
-          <DialogDescription>
-            {setupOnly
-              ? "Browser permission is saved. Finish setup to enable browser tools for your clients. "
-              : "Allow agents to navigate, click, type, and read pages in a browser on this machine. "}
-            Page content may be sent to your model.
+          <DialogDescription asChild>
+            <p className="text-sm text-muted-foreground">
+              {setupOnly ? (
+                <>
+                  Browser permission is saved. Finish setup to enable browser
+                  tools for your clients.
+                </>
+              ) : (
+                <LocalBrowserConsentDescription
+                  guest={!user}
+                  {...(onOpenClientSettings
+                    ? { onOpenBrowserSettings: onOpenClientSettings }
+                    : {})}
+                />
+              )}
+            </p>
           </DialogDescription>
-          <p className="text-sm text-muted-foreground">
-            {user
-              ? "Enables browser tools for clients in projects you manage. Clients you’ve explicitly disabled stay disabled."
-              : "Enables browser tools for your local clients on this device."}{" "}
-            You can change this in the Browser tab or client Browser settings.
-          </p>
           {error ? (
             <p
               role="alert"
@@ -162,8 +208,13 @@ export function LocalBrowserConsentGate({
         className="space-y-2 px-3"
       >
         <p className="text-xs leading-snug text-muted-foreground">
-          Allow agents to navigate, click, type, and read pages on this machine.
-          Page content may be sent to your model.
+          <LocalBrowserConsentDescription
+            guest={!user}
+            linkClassName="text-xs"
+            {...(onOpenClientSettings
+              ? { onOpenBrowserSettings: onOpenClientSettings }
+              : {})}
+          />
         </p>
         <Button
           size="sm"
@@ -175,20 +226,6 @@ export function LocalBrowserConsentGate({
         {error ? (
           <p className="text-xs text-destructive" data-testid="consent-error">
             {error}
-          </p>
-        ) : null}
-        {onOpenClientSettings ? (
-          <p className="text-xs leading-snug text-muted-foreground">
-            {user ? "Enables every client you manage. " : null}
-            To turn it off, open{" "}
-            <Button
-              variant="link"
-              className="h-auto p-0 text-xs"
-              onClick={onOpenClientSettings}
-            >
-              client Browser settings
-            </Button>
-            .
           </p>
         ) : null}
       </div>
@@ -204,11 +241,12 @@ export function LocalBrowserConsentGate({
         Enable local Browser for all clients
       </h2>
       <p className="text-sm leading-relaxed text-muted-foreground">
-        Allow agents to navigate, click, type, and read pages on this machine.
-        Page content may be sent to your model.{" "}
-        {user
-          ? "You can remove it in each client's Connect settings."
-          : "This enables Browser for your local clients across WebMCP, Playground, and tabs on this device."}
+        <LocalBrowserConsentDescription
+          guest={!user}
+          {...(onOpenClientSettings
+            ? { onOpenBrowserSettings: onOpenClientSettings }
+            : {})}
+        />
       </p>
       {user && (
         <p className="text-xs leading-relaxed text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/browser/PaneControlBar.tsx
+++ b/mcpjam-inspector/client/src/components/browser/PaneControlBar.tsx
@@ -114,7 +114,7 @@ export function PaneSettingsMenu({
           onCheckedChange={(next) => onToggleStats(Boolean(next))}
           data-testid="pane-stats-toggle"
         >
-          Stats for nerds
+          Stats
         </DropdownMenuCheckboxItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/mcpjam-inspector/client/src/components/browser/StatsOverlay.tsx
+++ b/mcpjam-inspector/client/src/components/browser/StatsOverlay.tsx
@@ -8,7 +8,7 @@ import {
 const REFRESH_MS = 500;
 
 /**
- * "Stats for nerds" — what this stream is actually doing, right now.
+ * Stats — what this stream is actually doing, right now.
  *
  * The pane degrades silently by design: a link that cannot carry video falls
  * back to JPEG, a client without `VideoDecoder` never asks for video at all,

--- a/mcpjam-inspector/client/src/components/browser/__tests__/BrowserRuntimeControls.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/BrowserRuntimeControls.test.tsx
@@ -34,6 +34,11 @@ vi.mock("@/stores/browser-readiness-store", () => ({
   useBrowserReadinessStore: (select: (s: unknown) => unknown) =>
     select({ reasons: {} }),
 }));
+const navigate = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/app-navigation", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/app-navigation")>()),
+  useAppNavigate: () => navigate,
+}));
 import { BrowserRuntimeControls } from "../BrowserRuntimeControls";
 beforeEach(() => {
   vi.clearAllMocks();
@@ -82,6 +87,13 @@ it("keeps runtime controls in the compact options menu", async () => {
   expect(await screen.findByLabelText("Browser location")).toBeVisible();
   fireEvent.click(screen.getByText("Revoke Browser"));
   expect(state.revoke).toHaveBeenCalledOnce();
+});
+
+it("links to client Browser settings inside the compact options menu", async () => {
+  render(<BrowserRuntimeControls projectId="p" compact hostId="host-1" />);
+  fireEvent.click(screen.getByRole("button", { name: "Browser options" }));
+  fireEvent.click(await screen.findByRole("button", { name: "Browser settings" }));
+  expect(navigate).toHaveBeenCalledWith("/hosts/host-1?hostTab=browser");
 });
 
 it("changes the personal preference without resetting or starting a chat", () => {

--- a/mcpjam-inspector/client/src/components/browser/__tests__/BrowserSettingsButton.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/BrowserSettingsButton.test.tsx
@@ -1,0 +1,16 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+
+const navigate = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/app-navigation", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/app-navigation")>()),
+  useAppNavigate: () => navigate,
+}));
+
+import { BrowserSettingsButton } from "../BrowserSettingsButton";
+
+it("opens the client Browser tab in host focus", () => {
+  render(<BrowserSettingsButton hostId="host-1" />);
+  fireEvent.click(screen.getByRole("button", { name: "Browser settings" }));
+  expect(navigate).toHaveBeenCalledWith("/hosts/host-1?hostTab=browser");
+});

--- a/mcpjam-inspector/client/src/components/browser/__tests__/HostedBrowserBody.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/HostedBrowserBody.test.tsx
@@ -53,6 +53,10 @@ vi.mock("@/hooks/useComputersEnabled", () => ({
   useBrowserWorkspaceEnabled: () => api.workspaceEnabled,
 }));
 
+vi.mock("@/components/browser/BrowserSettingsButton", () => ({
+  BrowserSettingsButton: () => null,
+}));
+
 vi.mock("@/lib/hosted-browser/client", async () => {
   const actual = await vi.importActual<
     typeof import("@/lib/hosted-browser/client")

--- a/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserBody.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserBody.test.tsx
@@ -78,6 +78,10 @@ vi.mock("@/hooks/useComputersEnabled", () => ({
   useBrowserWorkspaceEnabled: () => api.workspaceEnabled,
 }));
 
+vi.mock("@/components/browser/BrowserSettingsButton", () => ({
+  BrowserSettingsButton: () => null,
+}));
+
 vi.mock("@/lib/local-browser/client", async () => {
   const actual = await vi.importActual<
     typeof import("@/lib/local-browser/client")

--- a/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserConsentGate.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserConsentGate.test.tsx
@@ -12,6 +12,11 @@ vi.mock("@/lib/config", () => ({
   },
 }));
 vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+const navigate = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/app-navigation", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/app-navigation")>()),
+  useAppNavigate: () => navigate,
+}));
 
 beforeEach(() => {
   mode.hosted = false;
@@ -38,12 +43,20 @@ describe("LocalBrowserConsentGate", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        /Allow agents to navigate, click, type, and read pages on this machine\. Page content may be sent to your model\. You can remove it in each client's Connect settings\./,
-      ),
+      screen.getByText(/Page content may be sent to your model/),
     ).toBeInTheDocument();
-    expect(screen.queryByText(/projects you manage/)).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Browser settings" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Connect settings/)).toBeNull();
     expect(onAllow).not.toHaveBeenCalled();
+  });
+
+  it("opens the clients list from Browser settings when no handler is passed", () => {
+    navigate.mockClear();
+    render(<LocalBrowserConsentGate onAllow={() => true} />);
+    fireEvent.click(screen.getByRole("button", { name: "Browser settings" }));
+    expect(navigate).toHaveBeenCalledWith("/hosts");
   });
 
   it("requires Allow and reports failed setup for an explicit retry", async () => {

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundBrowserPanel.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundBrowserPanel.tsx
@@ -1,4 +1,3 @@
-import { BrowserRuntimeControls } from "@/components/browser/BrowserRuntimeControls";
 import { useCallback, useEffect } from "react";
 import { Maximize2, Minimize2, PanelRightClose } from "lucide-react";
 import { cn } from "@mcpjam/design-system/cn";
@@ -31,6 +30,7 @@ import { ComparisonBrowser } from "@/components/browser/ComparisonBrowser";
 
 export interface PlaygroundBrowserPanelProps {
   projectId: string | null;
+  hostId?: string | null;
   /**
    * Is the panel on screen?
    *
@@ -47,6 +47,7 @@ export interface PlaygroundBrowserPanelProps {
 
 export function PlaygroundBrowserPanel({
   projectId,
+  hostId = null,
   visible,
   onClose,
 }: PlaygroundBrowserPanelProps) {
@@ -141,7 +142,6 @@ export function PlaygroundBrowserPanel({
             <Maximize2 className="size-3.5" aria-hidden />
           )}
         </button>
-        <BrowserRuntimeControls projectId={projectId} compact />
         <button
           type="button"
           onClick={onClose}
@@ -177,6 +177,7 @@ export function PlaygroundBrowserPanel({
             sessionId={browserSessionId}
             consentGranted={engine.consent.granted}
             consentToken={engine.consent.token}
+            hostId={hostId}
             active={visible}
           />
         ) : (
@@ -185,6 +186,7 @@ export function PlaygroundBrowserPanel({
             projectId={projectId}
             sessionId={browserSessionId}
             mintToken={mintHostedBrowserToken}
+            hostId={hostId}
             active={visible}
           />
         )}

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
@@ -1,7 +1,4 @@
 import { BrowserActivityList } from "@/components/browser/BrowserActivityList";
-import { buildHostFocusTabPath } from "@/components/hosts/host-verify-deep-link";
-import { useAppNavigate } from "@/lib/app-navigation";
-import { BrowserRuntimeControls } from "@/components/browser/BrowserRuntimeControls";
 import { useBrowserEngine } from "@/hooks/useBrowserEngine";
 import { useBrowserToolIds } from "@/hooks/useBrowserToolIds";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -116,7 +113,6 @@ function RightRailTabbed({
   hostConfig: HostConfigDtoV2 | null;
   hostId: string | null;
 }) {
-  const navigate = useAppNavigate();
   const [activeTab, setActiveTab] = useState<RightRailTab>("logs");
   const leftBrowserForLogs = useRef(false);
   const computersEnabled = useComputersEnabledState();
@@ -130,7 +126,11 @@ function RightRailTabbed({
   // harmless (the engine hooks no-op without a shared project) and deliberate.
   const engine = useComputerEngine(projectId);
   const browserEngine = useBrowserEngine(projectId);
-  const browserToolIds = useBrowserToolIds(hostConfig, browserEngine.selectedEngine, { projectId, hostId });
+  const browserToolIds = useBrowserToolIds(
+    hostConfig,
+    browserEngine.selectedEngine,
+    { projectId, hostId },
+  );
   // The BODY follows `selectedEngine` (consent-blind), mirroring the Computer
   // tab's face choice: someone who picked "This machine" but hasn't authorized
   // it yet must see the local body's pointer, not a cloud terminal they didn't
@@ -292,22 +292,6 @@ function RightRailTabbed({
           />
         ) : null}
         <div className="ml-auto flex items-center gap-1">
-          {hasBrowser && activeTab === "browser" ? (
-            <>
-              <BrowserRuntimeControls projectId={projectId} compact />
-              {hostId && (
-                <button
-                  type="button"
-                  onClick={() =>
-                    navigate(buildHostFocusTabPath(hostId, "browser"))
-                  }
-                  className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
-                >
-                  Browser settings
-                </button>
-              )}
-            </>
-          ) : null}
           <button
             type="button"
             onClick={onClose}
@@ -368,6 +352,7 @@ function RightRailTabbed({
               sessionId={browserSessionId}
               consentGranted={browserEngine.consent.granted}
               consentToken={browserEngine.consent.token}
+              hostId={hostId}
               active={activeTab === "browser"}
             />
           ) : (
@@ -376,6 +361,7 @@ function RightRailTabbed({
               projectId={projectId}
               sessionId={browserSessionId}
               mintToken={mintHostedBrowserToken}
+              hostId={hostId}
               active={activeTab === "browser"}
             />
           )}

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
@@ -549,6 +549,7 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
                           >
                             <PlaygroundBrowserPanel
                               projectId={projectScope}
+                              hostId={previewedHostId ?? null}
                               // MOUNTED but not claiming while the panel is off
                               // screen. Dropping the socket would stop the
                               // screencast and lose whatever the agent was


### PR DESCRIPTION
## Why

The "Browser settings" link lived in the Playground right rail, next to a second copy of the runtime controls. That put the entry point where the rail happened to be mounted rather than on the browser itself — so from the browser pane anywhere else in the product, there was no way to reach the client's Browser tab.

Separately, the consent copy had drifted into three versions (dialog, inline prompt, onboarding), each giving a different account of where to turn browser access off.

## What changed

- **New `BrowserSettingsButton`** — a ghost Globe button that navigates to `buildHostFocusTabPath(hostId, "browser")`.
- **Both bodies take `hostId`** — `HostedBrowserBody` and `LocalBrowserBody` render it in the nav bar beside the settings menu, so the link follows the browser wherever the pane appears. `PlaygroundRightRail` passes `hostId` down.
- **Compact runtime controls** grow the same link under a separator, for the surfaces still using that menu.
- **Duplicates removed** from `PlaygroundRightRail` and the `PlaygroundBrowserPanel` header; `PlaygroundTab` threads `hostId={previewedHostId}` into the panel.
- **One consent description** — `LocalBrowserConsentDescription` with a guest and an authed variant, used by the dialog, the inline prompt, and onboarding.
- Minor: "Stats for nerds" → "Stats" in the pane settings menu.

## Testing

- `vitest run client/src/components/browser` — 103 passed (including a new `BrowserSettingsButton` test and two navigation assertions).
- `vitest run client/src/components/playground` — 113 passed.
- `npm run typecheck:client -w @mcpjam/inspector` — clean.

Prettier reports pre-existing style warnings on several of these files on `main`; left untouched rather than mixing a reformat into the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6wmMRbGuqym4Gb3pXkeHL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI navigation and consent copy only; no auth, API, or browser runtime behavior changes beyond where settings links render.
> 
> **Overview**
> **Browser settings** move from the Playground right rail and panel header into the browser pane itself, so the entry point travels with the stream wherever it appears.
> 
> A new **`BrowserSettingsButton`** (Globe icon) navigates to the focused client’s Browser tab via `buildHostFocusTabPath(hostId, "browser")`. **`LocalBrowserBody`** and **`HostedBrowserBody`** accept optional `hostId` and render that button in the shell nav bar next to the view settings menu. **`BrowserRuntimeControls`** in compact mode adds the same link under a separator when `hostId` is set. **`PlaygroundRightRail`** and **`PlaygroundBrowserPanel`** drop the duplicate compact controls and rail “Browser settings” text button; **`PlaygroundTab`** passes `hostId={previewedHostId}` into the browser panel.
> 
> **Local browser consent** copy is centralized in **`LocalBrowserConsentDescription`** (guest vs signed-in), reused by the dialog, inline prompt, and card—replacing drifted text that pointed at Connect settings with a consistent **Browser settings** link (defaulting to `/hosts` when no custom handler is passed).
> 
> Minor label change: pane menu **“Stats for nerds”** → **“Stats”**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6def93b43fc778e25805bbf1f33f64c5f63c85a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Browser settings into the browser pane itself so the link follows the browser wherever it appears, and consolidates three drifted versions of consent copy into one shared description.

- New `BrowserSettingsButton` renders in the hosted and local browser bodies' nav bars, threaded through with a `hostId` prop.
- The compact runtime-controls menu links there too, and the duplicates in the Playground right rail and browser panel header are removed.
- `LocalBrowserConsentDescription` with guest and authed variants now backs the consent dialog, inline prompt, and onboarding.
- Renames "Stats for nerds" to "Stats" in the pane settings menu.

<sup>Written for commit e6def93b43fc778e25805bbf1f33f64c5f63c85a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

