### PR TITLE
Checks: a new check starts neutral and validates once touched or on Save

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/checks-section-draft-validity.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/checks-section-draft-validity.test.tsx
@@ -18,21 +18,31 @@ function Harness({
   initial,
   onDraftValidityChange,
   onValue,
+  replacement,
 }: {
   initial: Predicate[];
   onDraftValidityChange: (hasInvalidDraft: boolean) => void;
   onValue?: (next: Predicate[]) => void;
+  /** A whole new list the test can swap in from outside the section. */
+  replacement?: Predicate[];
 }) {
   const [value, setValue] = useState(initial);
   return (
-    <ChecksSection
-      value={value}
-      onChange={(next) => {
-        setValue(next);
-        onValue?.(next);
-      }}
-      onDraftValidityChange={onDraftValidityChange}
-    />
+    <>
+      <ChecksSection
+        value={value}
+        onChange={(next) => {
+          setValue(next);
+          onValue?.(next);
+        }}
+        onDraftValidityChange={onDraftValidityChange}
+      />
+      {replacement ? (
+        <button type="button" onClick={() => setValue(replacement)}>
+          replace list
+        </button>
+      ) : null}
+    </>
   );
 }
 
@@ -197,6 +207,63 @@ describe("ChecksSection raw-JSON draft validity", () => {
         screen.getByRole("button", { name: "Remove check" }),
       );
     });
