### PR TITLE
Fix missing Browser and WebMCP tools for guests

### DIFF
--- a/mcpjam-inspector/client/src/components/playground/BrowserToolsSection.tsx
+++ b/mcpjam-inspector/client/src/components/playground/BrowserToolsSection.tsx
@@ -31,6 +31,8 @@ import {
 } from "./browser-pane-tools";
 
 interface BrowserToolsSectionProps {
+  catalogError?: boolean;
+  onRetryCatalog?: () => void;
   tools: SerializedModelRequestTool[];
   page: BrowserPageToolsResponse | null;
   searchQuery: string;
@@ -99,6 +101,8 @@ export function BrowserToolsSection({
   selectedKey = null,
   onSelect,
   localConsent = null,
+  catalogError = false,
+  onRetryCatalog,
 }: BrowserToolsSectionProps) {
   const navigate = useAppNavigate();
   const query = searchQuery.trim().toLowerCase();
@@ -126,6 +130,24 @@ export function BrowserToolsSection({
     );
   }, [browserItems, query]);
 
+  if (catalogError && !localConsent && !query) {
+    return (
+      <ToolSourceHeader title="Browser">
+        <p className="px-3 text-xs text-muted-foreground" role="status">
+          Couldn't load Browser tools.
+          {onRetryCatalog && (
+            <Button
+              variant="link"
+              className="h-auto px-1 py-0 text-xs"
+              onClick={onRetryCatalog}
+            >
+              Retry
+            </Button>
+          )}
+        </p>
+      </ToolSourceHeader>
+    );
+  }
   if (tools.length === 0 && !localConsent) return null;
   if (query && filteredTools.length === 0 && filteredPageTools.length === 0) {
     return null;
@@ -178,10 +200,10 @@ export function BrowserToolsSection({
               {query
                 ? "No page tools match your search."
                 : page.webmcpSupported
-                ? `This page offers no WebMCP tools${
-                    page.url ? ` (${page.url})` : ""
-                  }.`
-                : "This page doesn't use WebMCP."}
+                  ? `This page offers no WebMCP tools${
+                      page.url ? ` (${page.url})` : ""
+                    }.`
+                  : "This page doesn't use WebMCP."}
             </p>
           ) : (
             <div className="space-y-0.5">

--- a/mcpjam-inspector/client/src/components/playground/__tests__/BrowserToolsSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/BrowserToolsSection.test.tsx
@@ -280,7 +280,9 @@ describe("BrowserToolsSection", () => {
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Allow" })).toBeNull();
     expect(
-      screen.getByText(/Enable browser access from the Browser tab on the right pane/),
+      screen.getByText(
+        /Enable browser access from the Browser tab on the right pane/,
+      ),
     ).toBeInTheDocument();
     expect(onAllow).not.toHaveBeenCalled();
   });
@@ -347,4 +349,22 @@ it("explains an explicit client opt-out without another permission prompt", () =
     screen.getByText("Browser tools are disabled for this client."),
   ).toBeInTheDocument();
   expect(screen.queryByRole("button", { name: "Allow" })).toBeNull();
+});
+
+it("shows a retry action instead of hiding a failed Browser catalog", () => {
+  const retry = vi.fn();
+  render(
+    <BrowserToolsSection
+      tools={[]}
+      page={null}
+      searchQuery=""
+      catalogError
+      onRetryCatalog={retry}
+    />,
+  );
+  expect(screen.getByRole("status").textContent).toContain(
+    "Couldn't load Browser tools.",
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+  expect(retry).toHaveBeenCalledOnce();
 });

--- a/mcpjam-inspector/client/src/components/playground/panes/MultiServerToolsPane.tsx
+++ b/mcpjam-inspector/client/src/components/playground/panes/MultiServerToolsPane.tsx
@@ -409,7 +409,7 @@ function FlatToolList({
   const hasBuiltin =
     builtinTools.length > 0 ||
     (browserTools?.tools.length ?? 0) > 0 ||
-    Boolean(browserTools?.localConsent);
+    Boolean(browserTools?.localConsent || browserTools?.catalogError);
   const uniqueServerIds = [...new Set(entries.map((entry) => entry.serverId))];
   const showServerBadge = uniqueServerIds.length > 1;
   const serversChip =
@@ -454,6 +454,8 @@ function FlatToolList({
                 selectedKey={selectedBrowserKey}
                 onSelect={onSelectBrowser}
                 localConsent={browserTools.localConsent}
+                catalogError={browserTools.catalogError}
+                onRetryCatalog={browserTools.refreshPage}
               />
             ) : null}
             {entries.length > 0 ? (
@@ -513,8 +515,7 @@ function FlatToolList({
                         {(() => {
                           const visibility = getToolVisibility(
                             entry.tool._meta as
-                              | Record<string, unknown>
-                              | undefined,
+                              Record<string, unknown> | undefined,
                           );
                           const visibilityLabel = `[${visibility
                             .map((v) => `"${v}"`)

--- a/mcpjam-inspector/client/src/components/ui-playground/ToolList.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/ToolList.tsx
@@ -17,7 +17,11 @@ import {
   getToolVisibility,
   UIType,
 } from "@/lib/mcp-ui/mcp-apps-utils";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@mcpjam/design-system/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
 import { useAppToolsRegistry } from "@/components/chat-v2/thread/mcp-apps/app-tools-registry";
 import { HarnessBuiltinToolsSection } from "@/components/playground/HarnessBuiltinToolsSection";
 import { BrowserToolsSection } from "@/components/playground/BrowserToolsSection";
@@ -101,7 +105,7 @@ export function ToolList({
     useShallow((s) => ({
       aliases: s.aliases,
       instancesByBridgeId: s.instancesByBridgeId,
-    }))
+    })),
   );
   const appEntries = useMemo<AppEntry[]>(() => {
     const aliasByBridgeAndName = new Map<string, string>();
@@ -111,7 +115,9 @@ export function ToolList({
     const out: AppEntry[] = [];
     for (const inst of instancesByBridgeId.values()) {
       for (const tool of inst.tools) {
-        const alias = aliasByBridgeAndName.get(`${inst.bridgeId}\0${tool.name}`);
+        const alias = aliasByBridgeAndName.get(
+          `${inst.bridgeId}\0${tool.name}`,
+        );
         if (!alias) continue;
         out.push({
           alias,
@@ -179,7 +185,10 @@ export function ToolList({
   // Local Browser permission is a row of its own: until it is granted the
   // browser's tools are withheld, and the section is where Allow lives.
   const browserConsentShown =
-    browserTools?.localConsent && !searchQuery.trim() ? 1 : 0;
+    (browserTools?.localConsent || browserTools?.catalogError) &&
+    !searchQuery.trim()
+      ? 1
+      : 0;
   const totalShown =
     browserConsentShown +
     filteredToolNames.length +
@@ -198,7 +207,8 @@ export function ToolList({
     appEntries.length === 0 &&
     builtinTools.length === 0 &&
     (browserTools?.tools.length ?? 0) === 0 &&
-    !browserTools?.localConsent;
+    !browserTools?.localConsent &&
+    !browserTools?.catalogError;
 
   return (
     <div className="h-full flex flex-col">
@@ -224,8 +234,8 @@ export function ToolList({
               {!hasNoTools
                 ? "No tools match your search"
                 : hasConnectedServer
-                ? "No tools found. Try refreshing and make sure the server is running."
-                : "No server connected yet. Connect one to load its tools and use them in chat."}
+                  ? "No tools found. Try refreshing and make sure the server is running."
+                  : "No server connected yet. Connect one to load its tools and use them in chat."}
             </p>
             {hasNoTools && !hasConnectedServer && (
               <Button
@@ -254,6 +264,8 @@ export function ToolList({
                 selectedKey={selectedBrowserKey}
                 onSelect={onSelectBrowser}
                 localConsent={browserTools.localConsent}
+                catalogError={browserTools.catalogError}
+                onRetryCatalog={browserTools.refreshPage}
               />
             ) : null}
             {filteredToolNames.length > 0 || filteredAppEntries.length > 0 ? (

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/ToolList.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/ToolList.test.tsx
@@ -569,7 +569,10 @@ describe("ToolList", () => {
         toolNames={[]}
         filteredToolNames={[]}
         searchQuery="grep"
-        builtinTools={[makeBuiltin("bash", "Bash"), makeBuiltin("grep", "Grep")]}
+        builtinTools={[
+          makeBuiltin("bash", "Bash"),
+          makeBuiltin("grep", "Grep"),
+        ]}
         onSelectBuiltin={vi.fn()}
       />,
     );
@@ -591,4 +594,15 @@ describe("ToolList", () => {
     );
     expect(screen.queryByText("Source:")).not.toBeInTheDocument();
   });
+});
+
+it("keeps catalog recovery visible when there are no server tools", () => {
+  const refreshPage = vi.fn();
+  render(<ToolList {...defaultProps} browserTools={{
+    attached: true, engine: "local", tools: [], page: null,
+    catalogError: true, refreshPage,
+    invokePage: async () => ({ ok: false, error: "no_browser_session" }),
+  }} />);
+  fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+  expect(refreshPage).toHaveBeenCalledOnce();
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/useBrowserTools.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useBrowserTools.test.tsx
@@ -12,7 +12,7 @@ vi.mock("@workos-inc/authkit-react", () => ({
  * panel beside it said no server was connected.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 
 const state = vi.hoisted(() => ({
   setting: undefined as { enabled: boolean | null } | undefined,
@@ -25,6 +25,7 @@ const state = vi.hoisted(() => ({
   } | null,
   selectedEngine: "cloud" as "cloud" | "local",
   consentToken: null as string | null,
+  catalogFailures: 0,
   definitions: [{ name: "browser_navigate", description: "Open a URL." }],
   definitionCalls: [] as string[],
   pageCalls: [] as string[],
@@ -94,6 +95,7 @@ vi.mock("@/lib/hosted-browser/client", () => ({
 vi.mock("@/lib/browser-page-tools/client", () => ({
   fetchBrowserToolDefinitions: vi.fn(async (engine: string) => {
     state.definitionCalls.push(engine);
+    if (state.catalogFailures-- > 0) throw new Error("catalog unavailable");
     return state.definitions;
   }),
   fetchHostedPageTools: vi.fn(
@@ -167,6 +169,30 @@ beforeEach(() => {
 afterEach(() => vi.clearAllMocks());
 
 describe("useBrowserTools — which host it describes", () => {
+  it("surfaces catalog failures and retries without remounting, then caches success", async () => {
+    state.projectDefault = WITH_BROWSER;
+    state.catalogFailures = 1;
+    const { result } = renderHook(() =>
+      useBrowserTools({ projectId: "project-1", hostId: null }),
+    );
+    await waitFor(() => expect(result.current.catalogError).toBe(true));
+    expect(result.current.tools).toEqual([]);
+    const definitions = state.definitions;
+    state.definitions = [];
+    act(() => result.current.refreshPage());
+    await waitFor(() => expect(state.definitionCalls).toHaveLength(2));
+    await waitFor(() => expect(result.current.catalogError).toBe(true));
+    state.definitions = definitions;
+    act(() => result.current.refreshPage());
+    await waitFor(() =>
+      expect(result.current.tools).toEqual(state.definitions),
+    );
+    expect(result.current.catalogError).toBe(false);
+    const reads = state.definitionCalls.length;
+    act(() => result.current.refreshPage());
+    expect(state.definitionCalls).toHaveLength(reads);
+  });
+
   it("lists Browser after shared local setup without requiring a legacy tool attachment", async () => {
     state.selectedEngine = "local";
     state.consentToken = "saved-device-consent";

--- a/mcpjam-inspector/client/src/hooks/useBrowserTools.ts
+++ b/mcpjam-inspector/client/src/hooks/useBrowserTools.ts
@@ -77,6 +77,7 @@ export interface BrowserLocalConsentPrompt {
 export interface BrowserToolsState {
   /** True when the previewed host actually attaches the browser capability. */
   attached: boolean;
+  catalogError?: boolean;
   /** Which browser a call would drive. */
   engine: "hosted" | "local";
   /** The `browser_*` tools, as the model is shown them. */
@@ -221,10 +222,10 @@ export function useBrowserTools(args: {
   /** Whether a hosted read is possible at all — a boolean, so it can be a dep. */
   const hostedReadable = tokens !== null;
 
-  // Definitions. Cached per engine for the session; a failure leaves the list
-  // empty rather than surfacing an error, because a pane that cannot describe
-  // the browser is still a working pane.
+  const [catalogError, setCatalogError] = useState(false);
+  // Successful definitions stay cached; Refresh retries failed catalog reads.
   useEffect(() => {
+    setCatalogError(false);
     if (!attached) {
       setTools([]);
       return;
@@ -238,17 +239,22 @@ export function useBrowserTools(args: {
     let cancelled = false;
     fetchBrowserToolDefinitions(engine, controller.signal)
       .then((items) => {
+        if (cancelled) return;
+        if (items.length === 0) throw new Error("Empty Browser catalog");
         DEFINITIONS_CACHE.set(engine, items);
-        if (!cancelled) setTools(items);
+        setTools(items);
       })
       .catch(() => {
-        if (!cancelled) setTools([]);
+        if (!cancelled) {
+          setTools([]);
+          setCatalogError(true);
+        }
       });
     return () => {
       cancelled = true;
       controller.abort();
     };
-  }, [attached, engine]);
+  }, [attached, engine, pageNonce]);
 
   /**
    * The page read, which is a live look at a running browser.
@@ -424,6 +430,7 @@ export function useBrowserTools(args: {
     attached,
     engine,
     localConsent,
+    catalogError: attached && available && catalogError,
     tools: available ? tools : [],
     page: available
       ? page

--- a/mcpjam-inspector/client/src/lib/browser-page-tools/client.ts
+++ b/mcpjam-inspector/client/src/lib/browser-page-tools/client.ts
@@ -30,9 +30,8 @@ import {
 /**
  * The `browser_*` definitions, as the model is shown them.
  *
- * Soft-fails to an empty list, like the harness catalog: a pane that cannot
- * reach the catalog should show no browser section, not an error over a
- * browser that is working.
+ * Failed reads are surfaced by useBrowserTools with a retry action. Catalog
+ * availability is separate from whether chat can drive the browser.
  */
 export async function fetchBrowserToolDefinitions(
   engine: "hosted" | "local",

--- a/mcpjam-inspector/server/routes/v1/__tests__/built-in-tools.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/built-in-tools.test.ts
@@ -7,22 +7,31 @@
  * forever while drifting from the schemas the model actually reads, and the
  * schemas are where the coordinate space and the ref rules live.
  *
- * Mounted DIRECTLY rather than through `routes/v1/index.ts`. The shared bearer
- * gate and the guest boundary are properties of that router, covered where they
- * live (`require-verified-auth.test.ts` and the guest-allowlist suite below),
- * and pulling the whole v1 tree in here would drag the harness adapters — and
- * their native dependencies — into a suite about a static catalog.
+ * Mounted with real bearer and route verification middleware, with external
+ * token verification stubbed. The v1 guest boundary is applied before the
+ * route too, so a payload-only test cannot miss an allowlist rejection.
  */
 import { describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 
-// This router mounts `requireVerifiedAuth` because it never calls Convex, so
-// nothing downstream would re-check the bearer. Its own branches are covered in
-// `server/middleware/__tests__/require-verified-auth.test.ts`; here it is
-// stubbed to admit, so these tests are about the payload.
-vi.mock("../../../middleware/require-verified-auth.js", () => ({
-  requireVerifiedAuth: () => (_c: unknown, next: () => unknown) => next(),
+// Exercise both real authentication middleware layers. Only the external
+// token verifiers are stubbed; the catalog must not need Convex or a browser.
+vi.mock("../../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: async (token: string) =>
+    token === "valid-guest"
+      ? { valid: true, guestId: "guest-1" }
+      : { valid: false },
 }));
+vi.mock("../../../services/authkit-jwt.js", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../../services/authkit-jwt.js")
+  >()),
+  verifyAuthKitToken: async (token: string) => {
+    if (token === "valid-member") return { sub: "member-1" };
+    throw new Error("Invalid token");
+  },
+}));
+import { bearerAuthMiddleware } from "../../../middleware/bearer-auth.js";
 
 import builtInTools from "../built-in-tools.js";
 import { v1OnError } from "../envelope.js";
@@ -47,14 +56,27 @@ type Definition = {
   inputSchema?: Record<string, unknown>;
 };
 
-function request(path: string) {
+function request(
+  path: string,
+  token: string | null = "valid-member",
+  method = "GET",
+) {
   const app = new Hono();
   // `v1OnError` too: the router raises `WebRouteError` and the parent maps it
   // to the wire, exactly as `routes/v1/index.ts` does. Without it a test would
   // be asserting statuses this route does not actually produce in production.
   app.onError(v1OnError);
+  app.use("/api/v1/*", bearerAuthMiddleware);
+  app.use("/api/v1/*", async (c, next) => {
+    if (c.get("guestId") && !isGuestAllowedV1Request(c.req.method, c.req.path))
+      return c.json({ error: "guest denied" }, 401);
+    return next();
+  });
   app.route("/api/v1", builtInTools);
-  return app.request(`http://local${path}`, { method: "GET" });
+  return app.request(`http://local${path}`, {
+    method,
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
 }
 
 async function definitions(path: string): Promise<Definition[]> {
@@ -124,18 +146,48 @@ describe("GET /built-in-tools/:builtInToolId/definitions", () => {
 });
 
 describe("guest access to built-in tool definitions", () => {
-  it("is denied — the browser is never advertised to a guest turn", () => {
-    // Default-deny: a new v1 route is closed to guests until it earns a
-    // pattern. This asserts the browser catalog has not quietly earned one,
-    // because a guest reading these schemas would be reading about a
-    // capability they cannot be given.
-    for (const method of ["GET", "POST"]) {
+  it.each(["local", "hosted"])(
+    "allows validated guests to read static %s schemas",
+    async (engine) => {
+      const response = await request(
+        `/api/v1/built-in-tools/browser/definitions?engine=${engine}`,
+        "valid-guest",
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { items: Definition[] };
+      expect(body.items.map((item) => item.name).sort()).toEqual(
+        [...FIRST_CLASS_TOOL_NAMES].sort(),
+      );
+    },
+  );
+  it.each([null, "invalid-token"])(
+    "rejects unverified credentials: %s",
+    async (token) => {
       expect(
-        isGuestAllowedV1Request(
-          method,
-          "/api/v1/built-in-tools/browser/definitions",
-        ),
-      ).toBe(false);
-    }
+        (await request("/api/v1/built-in-tools/browser/definitions", token))
+          .status,
+      ).toBe(401);
+    },
+  );
+  it.each(["POST", "PUT", "PATCH", "DELETE"])(
+    "keeps %s guest-denied",
+    async (method) => {
+      expect(
+        (
+          await request(
+            "/api/v1/built-in-tools/browser/definitions",
+            "valid-guest",
+            method,
+          )
+        ).status,
+      ).toBe(401);
+    },
+  );
+  it.each([
+    "/built-in-tools/bash/definitions",
+    "/built-in-tools/browser/execute",
+    "/built-in-tools/browser/definitions/extra",
+  ])("does not widen guest access to %s", (path) => {
+    expect(isGuestAllowedV1Request("GET", `/api/v1${path}`)).toBe(false);
   });
 });

--- a/mcpjam-inspector/server/routes/v1/guest-allowed-paths.ts
+++ b/mcpjam-inspector/server/routes/v1/guest-allowed-paths.ts
@@ -23,6 +23,10 @@
 type GuestRule = { pattern: RegExp; methods?: readonly string[] };
 
 const GUEST_ALLOWED_V1_RULES: readonly GuestRule[] = [
+  // Static Browser schemas, with no session creation or page/user data.
+  // Guests can use local Browser after consent and need the same catalog
+  // as members. Execution and page reads retain their separate gates.
+  { pattern: /^\/built-in-tools\/browser\/definitions$/, methods: ["GET"] },
   // Harness built-in tool catalog: static published-package metadata (no
   // project/user data), read by the first-party UI to show a harness host's
   // native tools. Safe for guests (local mode + share-link previews); GET-only.


### PR DESCRIPTION
Guests could navigate with Browser in chat while the left Tools pane showed only MCP server tools. The static Browser definitions endpoint was still guest-denied, and the client silently hid both Browser and WebMCP after the failed catalog read.

Allow validated guests to GET only `/api/v1/built-in-tools/browser/definitions`. Browser execution, page reads, consent, and rollout checks remain independently enforced. Failed or empty catalog reads now show a Retry action in both tool-list layouts; refresh retries failures while successful definitions stay cached, and canceled requests cannot populate the cache.

Validation: 107 targeted tests passed, including the real bearer and route-verification middleware with external token verifiers stubbed, rejected invalid/missing credentials and guest writes, retry/empty-response recovery, and the zero-server empty state. Client typecheck and design drift/lint checks passed (design lint reports existing warnings). No end-to-end desktop verification performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cfc2e1f2d3263d40e8526610a77dc0d7e9da4204. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes guest access to the Browser and WebMCP tool catalogs so the Tools pane no longer hides tools that chat can actually use.

- Validated guests can now GET only the static Browser definitions endpoint; execution, page reads, consent, and rollout checks stay separately enforced.
- Failed or empty catalog reads now show a Retry action instead of hiding Browser and WebMCP; successful definitions remain cached and canceled requests cannot populate the cache.
- Verified with real bearer and route middleware (external token verifiers stubbed): rejected invalid/missing credentials and guest writes, and covered retry, empty-response, and zero-server states. No end-to-end desktop verification performed.

<sup>Written for commit cfc2e1f2d3263d40e8526610a77dc0d7e9da4204. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

