### PR TITLE
A guest who granted browser permission still had no Browser in a column

### DIFF
--- a/.changeset/guest-columns-browse.md
+++ b/.changeset/guest-columns-browse.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Fix comparison columns leaving Browser tools off for a guest who had already granted browser permission on the device. A column with no explicit per-client setting now follows that device consent for guests, while an authenticated user's columns keep following their saved client setting.

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -591,7 +591,7 @@ export function PlaygroundMain({
   recorder,
   syncConversationToUrl = false,
 }: PlaygroundMainProps) {
-  const { signUp } = useAuth();
+  const { signUp, user } = useAuth();
   const clearLogs = useTrafficLogStore((s) => s.clear);
 
   // Chat-history coordination — Playground equivalent of ChatTabV2's history
@@ -5666,7 +5666,10 @@ export function PlaygroundMain({
                             ...column.executionConfig,
                             builtInToolIds: resolveLocalBrowserTools(
                               column.hostConfig.builtInToolIds,
-                              column.hostConfig.localBrowserEnabled,
+                              column.hostConfig.localBrowserEnabled ??
+                                (!user && playgroundBrowserEngine.consent.granted
+                                  ? true
+                                  : undefined),
                               !HOSTED_MODE && playgroundBrowserEngine.engine === "local",
                             ),
                           }}

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -162,10 +162,17 @@ vi.mock("@/lib/PosthogUtils", () => ({
   standardEventProps: () => ({}),
 }));
 
+const browserFixture = vi.hoisted(() => ({ guest: false, granted: false }));
+vi.mock("@/hooks/useBrowserEngine", () => ({
+  useBrowserEngine: () => ({
+    engine: "local", selectedEngine: "local", localAvailable: true,
+    consent: { granted: browserFixture.granted, token: browserFixture.granted ? "device-consent" : null },
+  }),
+}));
 vi.mock("@workos-inc/authkit-react", () => ({
   useAuth: () => ({
     signUp: vi.fn(),
-    user: { id: "u1" },
+    user: browserFixture.guest ? null : { id: "u1" },
     isLoading: false,
   }),
 }));
@@ -668,6 +675,8 @@ describe("PlaygroundMain — multi-host render path", () => {
   };
 
   beforeEach(() => {
+    browserFixture.guest = false;
+    browserFixture.granted = false;
     vi.clearAllMocks();
     usePlaygroundChatHistoryBridgeStore.getState().setBridge(null);
     useHostContextStore.setState({
@@ -1238,6 +1247,29 @@ describe("PlaygroundMain — multi-host render path", () => {
       "h-second-claude",
       "h-second-cursor",
     ]);
+  });
+
+  it.each([
+    { guest: true, granted: true, enabled: undefined, expected: ["browser"] },
+    { guest: true, granted: false, enabled: undefined, expected: [] },
+    { guest: true, granted: true, enabled: false, expected: [] },
+    { guest: false, granted: true, enabled: undefined, expected: [] },
+  ])("resolves comparison Browser tools: guest=$guest consent=$granted setting=$enabled", ({ guest, granted, enabled, expected }) => {
+    browserFixture.guest = guest;
+    browserFixture.granted = granted;
+    multiHostFixture.hostList = [{ hostId: "h-A", name: "A" }, { hostId: "h-B", name: "B" }];
+    multiHostFixture.hosts = {
+      "h-A": makeHost("h-A", "A", { builtInToolIds: [], localBrowserEnabled: enabled }),
+      "h-B": makeHost("h-B", "B", { builtInToolIds: ["web_search"], localBrowserEnabled: enabled }),
+    };
+    multiHostFixture.selectedHostIds = ["h-A", "h-B"];
+    render(<PlaygroundMain {...defaultProps} />);
+    expect(screen.getAllByTestId("multi-host-card")).toHaveLength(2);
+    for (const [props] of mockMultiModelPlaygroundCard.mock.calls) {
+      expect(props.executionConfig.builtInToolIds).toEqual(
+        props.compareId === "h-B" ? ["web_search", ...expected] : expected,
+      );
+    }
   });
 
   it("renders one card per resolved host in a multi-host grid", () => {


### PR DESCRIPTION
## The bug

A guest grants browser permission, watches the consent dialog close — and the comparison columns still run without Browser tools.

Comparison columns resolve their Browser tools from the column's own `localBrowserEnabled`. A guest has no saved client settings, so that value is `undefined`, and `resolveLocalBrowserTools` resolved to no browser tools no matter what the guest had just authorized on the device.

## The fix

`PlaygroundMain` now reads `user` from AuthKit and falls back to device consent — but only where there is nothing more specific to follow:

| viewer | column setting | device consent | Browser tools |
|---|---|---|---|
| guest | unset | granted | **on** (was off) |
| guest | unset | not granted | off |
| guest | explicit `false` | granted | off |
| authed | unset | granted | off |

An explicit `false` still wins, and an authenticated user's columns keep following the client setting they saved rather than a device grant they may not have meant to apply everywhere.

## Testing

- New `it.each` table in `PlaygroundMain.multi-host.test.tsx` covering all four rows above.
- `vitest run client/src/components/ui-playground` — 331 passed.
- `npm run typecheck:client -w @mcpjam/inspector` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6wmMRbGuqym4Gb3pXkeHL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped playground UI logic for resolving built-in Browser tools in multi-host compare mode, with targeted tests and no auth or server changes.
> 
> **Overview**
> **Comparison columns** no longer leave Browser tools disabled for **guests** who already granted browser permission on the device when the column has no saved `localBrowserEnabled` value.
> 
> `PlaygroundMain` now uses AuthKit’s `user` and, when building each column’s `executionConfig`, falls back to device consent (`playgroundBrowserEngine.consent.granted`) for guests only—setting effective browser enablement to **on** instead of leaving it `undefined`. **Explicit `false` on a column still disables Browser**, and **signed-in users** with an unset column setting still behave as before (they follow saved client settings, not device consent).
> 
> Adds a changeset patch note and an **`it.each`** test matrix in `PlaygroundMain.multi-host.test.tsx` (with hoisted mocks for auth and browser engine) covering guest vs authed, consent, and explicit column settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2409d89fcfd0b904a00526ac706be2d4b3165412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes comparison columns leaving the Browser tool off for guests who had already granted browser permission on the device. `PlaygroundMain` now falls back to device consent for guests when the column has no explicit setting, so the Browser tool appears as expected.

- An explicit `false` column setting still disables the Browser tool.
- Authenticated users' columns keep following their saved client setting instead of device consent.
- Adds table-driven tests covering the guest and authenticated combinations.

<sup>Written for commit 2409d89fcfd0b904a00526ac706be2d4b3165412. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

