### PR TITLE
ci: run the PR gate on every pull request, whatever its base

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,14 +1,20 @@
 name: Build and Test
 
 on:
+  # Run on every PR regardless of its base branch. See the note in test.yml:
+  # `branches` filters on the PR's BASE, so a stacked PR — based on the branch
+  # below it until that one merges — never matched `main` and was never built
+  # or linted.
   pull_request:
-    # See the note in test.yml: `branches` filters on the PR's BASE, so a
-    # stacked PR never matched `main` and was never built or linted.
-    branches:
-      - main
-      - "claude/mcp-benchmarks-v2-b0tw4b-**"
   push:
     branches: [main]
+
+# A newer push to the same branch makes in-flight runs obsolete — cancel them
+# so superseded runs don't keep burning a runner. Matters more now that this
+# workflow runs on every PR rather than only main-based ones.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 env:
   NODE_VERSION: "24.14.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,20 +1,20 @@
 name: Tests
 
 on:
+  # Run on every PR regardless of its base branch. `branches` filters on the
+  # PR's BASE, and a stacked PR is based on the branch below it until that one
+  # merges — so any base filter, `main` alone or `main` plus a hand-added
+  # pattern, skips every PR above the root of a stack and leaves the required
+  # check stuck at "Expected — waiting for status" once the base re-targets to
+  # main.
+  #
+  # Worth keeping the reason: this bit us on the UVH stack, where a test
+  # asserted a label's wording verbatim, a later PR in the same stack changed
+  # that wording, and the break sat unnoticed because every PR above the root
+  # was green on previews and review bots alone. The fix is no base filter at
+  # all — not a pattern added by hand while some stack happens to be in flight,
+  # which only works for the stack somebody remembered to name.
   pull_request:
-    # `branches` filters on the PR's BASE. A stacked PR is based on the branch
-    # below it rather than on main, so with `main` alone every PR above the
-    # root of a stack merges without these tests having run against it once.
-    # Add a pattern while a stack is in flight; drop it once that stack lands.
-    #
-    # Worth keeping the reason: this bit us on the UVH stack, where a test
-    # asserted a label's wording verbatim, a later PR in the same stack changed
-    # that wording, and the break sat unnoticed because every PR above the root
-    # was green on previews and review bots alone. That stack has landed and
-    # its pattern is gone; the lesson is why the mechanism stays.
-    branches:
-      - main
-      - "claude/mcp-benchmarks-v2-b0tw4b-**"
   push:
     branches: [main]
 


### PR DESCRIPTION
## What was filtered

Two workflows — the two that actually gate correctness — filtered their `pull_request:` trigger on the PR's base branch:

| Workflow | Trigger | `branches:` filter (before) |
| --- | --- | --- |
| `.github/workflows/test.yml` (Tests) | `pull_request` | `main`, `claude/mcp-benchmarks-v2-b0tw4b-**` |
| `.github/workflows/lint.yml` (Build and Test) | `pull_request` | `main`, `claude/mcp-benchmarks-v2-b0tw4b-**` |

Every other `pull_request` workflow in the repo (`desktop-package-smoke`, `local-browser-security`, `local-harness-conformance`, `mintlify-triage`, `pr-mcp-preview`, `pr-preview`, `update-docs`, and `dependabot-auto-merge` on `pull_request_target`) already has no base-branch filter — some scope on `paths:` or `types:`, which is a different axis and is left alone.

## Why a stacked PR skipped them

`branches:` on a `pull_request:` trigger filters on the PR's **base**, not on the branch under review. A stacked PR is based on the branch below it until that one merges, so it never matched `main`. The result is the worst possible failure mode: the PR reports green having run no tests and no build at all, and once the base re-targets to `main` after the PR below merges, the required check sits at "Expected — waiting for status".

Adding a pattern per stack (as the `claude/mcp-benchmarks-v2-b0tw4b-**` entry did) only covers the one stack somebody remembered to name, and has to be removed again afterwards. The fix is no base filter at all.

## What changed

- Removed the `branches:` filter from the `pull_request:` trigger in `test.yml` and `lint.yml`. `push:` filters (`branches: [main]`) are untouched in both.
- Added a `concurrency` block to `lint.yml` (it had none), matching the backend's shape, so a newer push to the same branch cancels the superseded run instead of burning a runner. `test.yml` already had an equivalent block and was left alone.
- Rewrote the explanatory comment in `test.yml` rather than deleting it. It keeps the UVH-stack incident that motivated the original note — a test asserting a label's wording verbatim, a later PR in the same stack changing that wording, and the break sitting unnoticed because every PR above the root was green on previews and review bots alone — with the conclusion updated to "no base filter at all".

No deploy, preview, release, or dependabot workflow is touched.

## Prior art

`mcpjam-backend/.github/workflows/test.yml` already does exactly this: a bare `pull_request:` with the same reasoning in its comment, plus a `${{ github.workflow }}-${{ github.head_ref || github.ref }}` concurrency group. This brings the inspector in line with it.

## Why now

Merging this is a prerequisite for an upcoming stacked-PR run. Without it, every PR in that stack above the root would merge without Tests or Build and Test having executed against it once.

## Validation

Both files were parsed with `js-yaml` after the edit and load cleanly; a re-run of the trigger audit confirms `branches=undefined` and `concurrency=yes` on both.

## Changeset

None. `.changeset/config.json` drives package version bumps only, and no workflow enforces a changeset on PRs. Recent CI-only commits carried none — including `cb282a5258` ("drop the landed UVH stack pattern from the CI branch filters"), which touched exactly these two files, plus `2d29873a2d`, `f652b52136`, and `0854b8dcc0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5YeLQ4ZFAAAzkMUcC4oE6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger and concurrency-only changes; no application code, secrets, or deploy paths.
> 
> **Overview**
> **Tests** and **Build and Test** now run on every `pull_request` by dropping the `branches:` base filter (`main` and the temporary stack pattern) from `.github/workflows/test.yml` and `.github/workflows/lint.yml`. Stacked PRs whose base is another feature branch were skipping those required checks or leaving them stuck at “Expected — waiting for status”; `push` to `main` is unchanged.
> 
> **Build and Test** (`lint.yml`) also gets a **concurrency** group (`cancel-in-progress`) so newer pushes on the same branch cancel superseded runs — aligned with `test.yml` and more important now that lint runs on all PRs. Comments in both files document the stacked-PR / UVH-stack rationale and that ad-hoc branch patterns are not the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc2c8c03b61426c0ba60117f6312d09c8d67d94e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the Tests and Build and Test workflows on every pull request, regardless of base branch. The old `branches:` filter on the `pull_request:` trigger keys off the PR's base, so stacked PRs skipped both gates entirely and merged green having run no tests or build.

**Details**
- Removed the base-branch filter from both `pull_request:` triggers; `push:` filters stay on `main`.
- Added a `concurrency` block to `lint.yml` so newer pushes cancel superseded runs; `test.yml` already had one.
- No deploy, preview, release, or dependabot workflow is touched.

<sup>Written for commit bc2c8c03b61426c0ba60117f6312d09c8d67d94e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

