### PR TITLE
Chromium install: keep the reason, retry on its own, skip Electron

### DIFF
--- a/mcpjam-inspector/client/src/components/browser/LocalBrowserBody.tsx
+++ b/mcpjam-inspector/client/src/components/browser/LocalBrowserBody.tsx
@@ -101,6 +101,13 @@ const SOMEBODY_ELSE_HAS_IT =
 /** How often to ask again while somebody else is holding the browser. */
 const LEASE_RECHECK_MS = 5_000;
 
+/** "~30s" / "~2m" for a countdown that the poll refreshes every few seconds. */
+function describeDelay(at: number): string {
+  const seconds = Math.max(0, Math.round((at - Date.now()) / 1000));
+  if (seconds < 60) return `~${seconds}s`;
+  return `~${Math.round(seconds / 60)}m`;
+}
+
 export function LocalBrowserBody({
   projectId,
   sessionId,
@@ -255,23 +262,36 @@ export function LocalBrowserBody({
     };
   }, []);
 
-  // While Chromium downloads, poll: it is hundreds of megabytes and a screen
-  // that looks frozen for several minutes reads as broken.
+  // Until this machine has a Chromium, poll. Fast while it downloads — it is
+  // hundreds of megabytes and a screen that looks frozen for several minutes
+  // reads as broken — and slowly otherwise, because the server retries a
+  // failed download on its own and a startup install this pane never saw
+  // begin still finishes; a pane that only polled while it happened to
+  // observe `installing` sat on a stale answer forever.
+  const installPollMs =
+    status && !status.installed
+      ? status.install.status === "installing"
+        ? 1_000
+        : 5_000
+      : null;
   useEffect(() => {
-    if (status?.install.status !== "installing") return;
+    if (installPollMs === null) return;
     const timer = setInterval(() => {
       void fetchLocalBrowserStatus()
         .then(setStatus)
         .catch(() => {});
-    }, 1_000);
+    }, installPollMs);
     return () => clearInterval(timer);
-  }, [status?.install.status]);
+  }, [installPollMs]);
 
   const install = useCallback(async () => {
     setError(null);
     try {
       const { install: state } = await startLocalBrowserInstall(consentToken);
       setStatus((prev) => (prev ? { ...prev, install: state } : prev));
+      // `ready` straight from the click means the browser was already there;
+      // the install response carries no `installed`, so ask for the rest.
+      if (state.status === "ready") setStatus(await fetchLocalBrowserStatus());
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     }
@@ -781,11 +801,37 @@ export function LocalBrowserBody({
             </span>
           ) : (
             <Button size="sm" onClick={() => void install()}>
-              Install Chromium
+              {state.status === "failed" ? "Retry now" : "Install Chromium"}
             </Button>
           )}
           {state.status === "failed" ? (
-            <span className="text-destructive">{state.error}</span>
+            <>
+              <span
+                className="text-destructive"
+                data-testid="rail-browser-install-error"
+              >
+                {state.error}
+              </span>
+              {state.retryAt !== undefined && state.retryAt > Date.now() ? (
+                <span
+                  className="text-xs text-muted-foreground"
+                  data-testid="rail-browser-install-retry"
+                >
+                  Retrying automatically in {describeDelay(state.retryAt)}
+                </span>
+              ) : null}
+              {state.details ? (
+                <details className="max-w-full text-xs text-muted-foreground">
+                  <summary className="cursor-pointer">Details</summary>
+                  <pre
+                    className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap break-all text-left font-mono"
+                    data-testid="rail-browser-install-details"
+                  >
+                    {state.details}
+                  </pre>
+                </details>
+              ) : null}
+            </>
           ) : null}
         </PaneMessage>
       );

--- a/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserBody.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserBody.test.tsx
@@ -32,6 +32,8 @@ const api = vi.hoisted(() => ({
   },
   lease: { state: "free" as string, holder: undefined as string | undefined },
   installs: 0,
+  /** Every status probe the pane made, so a test can see it keep asking. */
+  statusFetches: 0,
   inputs: [] as unknown[],
   ensures: [] as string[],
   ensureError: null as Error | null,
@@ -88,7 +90,10 @@ vi.mock("@/lib/local-browser/client", async () => {
   >("@/lib/local-browser/client");
   return {
     ...actual,
-    fetchLocalBrowserStatus: async () => api.status,
+    fetchLocalBrowserStatus: async () => {
+      api.statusFetches += 1;
+      return api.status;
+    },
     fetchLocalBrowserSession: api.lookup,
     startLocalBrowserInstall: async () => {
       api.installs += 1;
@@ -194,6 +199,7 @@ beforeEach(() => {
   };
   api.lease = { state: "free", holder: undefined };
   api.installs = 0;
+  api.statusFetches = 0;
   api.inputs = [];
   api.ensures = [];
   api.ensureError = null;
@@ -406,6 +412,91 @@ describe("the agent browser pane", () => {
     ).toBeTruthy();
     await userEvent.click(screen.getByRole("button", { name: /install/i }));
     await waitFor(() => expect(api.installs).toBe(1));
+  });
+
+  it("says why the download failed, when it will try again, and offers Retry now", async () => {
+    // "exited with code 1" sent nobody anywhere. The server now keeps
+    // Playwright's own reason and books its own retry; the pane shows both,
+    // with the installer's output behind a disclosure rather than in the face.
+    api.status = {
+      installed: false,
+      install: {
+        status: "failed",
+        error: "Download failed: server returned code 403",
+        details:
+          "Downloading Chromium 1234\nFailed to install browsers\nDownload failed: server returned code 403",
+        retryAt: Date.now() + 30_000,
+        attempts: 1,
+      },
+      running: false,
+      leaseHeld: false,
+    };
+    renderBody();
+    expect(
+      await screen.findByTestId("rail-browser-install-error"),
+    ).toHaveTextContent("Download failed: server returned code 403");
+    expect(screen.getByTestId("rail-browser-install-retry")).toHaveTextContent(
+      /Retrying automatically in ~(29|30)s/,
+    );
+    expect(
+      screen.getByTestId("rail-browser-install-details"),
+    ).toHaveTextContent("Failed to install browsers");
+    await userEvent.click(screen.getByRole("button", { name: "Retry now" }));
+    await waitFor(() => expect(api.installs).toBe(1));
+  });
+
+  it("shows no countdown once the automatic retries are spent", async () => {
+    api.status = {
+      installed: false,
+      install: { status: "failed", error: "network down", attempts: 4 },
+      running: false,
+      leaseHeld: false,
+    };
+    renderBody();
+    await screen.findByTestId("rail-browser-install-error");
+    expect(screen.queryByTestId("rail-browser-install-retry")).toBeNull();
+    expect(screen.queryByTestId("rail-browser-install-details")).toBeNull();
+  });
+
+  it("keeps asking until this machine has a browser, then stops", async () => {
+    // A startup install the pane never saw begin, and a retry the server
+    // booked on its own, both finish without anyone clicking. A pane that
+    // only polled while it happened to observe `installing` never noticed.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      api.status = {
+        installed: false,
+        install: { status: "failed", error: "network down", attempts: 1 },
+        running: false,
+        leaseHeld: false,
+      };
+      renderBody();
+      await screen.findByTestId("rail-browser-install-error");
+      const before = api.statusFetches;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_100);
+      });
+      expect(api.statusFetches).toBeGreaterThan(before);
+
+      api.status = {
+        ...api.status,
+        installed: true,
+        install: { status: "ready" },
+      };
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_100);
+      });
+      await waitFor(() =>
+        expect(screen.queryByTestId("rail-browser-needs-chromium")).toBeNull(),
+      );
+      const settled = api.statusFetches;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(11_000);
+      });
+      expect(api.statusFetches).toBe(settled);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("shows the download's progress rather than looking frozen", async () => {

--- a/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserOnboarding.test.tsx
+++ b/mcpjam-inspector/client/src/components/browser/__tests__/LocalBrowserOnboarding.test.tsx
@@ -211,7 +211,9 @@ it("explains device scope for guests", () => {
   state.guest = true;
   render(<LocalBrowserOnboarding projectId={null} authReady />);
   expect(
-    screen.getByText(/your local clients on this device/),
+    screen.getByText(
+      /your local clients across WebMCP, Playground, and tabs on this device/,
+    ),
   ).toBeInTheDocument();
   expect(screen.queryByText(/projects you manage/)).toBeNull();
 });

--- a/mcpjam-inspector/client/src/lib/local-browser/client.ts
+++ b/mcpjam-inspector/client/src/lib/local-browser/client.ts
@@ -95,7 +95,14 @@ export interface LocalBrowserStatus {
   install: {
     status: "idle" | "installing" | "ready" | "failed";
     percent?: number;
+    /** One line, human-readable, when `failed`. */
     error?: string;
+    /** The installer's last output, when `failed`, for a details block. */
+    details?: string;
+    /** Epoch ms of the next automatic attempt, when one is booked. */
+    retryAt?: number;
+    /** Failed attempts so far in this server process. */
+    attempts?: number;
   };
   running: boolean;
   leaseHeld: boolean;

--- a/mcpjam-inspector/server/routes/mcp/__tests__/computers-local-browser.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/computers-local-browser.test.ts
@@ -75,10 +75,11 @@ vi.mock("../../../config.js", async () => {
 const chromiumState = vi.hoisted(() => ({
   installed: false,
   installs: 0,
+  install: { status: "idle" } as Record<string, unknown>,
 }));
 vi.mock("../../../utils/browser-rendering-setup.js", () => ({
   isChromiumInstalled: async () => chromiumState.installed,
-  getChromiumInstallState: () => ({ status: "idle" as const }),
+  getChromiumInstallState: () => chromiumState.install,
   startChromiumInstall: async () => {
     chromiumState.installs += 1;
     return { status: "installing" as const, percent: 0 };
@@ -533,6 +534,27 @@ describe("GET /local-browser/status", () => {
       running: false,
       leaseHeld: false,
     });
+  });
+
+  it("passes a failure through whole: reason, details, and the next retry", async () => {
+    // The pane shows all three; a route that re-derived the state would
+    // have to know the shape, and would drop whatever it did not know.
+    chromiumState.install = {
+      status: "failed",
+      error: "Download failed: server returned code 403",
+      details:
+        "Failed to install browsers\nDownload failed: server returned code 403",
+      retryAt: 1_700_000_000_000,
+      attempts: 1,
+    };
+    try {
+      expect(await (await status()).json()).toMatchObject({
+        installed: false,
+        install: chromiumState.install,
+      });
+    } finally {
+      chromiumState.install = { status: "idle" };
+    }
   });
 
   it("answers without consent, so the consent screen can describe itself", async () => {

--- a/mcpjam-inspector/server/services/webmcp-inspector/local-browserd-provider.ts
+++ b/mcpjam-inspector/server/services/webmcp-inspector/local-browserd-provider.ts
@@ -33,7 +33,10 @@ import {
   type CreateWebMcpSessionOptions,
   type WebMcpBrowserProvider,
 } from "./provider";
-import { ensureLocalChromiumInstalled } from "../../utils/browser-rendering-setup";
+import {
+  ensureLocalChromiumInstalled,
+  getChromiumInstallState,
+} from "../../utils/browser-rendering-setup";
 
 export class LocalBrowserdWebMcpSession extends BrowserdWebMcpSession {
   private unsubscribe?: () => void;
@@ -190,7 +193,7 @@ export const localBrowserdWebMcpProvider: WebMcpBrowserProvider = {
     const native =
       process.env.ELECTRON_APP === "true" &&
       options.viewportMode === "embedded";
-    if (!native) await ensureLocalChromiumInstalled();
+    if (!native) await ensureLocalChromiumInstalled({ reason: "webmcp" });
     let driver: ChromiumDriver | undefined;
     const surface = native
       ? createContextSurface({
@@ -225,10 +228,19 @@ export const localBrowserdWebMcpProvider: WebMcpBrowserProvider = {
             deviceScaleFactor: options.devicePixelRatio ?? 1,
           });
     } catch (error) {
-      if (/Executable.*doesn.t exist/i.test(String(error)))
+      if (/Executable.*doesn.t exist/i.test(String(error))) {
+        // The install that should have put it there may have just failed;
+        // say why, because "not installed" after an automatic install
+        // attempt reads as a mystery, and the reason is one call away.
+        const install = getChromiumInstallState();
+        const reason =
+          install.status === "failed"
+            ? ` The download failed: ${install.error}.`
+            : "";
         throw new WebMcpChromiumNotInstalledError(
-          "Chromium is not installed. Run npx playwright install chromium and retry.",
+          `Chromium is not installed.${reason} Run npx playwright install chromium and retry.`,
         );
+      }
       if (/XServer|Missing X server|DISPLAY/i.test(String(error)))
         throw new WebMcpNoDisplayError(
           "No display is available. Use the embedded browser or set MCPJAM_WEBMCP_HEADLESS=true.",

--- a/mcpjam-inspector/server/utils/__tests__/browser-rendering-setup.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/browser-rendering-setup.test.ts
@@ -1,11 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ChromiumInstallError,
   ensureLocalChromiumInstalled,
   getChromiumInstallState,
+  InstallOutputCollector,
   resetBrowserRenderingSetupForTests,
   resetChromiumInstallStateForTests,
   shouldAutoInstallChromium,
   startChromiumInstall,
+  summarizeInstallFailure,
 } from "../browser-rendering-setup";
 
 const localEnv = {
@@ -41,11 +44,25 @@ describe("browser rendering setup", () => {
     ).toBe(false);
     expect(shouldAutoInstallChromium(localEnv)).toBe(true);
     expect(
-      shouldAutoInstallChromium({
-        NODE_ENV: "development",
-        ELECTRON_APP: "true",
-      })
+      shouldAutoInstallChromium(
+        {
+          NODE_ENV: "development",
+          ELECTRON_APP: "true",
+        },
+        {},
+      ),
     ).toBe(true);
+  });
+
+  it("does not auto-install inside the desktop app", () => {
+    // The packaged app IS a Chromium and cannot run the Playwright CLI —
+    // `process.execPath` is Electron with the RunAsNode fuse off — so the
+    // install is not merely wasted, it fails. The env var is the wrong
+    // signal: a dev server started with it set is still a Node process.
+    expect(shouldAutoInstallChromium(localEnv, { electron: "39.0.0" })).toBe(
+      false,
+    );
+    expect(shouldAutoInstallChromium(localEnv, {})).toBe(true);
   });
 
   it("installs Chromium once when local rendering is missing it", async () => {
@@ -164,13 +181,16 @@ describe("chromium install — one lock, both doors", () => {
     expect(getChromiumInstallState()).toEqual({ status: "ready" });
   });
 
-  it("reports the cooldown rather than leaving a join at `installing`", async () => {
-    // The path with no install at all: a recent failure means the runner
-    // returns without running anything, and a joiner still needs an answer.
+  it("reports the pending retry rather than leaving a join at `installing`", async () => {
+    // The path with no install at all: a recent failure has a retry booked,
+    // so the runner returns without running anything, and a joiner still
+    // needs an answer — the failure it is waiting behind, countdown included.
     const failing = vi.fn<() => Promise<void>>(async () => {
       throw new Error("network down");
     });
-    const isInstalled = vi.fn<() => Promise<boolean>>().mockResolvedValue(false);
+    const isInstalled = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValue(false);
 
     await ensureLocalChromiumInstalled({
       env: localEnv,
@@ -178,9 +198,8 @@ describe("chromium install — one lock, both doors", () => {
       runInstall: failing,
       logger: silentLogger,
     });
-    resetChromiumInstallStateForTests();
 
-    // Straight back in, inside the cooldown.
+    // Straight back in, while the retry is pending.
     await ensureLocalChromiumInstalled({
       env: localEnv,
       isInstalled,
@@ -189,7 +208,12 @@ describe("chromium install — one lock, both doors", () => {
     });
 
     expect(failing).toHaveBeenCalledTimes(1);
-    expect(getChromiumInstallState().status).toBe("failed");
+    const state = getChromiumInstallState();
+    expect(state.status).toBe("failed");
+    if (state.status === "failed") {
+      expect(state.error).toBe("network down");
+      expect(state.retryAt).toBeGreaterThan(Date.now());
+    }
   });
 
   it("says it is installing again after an earlier attempt failed", async () => {
@@ -276,5 +300,276 @@ describe("chromium install — one lock, both doors", () => {
     expect(state).toEqual({ status: "ready" });
     expect(getChromiumInstallState()).toEqual({ status: "ready" });
     expect(runInstall).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * "exited with code 1" told nobody anything. Playwright prints the reason
+ * right before it exits; the installer has to keep it.
+ */
+describe("chromium install — the reason survives", () => {
+  it("keeps a bounded, plain-text tail and reports the last percentage", () => {
+    const progress: number[] = [];
+    const lines: string[] = [];
+    const collector = new InstallOutputCollector(
+      (p) => progress.push(p),
+      (l) => lines.push(l),
+    );
+    collector.push(
+      "\u001b[1mDownloading Chromium 1234\u001b[0m from https://x\n",
+    );
+    // One chunk, several redraws of the progress bar: only the newest is true.
+    collector.push("|██  | 12% of 168 MiB\r|████| 37% of 168 MiB\r");
+    collector.push("|████████| 100% of 168 MiB\n");
+    collector.push("Chromium 1234 downloaded to /cache\n");
+
+    expect(progress).toEqual([37, 100]);
+    expect(lines).toEqual([
+      "Downloading Chromium 1234 from https://x",
+      "Chromium 1234 downloaded to /cache",
+    ]);
+    expect(collector.output()).toBe(
+      [
+        "Downloading Chromium 1234 from https://x",
+        "|████████| 100% of 168 MiB",
+        "Chromium 1234 downloaded to /cache",
+      ].join("\n"),
+    );
+  });
+
+  it("treats CRLF as a line ending, not a redraw", () => {
+    const lines: string[] = [];
+    const collector = new InstallOutputCollector(
+      () => {},
+      (l) => lines.push(l),
+    );
+    collector.push("Failed to install browsers\r\n");
+    collector.push("Error: EACCES: permission denied\r");
+    collector.push("\n");
+    expect(lines).toEqual([
+      "Failed to install browsers",
+      "Error: EACCES: permission denied",
+    ]);
+  });
+
+  it("bounds the tail", () => {
+    const collector = new InstallOutputCollector(
+      () => {},
+      () => {},
+    );
+    for (let i = 0; i < 500; i += 1)
+      collector.push(`line ${i} ${"x".repeat(40)}\n`);
+    const output = collector.output();
+    expect(output.length).toBeLessThanOrEqual(4096);
+    expect(output.endsWith("line 499 " + "x".repeat(40))).toBe(true);
+  });
+
+  it("uses Playwright's own reason as the one-line error when it printed one", () => {
+    const output = [
+      "Downloading Chromium 1234 from https://playwright.azureedge.net/…",
+      "Failed to install browsers",
+      "Error: Download failed: server returned code 403 body '' URL: https://…",
+      "    at Object.<anonymous> (registry.js:1:1)",
+    ].join("\n");
+    expect(summarizeInstallFailure(1, null, output)).toBe(
+      "Download failed: server returned code 403 body '' URL: https://…",
+    );
+    // Playwright's real shape for a dead network: the sentence ends mid-air
+    // with "caused by", the cause is the next line, and the socket error the
+    // downloader child printed earlier is the part a person can act on.
+    const offline = [
+      "Downloading Chrome for Testing 151.0.7922.34 (playwright chromium v1234) from http://127.0.0.1:9/x.zip",
+      "Error: connect ECONNREFUSED 127.0.0.1:9",
+      "    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1705:16) {",
+      "  errno: -61,",
+      "}",
+      "Failed to install browsers",
+      "Error: Failed to download Chrome for Testing 151.0.7922.34 (playwright chromium v1234), caused by",
+      "Error: Download failure, code=1",
+      "    at ChildProcess.<anonymous> (coreBundle.js:32015:32)",
+    ].join("\n");
+    expect(summarizeInstallFailure(1, null, offline)).toBe(
+      "Failed to download Chrome for Testing 151.0.7922.34 (playwright chromium v1234), caused by Download failure, code=1 (connect ECONNREFUSED 127.0.0.1:9)",
+    );
+    expect(summarizeInstallFailure(1, null, "")).toBe(
+      "playwright install chromium exited with code 1",
+    );
+    expect(summarizeInstallFailure(null, "SIGKILL", "")).toBe(
+      "playwright install chromium exited with signal SIGKILL",
+    );
+  });
+
+  it("publishes the reason and the details on a failure", async () => {
+    const isInstalled = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValue(false);
+    await ensureLocalChromiumInstalled({
+      env: localEnv,
+      isInstalled,
+      runInstall: async () => {
+        throw new ChromiumInstallError(
+          "Download failed: server returned code 403",
+          "Downloading Chromium\nFailed to install browsers\nDownload failed: server returned code 403",
+        );
+      },
+      logger: silentLogger,
+    });
+    expect(getChromiumInstallState()).toMatchObject({
+      status: "failed",
+      error: "Download failed: server returned code 403",
+      details: expect.stringContaining("Failed to install browsers"),
+      attempts: 1,
+    });
+    expect(silentLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Download failed: server returned code 403"),
+    );
+  });
+});
+
+/**
+ * "The inspector will try again shortly" used to be a lie: nothing retried.
+ * Now it books the next attempt and says when.
+ */
+describe("chromium install — automatic retries", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const failingInstall = () =>
+    vi.fn<() => Promise<void>>(async () => {
+      throw new Error("network down");
+    });
+
+  it("books the next attempt at 30s, 2m and 10m, then stops", async () => {
+    const runInstall = failingInstall();
+    const isInstalled = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValue(false);
+    const start = Date.now();
+
+    await ensureLocalChromiumInstalled({
+      env: localEnv,
+      isInstalled,
+      runInstall,
+      logger: silentLogger,
+    });
+    expect(getChromiumInstallState()).toMatchObject({
+      status: "failed",
+      attempts: 1,
+      retryAt: start + 30_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(runInstall).toHaveBeenCalledTimes(2);
+    expect(getChromiumInstallState()).toMatchObject({
+      status: "failed",
+      attempts: 2,
+      retryAt: start + 30_000 + 120_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(runInstall).toHaveBeenCalledTimes(3);
+    expect(getChromiumInstallState()).toMatchObject({
+      status: "failed",
+      attempts: 3,
+      retryAt: start + 30_000 + 120_000 + 600_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(600_000);
+    expect(runInstall).toHaveBeenCalledTimes(4);
+    const exhausted = getChromiumInstallState();
+    expect(exhausted).toMatchObject({ status: "failed", attempts: 4 });
+    expect((exhausted as { retryAt?: number }).retryAt).toBeUndefined();
+
+    // Nothing else is booked.
+    await vi.advanceTimersByTimeAsync(3_600_000);
+    expect(runInstall).toHaveBeenCalledTimes(4);
+  });
+
+  it("a retry that succeeds clears the ladder", async () => {
+    const runInstall = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValue(undefined);
+    const isInstalled = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true);
+
+    await ensureLocalChromiumInstalled({
+      env: localEnv,
+      isInstalled,
+      runInstall,
+      logger: silentLogger,
+    });
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(getChromiumInstallState()).toEqual({ status: "ready" });
+
+    // A later failure starts the ladder from the first rung again.
+    resetChromiumInstallStateForTests();
+    const again = failingInstall();
+    await ensureLocalChromiumInstalled({
+      env: localEnv,
+      isInstalled: async () => false,
+      runInstall: again,
+      logger: silentLogger,
+    });
+    expect(getChromiumInstallState()).toMatchObject({
+      attempts: 1,
+      retryAt: Date.now() + 30_000,
+    });
+  });
+
+  it("a click cancels the booked retry and starts now", async () => {
+    const auto = failingInstall();
+    const isInstalled = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValue(false);
+    await ensureLocalChromiumInstalled({
+      env: localEnv,
+      isInstalled,
+      runInstall: auto,
+      logger: silentLogger,
+    });
+
+    const explicit = vi.fn<() => Promise<void>>(async () => {});
+    const state = await startChromiumInstall({
+      isInstalled: vi
+        .fn<() => Promise<boolean>>()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValue(true),
+      runInstall: explicit,
+    });
+    expect(state.status).toBe("installing");
+    await vi.waitFor(() =>
+      expect(getChromiumInstallState()).toEqual({ status: "ready" }),
+    );
+    expect(explicit).toHaveBeenCalledTimes(1);
+
+    // The automatic attempt that was booked never runs.
+    await vi.advanceTimersByTimeAsync(3_600_000);
+    expect(auto).toHaveBeenCalledTimes(1);
+  });
+
+  it("a click that fails books its own retry", async () => {
+    const runInstall = failingInstall();
+    await startChromiumInstall({
+      isInstalled: async () => false,
+      runInstall,
+    });
+    await vi.waitFor(() =>
+      expect(getChromiumInstallState().status).toBe("failed"),
+    );
+    const state = getChromiumInstallState();
+    expect(state).toMatchObject({ attempts: 1 });
+    const retryAt = (state as { retryAt?: number }).retryAt ?? 0;
+    expect(retryAt).toBeGreaterThan(Date.now());
+    expect(retryAt).toBeLessThanOrEqual(Date.now() + 30_000);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(runInstall).toHaveBeenCalledTimes(2);
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/browser-rendering-setup.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/browser-rendering-setup.test.ts
@@ -489,6 +489,56 @@ describe("chromium install — automatic retries", () => {
     expect(runInstall).toHaveBeenCalledTimes(4);
   });
 
+  it("keeps refusing after the ladder is spent, until someone asks", async () => {
+    const runInstall = failingInstall();
+    const isInstalled = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValue(false);
+    const attempt = () =>
+      ensureLocalChromiumInstalled({
+        env: localEnv,
+        isInstalled,
+        runInstall,
+        logger: silentLogger,
+      });
+
+    await attempt();
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(120_000);
+    await vi.advanceTimersByTimeAsync(600_000);
+    expect(runInstall).toHaveBeenCalledTimes(4);
+
+    // The cap is spent and nothing is booked, so there is no timer left to
+    // suppress anything. A widget render and a WebMCP session both ask now.
+    await attempt();
+    await ensureLocalChromiumInstalled({
+      env: localEnv,
+      isInstalled,
+      runInstall,
+      logger: silentLogger,
+      reason: "webmcp",
+    });
+    expect(runInstall).toHaveBeenCalledTimes(4);
+    // They are told why, rather than silently getting nothing.
+    expect(getChromiumInstallState()).toMatchObject({
+      status: "failed",
+      error: "network down",
+      attempts: 4,
+    });
+
+    // "Retry now" is the one thing that lifts it: the installer runs a fifth
+    // time. `isInstalled` stays false for the probe inside the reservation —
+    // answering true there would report `ready` without installing anything,
+    // which is a different path than the one under test.
+    runInstall.mockResolvedValueOnce(undefined);
+    isInstalled.mockResolvedValueOnce(false).mockResolvedValue(true);
+    await startChromiumInstall({ isInstalled, runInstall });
+    await vi.waitFor(() =>
+      expect(getChromiumInstallState()).toEqual({ status: "ready" }),
+    );
+    expect(runInstall).toHaveBeenCalledTimes(5);
+  });
+
   it("a retry that succeeds clears the ladder", async () => {
     const runInstall = vi
       .fn<() => Promise<void>>()

--- a/mcpjam-inspector/server/utils/__tests__/browser-rendering-setup.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/browser-rendering-setup.test.ts
@@ -539,6 +539,34 @@ describe("chromium install — automatic retries", () => {
     expect(runInstall).toHaveBeenCalledTimes(5);
   });
 
+  it("lets a Chromium installed by hand clear a spent cap", async () => {
+    const runInstall = failingInstall();
+    const isInstalled = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValue(false);
+    const attempt = () =>
+      ensureLocalChromiumInstalled({
+        env: localEnv,
+        isInstalled,
+        runInstall,
+        logger: silentLogger,
+      });
+
+    await attempt();
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(120_000);
+    await vi.advanceTimersByTimeAsync(600_000);
+    expect(runInstall).toHaveBeenCalledTimes(4);
+
+    // Someone ran `npx playwright install chromium` themselves. The probe
+    // runs BEFORE the suppression gate for exactly this reason: a cap that
+    // outlived the problem it was capping would be a bug of its own.
+    isInstalled.mockResolvedValue(true);
+    await expect(attempt()).resolves.toBe(true);
+    expect(getChromiumInstallState()).toEqual({ status: "ready" });
+    expect(runInstall).toHaveBeenCalledTimes(4);
+  });
+
   it("a retry that succeeds clears the ladder", async () => {
     const runInstall = vi
       .fn<() => Promise<void>>()

--- a/mcpjam-inspector/server/utils/browser-rendering-setup.ts
+++ b/mcpjam-inspector/server/utils/browser-rendering-setup.ts
@@ -342,7 +342,7 @@ function publishReady(): void {
 function publishFailure(
   error: unknown,
   retryWith: BrowserRenderingSetupOptions,
-): void {
+): Extract<ChromiumInstallState, { status: "failed" }> {
   cancelScheduledRetry();
   failedAttempts += 1;
   const message = error instanceof Error ? error.message : String(error);
@@ -365,6 +365,7 @@ function publishFailure(
     }, delay);
     retryTimer.unref?.();
   }
+  return failed;
 }
 
 /**
@@ -394,8 +395,12 @@ export async function startChromiumInstall(
   const isInstalled = options.isInstalled ?? isChromiumInstalled;
   const runInstall = options.runInstall ?? runPlaywrightChromiumInstall;
 
+  // Clears the STANDING FAILURE too, not just the ladder: it is what gates
+  // every automatic caller above, and this click is the one thing that is
+  // allowed to lift it.
   cancelScheduledRetry();
   failedAttempts = 0;
+  lastFailure = null;
 
   // The reservation is made SYNCHRONOUSLY and the "is it already there?" probe
   // happens inside it. Probing first meant two clicks, or a click and the
@@ -496,9 +501,18 @@ export async function ensureLocalChromiumInstalled(
       return true;
     }
 
-    if (retryTimer && reason !== "retry" && lastFailure) {
-      // An automatic retry is already booked. Report THAT failure, with its
-      // countdown, rather than starting a fresh attempt nobody asked for.
+    if (lastFailure && reason !== "retry") {
+      // A failure stands. Report THAT rather than starting a fresh attempt
+      // nobody asked for — whether an automatic retry is still booked (the
+      // state carries its countdown) or the ladder is spent.
+      //
+      // Gated on the FAILURE, not on the pending timer. Gating on the timer
+      // meant the cap evaporated the moment it was reached: with nothing
+      // booked, every later render or WebMCP request walked straight past
+      // this and spawned its own installer, so a machine that could never
+      // download Chromium ran one per request forever. Once the ladder is
+      // spent only an explicit "Retry now" clears this, which is the whole
+      // point of a cap.
       explicitInstallState = lastFailure;
       return false;
     }
@@ -534,11 +548,10 @@ export async function ensureLocalChromiumInstalled(
       log.info("[browser-rendering] Playwright Chromium is ready");
       return true;
     } catch (error) {
-      publishFailure(error, retryWith);
-      const failed = explicitInstallState as Extract<
-        ChromiumInstallState,
-        { status: "failed" }
-      >;
+      // Taken from the publisher's return rather than re-read from the
+      // module state and cast back: the cast was a lie the compiler could not
+      // check, and it narrowed to `installing` here anyway.
+      const failed = publishFailure(error, retryWith);
       const when = failed.retryAt
         ? `; retrying in ${Math.round((failed.retryAt - Date.now()) / 1000)}s`
         : "; no more automatic retries";

--- a/mcpjam-inspector/server/utils/browser-rendering-setup.ts
+++ b/mcpjam-inspector/server/utils/browser-rendering-setup.ts
@@ -2,41 +2,79 @@ import { spawn } from "child_process";
 import { existsSync } from "fs";
 import { createRequire } from "module";
 import { dirname, resolve as resolvePath } from "path";
+import { stripVTControlCharacters } from "util";
 import { logger } from "./logger.js";
 
 const require = createRequire(import.meta.url);
 
-const INSTALL_RETRY_COOLDOWN_MS = 5 * 60 * 1000;
+/**
+ * How long to wait before each AUTOMATIC retry after a failed install, in
+ * order. Three tries, then the pane's Retry button is the only way back in.
+ *
+ * Playwright already retries each download five times within one run and
+ * locks the cache directory across processes; this ladder is for the failure
+ * modes that outlive a single run — a network that is down at launch and back
+ * two minutes later — not for the ones Playwright handles itself.
+ */
+const AUTO_RETRY_DELAYS_MS = [30_000, 120_000, 600_000];
 
-type BrowserSetupReason = "startup" | "render" | "webmcp";
+/** How much of the installer's output a failure keeps. */
+const OUTPUT_TAIL_BYTES = 4096;
+
+type BrowserSetupReason = "startup" | "render" | "webmcp" | "retry";
 
 type BrowserRenderingSetupLogger = {
   info: (message: string) => void;
   warn: (message: string) => void;
 };
 
+type InstallRunner = (onProgress: (percent: number) => void) => Promise<void>;
+
 interface BrowserRenderingSetupOptions {
   reason?: BrowserSetupReason;
   env?: NodeJS.ProcessEnv;
   isInstalled?: () => Promise<boolean>;
-  runInstall?: () => Promise<void>;
+  runInstall?: InstallRunner;
   logger?: BrowserRenderingSetupLogger;
 }
 
 /**
- * What an explicit, user-triggered Chromium install is doing right now.
+ * What the Chromium install is doing right now, whichever door started it.
  *
- * The background install at server startup can afford to be silent; this one
- * cannot. It is hundreds of megabytes started by someone who just clicked
- * "install", and the alternative to reporting progress is a screen that looks
- * broken for several minutes. It deliberately does NOT run inside a chat turn:
- * a model waiting on a tool call has no way to say what is taking so long.
+ * The background install at server startup can afford to be silent in the
+ * console; the pane cannot. It is hundreds of megabytes, and the alternative to
+ * reporting progress is a screen that looks broken for several minutes. It
+ * deliberately does NOT run inside a chat turn: a model waiting on a tool call
+ * has no way to say what is taking so long.
+ *
+ * A failure carries the REASON. Playwright prints why it gave up — a 403 from
+ * the download host, a full disk, an unwritable cache — right before exiting
+ * 1, and "exited with code 1" alone sends nobody anywhere.
  */
 export type ChromiumInstallState =
   | { status: "idle" }
   | { status: "installing"; percent?: number }
   | { status: "ready" }
-  | { status: "failed"; error: string };
+  | {
+      status: "failed";
+      /** One line, human-readable. */
+      error: string;
+      /** The installer's last output, for the expandable details block. */
+      details?: string;
+      /** Epoch ms of the next automatic attempt; absent when there is none. */
+      retryAt?: number;
+      /** Failed attempts so far, counting this one. */
+      attempts: number;
+    };
+
+export class ChromiumInstallError extends Error {
+  readonly details?: string;
+  constructor(message: string, details?: string) {
+    super(message);
+    this.name = "ChromiumInstallError";
+    this.details = details;
+  }
+}
 
 let explicitInstallState: ChromiumInstallState = { status: "idle" };
 /**
@@ -49,11 +87,15 @@ let explicitInstallState: ChromiumInstallState = { status: "idle" };
  */
 let activeInstall: Promise<boolean> | null = null;
 
+/** The most recent failure, republished to anyone who asks while a retry is pending. */
+let lastFailure: Extract<ChromiumInstallState, { status: "failed" }> | null =
+  null;
+let failedAttempts = 0;
+let retryTimer: NodeJS.Timeout | null = null;
+
 export function getChromiumInstallState(): ChromiumInstallState {
   return explicitInstallState;
 }
-
-let lastInstallFailureAt = 0;
 
 function defaultLogger(_env: NodeJS.ProcessEnv): BrowserRenderingSetupLogger {
   return {
@@ -66,9 +108,21 @@ function defaultLogger(_env: NodeJS.ProcessEnv): BrowserRenderingSetupLogger {
   };
 }
 
+/**
+ * Whether this process should download Chromium on its own.
+ *
+ * `versions.electron` rather than the `ELECTRON_APP` env var, for the same
+ * reason the session layer checks it: the var says how the app was STARTED,
+ * and a dev server started with it set is a plain Node process that still
+ * needs a browser. The packaged desktop app IS a Chromium and cannot run the
+ * Playwright CLI anyway — `process.execPath` is Electron with the RunAsNode
+ * fuse off — so an install there is not wasteful, it is doomed.
+ */
 export function shouldAutoInstallChromium(
-  env: NodeJS.ProcessEnv = process.env
+  env: NodeJS.ProcessEnv = process.env,
+  versions: { electron?: string } = process.versions,
 ): boolean {
+  if (versions.electron) return false;
   if (env.NODE_ENV === "test") return false;
   if (env.DOCKER_CONTAINER === "true") return false;
   if (env.VITE_MCPJAM_HOSTED_MODE === "true") return false;
@@ -101,86 +155,216 @@ function resolvePlaywrightCli(): string {
   const pkg = require("playwright/package.json") as {
     bin?: string | Record<string, string>;
   };
-  const binRel =
-    typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.playwright;
+  const binRel = typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.playwright;
   if (!binRel) {
     throw new Error("Could not resolve the playwright CLI bin entry");
   }
   return resolvePath(dirname(pkgJsonPath), binRel);
 }
 
+const PROGRESS_RE = /(\d{1,3})%/g;
+
+/**
+ * Reads the installer's output as it arrives, keeping three things apart:
+ * the percentage (for the pane), a bounded tail (for a failure's details),
+ * and complete non-progress lines (for the server log). The downloader
+ * redraws one line with `\r`, so a chunk can carry several percentages and
+ * several drafts of the same line; only the newest of each is true.
+ */
+export class InstallOutputCollector {
+  private tail = "";
+  private line = "";
+  private pendingCR = false;
+
+  constructor(
+    private readonly onProgress: (percent: number) => void,
+    private readonly onLine: (line: string) => void,
+  ) {}
+
+  push(chunk: Buffer | string): void {
+    const text = stripVTControlCharacters(chunk.toString());
+    const matches = [...text.matchAll(PROGRESS_RE)];
+    const last = matches[matches.length - 1]?.[1];
+    if (last !== undefined) this.onProgress(Math.min(100, Number(last)));
+
+    for (const char of text) {
+      if (this.pendingCR) {
+        this.pendingCR = false;
+        // `\r\n` is a line ending; a bare `\r` is a redraw, and the line so
+        // far is a draft that is about to be replaced.
+        if (char !== "\n") this.line = "";
+      }
+      if (char === "\r") {
+        this.pendingCR = true;
+      } else if (char === "\n") {
+        this.flush();
+      } else {
+        this.line += char;
+      }
+    }
+  }
+
+  private flush(): void {
+    const line = this.line.trimEnd();
+    this.line = "";
+    if (line.length === 0) return;
+    this.tail = (this.tail + line + "\n").slice(-OUTPUT_TAIL_BYTES);
+    if (!PROGRESS_RE.test(line)) this.onLine(line);
+    PROGRESS_RE.lastIndex = 0;
+  }
+
+  /** Everything kept so far, including a final line without a newline. */
+  output(): string {
+    this.flush();
+    return this.tail.trimEnd();
+  }
+}
+
+/**
+ * Turn an exit and the installer's output into the one line the pane shows.
+ *
+ * Playwright's CLI prints `Failed to install browsers` followed by the error
+ * on its own line(s) right before it exits 1, so that next line is the
+ * sentence a person can act on. Everything else is in `details`.
+ */
+export function summarizeInstallFailure(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  output: string,
+): string {
+  const lines = output.split("\n").map((line) => line.trim());
+  const marker = lines.findIndex((line) =>
+    /^Failed to install browsers/i.test(line),
+  );
+  if (marker !== -1) {
+    const prose = lines
+      .slice(marker + 1)
+      .filter((line) => line.length > 0 && !/^at /.test(line))
+      .map((line) => line.replace(/^Error:\s*/, ""));
+    let reason = prose[0];
+    if (reason) {
+      // "Failed to download X, caused by" ends mid-sentence; the cause is
+      // the next line.
+      if (/caused by:?$/i.test(reason) && prose[1]) {
+        reason = `${reason.replace(/:?$/, "")} ${prose[1]}`;
+      }
+      // The downloader runs in its own child and prints the underlying
+      // socket error before the summary — the part a person can act on.
+      const socket = lines
+        .map((line) => line.replace(/^Error:\s*/, ""))
+        .find((line) =>
+          /\b(ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|EACCES|EPERM|ENOSPC|EHOSTUNREACH|ENETUNREACH|CERT_|self.signed certificate)\b/.test(
+            line,
+          ),
+        );
+      if (socket && !reason.includes(socket)) reason = `${reason} (${socket})`;
+      return reason.length > 240 ? `${reason.slice(0, 237)}…` : reason;
+    }
+  }
+  return `playwright install chromium exited with ${
+    signal ? `signal ${signal}` : `code ${code}`
+  }`;
+}
+
 /**
  * Run `playwright install chromium` through the published CLI rather than
  * reaching into `playwright-core/lib/server/registry`, which is an internal
  * module Playwright reorganizes between releases. The CLI is a supported entry
- * point, survives version bumps, and inheriting its stdio shows the user the
- * real download progress instead of a single log line.
- */
-export async function installPlaywrightChromium(): Promise<void> {
-  const cliPath = resolvePlaywrightCli();
-  await new Promise<void>((resolve, reject) => {
-    const child = spawn(process.execPath, [cliPath, "install", "chromium"], {
-      stdio: "inherit",
-    });
-    child.on("error", reject);
-    child.on("exit", (code, signal) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(
-          new Error(
-            `playwright install chromium exited with ${
-              signal ? `signal ${signal}` : `code ${code}`
-            }`
-          )
-        );
-      }
-    });
-  });
-}
-
-/**
- * Run the install with its output PARSED rather than inherited.
+ * point and survives version bumps.
  *
- * `installPlaywrightChromium` inherits stdio, which shows progress in the
- * server's own terminal — useless to a browser tab. This reads the same output
- * and reports percentages, at the cost of no longer echoing to the console;
- * both exist because the startup path genuinely wants the console and the
- * user-triggered path genuinely wants the number.
+ * The ONE installer, for every door. Its output is piped, never inherited:
+ * the percentage goes to `onProgress` for the pane, complete lines go to the
+ * server log so the console still shows what it used to, and the last few
+ * kilobytes ride along on a failure so the pane can say WHY. Settles on
+ * `close`, after both streams have drained, because the reason is the last
+ * thing Playwright prints and `exit` can fire before it lands.
  */
-export async function installPlaywrightChromiumWithProgress(
-  onProgress: (percent: number) => void,
+export async function runPlaywrightChromiumInstall(
+  onProgress: (percent: number) => void = () => {},
+  log: BrowserRenderingSetupLogger = defaultLogger(process.env),
 ): Promise<void> {
   const cliPath = resolvePlaywrightCli();
   await new Promise<void>((resolvePromise, reject) => {
     const child = spawn(process.execPath, [cliPath, "install", "chromium"], {
       stdio: ["ignore", "pipe", "pipe"],
     });
-    // Playwright reports "|████ | 37% of 168.4 MiB". Take the last percentage
-    // on each chunk: the downloader redraws one line, so a chunk can carry
-    // several and only the newest is true.
-    const read = (chunk: Buffer) => {
-      const matches = [...chunk.toString().matchAll(/(\d{1,3})%/g)];
-      const last = matches[matches.length - 1]?.[1];
-      if (last !== undefined) onProgress(Math.min(100, Number(last)));
-    };
-    child.stdout?.on("data", read);
-    child.stderr?.on("data", read);
-    child.on("error", reject);
-    child.on("exit", (code, signal) => {
+    const collector = new InstallOutputCollector(onProgress, (line) =>
+      log.info(`[browser-rendering] ${line}`),
+    );
+    child.stdout?.on("data", (chunk: Buffer) => collector.push(chunk));
+    child.stderr?.on("data", (chunk: Buffer) => collector.push(chunk));
+    child.on("error", (error) =>
+      reject(new ChromiumInstallError(error.message, collector.output())),
+    );
+    child.on("close", (code, signal) => {
       if (code === 0) {
         resolvePromise();
         return;
       }
+      const output = collector.output();
       reject(
-        new Error(
-          `playwright install chromium exited with ${
-            signal ? `signal ${signal}` : `code ${code}`
-          }`,
+        new ChromiumInstallError(
+          summarizeInstallFailure(code, signal, output),
+          output || undefined,
         ),
       );
     });
   });
+}
+
+/** @deprecated Use `runPlaywrightChromiumInstall`; kept for callers that predate the one installer. */
+export const installPlaywrightChromium = (): Promise<void> =>
+  runPlaywrightChromiumInstall();
+/** @deprecated Use `runPlaywrightChromiumInstall`. */
+export const installPlaywrightChromiumWithProgress = (
+  onProgress: (percent: number) => void,
+): Promise<void> => runPlaywrightChromiumInstall(onProgress);
+
+function cancelScheduledRetry(): void {
+  if (retryTimer) {
+    clearTimeout(retryTimer);
+    retryTimer = null;
+  }
+}
+
+function publishReady(): void {
+  cancelScheduledRetry();
+  failedAttempts = 0;
+  lastFailure = null;
+  explicitInstallState = { status: "ready" };
+}
+
+/**
+ * Record a failure and, while the ladder has rungs left, book the next
+ * automatic attempt. The retry runs through the same seams the failed attempt
+ * used, so a test can drive it with fake timers and a fake installer.
+ */
+function publishFailure(
+  error: unknown,
+  retryWith: BrowserRenderingSetupOptions,
+): void {
+  cancelScheduledRetry();
+  failedAttempts += 1;
+  const message = error instanceof Error ? error.message : String(error);
+  const details =
+    error instanceof ChromiumInstallError ? error.details : undefined;
+  const delay = AUTO_RETRY_DELAYS_MS[failedAttempts - 1];
+  const failed: Extract<ChromiumInstallState, { status: "failed" }> = {
+    status: "failed",
+    error: message,
+    ...(details ? { details } : {}),
+    ...(delay !== undefined ? { retryAt: Date.now() + delay } : {}),
+    attempts: failedAttempts,
+  };
+  lastFailure = failed;
+  explicitInstallState = failed;
+  if (delay !== undefined) {
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      void ensureLocalChromiumInstalled({ ...retryWith, reason: "retry" });
+    }, delay);
+    retryTimer.unref?.();
+  }
 }
 
 /**
@@ -189,11 +373,17 @@ export async function installPlaywrightChromiumWithProgress(
  * Idempotent by design: the consent screen polls the state and may click
  * twice, and two concurrent `playwright install` runs writing the same browser
  * cache is a corrupted install.
+ *
+ * A click is a person asking NOW: it cancels any automatic retry that was
+ * booked and starts the ladder over, so the pane never answers a click with
+ * "retrying in nine minutes".
  */
-export async function startChromiumInstall(options: {
-  isInstalled?: () => Promise<boolean>;
-  runInstall?: (onProgress: (percent: number) => void) => Promise<void>;
-} = {}): Promise<ChromiumInstallState> {
+export async function startChromiumInstall(
+  options: {
+    isInstalled?: () => Promise<boolean>;
+    runInstall?: InstallRunner;
+  } = {},
+): Promise<ChromiumInstallState> {
   // Whoever is already installing owns it, including the startup auto-install.
   if (activeInstall) {
     if (explicitInstallState.status === "idle") {
@@ -202,7 +392,10 @@ export async function startChromiumInstall(options: {
     return explicitInstallState;
   }
   const isInstalled = options.isInstalled ?? isChromiumInstalled;
-  const runInstall = options.runInstall ?? installPlaywrightChromiumWithProgress;
+  const runInstall = options.runInstall ?? runPlaywrightChromiumInstall;
+
+  cancelScheduledRetry();
+  failedAttempts = 0;
 
   // The reservation is made SYNCHRONOUSLY and the "is it already there?" probe
   // happens inside it. Probing first meant two clicks, or a click and the
@@ -223,7 +416,7 @@ export async function startChromiumInstall(options: {
     if (already) {
       // Reported from INSIDE the reservation, so the answer the caller gets
       // back is as fresh as the probe that produced it.
-      explicitInstallState = { status: "ready" };
+      publishReady();
       probed(true);
       return true;
     }
@@ -233,19 +426,19 @@ export async function startChromiumInstall(options: {
         explicitInstallState = { status: "installing", percent };
       });
       const ready = await isInstalled();
-      explicitInstallState = ready
-        ? { status: "ready" }
-        : {
-            status: "failed",
-            error:
-              "the install finished but no launchable Chromium was found on this machine",
-          };
+      if (ready) {
+        publishReady();
+      } else {
+        publishFailure(
+          new Error(
+            "the install finished but no launchable Chromium was found on this machine",
+          ),
+          { isInstalled, runInstall },
+        );
+      }
       return ready;
     } catch (error) {
-      explicitInstallState = {
-        status: "failed",
-        error: error instanceof Error ? error.message : String(error),
-      };
+      publishFailure(error, { isInstalled, runInstall });
       return false;
     }
   })().finally(() => {
@@ -263,16 +456,23 @@ export async function startChromiumInstall(options: {
 export function resetChromiumInstallStateForTests(): void {
   explicitInstallState = { status: "idle" };
   activeInstall = null;
+  cancelScheduledRetry();
+  failedAttempts = 0;
+  lastFailure = null;
 }
 
 export async function ensureLocalChromiumInstalled(
-  options: BrowserRenderingSetupOptions = {}
+  options: BrowserRenderingSetupOptions = {},
 ): Promise<boolean> {
   const env = options.env ?? process.env;
   const log = options.logger ?? defaultLogger(env);
   const isInstalled = options.isInstalled ?? isChromiumInstalled;
 
-  if (!shouldAutoInstallChromium(env)) {
+  const reason = options.reason ?? "render";
+
+  // A retry continues an attempt that already got past this gate — or past
+  // consent, when a click started it — so it is not asked again.
+  if (reason !== "retry" && !shouldAutoInstallChromium(env)) {
     return false;
   }
 
@@ -280,11 +480,10 @@ export async function ensureLocalChromiumInstalled(
   // started from the consent screen.
   if (activeInstall) return activeInstall;
 
-  const runInstall = options.runInstall ?? installPlaywrightChromium;
-  const reason = options.reason ?? "render";
+  const runInstall = options.runInstall ?? runPlaywrightChromiumInstall;
 
   // Reserved SYNCHRONOUSLY, with the "is it there already?" probe and the
-  // failure cooldown moved inside. Both are awaits, and a second caller
+  // pending-retry check moved inside. Both are awaits, and a second caller
   // getting past them starts a second `playwright install` over the same
   // browser cache.
   activeInstall = (async () => {
@@ -293,27 +492,19 @@ export async function ensureLocalChromiumInstalled(
     // that never sees an answer leaves the pane reading "Downloading
     // Chromium" forever, with no way to ask again.
     if (await isInstalled()) {
-      explicitInstallState = { status: "ready" };
+      publishReady();
       return true;
     }
 
-    const now = Date.now();
-    if (
-      lastInstallFailureAt > 0 &&
-      now - lastInstallFailureAt < INSTALL_RETRY_COOLDOWN_MS
-    ) {
-      // Still inside the cooldown from an earlier failure. Report THAT rather
-      // than a fresh attempt nobody made.
-      explicitInstallState = {
-        status: "failed",
-        error:
-          "the last Chromium install failed; the inspector will try again shortly",
-      };
+    if (retryTimer && reason !== "retry" && lastFailure) {
+      // An automatic retry is already booked. Report THAT failure, with its
+      // countdown, rather than starting a fresh attempt nobody asked for.
+      explicitInstallState = lastFailure;
       return false;
     }
 
     log.info(
-      `[browser-rendering] Chromium missing; setting up Playwright Chromium (${reason})`
+      `[browser-rendering] Chromium missing; setting up Playwright Chromium (${reason})`,
     );
     // An install is genuinely starting NOW, so say so — this is the last of
     // the runner's states to be published and the one it was missing. Without
@@ -321,29 +512,40 @@ export async function ensureLocalChromiumInstalled(
     // reading "install failed": the button appears dead, because the consent
     // screen's own call joins this run and is handed back the stale failure.
     explicitInstallState = { status: "installing" };
+    const retryWith: BrowserRenderingSetupOptions = {
+      env,
+      isInstalled,
+      runInstall,
+      logger: log,
+    };
     try {
-      await runInstall();
+      await runInstall((percent) => {
+        explicitInstallState = { status: "installing", percent };
+      });
       const ready = await isInstalled();
       if (!ready) {
         throw new Error(
-          "Playwright Chromium install finished, but no launchable Chromium was found"
+          "Playwright Chromium install finished, but no launchable Chromium was found",
         );
       }
-      lastInstallFailureAt = 0;
       // One install, one reported state: a consent screen that JOINED this run
       // rather than starting it still has to see it finish.
-      explicitInstallState = { status: "ready" };
+      publishReady();
       log.info("[browser-rendering] Playwright Chromium is ready");
       return true;
     } catch (error) {
-      lastInstallFailureAt = Date.now();
-      const message = error instanceof Error ? error.message : String(error);
-      // Unconditional now that the `installing` above is this runner's own:
-      // the state to replace is the one it just published, whatever a joiner
-      // did with it meanwhile.
-      explicitInstallState = { status: "failed", error: message };
+      publishFailure(error, retryWith);
+      const failed = explicitInstallState as Extract<
+        ChromiumInstallState,
+        { status: "failed" }
+      >;
+      const when = failed.retryAt
+        ? `; retrying in ${Math.round((failed.retryAt - Date.now()) / 1000)}s`
+        : "; no more automatic retries";
+      // The installer's own lines were already echoed as they arrived, so the
+      // warning carries the one-line reason and the plan, not the transcript.
       log.warn(
-        `[browser-rendering] Failed to set up Playwright Chromium: ${message}`
+        `[browser-rendering] Failed to set up Playwright Chromium (attempt ${failed.attempts}): ${failed.error}${when}`,
       );
       return false;
     }
@@ -364,5 +566,7 @@ export function startLocalBrowserRenderingSetupInBackground(): void {
 
 export function resetBrowserRenderingSetupForTests(): void {
   activeInstall = null;
-  lastInstallFailureAt = 0;
+  cancelScheduledRetry();
+  failedAttempts = 0;
+  lastFailure = null;
 }


### PR DESCRIPTION
## Why

MCPJam in Node already downloads Playwright's Chromium in the background at startup. When that download failed, the Browser pane showed:

> The agent needs a browser on this machine. [Install Chromium]
> playwright install chromium exited with code 1

Nobody could act on that, because:

- Both installers either inherited stdio or scanned it only for `NN%`. Playwright prints the real reason to stdout (`Failed to install browsers` + the error) right before exiting 1. We dropped it.
- Nothing retried. The 5-minute cooldown copy said "the inspector will try again shortly", which was false.
- The pane only polled while it happened to observe `installing`, so a background install that finished, or any retry, was never noticed.
- The packaged desktop app still spawned a doomed install at startup (Electron is the launcher, RunAsNode fuse off). Never reached the UI, but a wasted spawn and a misleading warn log.
- The WebMCP Inspector joined the same install but on failure only said "run `npx playwright install chromium`", with no reason.

Not added, because Playwright already does it: a cache lock (`__dirlock`, 20 retries over ~10 min) and per-download retries (5×).

## What changed

**Server — `server/utils/browser-rendering-setup.ts`**
- One installer, `runPlaywrightChromiumInstall`, for every door. Output is piped: percentage → pane, complete lines → server log, last 4 KB → `details` on failure. Settles on `close` so the reason is never cut off.
- `ChromiumInstallState.failed` now carries `error` (Playwright's own reason, joined with its "caused by" line and the socket error the downloader printed), `details`, `retryAt`, `attempts`.
- Automatic retry ladder: 30s, 2m, 10m, then stop. A click cancels the booked retry and restarts the ladder. A retry skips the auto-install gate it already passed. The old fixed cooldown and its false copy are gone.
- While a failure stands, automatic callers (startup, widget render, WebMCP) are refused and handed that failure rather than starting an installer — including after the ladder is spent, when only an explicit "Retry now" lifts it. A Chromium installed by hand still clears it, because the already-installed probe runs first.
- `shouldAutoInstallChromium` returns false under `process.versions.electron` (not the `ELECTRON_APP` env var, since a dev server started with it set is still a Node process).

**Client — `LocalBrowserBody.tsx`, `local-browser/client.ts`**
- Failed state shows the one-line reason, "Retrying automatically in ~30s" while a retry is booked, and the installer output behind a collapsed Details disclosure. Button reads "Retry now" after a failure.
- Polls until the machine has a browser: 1s while downloading, 5s otherwise. Stops once `installed`. A click answered `ready` refetches status so the panel clears at once.

**WebMCP** — `local-browserd-provider.ts` passes `reason: "webmcp"` and the "not installed" error carries the install's one-line reason.

## Verified

- `browser-rendering-setup.test.ts`: 21 passed (new: Electron gate, output collector incl. CRLF and bounded tail, failure summary on Playwright's real offline shape, retry ladder with fake timers, click cancels retry, click failure books its own retry, pending-retry join).
- `computers-local-browser.test.ts`: 63 passed (new: failure passes through whole).
- `LocalBrowserBody.test.tsx`: 50 passed (new: reason + countdown + details + Retry now, no countdown when exhausted, keeps polling until installed then stops).
- `webmcp-inspector` route + service suites pass (one real-browser integration test timed out under parallel load and passed alone; unrelated to this change).
- Client typecheck clean. Server `tsc -p server/tsconfig.json` reports only pre-existing errors in files this PR does not touch.
- Manual, real installer, empty cache + `PLAYWRIGHT_DOWNLOAD_HOST=http://127.0.0.1:9`: state becomes `failed` with `error` = `Failed to download Chrome for Testing 151.0.7922.34 (playwright chromium v1234), caused by Download failure, code=1 (connect ECONNREFUSED 127.0.0.1:9)`, full transcript in `details`, `retryAt` 30s out.
- Manual, real installer, empty cache, real CDN: progress states 0→100 observed, ends `ready`, `isChromiumInstalled()` true afterwards.

Not verified by hand: the pane inside a running dev server (covered by the component tests), and a packaged Electron build (the gate is unit-tested against `process.versions.electron`).

## Deferred

Pre-download probes (offline / unwritable cache / low disk), post-install headless launch check, and an install button inside the WebMCP Inspector. Worth doing only once the new error text shows which of them matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nnj1FPYVBbKf6i2VMyJpU

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Chromium install flow so failures show the real reason, retry on their own, and stop once the retry budget is spent.

- The installer keeps Playwright's one-line failure reason plus the last 4 KB of output, and retries at 30s, 2m, and 10m; a click cancels the schedule and starts now.
- The Browser pane shows the reason, a retry countdown, and output behind a Details disclosure, and keeps polling until Chromium is installed.
- After the ladder is spent, a render or WebMCP request reports the standing failure without spawning another installer; only Retry now — or a Chromium installed by hand — clears it.
- The WebMCP Inspector's "not installed" error now includes the failure reason.
- `shouldAutoInstallChromium` returns false when `process.versions.electron` is set.
- The onboarding test asserts the shipped guest consent copy, fixing the failing test that was breaking the Tests run on main.

<sup>Written for commit 47733cb9086ebdbea6225ad32b08999561839ade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared Chromium install state, auto-install gating, and background retries used by the Browser pane and WebMCP; behavior is heavily unit-tested but affects first-run local browser setup.
> 
> **Overview**
> Playwright Chromium setup now **surfaces real failure reasons** and **retries on a schedule** instead of opaque exit codes and a false “will try again” cooldown.
> 
> **Server (`browser-rendering-setup.ts`)** unifies installs in `runPlaywrightChromiumInstall`: piped stdout/stderr drives progress %, log lines, and a bounded tail; failures publish `error`, `details`, `retryAt`, and `attempts` with automatic retries at **30s → 2m → 10m** (then only **Retry now**). Standing failures block silent re-spawn after the ladder is spent; explicit install clears the ladder and cancels booked retries. **`shouldAutoInstallChromium`** skips when **`process.versions.electron`** is set (packaged app cannot run the Playwright CLI).
> 
> **Browser pane** polls status until `installed` (1s while downloading, 5s otherwise), shows the one-line error, optional auto-retry countdown, collapsible **Details**, and **Retry now**; a click that returns `ready` refetches full status. **WebMCP** “not installed” errors include the install failure reason. Types and route tests pass the enriched install object through unchanged.
> 
> Guest onboarding test copy is aligned with shipped device-scope text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47733cb9086ebdbea6225ad32b08999561839ade. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