+    expect(onDraftValidityChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("removing the row above keeps the row below's draft with its own predicate", async () => {
+    const onDraftValidityChange = vi.fn();
+    render(
+      <Harness
+        initial={[toolCalledWith("search"), toolCalledWith("fetch")]}
+        onDraftValidityChange={onDraftValidityChange}
+      />,
+    );
+    await switchToRawJson(0);
+    const second = await switchToRawJson(1);
+    // A half-typed draft on the SECOND row only.
+    fireEvent.change(second, { target: { value: '{"q": ' } });
+    expect(onDraftValidityChange).toHaveBeenLastCalledWith(true);
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getAllByRole("button", { name: "Remove check" })[0]!,
+      );
+    });
+
+    // One row left, and it is still the fetch row mid-edit — not the search
+    // row's editor now pointed at fetch's args.
+    expect(screen.getAllByLabelText("Tool")).toHaveLength(1);
+    expect(screen.getByLabelText("Tool")).toHaveValue("fetch");
+    expect(screen.getByLabelText(/Expected args \(JSON\)/)).toHaveValue(
+      '{"q": ',
+    );
+    expect(onDraftValidityChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it("re-derives the draft when the whole list is replaced from outside", async () => {
+    const onDraftValidityChange = vi.fn();
+    render(
+      <Harness
+        initial={[toolCalledWith("search")]}
+        replacement={[
+          {
+            type: "toolCalledWith",
+            toolName: "other",
+            args: { args: { city: "Lima" } },
+          } as Predicate,
+        ]}
+        onDraftValidityChange={onDraftValidityChange}
+      />,
+    );
+    const textarea = await switchToRawJson();
+    fireEvent.change(textarea, { target: { value: "{" } });
+    expect(onDraftValidityChange).toHaveBeenLastCalledWith(true);
+
+    await userEvent.click(screen.getByText("replace list"));
+
+    expect(screen.getByLabelText(/Expected args \(JSON\)/)).toHaveValue(
+      JSON.stringify({ city: "Lima" }, null, 2),
+    );
     expect(onDraftValidityChange).toHaveBeenLastCalledWith(false);
   });
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/checks-section-field-validation.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/checks-section-field-validation.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * A freshly added check fails the SDK schema before anyone has typed: eight
+ * kinds start with a required string empty. These cases pin that the failure
+ * is SHOWN only once the field is touched or the caller asks for everything
+ * (`showAllErrors`), with copy that names the field, not Zod's wording.
+ */
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { Predicate } from "@mcpjam/sdk/browser";
+
+vi.mock("posthog-js/react", () => ({ useFeatureFlagEnabled: () => false }));
+
+import { ChecksSection } from "../checks-section";
+
+function Harness({
+  initial,
+  availableTools,
+  showAllErrors,
+}: {
+  initial: Predicate[];
+  availableTools?: string[];
+  showAllErrors?: boolean;
+}) {
+  const [value, setValue] = useState(initial);
+  return (
+    <ChecksSection
+      value={value}
+      onChange={setValue}
+      availableTools={availableTools}
+      showAllErrors={showAllErrors}
+    />
+  );
+}
+
+const blankToolCalledWith = (): Predicate =>
+  ({ type: "toolCalledWith", toolName: "", args: { args: {} } }) as Predicate;
+
+/** The card around a row, found from any control inside it. */
+function rowCardOf(control: HTMLElement): HTMLElement {
+  return control.closest("li")!.firstElementChild as HTMLElement;
+}
+
+const ZOD_WORDING = /Too small|Invalid input/;
+
+describe("CheckRow untouched state", () => {
+  it("a fresh check shows no error and no red border", () => {
+    render(<Harness initial={[blankToolCalledWith()]} />);
+    const tool = screen.getByLabelText("Tool");
+    expect(tool).not.toHaveAttribute("aria-invalid");
+    expect(screen.queryByText("Enter a tool name")).toBeNull();
+    expect(screen.queryByText(ZOD_WORDING)).toBeNull();
+    expect(rowCardOf(tool).className).not.toContain("border-destructive");
+  });
+
+  it("blurring the empty field shows the field's own message", () => {
+    render(<Harness initial={[blankToolCalledWith()]} />);
+    const tool = screen.getByLabelText("Tool");
+    fireEvent.blur(tool);
+
+    const message = screen.getByText("Enter a tool name");
+    expect(tool).toHaveAttribute("aria-invalid", "true");
+    expect(tool).toHaveAttribute("aria-describedby", message.id);
+    expect(rowCardOf(tool).className).toContain("border-destructive");
+    expect(screen.queryByText(ZOD_WORDING)).toBeNull();
+  });
+
+  it("typing a value clears the message and the border", () => {
+    render(<Harness initial={[blankToolCalledWith()]} />);
+    const tool = screen.getByLabelText("Tool");
+    fireEvent.blur(tool);
+    expect(screen.getByText("Enter a tool name")).toBeInTheDocument();
+
+    fireEvent.change(tool, { target: { value: "search" } });
+    expect(screen.queryByText("Enter a tool name")).toBeNull();
+    expect(tool).not.toHaveAttribute("aria-invalid");
+    expect(rowCardOf(tool).className).not.toContain("border-destructive");
+  });
+
+  it("clearing a value the user typed brings the message back", () => {
+    render(<Harness initial={[blankToolCalledWith()]} />);
+    const tool = screen.getByLabelText("Tool");
+    fireEvent.change(tool, { target: { value: "s" } });
+    fireEvent.change(tool, { target: { value: "" } });
+    expect(screen.getByText("Enter a tool name")).toBeInTheDocument();
+  });
+
+  it("showAllErrors reveals every incomplete row at once", () => {
+    render(
+      <Harness
+        initial={[
+          blankToolCalledWith(),
+          { type: "responseContains", needle: "" } as Predicate,
+          { type: "noToolErrors" } as Predicate,
+        ]}
+        showAllErrors
+      />,
+    );
+    expect(screen.getByText("Enter a tool name")).toBeInTheDocument();
+    expect(screen.getByText("Enter the text to look for")).toBeInTheDocument();
+    // A kind that is valid when blank has nothing to reveal.
+    const cards = screen.getAllByRole("listitem");
+    expect(cards).toHaveLength(3);
+    expect(
+      (cards[2]!.firstElementChild as HTMLElement).className,
+    ).not.toContain("border-destructive");
+  });
+
+  it("uses dropdown copy when the tool list is known", () => {
+    render(
+      <Harness
+        initial={[blankToolCalledWith()]}
+        availableTools={["search", "fetch"]}
+        showAllErrors
+      />,
+    );
+    expect(screen.getByText("Pick a tool")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Tool" })).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  });
+
+  it("reports the ordering rule's two fields separately", () => {
+    render(
+      <Harness
+        initial={[
+          {
+            type: "toolCalledBefore",
+            toolName: "",
+            beforeToolName: "",
+          } as Predicate,
+        ]}
+      />,
+    );
+    const first = screen.getByLabelText("Must be called first");
+    const second = screen.getByLabelText("Before this tool");
+
+    fireEvent.blur(first);
+    expect(screen.getAllByText("Enter a tool name")).toHaveLength(1);
+    expect(first).toHaveAttribute("aria-invalid", "true");
+    expect(second).not.toHaveAttribute("aria-invalid");
+
+    fireEvent.change(first, { target: { value: "login" } });
+    fireEvent.blur(second);
+    expect(screen.getAllByText("Enter a tool name")).toHaveLength(1);
+    expect(second).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("an invalid regex shows as typed; an empty pattern waits for a touch", () => {
+    render(
+      <Harness
+        initial={[{ type: "responseMatches", pattern: "" } as Predicate]}
+      />,
+    );
+    const pattern = screen.getByLabelText(/Regex pattern/);
+    expect(screen.queryByText("Enter a pattern")).toBeNull();
+
+    fireEvent.change(pattern, { target: { value: "(" } });
+    expect(screen.getByText(/Invalid regular expression/)).toBeInTheDocument();
+
+    fireEvent.change(pattern, { target: { value: "" } });
+    expect(screen.getByText("Enter a pattern")).toBeInTheDocument();
+
+    fireEvent.change(pattern, { target: { value: "^ok$" } });
+    expect(screen.queryByText("Enter a pattern")).toBeNull();
+    expect(screen.queryByText(/Invalid regular expression/)).toBeNull();
+  });
+
+  it("covers the tool-result text field", () => {
+    render(
+      <Harness
+        initial={[{ type: "toolResultContains", needle: "" } as Predicate]}
+      />,
+    );
+    const needle = screen.getByLabelText("Text the result must contain");
+    fireEvent.blur(needle);
+    expect(
+      screen.getByText("Enter the text the result must contain"),
+    ).toBeInTheDocument();
+  });
+
+  it("deleting a touched row does not hand its touched state to the row below", async () => {
+    render(
+      <Harness initial={[blankToolCalledWith(), blankToolCalledWith()]} />,
+    );
+    const [first] = screen.getAllByLabelText("Tool");
+    fireEvent.blur(first!);
+    expect(screen.getAllByText("Enter a tool name")).toHaveLength(1);
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getAllByRole("button", { name: "Remove check" })[0]!,
+      );
+    });
+
+    // The surviving row was never touched and must still look neutral.
+    expect(screen.getAllByLabelText("Tool")).toHaveLength(1);
+    expect(screen.queryByText("Enter a tool name")).toBeNull();
+    expect(rowCardOf(screen.getByLabelText("Tool")).className).not.toContain(
+      "border-destructive",
+    );
+  });
+
+  it("a saved check with a legacy empty field stays neutral until touched", () => {
+    render(
+      <Harness
+        initial={[{ type: "toolCalledAtLeastOnce", toolName: "" } as Predicate]}
+      />,
+    );
+    expect(screen.queryByText("Enter a tool name")).toBeNull();
+    fireEvent.blur(screen.getByLabelText("Tool"));
+    expect(screen.getByText("Enter a tool name")).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/checks-section.tsx
@@ -23,6 +23,7 @@ import {
   useEffect,
   useId,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -182,6 +183,22 @@ export function ChecksSection({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasInvalidDraft]);
 
+  // One stable key per row, so React keeps each `CheckRow` instance — and the
+  // textarea drafts and touched state inside it — with ITS predicate when a
+  // row above is removed. Predicates carry no id, and keying by index handed
+  // row 2's editor to row 3's predicate on every delete. Kept in a ref, not
+  // state: the list is aligned to `value` in render and spliced in the same
+  // handler that splices `value`, so nothing needs to re-render because of it.
+  const rowKeys = useRef<string[]>([]);
+  const mintedRows = useRef(0);
+  const mintRowKey = () => `row-${(mintedRows.current += 1)}`;
+  while (rowKeys.current.length < value.length) {
+    rowKeys.current.push(mintRowKey());
+  }
+  if (rowKeys.current.length > value.length) {
+    rowKeys.current.length = value.length;
+  }
+
   const updateAt = (index: number, next: Predicate) => {
     const copy = value.slice();
     copy[index] = next;
@@ -190,9 +207,11 @@ export function ChecksSection({
   const removeAt = (index: number) => {
     const copy = value.slice();
     copy.splice(index, 1);
+    rowKeys.current.splice(index, 1);
     onChange(copy);
   };
   const addOfKind = (kind: Kind) => {
+    rowKeys.current.push(mintRowKey());
     onChange([...value, blankPredicate(kind)]);
   };
 
@@ -225,7 +244,7 @@ export function ChecksSection({
         ) : (
           <ul className="space-y-2">
             {value.map((predicate, i) => (
-              <li key={i}>
+              <li key={rowKeys.current[i]}>
                 <CheckRow
                   predicate={predicate}
                   onChange={
@@ -1438,33 +1457,26 @@ function RawArgsJsonEditor({
       return "{}";
     }
   };
-  const [draftJson, setDraftJson] = useState(() => formatValue(value));
+  // The draft remembers which `value` it is the text FOR. When the prop
+  // arrives from somewhere other than this textarea's own last parse — the
+  // whole list replaced on a scenario switch, say — the text is re-derived in
+  // render rather than one effect-tick later. A row removed or reordered
+  // above no longer reaches here at all: `ChecksSection` keys rows stably, so
+  // that remounts the editor with its own predicate.
+  const valueKey = JSON.stringify(value ?? {});
+  const [draft, setDraft] = useState(() => ({
+    text: formatValue(value),
+    forValue: valueKey,
+  }));
+  if (draft.forValue !== valueKey) {
+    setDraft({ text: formatValue(value), forValue: valueKey });
+  }
+  const draftJson =
+    draft.forValue === valueKey ? draft.text : formatValue(value);
   // Derived from the text, never stored beside it: a stored flag is one more
   // thing an unrelated edit can leave stale, and this one gates Save.
   const jsonError = useMemo(() => parseArgsDraft(draftJson).error, [draftJson]);
   useInvalidDraftRegistration(jsonError !== null);
-
-  // Resync the draft text when `value` changes from outside this instance
-  // (e.g. switching cases, deleting/reordering checks). Predicate rows are
-  // keyed by index, so the same RawArgsJsonEditor instance is reused with
-  // a different `value` prop — without this, the textarea kept showing the
-  // previous predicate's JSON and the next edit could clobber the new
-  // predicate's args. We compare against the parse of our own draft to
-  // avoid overwriting mid-edit (when the user's draft is the upstream of
-  // `value`, JSON parses equal and we leave the text alone).
-  useEffect(() => {
-    let drift = true;
-    try {
-      const parsed = JSON.parse(draftJson);
-      drift = JSON.stringify(parsed) !== JSON.stringify(value ?? {});
-    } catch {
-      drift = true;
-    }
-    if (drift) {
-      setDraftJson(formatValue(value));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
 
   return (
     <div className="space-y-1">
@@ -1485,8 +1497,14 @@ function RawArgsJsonEditor({
         value={draftJson}
         onChange={(e) => {
           const next = e.target.value;
-          setDraftJson(next);
           const { parsed } = parseArgsDraft(next);
+          // A parse that fails keeps pointing at the value already shown, so
+          // the text survives the re-render; one that succeeds points at the
+          // value it is about to become.
+          setDraft({
+            text: next,
+            forValue: parsed ? JSON.stringify(parsed) : valueKey,
+          });
           if (parsed) onChange(parsed);
         }}
         spellCheck={false}
@@ -1979,32 +1997,22 @@ function ToolResultSchemaFields({
   readOnly: boolean;
 }) {
   const id = useId();
-  const [draft, setDraft] = useState(() =>
-    JSON.stringify(predicate.schema ?? {}, null, 2),
-  );
+  // Same draft model as `RawArgsJsonEditor`: the text knows which schema it is
+  // for, and is re-derived in render when the schema arrives from outside.
+  const schemaKey = JSON.stringify(predicate.schema ?? {});
+  const formatSchema = () => JSON.stringify(predicate.schema ?? {}, null, 2);
+  const [draftState, setDraftState] = useState(() => ({
+    text: formatSchema(),
+    forSchema: schemaKey,
+  }));
+  if (draftState.forSchema !== schemaKey) {
+    setDraftState({ text: formatSchema(), forSchema: schemaKey });
+  }
+  const draft =
+    draftState.forSchema === schemaKey ? draftState.text : formatSchema();
   // Derived from the text — see `RawArgsJsonEditor`.
   const error = useMemo(() => parseSchemaDraft(draft).error, [draft]);
   useInvalidDraftRegistration(error !== null);
-  // Resync when `predicate` changes from OUTSIDE this instance. Rows are keyed
-  // by array index, so removing or reordering a row above reuses this same
-  // component with a different predicate — and without this the textarea keeps
-  // showing the previous check's schema, which the next keystroke then writes
-  // onto the current one. Compared against our own draft so a mid-edit value is
-  // left alone; `RawArgsJsonEditor` documents the identical hazard.
-  useEffect(() => {
-    let drift = true;
-    try {
-      drift =
-        JSON.stringify(JSON.parse(draft)) !==
-        JSON.stringify(predicate.schema ?? {});
-    } catch {
-      drift = true;
-    }
-    if (drift) {
-      setDraft(JSON.stringify(predicate.schema ?? {}, null, 2));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [predicate.schema]);
   return (
     <div className="space-y-2">
       <div className="space-y-1">
@@ -2018,14 +2026,17 @@ function ToolResultSchemaFields({
           rows={6}
           onChange={(e) => {
             const next = e.target.value;
-            setDraft(next);
+            const { parsed, ok } = parseSchemaDraft(next);
+            setDraftState({
+              text: next,
+              forSchema: ok ? JSON.stringify(parsed) : schemaKey,
+            });
             // Written through only when it parses: a half-typed schema is not
             // an assertion, and persisting one would make the check
             // unusable-schema on the next run. The row meanwhile HOLDS the
             // last schema that parsed, so the message below says so, and the
             // section reports the unparsable draft upward so a caller can
             // keep Save closed until it parses again.
-            const { parsed, ok } = parseSchemaDraft(next);
             if (ok) onChange({ ...predicate, schema: parsed });
           }}
           className="font-mono text-xs"

--- a/mcpjam-inspector/client/src/components/evals/checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/checks-section.tsx
@@ -20,6 +20,7 @@
 import {
   createContext,
   useContext,
+  useCallback,
   useEffect,
   useId,
   useMemo,
@@ -125,6 +126,11 @@ export interface ChecksSectionProps {
    * downstream reads it.
    */
   onDraftValidityChange?: (hasInvalidDraft: boolean) => void;
+  /**
+   * Show every row's validation issues, touched or not. Callers turn this on
+   * when the user tries to save with an incomplete check — see `CheckRow`.
+   */
+  showAllErrors?: boolean;
 }
 
 /**
@@ -145,6 +151,50 @@ function useInvalidDraftRegistration(invalid: boolean): void {
   }, [report, editorId, invalid]);
 }
 
+/**
+ * How a `CheckRow` hands its Zod verdict to the fields inside it.
+ *
+ * A blank check fails the schema before anyone has typed — eight kinds start
+ * with a required string empty — and painting that on first render made a
+ * fresh row look broken. So an issue is SHOWN only once its field has been
+ * touched, or when the caller asks for everything (a Save attempt). The field
+ * owns the copy: "Pick a tool" says what to do, where Zod's message says what
+ * went wrong with a string.
+ */
+interface FieldValidation {
+  /** Whether the current predicate has a Zod issue at this top-level path. */
+  isInvalid: (path: string) => boolean;
+  /** Whether an issue at this path should be visible right now. */
+  isShown: (path: string) => boolean;
+  markTouched: (path: string) => void;
+}
+
+const FieldValidationContext = createContext<FieldValidation | null>(null);
+
+/**
+ * Paths whose issue a field renders itself, with its own copy. Any other
+ * issue falls back to the row-level line. Static rather than registered:
+ * the row renders before its fields, so it could not learn the claims of
+ * the same pass any other way.
+ */
+const FIELD_OWNED_PATHS: ReadonlySet<string> = new Set([
+  "toolName",
+  "beforeToolName",
+  "needle",
+  "pattern",
+]);
+
+function useFieldValidation(
+  path: string,
+  message: string,
+): { error: string | null; markTouched: () => void } {
+  const ctx = useContext(FieldValidationContext);
+  const error =
+    ctx && ctx.isInvalid(path) && ctx.isShown(path) ? message : null;
+  const markTouched = useCallback(() => ctx?.markTouched(path), [ctx, path]);
+  return { error, markTouched };
+}
+
 export function ChecksSection({
   value,
   onChange,
@@ -159,6 +209,7 @@ export function ChecksSection({
   allowedKinds,
   globalGatesMenu = false,
   onDraftValidityChange,
+  showAllErrors = false,
 }: ChecksSectionProps & { hideAddButton?: boolean; hideEmptyState?: boolean }) {
   const [invalidDraftIds, setInvalidDraftIds] = useState<ReadonlySet<string>>(
     () => new Set(),
@@ -271,6 +322,7 @@ export function ChecksSection({
                   globalGate={
                     globalGatesMenu && isGlobalPolicyKind(predicate.type)
                   }
+                  showAllErrors={showAllErrors}
                 />
               </li>
             ))}
@@ -363,6 +415,8 @@ export interface CheckRowProps {
   legacyScenarioGate?: boolean;
   /** Compact whole-run gate row (label + hint in header, minimal fields). */
   globalGate?: boolean;
+  /** Reveal issues on untouched fields too — the Save-attempt case. */
+  showAllErrors?: boolean;
 }
 
 export function CheckRow({
@@ -376,17 +430,60 @@ export function CheckRow({
   embedded = false,
   legacyScenarioGate = false,
   globalGate = false,
+  showAllErrors = false,
 }: CheckRowProps) {
-  // Zod-validate the current row so an in-progress edit (e.g. empty toolName,
-  // malformed args JSON) surfaces an inline error and disables Save up the
-  // tree (callers wire `isAnyCheckInvalid` into their disable state).
-  const validation = useMemo(
-    () => predicateSchema.safeParse(predicate),
-    [predicate],
+  // Zod-validate the current row. Callers gate Save on the same schema via
+  // `areAllChecksValid`; this copy of the verdict is what the fields show,
+  // and only once touched — see `FieldValidation`.
+  const issues = useMemo(() => {
+    const result = predicateSchema.safeParse(predicate);
+    const byPath = new Map<string, string>();
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        const path = String(issue.path[0] ?? "");
+        if (!byPath.has(path)) byPath.set(path, issue.message);
+      }
+    }
+    return byPath;
+  }, [predicate]);
+
+  const [touched, setTouched] = useState<ReadonlySet<string>>(() => new Set());
+  const markTouched = useCallback((path: string) => {
+    setTouched((prev) => {
+      if (prev.has(path)) return prev;
+      const next = new Set(prev);
+      next.add(path);
+      return next;
+    });
+  }, []);
+  const isShown = useCallback(
+    (path: string) => showAllErrors || touched.has(path),
+    [showAllErrors, touched],
   );
-  const error = validation.success
-    ? null
-    : validation.error.issues.map((i) => i.message).join("; ");
+  const fieldValidation = useMemo<FieldValidation>(
+    () => ({
+      isInvalid: (path) => issues.has(path),
+      isShown,
+      markTouched,
+    }),
+    [issues, isShown, markTouched],
+  );
+
+  // Issues no field renders itself. Zod's own wording, since we know nothing
+  // more specific about them; shown once the row has been touched anywhere.
+  const rowLevelError = useMemo(() => {
+    const rest = [...issues.entries()]
+      .filter(([path]) => !FIELD_OWNED_PATHS.has(path))
+      .map(([, message]) => message);
+    return rest.length > 0 ? rest.join("; ") : null;
+  }, [issues]);
+  const showRowLevelError =
+    rowLevelError !== null && (showAllErrors || touched.size > 0);
+  const anyErrorShown =
+    showRowLevelError ||
+    [...issues.keys()].some(
+      (path) => FIELD_OWNED_PATHS.has(path) && isShown(path),
+    );
 
   return (
     <div
@@ -395,7 +492,7 @@ export function CheckRow({
           ? "min-w-0 space-y-3"
           : cn(
               "rounded-md border p-3",
-              error
+              anyErrorShown
                 ? "border-destructive/40 bg-destructive/5"
                 : "border-border/60 bg-muted/10",
             ),
@@ -418,18 +515,20 @@ export function CheckRow({
             )
           ) : null}
 
-          <CheckFields
-            predicate={predicate}
-            onChange={onChange}
-            availableTools={availableTools}
-            widgetToolNames={widgetToolNames}
-            toolArgSchemas={toolArgSchemas}
-            readOnly={readOnly}
-            compactGlobalGate={globalGate}
-          />
+          <FieldValidationContext.Provider value={fieldValidation}>
+            <CheckFields
+              predicate={predicate}
+              onChange={onChange}
+              availableTools={availableTools}
+              widgetToolNames={widgetToolNames}
+              toolArgSchemas={toolArgSchemas}
+              readOnly={readOnly}
+              compactGlobalGate={globalGate}
+            />
+          </FieldValidationContext.Provider>
 
-          {error ? (
-            <div className="text-[11px] text-destructive">{error}</div>
+          {showRowLevelError ? (
+            <div className="text-[11px] text-destructive">{rowLevelError}</div>
           ) : null}
           {legacyScenarioGate ? (
             <p className="text-[11px] text-muted-foreground">
@@ -867,6 +966,7 @@ function ToolNameField({
   readOnly,
   label = "Tool",
   compact = false,
+  path = "toolName",
 }: {
   value: string;
   onChange: (next: string) => void;
@@ -880,13 +980,23 @@ function ToolNameField({
    */
   label?: string;
   compact?: boolean;
+  /**
+   * Which predicate field this control edits, for validation. Defaults to
+   * `toolName`; the ordering rule's second field is `beforeToolName`.
+   */
+  path?: "toolName" | "beforeToolName";
 }) {
   const id = useId();
+  const errorId = `${id}-error`;
   // When a suite has attached servers and we know the tool list, prefer a
   // dropdown to prevent typos. Fall back to free text otherwise (legacy
   // suites without an attached server, or for tools the editor doesn't
   // know about yet).
   const useDropdown = availableTools && availableTools.length > 0;
+  const { error, markTouched } = useFieldValidation(
+    path,
+    useDropdown ? "Pick a tool" : "Enter a tool name",
+  );
   return (
     <div
       className={
@@ -899,7 +1009,17 @@ function ToolNameField({
         {label}
       </Label>
       {useDropdown && !readOnly ? (
-        <Select value={value || undefined} onValueChange={onChange}>
+        <Select
+          value={value || undefined}
+          onValueChange={(next) => {
+            markTouched();
+            onChange(next);
+          }}
+          // Closing the menu without choosing is the dropdown's blur.
+          onOpenChange={(open) => {
+            if (!open) markTouched();
+          }}
+        >
           <SelectTrigger
             id={id}
             className={
@@ -908,6 +1028,8 @@ function ToolNameField({
                 : "h-8 text-xs"
             }
             aria-label={label}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? errorId : undefined}
           >
             <SelectValue placeholder="Pick a tool…" />
           </SelectTrigger>
@@ -924,12 +1046,29 @@ function ToolNameField({
           id={id}
           value={value}
           aria-label={label}
-          onChange={(e) => onChange(e.target.value)}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? errorId : undefined}
+          onChange={(e) => {
+            markTouched();
+            onChange(e.target.value);
+          }}
+          onBlur={markTouched}
           placeholder="e.g. search"
           className="h-8 text-xs"
           disabled={readOnly}
         />
       )}
+      {error ? (
+        <p
+          id={errorId}
+          className={cn(
+            "text-[11px] text-destructive",
+            compact && "col-start-2",
+          )}
+        >
+          {error}
+        </p>
+      ) : null}
     </div>
   );
 }
@@ -1528,6 +1667,10 @@ function ResponseContainsFields({
 }) {
   const needleId = useId();
   const csId = useId();
+  const { error, markTouched } = useFieldValidation(
+    "needle",
+    "Enter the text to look for",
+  );
   return (
     <div className="space-y-2">
       <div className="space-y-1">
@@ -1537,11 +1680,22 @@ function ResponseContainsFields({
         <Input
           id={needleId}
           value={predicate.needle}
-          onChange={(e) => onChange({ ...predicate, needle: e.target.value })}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? `${needleId}-error` : undefined}
+          onChange={(e) => {
+            markTouched();
+            onChange({ ...predicate, needle: e.target.value });
+          }}
+          onBlur={markTouched}
           placeholder="e.g. refund issued"
           className="h-8 text-xs"
           disabled={readOnly}
         />
+        {error ? (
+          <p id={`${needleId}-error`} className="text-[11px] text-destructive">
+            {error}
+          </p>
+        ) : null}
       </div>
       <div className="flex items-center gap-2">
         <Switch
@@ -1570,9 +1724,11 @@ function ResponseMatchesFields({
   readOnly: boolean;
 }) {
   const id = useId();
-  // Live-validate the regex on input. An invalid pattern shows inline and the
-  // row-level Zod validation will also flag it (empty pattern). We don't
-  // attempt to detect ReDoS here — the evaluator has its own heuristic guard.
+  // Live-validate the regex on input. An invalid pattern shows inline as soon
+  // as it is typed — the user wrote it, so it is not an untouched-field
+  // message. The empty case goes through the touched rule like every other
+  // required field. We don't attempt to detect ReDoS here — the evaluator has
+  // its own heuristic guard.
   let regexError: string | null = null;
   if (predicate.pattern) {
     try {
@@ -1581,6 +1737,11 @@ function ResponseMatchesFields({
       regexError = e instanceof Error ? e.message : "Invalid regex";
     }
   }
+  const { error: emptyError, markTouched } = useFieldValidation(
+    "pattern",
+    "Enter a pattern",
+  );
+  const error = regexError ?? emptyError;
   return (
     <div className="space-y-1">
       <Label htmlFor={id} className="text-[11px]">
@@ -1589,13 +1750,21 @@ function ResponseMatchesFields({
       <Input
         id={id}
         value={predicate.pattern}
-        onChange={(e) => onChange({ ...predicate, pattern: e.target.value })}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? `${id}-error` : undefined}
+        onChange={(e) => {
+          markTouched();
+          onChange({ ...predicate, pattern: e.target.value });
+        }}
+        onBlur={markTouched}
         placeholder="e.g. ^Order #\\d{4} confirmed$"
         className="h-8 font-mono text-xs"
         disabled={readOnly}
       />
-      {regexError ? (
-        <div className="text-[11px] text-destructive">{regexError}</div>
+      {error ? (
+        <div id={`${id}-error`} className="text-[11px] text-destructive">
+          {error}
+        </div>
       ) : null}
     </div>
   );
@@ -1846,6 +2015,7 @@ function ToolOrderFields({
       />
       <ToolNameField
         label="Before this tool"
+        path="beforeToolName"
         value={predicate.beforeToolName}
         onChange={(beforeToolName) =>
           onChange({ ...predicate, beforeToolName })
@@ -1943,6 +2113,10 @@ function ToolResultContainsFields({
   readOnly: boolean;
 }) {
   const id = useId();
+  const { error, markTouched } = useFieldValidation(
+    "needle",
+    "Enter the text the result must contain",
+  );
   return (
     <div className="space-y-2">
       <div className="space-y-1">
@@ -1952,11 +2126,22 @@ function ToolResultContainsFields({
         <Input
           id={id}
           value={predicate.needle}
-          onChange={(e) => onChange({ ...predicate, needle: e.target.value })}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? `${id}-error` : undefined}
+          onChange={(e) => {
+            markTouched();
+            onChange({ ...predicate, needle: e.target.value });
+          }}
+          onBlur={markTouched}
           placeholder="ISS-4412"
           className="h-8 text-xs"
           disabled={readOnly}
         />
+        {error ? (
+          <p id={`${id}-error`} className="text-[11px] text-destructive">
+            {error}
+          </p>
+        ) : null}
       </div>
       <ResultToolFilterField
         value={predicate.toolName}

--- a/mcpjam-inspector/client/src/components/scenarios/ScenarioGradingSection.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/ScenarioGradingSection.tsx
@@ -7,11 +7,14 @@
  *
  * Editing model mirrors `JourneyGradingEditor` (swarms/journey-list.tsx):
  * local draft seeded from the live-subscription prop ONCE per scenario (a
- * reseed mid-edit would discard unsaved checks), explicit Save, and Save
- * gated on `areAllChecksValid` so a half-finished row can't reach the backend
- * validator and lose the whole edit. That check reads the predicates, and a
- * raw-JSON draft that does not parse is never written into one — the editor
- * reports it separately, and Save waits on both.
+ * reseed mid-edit would discard unsaved checks) and explicit Save.
+ *
+ * An incomplete check does not disable Save: a fresh row is incomplete by
+ * construction, and a disabled button gives the user nothing to act on. The
+ * click runs `areAllChecksValid`, and when that fails it reveals every
+ * field's message and sends nothing. A raw-JSON draft that does not parse is
+ * the exception and keeps Save disabled — the user typed that text and its
+ * error is already inline under it.
  *
  * Sampling is authored as a percentage but stored as a [0, 1] fraction —
  * convert at the wire, never store the percent.
@@ -79,6 +82,9 @@ export function ScenarioGradingSection({
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
   const [hasInvalidDraft, setHasInvalidDraft] = useState(false);
+  // Set by a Save attempt that found an incomplete check; stays on so a field
+  // the user blanks again is flagged as they do it.
+  const [showAllErrors, setShowAllErrors] = useState(false);
 
   // Reseed only when the SCENARIO changes, never on subscription churn of the
   // same row — the draft is the user's unsaved work.
@@ -87,6 +93,7 @@ export function ScenarioGradingSection({
     seededFor.current = scenario.scenarioId;
     setDraft(draftFromSettings(scenario));
     setDirty(false);
+    setShowAllErrors(false);
   }
 
   // The draft as of this render, readable from inside an in-flight save's
@@ -120,13 +127,14 @@ export function ScenarioGradingSection({
   // impossible rather than toasted.
   const enabledButEmpty = draft.enabled && draft.rubric.length === 0;
   const canSave =
-    dirty &&
-    samplingValid &&
-    rubricValid &&
-    !hasInvalidDraft &&
-    !enabledButEmpty;
+    dirty && samplingValid && !hasInvalidDraft && !enabledButEmpty;
+  const blockedByIncompleteCheck = showAllErrors && !rubricValid;
 
   const save = async () => {
+    if (!rubricValid) {
+      setShowAllErrors(true);
+      return;
+    }
     // What this save actually persists. Compared by identity after the await
     // so an edit made DURING the request keeps the form dirty — clearing it
     // unconditionally would disable Save over changes that were never sent.
@@ -204,6 +212,7 @@ export function ScenarioGradingSection({
         value={draft.rubric}
         onChange={(next) => update({ rubric: next })}
         onDraftValidityChange={setHasInvalidDraft}
+        showAllErrors={showAllErrors}
       />
       {enabledButEmpty ? (
         <p className="text-xs text-destructive">
@@ -211,7 +220,15 @@ export function ScenarioGradingSection({
         </p>
       ) : null}
 
-      <div className="flex justify-end">
+      <div className="flex items-center justify-end gap-3">
+        {blockedByIncompleteCheck ? (
+          <p
+            className="text-xs text-destructive"
+            data-testid="scenario-grading-incomplete"
+          >
+            Fix the highlighted check to save.
+          </p>
+        ) : null}
         <Button
           size="sm"
           onClick={save}

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioGradingSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioGradingSection.test.tsx
@@ -23,13 +23,52 @@ vi.mock("@/components/swarms/journey-rubric-editor", () => ({
     value,
     onChange,
     onDraftValidityChange,
+    showAllErrors,
   }: {
     value: JourneyCriterion[];
     onChange: (next: JourneyCriterion[]) => void;
     onDraftValidityChange?: (hasInvalidDraft: boolean) => void;
+    showAllErrors?: boolean;
   }) => (
     <div>
       <span data-testid="rubric-count">{value.length}</span>
+      <span data-testid="rubric-show-all">
+        {String(showAllErrors ?? false)}
+      </span>
+      <button
+        type="button"
+        onClick={() =>
+          onChange([
+            ...value,
+            {
+              id: "crit-blank",
+              predicate: { type: "toolCalledAtLeastOnce", toolName: "" },
+            } as JourneyCriterion,
+          ])
+        }
+      >
+        add incomplete check
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          onChange(
+            value.map((entry) =>
+              entry.id === "crit-blank"
+                ? ({
+                    ...entry,
+                    predicate: {
+                      type: "toolCalledAtLeastOnce",
+                      toolName: "search",
+                    },
+                  } as JourneyCriterion)
+                : entry,
+            ),
+          )
+        }
+      >
+        complete check
+      </button>
       <button type="button" onClick={() => onDraftValidityChange?.(true)}>
         break json
       </button>
@@ -260,6 +299,45 @@ describe("ScenarioGradingSection", () => {
     await waitFor(() =>
       expect(setProductionScoringMock).toHaveBeenCalledTimes(1),
     );
+  });
+
+  it("a Save attempt with an incomplete check reveals the fields and sends nothing", async () => {
+    const user = userEvent.setup();
+    render(
+      <ScenarioGradingSection
+        scenario={scenarioWith({
+          enabled: true,
+          samplingRate: 1,
+          rubric: RUBRIC,
+        })}
+      />,
+    );
+    const save = screen.getByTestId(
+      "scenario-grading-save",
+    ) as HTMLButtonElement;
+
+    await user.click(screen.getByText("add incomplete check"));
+    // Incomplete, but the button is live: the click is what gives feedback.
+    expect(save.disabled).toBe(false);
+    expect(screen.getByTestId("rubric-show-all")).toHaveTextContent("false");
+    expect(screen.queryByTestId("scenario-grading-incomplete")).toBeNull();
+
+    await user.click(save);
+    expect(setProductionScoringMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("rubric-show-all")).toHaveTextContent("true");
+    expect(screen.getByTestId("scenario-grading-incomplete")).toHaveTextContent(
+      "Fix the highlighted check to save.",
+    );
+
+    await user.click(screen.getByText("complete check"));
+    expect(screen.queryByTestId("scenario-grading-incomplete")).toBeNull();
+
+    await user.click(save);
+    await waitFor(() =>
+      expect(setProductionScoringMock).toHaveBeenCalledTimes(1),
+    );
+    const rubric = setProductionScoringMock.mock.calls[0]![0].config.rubric;
+    expect(rubric).toHaveLength(2);
   });
 
   it("save stays disabled while pristine", () => {

--- a/mcpjam-inspector/client/src/components/swarms/journey-rubric-editor.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-rubric-editor.tsx
@@ -28,6 +28,7 @@ export function JourneyRubricEditor({
   allowedKinds,
   maxCriteria = MAX_RUBRIC_CRITERIA,
   onDraftValidityChange,
+  showAllErrors,
 }: {
   value: JourneyCriterion[];
   onChange: (next: JourneyCriterion[]) => void;
@@ -46,6 +47,8 @@ export function JourneyRubricEditor({
   maxCriteria?: number;
   /** Passed through to `ChecksSection` — see its prop of the same name. */
   onDraftValidityChange?: (hasInvalidDraft: boolean) => void;
+  /** Passed through to `ChecksSection` — see its prop of the same name. */
+  showAllErrors?: boolean;
 }) {
   // Stable across renders as long as the entries are: `ChecksSection` compares
   // by identity when the user edits a row, and a fresh array every render
@@ -67,6 +70,7 @@ export function JourneyRubricEditor({
         }
         title="Checks"
         onDraftValidityChange={onDraftValidityChange}
+        showAllErrors={showAllErrors}
         // "Measure", never "gate": a failing check is a finding in Insights,
         // and nothing downstream blocks or fails because of it.
         // One line on purpose — this doubles as card-header copy on the


### PR DESCRIPTION
> **Depends on #4970.** This branch is based on `fix/grading-check-json-validation` and the PR targets that branch. Commit 1 here replaces the two JSON-editor resync effects, which only exist in the form they do because of that branch's work. Merge #4970 first, then retarget this to `main`.

## Bug

Adding a new check immediately shows a red container border and a validation message, before the user has entered anything, touched any field, or tried to save. A newly created, untouched form looks broken.

## Why a new check was invalid before any interaction

- `blankPredicate` (`shared/predicate-kinds.ts:225`) returns a row with an empty required string for eight kinds: `toolCalledWith`, `toolCalledAtLeastOnce`, `toolNeverCalled`, `firstToolWas`, `toolCalledBefore` (two fields), `responseContains`, `responseMatches`, and `toolResultContains`. The other nineteen kinds are valid when blank.
- `CheckRow` ran the SDK Zod schema on the predicate in a `useMemo` on every render, including the first, with no notion of touched or submitted. Any failure painted the red border and printed the joined Zod issue messages.
- The schema uses `z.string().min(1)` with no custom message, so the text was whatever Zod generates.

**"Invalid input" does not reproduce in this checkout.** Running the schema over every blank kind here yields `Too small: expected string to have >=1 characters` for all eight. "Invalid input" is Zod's fallback for a failed union or literal, so the reported build was resolving a different schema branch or SDK version. The fix replaces the Zod string with field-owned copy, so which branch or SDK version produced the reported text stops mattering.

## What changed, one commit per step

### 1. Stable row keys, JSON drafts derived in render — `checks-section.tsx`

Rows were keyed by index, so removing a row handed the editor below to the predicate above it. Both JSON editors carried a resync `useEffect` (with an eslint disable) to repair the textarea after the fact. `ChecksSection` now mints one stable key per row in a ref, aligned to `value` in render and spliced in `removeAt`, so React keeps each `CheckRow` and the drafts inside it with its own predicate.

The resync effects are **replaced rather than dropped**. Keys cover delete and reorder, but not a whole-list replacement while the section stays mounted, which the grading section does when it reseeds on a scenario switch. Each draft now records which value it is the text for and is re-derived in render when the prop arrives from anywhere other than its own last parse. No effects, no eslint disables. The previous branch's draft-validity tests already cover delete and toggle; two cases were added for delete-above and whole-list replacement.

### 2. Field-level touched state and per-field copy — `checks-section.tsx`

`CheckRow` keeps a set of touched Zod paths and provides a small `FieldValidationContext` to its fields. An issue is shown only once its field is touched (first change or blur, or closing the dropdown without choosing) or when the new `showAllErrors` prop is on. The red border follows the same rule. `ChecksSection` and `CheckRow` both accept `showAllErrors`, optional and default off.

The fields that own a required string render their own message under the control, with `aria-invalid` and `aria-describedby`:

| Field | Copy |
|---|---|
| Tool name, dropdown | Pick a tool |
| Tool name, free text | Enter a tool name |
| `toolCalledBefore` second tool | same copy, reported separately via `path="beforeToolName"` |
| `responseContains` needle | Enter the text to look for |
| `responseMatches` pattern, empty | Enter a pattern |
| `toolResultContains` needle | Enter the text the result must contain |

An invalid regex the user typed still shows immediately, since it is not an untouched-field message. Issues no field claims keep the row-level line with Zod's wording, shown once the row has been touched anywhere. Save gates everywhere are unchanged by this commit: `areAllChecksValid` reads the same schema.

### 3. The Save gate — `ScenarioGradingSection.tsx`, `journey-rubric-editor.tsx`

This commit changes the button's behavior, not just what is displayed, and is last and on its own so it can come out in review with the rest still standing.

Save no longer disables over an incomplete check. A fresh row is incomplete by construction, and a disabled button gave the user nothing to act on. The click runs `areAllChecksValid`; when it fails it turns on `showAllErrors` down the rubric editor, shows "Fix the highlighted check to save." beside the button, and sends nothing. The flag stays on so a field the user blanks again is flagged as they do it, and resets on a scenario switch. Save still requires `dirty`, valid sampling, not enabled-with-empty-rubric, and no unparsable JSON draft. The JSON case keeps Save disabled deliberately: the user typed that text and its error is already inline under it (#4970).

`JourneyRubricEditor` passes `showAllErrors` through. Other `ChecksSection` and `CheckRow` callers get the touched-state display from step 2 and keep their Save gates exactly as they are.

## Tests

**New `checks-section-field-validation.test.tsx`**, against the real `ChecksSection`:
- Untouched: a fresh check shows no message, no `aria-invalid`, no red border, and none of Zod's wording.
- Interacted: blurring the empty Tool field shows "Enter a tool name" with `aria-invalid` and a matching `aria-describedby`; the border turns red.
- Corrected: typing clears message, attribute, and border; clearing a typed value brings the message back.
- Submitted: `showAllErrors` reveals every incomplete row at once, and a kind that is valid when blank stays neutral.
- Dropdown copy "Pick a tool" when the tool list is known.
- `toolCalledBefore` reports its two fields separately.
- An invalid regex shows as typed; an empty pattern waits for a touch.
- The tool-result text field.
- Deleting a touched row does not hand its touched state to the row below.
- A saved check with a legacy empty field stays neutral until touched.

**`checks-section-draft-validity.test.tsx`**, two added cases: removing the row above keeps the row below's mid-edit draft with its own predicate, and a whole-list replacement re-derives the textarea.

**`ScenarioGradingSection.test.tsx`**, one added case: with an incomplete check Save is live, the click sends nothing, the stub receives `showAllErrors`, the beside-button line appears, completing the check clears it, and the next click saves once with both checks. The existing pristine, empty-rubric, and unparsable-JSON cases are unchanged.

## Gates, run after each commit

- vitest over `evals`, `scenarios`, `swarms`, `evaluate`, and `conformance` components: 358 files, 3961 passed, 5 pre-existing skips
- `npm run typecheck:client`: clean
- Prettier: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes a newly added check start neutral: validation errors no longer paint a red border on untouched fields, and Save stays live so the user can find what's incomplete.

- Fields show their own inline message ("Pick a tool", "Enter a tool name", etc.) only once touched or after a failed Save attempt; Zod's wording is reserved for issues no field owns.
- Save no longer disables over an incomplete check; clicking it reveals every issue and sends nothing until they're fixed.
- Rows are keyed stably and JSON drafts are re-derived in render, fixing a bug where removing a row handed the editor below to the wrong predicate and replacing the whole list left stale textarea text.
- Regex errors the user typed still show immediately; an empty pattern waits for a touch.

<sup>Written for commit 5d40130176badf39ebca52f35e45bca812005243. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

