### PR TITLE
One Browser answer for the single pane and every compare column

### DIFF
--- a/.changeset/columns-share-browser-resolution.md
+++ b/.changeset/columns-share-browser-resolution.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Comparison columns now resolve Browser through the same hook the single chat pane uses, instead of an inline copy of its logic. A column previously ignored the saved per-client Browser setting an authenticated user had made, and could settle on "no Browser" before that setting had loaded — so the same client could drive a browser on its own and refuse to in a column. Local Browser also follows an explicit device grant for anyone with no shared setting to read, which now covers a signed-in user on a local-only project as well as a guest; a project that never enabled Browser still keeps its answer.

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -1,7 +1,6 @@
 import { useBrowserWorkspaceStore } from "@/stores/browser-workspace-store";
 import { useBrowserEngine } from "@/hooks/useBrowserEngine";
 import { useBrowserToolIds } from "@/hooks/useBrowserToolIds";
-import { resolveLocalBrowserTools } from "@/shared/local-browser-settings";
 /**
  * PlaygroundMain
  *
@@ -172,6 +171,7 @@ import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 import { useAgentToolPromptBridge } from "@/stores/agent-tool-prompt-bridge";
 import { usePersistedHost } from "@/hooks/use-persisted-host";
 import { usePlaygroundHostSlots } from "@/hooks/use-playground-host-slots";
+import { usePlaygroundBrowserToolSlots } from "@/hooks/use-playground-browser-tool-slots";
 import { clientDisplayName } from "@/lib/client-display-name";
 import {
   loadSelectedHostIds,
@@ -591,7 +591,7 @@ export function PlaygroundMain({
   recorder,
   syncConversationToUrl = false,
 }: PlaygroundMainProps) {
-  const { signUp, user } = useAuth();
+  const { signUp } = useAuth();
   const clearLogs = useTrafficLogStore((s) => s.clear);
 
   // Chat-history coordination — Playground equivalent of ChatTabV2's history
@@ -2062,6 +2062,20 @@ export function PlaygroundMain({
     temperature,
     requireToolApproval,
   ]);
+
+  // What each column's host actually attaches, resolved by the SAME hook the
+  // single pane uses (`effectiveBuiltInToolIds` above). The grid used to
+  // inline its own copy of that logic, which read neither the member's saved
+  // Browser setting nor its loading state — see
+  // `usePlaygroundBrowserToolSlots`.
+  const columnBuiltInToolIds = usePlaygroundBrowserToolSlots(
+    multiHostColumns.map((column) => ({
+      hostId: column.compareId,
+      config: column.hostConfig,
+    })),
+    playgroundBrowserEngine.engine,
+    convexProjectId,
+  );
 
   // ── The same question, asked once per COLUMN ─────────────────────────────
   //
@@ -5664,14 +5678,12 @@ export function PlaygroundMain({
                           stopRequestId={stopBroadcastRequestId}
                           executionConfig={{
                             ...column.executionConfig,
-                            builtInToolIds: resolveLocalBrowserTools(
-                              column.hostConfig.builtInToolIds,
-                              column.hostConfig.localBrowserEnabled ??
-                                (!user && playgroundBrowserEngine.consent.granted
-                                  ? true
-                                  : undefined),
-                              !HOSTED_MODE && playgroundBrowserEngine.engine === "local",
-                            ),
+                            // Undefined is a real answer — "this turn states
+                            // nothing", which lets the server fall back to the
+                            // host's own config. Exactly what the single pane
+                            // sends, rather than substituting the raw host
+                            // list and pre-empting the loading guard.
+                            builtInToolIds: columnBuiltInToolIds[columnIndex],
                           }}
                           hostedContext={{
                             projectId: convexProjectId,

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -162,12 +162,32 @@ vi.mock("@/lib/PosthogUtils", () => ({
   standardEventProps: () => ({}),
 }));
 
-const browserFixture = vi.hoisted(() => ({ guest: false, granted: false }));
+// `setting` is the MEMBER's stored answer, the one `useBrowserToolIds` reads
+// from `hosts:getLocalBrowserSettings` (see the convex mock below). A guest
+// never reaches that query, so guest rows drive the host config's
+// `localBrowserEnabled` instead.
+const browserFixture = vi.hoisted(() => ({
+  guest: false,
+  granted: false,
+  setting: null as boolean | null,
+}));
+const browserConsent = vi.hoisted(() => () => ({
+  status: browserFixture.granted ? "granted" : "absent",
+  granted: browserFixture.granted,
+  token: browserFixture.granted ? "device-consent" : null,
+  grant: async () => true,
+  revoke: async () => {},
+}));
 vi.mock("@/hooks/useBrowserEngine", () => ({
   useBrowserEngine: () => ({
     engine: "local", selectedEngine: "local", localAvailable: true,
-    consent: { granted: browserFixture.granted, token: browserFixture.granted ? "device-consent" : null },
+    consent: browserConsent(),
   }),
+}));
+// The same store the engine hook reads — `useBrowserToolIds` subscribes to it
+// directly, and the two must not be able to disagree about one device grant.
+vi.mock("@/hooks/useLocalBrowserConsent", () => ({
+  useLocalBrowserConsent: () => browserConsent(),
 }));
 vi.mock("@workos-inc/authkit-react", () => ({
   useAuth: () => ({
@@ -182,8 +202,15 @@ vi.mock("convex/react", () => ({
   // straight to the rendezvous table (the blocked replica isn't addressable).
   useConvex: () => ({ mutation: vi.fn().mockResolvedValue({ ok: true }) }),
   useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
-  useQuery: (_name: string, args: unknown) =>
-    args === "skip" ? undefined : null,
+  useQuery: (name: string, args: unknown) => {
+    if (args === "skip") return undefined;
+    // Shaped like the real query: an object whose `enabled` is null when the
+    // member has stored nothing. Returning a bare null would read as "still
+    // loading" and mask what these tests are asserting.
+    if (name === "hosts:getLocalBrowserSettings")
+      return { enabled: browserFixture.setting };
+    return null;
+  },
   useMutation: () => () => Promise.resolve(),
   // COMP-14: useComputerAttachmentUpload pulls in useMintTerminalToken (a
   // Convex action). The flag mock keeps the flow inert; this keeps it mountable.
@@ -677,6 +704,7 @@ describe("PlaygroundMain — multi-host render path", () => {
   beforeEach(() => {
     browserFixture.guest = false;
     browserFixture.granted = false;
+    browserFixture.setting = null;
     vi.clearAllMocks();
     usePlaygroundChatHistoryBridgeStore.getState().setBridge(null);
     useHostContextStore.setState({
@@ -1249,12 +1277,19 @@ describe("PlaygroundMain — multi-host render path", () => {
     ]);
   });
 
+  // EVERY COLUMN ANSWERS LIKE THE SINGLE PANE. The grid resolves each column
+  // through `useBrowserToolIds` — the same hook the pane uses — so the rule
+  // itself is pinned at that hook's altitude (a member's stored setting needs
+  // a queryable project scope, which this harness deliberately does not have).
+  // What matters here is that the grid asks the question at all, per column,
+  // and does not re-answer it with a copy that drifts.
   it.each([
     { guest: true, granted: true, enabled: undefined, expected: ["browser"] },
     { guest: true, granted: false, enabled: undefined, expected: [] },
     { guest: true, granted: true, enabled: false, expected: [] },
-    { guest: false, granted: true, enabled: undefined, expected: [] },
-  ])("resolves comparison Browser tools: guest=$guest consent=$granted setting=$enabled", ({ guest, granted, enabled, expected }) => {
+    { guest: false, granted: true, enabled: undefined, expected: ["browser"] },
+    { guest: false, granted: true, enabled: false, expected: [] },
+  ])("resolves comparison Browser tools: guest=$guest consent=$granted host=$enabled", ({ guest, granted, enabled, expected }) => {
     browserFixture.guest = guest;
     browserFixture.granted = granted;
     multiHostFixture.hostList = [{ hostId: "h-A", name: "A" }, { hostId: "h-B", name: "B" }];

--- a/mcpjam-inspector/client/src/hooks/__tests__/useBrowserToolIds.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useBrowserToolIds.test.tsx
@@ -66,7 +66,7 @@ it("enables every guest local view only after explicit Allow, including views op
   expect(second.result.current).toBeUndefined();
 });
 
-it("never turns guest device consent into hosted tools or shared settings after sign-in", () => {
+it("never turns device consent into hosted tools or a shared project's answer", () => {
   localStorage.setItem(
     "mcp-local-browser-consent-v1",
     JSON.stringify({ token: "guest-device-browser-consent", grantedAt: "now" }),
@@ -78,12 +78,36 @@ it("never turns guest device consent into hosted tools or shared settings after 
   expect(
     renderHook(() => useBrowserToolIds(null, "local")).result.current,
   ).toBeUndefined();
+  // A project that never enabled Browser keeps its answer. `Allow` SKIPS
+  // projects the member cannot manage, so an unset default there is an org
+  // decision — not a gap for this machine's grant to fill.
   state.hosted = false;
   state.user = { id: "member" };
+  state.setting = { enabled: null };
   expect(
-    renderHook(() => useBrowserToolIds(null, "local")).result.current,
+    renderHook(() => useBrowserToolIds(null, "local", { projectId: "proj_1" }))
+      .result.current,
   ).toBeUndefined();
   expect(state.request).not.toHaveBeenCalled();
+});
+
+it("lets the device grant answer for a member with no shared setting to read", () => {
+  // A local-only project has no Convex row to store a default in, so the
+  // settings query never runs. Before this, Allow left the member in the same
+  // silent no-Browser turn as a guest: nothing stored, nothing consulted, no
+  // tool — on a machine they had explicitly authorized.
+  state.user = { id: "member" };
+  localStorage.setItem(
+    "mcp-local-browser-consent-v1",
+    JSON.stringify({ token: "member-device-browser-consent", grantedAt: "now" }),
+  );
+  const scope = { projectId: "local_1" };
+  expect(
+    renderHook(() => useBrowserToolIds(null, "local", scope)).result.current,
+  ).toEqual(["browser"]);
+  expect(state.queries.mock.calls.every(([, args]) => args === "skip")).toBe(
+    true,
+  );
 });
 
 it("preserves an explicit client opt-out for guests", () => {

--- a/mcpjam-inspector/client/src/hooks/use-playground-browser-tool-slots.ts
+++ b/mcpjam-inspector/client/src/hooks/use-playground-browser-tool-slots.ts
@@ -1,0 +1,48 @@
+import { useBrowserToolIds } from "@/hooks/useBrowserToolIds";
+import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
+
+/**
+ * Resolve each compare column's built-in tool ids — browser attachment
+ * included — through the SAME hook the single-pane chat and the Tools rail
+ * use, in a rules-of-hooks-safe way.
+ *
+ * WHY THIS EXISTS. The grid used to resolve its columns with an inline copy
+ * of the hook's logic, because a hook cannot be called from inside a `.map()`.
+ * The copy drifted, as copies do: it never read the member's saved
+ * `hosts:getLocalBrowserSettings`, so a per-host Browser setting applied to
+ * the single pane and silently did nothing to a column of the same host; and
+ * it had no "the setting is still loading" guard, so a column could commit to
+ * no-browser on its first render and keep that answer for the turn. A guest
+ * who had allowed Browser got three columns that told them they cannot browse.
+ *
+ * Same shape and same reasoning as `usePlaygroundHostSlots`: the compare grid
+ * caps at 3 columns, so make 3 unconditional calls and let the hook
+ * short-circuit on a missing config. Callers slice to the live column count.
+ * Raising the cap means editing this file, that one, and the grid-column
+ * helper — which is the point of keeping the cap in named places rather than
+ * in a `.map()` nobody can extend safely.
+ */
+export function usePlaygroundBrowserToolSlots(
+  columns: {
+    hostId: string;
+    config: HostConfigDtoV2;
+  }[],
+  engine: "local" | "cloud",
+  projectId: string | null,
+): [string[] | undefined, string[] | undefined, string[] | undefined] {
+  // An empty slot passes a null project so the settings query is skipped
+  // rather than subscribing on behalf of a column that does not exist.
+  const slot0 = useBrowserToolIds(columns[0]?.config, engine, {
+    projectId: columns[0] ? projectId : null,
+    hostId: columns[0]?.hostId ?? null,
+  });
+  const slot1 = useBrowserToolIds(columns[1]?.config, engine, {
+    projectId: columns[1] ? projectId : null,
+    hostId: columns[1]?.hostId ?? null,
+  });
+  const slot2 = useBrowserToolIds(columns[2]?.config, engine, {
+    projectId: columns[2] ? projectId : null,
+    hostId: columns[2]?.hostId ?? null,
+  });
+  return [slot0, slot1, slot2];
+}

--- a/mcpjam-inspector/client/src/hooks/useBrowserToolIds.ts
+++ b/mcpjam-inspector/client/src/hooks/useBrowserToolIds.ts
@@ -32,11 +32,23 @@ export function useBrowserToolIds(
         } as never)
       : "skip",
   ) as { enabled: boolean | null } | undefined;
-  // Guest clients have no shared project setting to update. Their explicit
-  // device grant supplies the local default, including views in other tabs.
+  // THE DEVICE GRANT ANSWERS WHEN NOTHING SHARED CAN — the same rule for
+  // every actor, rather than one rule for guests and another for members.
+  //
+  // A shared setting, where one is readable, stays authoritative in both
+  // directions: an explicit opt-out still wins, and a project that never
+  // enabled Browser still means no Browser (`enableLocalBrowserForManagedProjects`
+  // SKIPS projects the member cannot manage, so "nothing stored" there is an
+  // org decision they are not allowed to overrule from their own machine).
+  //
+  // `!querySettings` is what "nothing shared can answer" means: a guest, whose
+  // Allow is device-scoped and writes no project default, and a member on a
+  // local-only project, who has no Convex project to store one in. Both
+  // authorized this machine explicitly; both used to get a silent
+  // no-Browser turn out of a setting that does not exist for them.
   const enabled =
     (querySettings ? settings?.enabled : config?.localBrowserEnabled) ??
-    (!user && consent.granted ? true : undefined);
+    (!querySettings && consent.granted ? true : undefined);
   return useMemo(
     () =>
       resolveLocalBrowserTools(


### PR DESCRIPTION
## The bug

A guest who had allowed Browser could navigate from the single chat pane, and be told "I don't have the ability to navigate to websites" by all three clients in the compare grid, in the same session. The failing column's Raw payload carried no `browser_*` tools at all, and no "Browser is temporarily unavailable" line in the system prompt — so the turn was built with the browser capability simply absent, not present-and-blocked.

## Why

The grid resolved each column's built-in tools with an inline copy of `useBrowserToolIds`, the hook the single pane uses. Two things had drifted in the copy:

- it never read the member's saved `hosts:getLocalBrowserSettings`, so a per-client Browser setting applied to the pane and silently did nothing to a column of that **same** client;
- it had no "the setting is still loading" guard, so a column could settle on no-Browser on its first render and keep that answer for the turn.

## The fix

Columns call the hook, three fixed slots deep, the way `usePlaygroundHostSlots` already wraps `useHost` for the same rules-of-hooks reason. One implementation, so the grid and the pane cannot disagree about one capability again.

The hook's device-grant fallback is no longer keyed on being a guest but on **whether a shared setting can be read at all**. What was consented to is this machine driving a browser, so where nothing shared can answer — a guest, whose Allow is device-scoped and writes no project default, or a member on a local-only project with no Convex row to store one in — the grant is the answer. Where something shared can answer, it still wins in both directions: an explicit opt-out holds, and a project that never enabled Browser keeps its answer, because `enableLocalBrowserForManagedProjects` **skips** projects the member cannot manage and an unset default there is an org decision, not a gap to fill from one machine.

No server change: `routes/mcp/chat-v2.ts` only strips `browser` when the host config explicitly says `false`, which already agrees with this rule.

## Tests

- `useBrowserToolIds`: the org-decision half is pinned directly (member + queryable project + nothing stored ⇒ no Browser), and a new case covers the member on a local-only project whose grant now answers.
- `PlaygroundMain.multi-host`: the column table now drives the real consent store rather than only the engine hook's copy of it, and asserts every column resolves like the pane.
- `client/src/components/ui-playground/__tests__` (292) and the browser-tool suites are green.

## Still open

This makes the pane and the grid answer identically, and it closes the loading-state and member-setting gaps. If the original repro survives on this branch, the remaining suspect is a `localBrowserEnabled: false` actually stored on those client rows — an explicit opt-out that is *supposed* to win — and the value to check is `hosts:getLocalBrowserSettings` for that project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJgo5p1uqwyaUjpm5ye5JS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which built-in tools each compare column sends on chat turns and broadens when local Browser is enabled for signed-in users; client-only but affects capability exposure per host.
> 
> **Overview**
> **Compare columns now attach Browser through `useBrowserToolIds`**, via the new `usePlaygroundBrowserToolSlots` hook (three fixed hook slots, same pattern as `usePlaygroundHostSlots`), instead of inlining `resolveLocalBrowserTools` in `PlaygroundMain`. That removes drift where columns ignored a member’s saved `hosts:getLocalBrowserSettings`, could lock in “no Browser” before settings loaded, and disagreed with the single chat pane for the same host.
> 
> **`useBrowserToolIds` applies the device grant when no shared setting can be queried** (`!querySettings && consent.granted`), not only for guests—so a signed-in user on a local-only project with an explicit Allow gets Browser. When a queryable project setting exists, shared/org answers still win (explicit opt-out and “never enabled” stay no Browser).
> 
> Tests cover the hook’s org-default vs local-only member cases and multi-host column resolution against the real consent/settings mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e529c3260715fa96dcce4bd83ccc65f2e8a4ddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes compare-column Browser resolution so every column answers exactly like the single chat pane. Columns previously used an inline copy of the pane's hook that never read the member's saved per-client Browser setting and had no loading guard — so a guest who had allowed Browser could browse from the pane and then be told "I can't navigate" by all three comparison columns in the same session.

Columns now call the same hook the pane uses, three fixed slots deep for rules-of-hooks safety. The hook's device-grant fallback no longer depends on being a guest; it applies whenever no shared setting can be read, which now covers a member on a local-only project as well as a guest. A project that never enabled Browser still keeps its answer, and an explicit opt-out still wins. No server change needed.

**Tests**
- `useBrowserToolIds` pins the member-on-local-only grant case and the keep-the-answer org-decision case.
- `PlaygroundMain.multi-host` drives the real consent store and asserts every column resolves like the pane.

<sup>Written for commit 0e529c3260715fa96dcce4bd83ccc65f2e8a4ddd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

