### PR TITLE
Pin the evaluator vocabulary, and freeze what a rename may not move

### DIFF
--- a/docs/.mintignore
+++ b/docs/.mintignore
@@ -1,0 +1,3 @@
+# Internal program contracts live beside the published pages but are not documentation.
+# Mintlify publishes every page file it finds, navigation or not, so exclude them explicitly.
+evals-vocabulary-consolidation.md

--- a/docs/evals-vocabulary-consolidation.md
+++ b/docs/evals-vocabulary-consolidation.md
@@ -1,0 +1,380 @@
+# Evals vocabulary consolidation — the pinned contract
+
+Status: **pinned**. Every later step in this program implements what is written here. A change to
+this file is a change to the contract and needs its own review; implementation PRs cite it rather
+than re-deciding it.
+
+## Why
+
+The eval authoring surface exposes its own development history rather than one model.
+
+One deterministic grading rule is spelled three ways: `checks` (public API, UI, and the SDK suite
+file since #4774), `predicates` (Convex storage and the SDK's evaluator library), and `assertions`
+(the backend's suite-file contract, `convex/lib/evalSuiteFile.ts`). The two halves of the suite-file
+contract already disagree with each other.
+
+One execution count is spelled four ways: `repetitions` (suite file, CLI flag, Convex verdict-policy
+v2), `runs` (Convex legacy, still required storage), `iterations` (SDK run options, public API case
+field), and `iterationOverride` (run launch).
+
+Four authoring entry points — `test`, `expectedToolCalls`, `predicates`, `scorers` — converge on one
+`ScoreResult`, but an author has to learn all four to know that.
+
+## The target model
+
+| Concept | Meaning | Consolidates |
+|---|---|---|
+| suite | cases with shared defaults and an acceptance policy | unchanged |
+| case | an authored scenario with stable identity | unchanged |
+| iteration | one execution of a case under one execution variant | `repetitions`, `runs`, `iterationOverride` |
+| trace | captured evidence of that execution | unchanged |
+| evaluator | an assertion or a judge | `Scorer`, `grader`, umbrella uses of `check` |
+| assertion | a deterministic rule | `Predicate`, `check`, matcher-backed rules |
+| judge | a model-based rubric | unchanged |
+| evaluator result | what one evaluator observed | `ScoreResult`, through a versioned projection |
+| verdict | the policy-derived decision | unchanged |
+
+`EvaluatorKind` has exactly two members, `assertion` and `judge`. Tool/trajectory matching is an
+assertion implementation, not a third kind. A rendering component may keep a matcher-specific
+presentation variant without changing the domain enum.
+
+## What does not change, ever
+
+These are the invariants. A PR that trips one has found a defect in itself, not in the ratchet.
+
+1. **Evaluator identity.** Every `scorerId` value stays byte-for-byte: the positional
+   `predicate:<type>#<ordinal>`, the content-derived `predicate:<type>#<sha256>`, the platform's
+   `predicate:<criterionId>`, `tool-match`, `legacy:test`, and every explicit author id. Nothing in
+   this program mints a new id for an existing definition.
+2. **Hash payloads.** `definitionHash` digests exactly the eleven fields
+   `sdk/src/contract/derive.ts` names today (`scorerId`, `idSource`, `scorerVersion`,
+   `implementationHash`, `deterministic`, `passThreshold`, `role`, `onError`, `onSkipped`, `model`,
+   `scope`). `evaluationConfigHash`, `PREDICATES_VERSION` (`"1"`) and `JUDGE_TEMPLATE_VERSION`
+   (`"3"`) are unchanged. The canonical public names are a projection **over** this payload, never a
+   new payload.
+3. **Backend configuration identity.** `convex/lib/evalConfigRevision.ts` keeps serializing the keys
+   `predicates`, `defaultPredicates`, `repetitions` and `runs`, and keeps its legacy escape hatch
+   that fires only when all eight suite fields are absent. Canonical arguments are normalized to the
+   legacy variables **before** anything hashes them, so an identical configuration authored either
+   way produces an identical revision string. The same holds for case fingerprints
+   (`convex/lib/testCaseBatch.ts`), rubric and judge-template hashes, and verdict-policy signatures.
+4. **`measurementUnit: "trial"`.** The wire value is frozen.
+   `EVAL_RUN_MEASUREMENT_UNIT_LABELS` already renders it as "iteration"/"iterations", so the
+   user-visible word is correct today. Changing the enum member would buy a versioned storage union
+   and a published-schema change for no visible gain. Rename the label vocabulary around it, not the
+   value.
+5. **Verdict-policy counters.** `configuredTrials`, `attemptedTrials`, `eligibleTrials`,
+   `passedTrials`, `failedTrials`, `minEligibleTrials`, `allConfiguredTrialsAttempted` and
+   `minGradeableTrials` stay as they are in policy schema v2. An iteration-named counter set is a
+   future schema version with its own readers, not an edit to the meaning of v2.
+6. **Historical evidence.** `schemaVersion: "1"` suite files, `testIteration.metadata.predicates`,
+   `promptTurns[].checks`, `testCaseSnapshot`, `configSnapshot`, revision snapshots, stage analytics
+   and route rollups keep their shape, their validators and their readers. Nothing rewrites
+   immutable history for a word.
+7. **The SDK reporter's upload body.** Unchanged by this program.
+
+## Protected vocabularies
+
+These words mean something else. A codemod that proposes to mutate one fails the run.
+
+- **GitHub Checks.** `server/routes/v1/eval-checks.ts`, `server/services/github-checks/**`,
+  `server/routes/web/checks.ts`, `checkRunId` outside `chatSessionChecks`, `checksEnabled`,
+  `githubCheck*`, `EvalCheckRepo*`, the `connect_eval_check_repo` / `list_eval_check_repos`
+  operations, the deprecated `mcpjam cloud eval checks` alias, and the `checks:` key in `mcpjam.yml`.
+- **Protocol and conformance checks.** `ServerDoctorCheck*`, `CheckOAuthResult`,
+  `--conformance-checks`, readiness and probe lists, `benchmarkProbeRuns.checks`.
+- **XAA, SAML and OIDC identity assertions.** `client/src/components/xaa/**`,
+  `cli/src/commands/xaa.ts`, `--assertion-format`, `IdentityAssertionFormat`,
+  `convex/lib/serverAuthFields.ts`.
+- **Billing trials.** `trialEndsAt`, `trialStartedAt`, `trialDays`, `trialing`, `trialEndSeconds`,
+  `trial_period_days`, `resetTrialsForBillingLaunch.ts`, the `billing:org-team-trials:*` scripts.
+- **The existing evaluator-error family**, which already means the right thing:
+  `maxEvaluatorErrorRate`, `evaluatorError`, `evaluatorErrorRate`, `evaluatorErrored`,
+  `failureCategory: "evaluator"`, `SUITE_GATE_EVALUATOR_VERSION`, `qualityGate.evaluator`.
+- **`sdk/src/host-compat/evaluator.ts`**, an unrelated evaluator (host compatibility).
+- **`steps[].assertion`**, which is kept. Its type is genuinely broader than a transcript rule, and
+  only the transcript half can be re-derived from a persisted trace.
+- **Benchmark and description-experiment `repetitions`** (`convex/schema.ts` benchmark tables,
+  `evalDescriptionExperiments.plan.repetitions`).
+- Generic verbs and helpers: `assertValid*`, vitest `expect`, prose "check that", mathematical
+  predicates.
+
+Files under `github-checks/**` are not categorically denied — they may legitimately import the eval
+SDK. Protect the unrelated identifiers, and review eval imports there by hand.
+
+## The public symbol map
+
+| Existing | Canonical | Kind of change |
+|---|---|---|
+| `Scorer` | `Evaluator` | new runtime shape (`evaluate`), legacy `Scorer` still accepted |
+| `ScoreDefinition` / `ResolvedScoreDefinition` | `EvaluatorDefinition` / `ResolvedEvaluatorDefinition` | **type alias** — runtime keys unchanged |
+| `ScorerContextV1` | `EvaluatorContextV1` | type alias |
+| `ScoreStatus`, `ScorerRole`, `ScorerErrorPolicy`, `ScorerIdSource` | `EvaluatorStatus`, `EvaluatorRole`, `EvaluatorErrorPolicy`, `EvaluatorIdSource` | type aliases |
+| `ScoreRawOutcome` | `EvaluatorRawOutcome` | renamed member field `value` → `score` |
+| `ScoreResult` | `EvaluatorResult` | **versioned projection**, not an alias |
+| `runScorers`, `scoresPassed` | `runEvaluators`, `evaluatorsPassed` | new functions delegating to the old |
+| `predicateScorer`, `judgeScorer` | `assertion()`, `judge()` | new constructors, identical definitions |
+| `scorerConcurrency`, `scorerTimeoutMs` (run options) | `evaluatorConcurrency`, `evaluatorTimeoutMs` | additive option aliases |
+| `DEFAULT_SCORER_CONCURRENCY` / `_TIMEOUT_MS` | `DEFAULT_EVALUATOR_CONCURRENCY` / `_TIMEOUT_MS` | same values |
+| `GRADER_STAGE`, `PREDICATE_STAGE`, `GRADER_PRESENTATION_GROUP` | `EVALUATOR_STAGE`, `ASSERTION_STAGE`, `EVALUATOR_PRESENTATION_GROUP` | same objects, new module |
+| `PREDICATE_KINDS`, `PredicateKind` | `ASSERTION_KINDS`, `AssertionKind` | same values |
+| `RECOMMENDED_DEFAULT_PREDICATES` | `RECOMMENDED_DEFAULT_ASSERTIONS` | re-export; **the literal does not move** (see below) |
+| `Predicate`, `PredicateResult`, `PredicateScope` | `Assertion`, `AssertionResult`, `AssertionScope` | type aliases from a new subpath |
+| `@mcpjam/sdk/predicates` | `@mcpjam/sdk/assertions` | new subpath; the old one keeps working |
+| `EvalTestConfig.predicates` / `.scorers` / `.test` | `.evaluators` / `.execute` | additive |
+
+`RECOMMENDED_DEFAULT_PREDICATES` stays declared in `sdk/src/contract/grader-stage.ts`, byte for byte.
+The backend pins it through a whole-file capture of the three `{type, role, severity}` triples
+(`convex/lib/mirrors.json`, pair `recommended-default-predicates`). Moving the literal to another
+file would make that capture match nothing, and a capture that matches nothing is a pin that goes
+green forever. The stage tables move; the seed does not.
+
+## `EvaluatorResult`
+
+```ts
+export const EVALUATOR_RESULT_SCHEMA_VERSION = 1 as const;
+
+export type EvaluatorResult = {
+  schemaVersion: 1;
+  evaluatorId: string;
+  evaluatorVersion: string;
+  definitionHash: string;
+  kind: EvaluatorKind;
+  status: EvaluatorStatus;
+  score?: number;
+  passThreshold: number;
+  passed?: boolean;
+  explanation?: string;
+  evidence?: string[];
+  deterministic: boolean;
+  model?: string;
+  promptHash?: string;
+  error?: string;
+  scope?: AssertionScope;
+};
+```
+
+| `ScoreResult` | `EvaluatorResult` | Rule |
+|---|---|---|
+| — | `schemaVersion: 1` | added; discriminates a future version rather than being sniffed |
+| — | `kind` | added; derived from `deterministic`, never stored on the definition |
+| `scorerId` | `evaluatorId` | value unchanged |
+| `scorerVersion` | `evaluatorVersion` | value unchanged |
+| `value?` | `score?` | present if and only if `status === "scored"` |
+| `rationale?` | `explanation?` | value unchanged |
+| everything else | same name | unchanged |
+
+`toEvaluatorResult` and `fromEvaluatorResult` are inverses: `fromEvaluatorResult` drops the two added
+fields and reproduces the original object. A test proves the round trip over every accept row of the
+shared score-contract parity corpus.
+
+Three rules survive the rename intact. `passed` is derived as `score >= passThreshold` and is never
+asserted by a model or a custom evaluator. An error, skipped or not-applicable result carries **no**
+`score` — a fabricated zero would put a defect on the dashboard that nobody observed. Role and error
+policy are not repeated on the result; consumers join to the config snapshot on `definitionHash`,
+because two copies of "does this gate" is precisely the disagreement you cannot afford.
+
+`EvaluatorKind` is derived rather than stored:
+
+```ts
+export function evaluatorKindOf(d: { deterministic: boolean }): EvaluatorKind {
+  return d.deterministic ? "assertion" : "judge";
+}
+```
+
+Tool matching and the legacy boolean are assertions by this rule, which is the intended answer: they
+are deterministic authored rules. Adding a required `kind` to the definition would change the hash
+payload, which invariant 2 forbids.
+
+## Authoring
+
+```ts
+const suite = new EvalSuite({
+  name: "Support workflows",
+  defaults: {
+    iterations: 5,
+    evaluators: [assertion({ type: "noToolErrors", role: "advisory" })],
+  },
+});
+
+suite.add(new EvalTest({
+  id: "c_explain_refund_policy",
+  name: "Explains the refund policy",
+  execute: async (executor) => {
+    await executor.run("Explain the refund policy.");
+  },
+  evaluators: [
+    assertion({ id: "nonempty-answer", type: "finalAssistantMessageNonEmpty" }),
+    judge({
+      id: "policy-grounding",
+      model: configuredJudgeModel,
+      apiKey,
+      rubric: ["The answer is supported by the retrieved policy."],
+      role: "advisory",
+    }),
+  ],
+}));
+
+const result = await suite.run(executor);
+```
+
+### Types
+
+```ts
+export type EvaluatorOverride = { mode: "inherit" | "extend" | "replace"; list: Evaluator[] };
+export interface EvalSuiteDefaults { iterations?: number; evaluators?: Evaluator[] }
+// EvalTestConfig gains: execute?, evaluators?: Evaluator[] | EvaluatorOverride; `test` becomes optional.
+```
+
+### Resolution
+
+Suite defaults and case evaluators resolve through the same three rules the backend's
+`resolvePredicates` already implements, so a code-first case and a hosted case with the same
+configuration grade the same way:
+
+- an absent case list, or `mode: "inherit"`, takes the suite defaults;
+- `mode: "replace"` takes the case list alone, and `{ mode: "replace", list: [] }` is how an author
+  explicitly disables an inherited default;
+- `mode: "extend"` is suite defaults followed by the case list;
+- a bare array is `extend`.
+
+`{ mode: "inherit" }` with a non-empty list is refused rather than silently ignored.
+
+### Equivalence
+
+The effective assertion list is `config.predicates` followed by the assertions in the resolved
+evaluator list. Ordinals are positions in that combined list. `assertion()` builds its definition
+through the same `predicateScoreDefinition` the legacy path uses, with the same `{id, ordinal, role}`
+inputs; `judge()` returns `judgeScorer`'s definition unchanged; `execute` reuses the `legacy:test`
+definition. Therefore:
+
+```
+{ predicates: [a, b] }
+  ≡ { evaluators: [assertion(a), assertion(b)] }
+  ≡ { predicates: [a], evaluators: [assertion(b)] }
+```
+
+all produce the same `EvaluationConfigSnapshot` — the same definitions in the same order, the same
+`scorerId` and `idSource` on each, the same `definitionHash`, the same aggregate hash. A golden
+fixture captured from unchanged code pins this, and asserts each id literally so an ordinal shift
+fails even if the hash coincidentally matched.
+
+Suite-default assertions come first and shift case ordinals, exactly as the backend's `extend` shifts
+the effective list. That is a real consequence of inheritance, not an accident: a generated id is
+positional and documented as unstable, which is why a gate may not select one.
+
+A case is evaluated **once**. Projecting a rule's verdict into several compatibility shapes never
+re-runs it.
+
+### Definition order
+
+`legacy:test`, then tool-match, then the effective assertions in authored order, then `config.scorers`,
+then the remaining evaluators. The hash is order-independent; the order is what a dashboard reads.
+
+### `execute` versus `test`
+
+Exactly one. `execute` may return nothing and lets the evaluators decide; `test` returns the boolean
+it always did. The `legacy:test` definition is emitted either way, so the two forms hash identically:
+an `execute` that completes scores 1 on that row, and one that throws produces an error row that
+fails the iteration closed, exactly as a throwing `test` does today.
+
+### Refusals
+
+| Condition | Message |
+|---|---|
+| both `test` and `execute` | ``EvalTest "<name>" sets both `execute` and its legacy `test` alias — set one. They are two spellings of the case's driver; `execute` may return nothing and lets the evaluators decide.`` |
+| neither | ``Invalid config: must provide 'execute' (or the legacy 'test') function`` |
+| duplicate evaluator id, including against a suite default | ``EvalTest "<name>": duplicate evaluator id "<id>". Evaluator ids must be unique within a case, and suite defaults.evaluators count too — rename one, or use mode "replace" to drop the suite's.`` |
+| `inherit` with a non-empty list | ``EvalTest "<name>" sets evaluators.mode "inherit" with a non-empty list — "inherit" takes the suite's defaults.evaluators only; use "extend" to append or "replace" to override.`` |
+| a widget assertion in a code-first case | ``Assertion <type> needs widget render observations, which only a hosted run captures. Remove it from this code-first evaluator, or move the case to a hosted eval suite.`` |
+| `EvalSuite.run` with no count | ``EvalSuite "<name>" has no iteration count: pass { iterations } to run(), or set defaults.iterations on the suite.`` |
+| both spellings of a bound | ``Set evaluatorConcurrency or its legacy alias scorerConcurrency, not both.`` |
+
+`predicates` alongside `evaluators`, and `scorers` alongside `evaluators`, are **additive** rather
+than refused: they compose into one list, and an id collision is already caught above. This is what
+makes migration incremental.
+
+Two evaluators with the same id and identical content collapse into one definition, as the snapshot
+builder already does. That is not an error; it is one definition named once.
+
+## The wire
+
+Requests and responses negotiate with a header rather than a version path:
+
+```
+x-mcpjam-eval-vocabulary: 2
+```
+
+Absent means 1, which is byte-for-byte today's contract: the same request fields, the same refusals,
+the same response projection. A response that varies by vocabulary sends
+`Vary: x-mcpjam-eval-vocabulary`. Any value other than `"1"` or `"2"` is a 400.
+
+Under **both** vocabularies every spelling of a field is accepted and any two of them together is a
+refusal, reported with the conflicting paths and decided by presence rather than truthiness so an
+explicit `null` clear still reaches storage:
+
+```
+Send <canonical> or <legacy>, not both — they are two spellings of one field.
+```
+
+Under vocabulary 2 the canonical spellings are `assertions` and `iterations`; the read projection
+renames `checks` to `assertions` and reports the configured count as `iterations`. Under vocabulary 1
+nothing moves. A canonical client must project a GET result into a valid write request rather than
+echoing both spellings back into a PATCH.
+
+The count family is the one place where meaning, not just spelling, differs, because the legacy API
+carries two counts with different semantics on the same object. Under vocabulary 2 `iterations` is
+the configured count; the adapter writes the legacy `runs` and, on a verdict-policy-v2 suite, the v2
+`repetitions` as well, keeping both stored spellings equal.
+
+### Capability
+
+A deployment advertises what it understands rather than being guessed at:
+
+```ts
+vocabulary: {
+  version: 2,
+  evaluatorKinds: ["assertion", "judge"],
+  assertionKinds: PREDICATE_KINDS,
+  fields: { assertions: ["checks", "predicates"], defaultAssertions: ["defaultPredicates"], iterations: ["repetitions", "runs", "iterationOverride"] },
+}
+```
+
+`scorers.predicateKinds` is retained for existing consumers. Absence of `vocabulary` selects the
+existing contract. A client reads the capability value; it never infers support from the presence of
+a field on an unrelated object.
+
+## The suite file
+
+Dialect `"2"` uses `assertions` and `iterations`. Dialect `"1"` is untouched — its `repetitions` stays
+required and its published JSON Schema keeps its contract, so an older strict reader can never
+misread a new file under its existing version.
+
+The loader accepts both. The writer emits the file's own dialect, and a new dialect is written only
+when the author asks for it. An offline tool has no capability handshake, so the conservative default
+is what keeps an export loadable by whatever is installed on the other side.
+
+## UVC is unchanged
+
+The chain stays `connection → discovery → selection → call → response → userValue`. Evaluator results
+plus captured evidence feed the existing derivation; results plus the pinned policy feed the
+authoritative verdict. The differences between `failed`, `notMeasured`, `notReached` and
+`notApplicable` are preserved, including the rule that no inspected evidence cannot establish a
+passing stage. An evaluator error does not establish a server defect. Stage attribution says where
+evidence is filed, not what caused a failure. `StageMeasurementsV1`, measurement coverage and
+persisted measurement units are real evidence contracts and do not change because evaluator outputs
+are now called results.
+
+## Compatibility posture
+
+Transitional, not permanent. Deploys are not atomic across two repositories, Convex argument objects
+are closed, and the inspector calls Convex through untyped strings, so old and new spellings coexist
+for the length of the rollout. Expand, migrate, contract applies in full.
+
+Installed-client compatibility is not a permanent commitment for this surface: the public API is
+documented as preview, and the eval commands are a ~100-person population with essentially no pinned
+CI. The old spellings are deleted at the end of the rollout, not carried indefinitely.
+
+Two things that look like compatibility are not, and both stay regardless: historical rows remain
+readable in the shape they were written, and evaluator identities and hash payloads stay frozen.
+Neither is about who is calling us.

--- a/docs/evals-vocabulary-consolidation.md
+++ b/docs/evals-vocabulary-consolidation.md
@@ -13,9 +13,10 @@ file since #4774), `predicates` (Convex storage and the SDK's evaluator library)
 (the backend's suite-file contract, `convex/lib/evalSuiteFile.ts`). The two halves of the suite-file
 contract already disagree with each other.
 
-One execution count is spelled four ways: `repetitions` (suite file, CLI flag, Convex verdict-policy
-v2), `runs` (Convex legacy, still required storage), `iterations` (SDK run options, public API case
-field), and `iterationOverride` (run launch).
+One configured execution count is spelled three ways: `repetitions` (suite file, CLI flag, Convex
+verdict-policy v2), `runs` (Convex legacy, still required storage), and `iterations` (SDK run options,
+public API case field). And the word for ONE execution is itself split: eval code says `trial` where
+the product already says "iteration".
 
 Four authoring entry points — `test`, `expectedToolCalls`, `predicates`, `scorers` — converge on one
 `ScoreResult`, but an author has to learn all four to know that.
@@ -26,7 +27,8 @@ Four authoring entry points — `test`, `expectedToolCalls`, `predicates`, `scor
 |---|---|---|
 | suite | cases with shared defaults and an acceptance policy | unchanged |
 | case | an authored scenario with stable identity | unchanged |
-| iteration | one execution of a case under one execution variant | `repetitions`, `runs`, `iterationOverride` |
+| iteration | one execution instance of a case under one execution variant | the eval sense of `trial` |
+| repetitions | the configured number of iterations of a case | `runs`, and `iterations` wherever it names the configured count (SDK run options, public API case field) |
 | trace | captured evidence of that execution | unchanged |
 | evaluator | an assertion or a judge | `Scorer`, `grader`, umbrella uses of `check` |
 | assertion | a deterministic rule | `Predicate`, `check`, matcher-backed rules |
@@ -96,6 +98,9 @@ These words mean something else. A codemod that proposes to mutate one fails the
   only the transcript half can be re-derived from a persisted trace.
 - **Benchmark and description-experiment `repetitions`** (`convex/schema.ts` benchmark tables,
   `evalDescriptionExperiments.plan.repetitions`).
+- **Description-experiment `iterationOverride`** (`convex/descriptionExperiments.ts`), the experiment's
+  own override beside `maxTrials`. It is not folded into `iteration`. `--max-trials`, `maxTrials` and
+  `plannedTrials` cap the product of cases and repetitions and are out of scope for this program.
 - Generic verbs and helpers: `assertValid*`, vitest `expect`, prose "check that", mathematical
   predicates.
 
@@ -122,6 +127,7 @@ SDK. Protect the unrelated identifiers, and review eval imports there by hand.
 | `Predicate`, `PredicateResult`, `PredicateScope` | `Assertion`, `AssertionResult`, `AssertionScope` | type aliases from a new subpath |
 | `@mcpjam/sdk/predicates` | `@mcpjam/sdk/assertions` | new subpath; the old one keeps working |
 | `EvalTestConfig.predicates` / `.scorers` / `.test` | `.evaluators` / `.execute` | additive |
+| `EvalSuite.run({ iterations })` | `EvalSuite.run({ repetitions })` | additive; `iterations` stays as a deprecated alias |
 
 `RECOMMENDED_DEFAULT_PREDICATES` stays declared in `sdk/src/contract/grader-stage.ts`, byte for byte.
 The backend pins it through a whole-file capture of the three `{type, role, severity}` triples
@@ -192,7 +198,7 @@ payload, which invariant 2 forbids.
 const suite = new EvalSuite({
   name: "Support workflows",
   defaults: {
-    iterations: 5,
+    repetitions: 5,
     evaluators: [assertion({ type: "noToolErrors", role: "advisory" })],
   },
 });
@@ -203,16 +209,19 @@ suite.add(new EvalTest({
   execute: async (executor) => {
     await executor.run("Explain the refund policy.");
   },
-  evaluators: [
-    assertion({ id: "nonempty-answer", type: "finalAssistantMessageNonEmpty" }),
-    judge({
-      id: "policy-grounding",
-      model: configuredJudgeModel,
-      apiKey,
-      rubric: ["The answer is supported by the retrieved policy."],
-      role: "advisory",
-    }),
-  ],
+  evaluators: {
+    mode: "extend",
+    list: [
+      assertion({ id: "nonempty-answer", type: "finalAssistantMessageNonEmpty" }),
+      judge({
+        id: "policy-grounding",
+        model: configuredJudgeModel,
+        apiKey,
+        rubric: ["The answer is supported by the retrieved policy."],
+        role: "advisory",
+      }),
+    ],
+  },
 }));
 
 const result = await suite.run(executor);
@@ -222,23 +231,27 @@ const result = await suite.run(executor);
 
 ```ts
 export type EvaluatorOverride = { mode: "inherit" | "extend" | "replace"; list: Evaluator[] };
-export interface EvalSuiteDefaults { iterations?: number; evaluators?: Evaluator[] }
-// EvalTestConfig gains: execute?, evaluators?: Evaluator[] | EvaluatorOverride; `test` becomes optional.
+export interface EvalSuiteDefaults { repetitions?: number; evaluators?: Evaluator[] }
+// EvalTestConfig gains: execute?, evaluators?: EvaluatorOverride; `test` becomes optional.
+// EvalSuite.run options gain: repetitions?; the existing `iterations` stays as its deprecated alias.
 ```
 
 ### Resolution
 
-Suite defaults and case evaluators resolve through the same three rules the backend's
-`resolvePredicates` already implements, so a code-first case and a hosted case with the same
-configuration grade the same way:
+Suite defaults and case evaluators resolve through exactly the three rules the backend's
+`resolvePredicates` (`convex/lib/predicates.ts`) implements, and no others, so a code-first case and a
+hosted case with the same configuration grade the same way:
 
-- an absent case list, or `mode: "inherit"`, takes the suite defaults;
-- `mode: "replace"` takes the case list alone, and `{ mode: "replace", list: [] }` is how an author
-  explicitly disables an inherited default;
-- `mode: "extend"` is suite defaults followed by the case list;
-- a bare array is `extend`.
+- an absent case override, or `mode: "inherit"`, takes the suite defaults, or an empty list when the
+  suite has none. Under `inherit` the case's `list` is ignored, not refused, exactly as the backend
+  ignores it;
+- `mode: "replace"` takes the case list verbatim, ignoring the suite defaults entirely, and
+  `{ mode: "replace", list: [] }` is how an author explicitly disables an inherited default;
+- `mode: "extend"` is suite defaults followed by the case list, suite first.
 
-`{ mode: "inherit" }` with a non-empty list is refused rather than silently ignored.
+A case override is always the `{ mode, list }` object. There is no bare-array shorthand: the backend's
+stored override has no such form, so a shorthand would be a code-first-only rule with no hosted
+equivalent.
 
 ### Equivalence
 
@@ -250,11 +263,11 @@ definition. Therefore:
 
 ```
 { predicates: [a, b] }
-  ≡ { evaluators: [assertion(a), assertion(b)] }
-  ≡ { predicates: [a], evaluators: [assertion(b)] }
+  ≡ { evaluators: { mode: "extend", list: [assertion(a), assertion(b)] } }
+  ≡ { predicates: [a], evaluators: { mode: "extend", list: [assertion(b)] } }
 ```
 
-all produce the same `EvaluationConfigSnapshot` — the same definitions in the same order, the same
+with no suite defaults, all produce the same `EvaluationConfigSnapshot` — the same definitions in the same order, the same
 `scorerId` and `idSource` on each, the same `definitionHash`, the same aggregate hash. A golden
 fixture captured from unchanged code pins this, and asserts each id literally so an ordinal shift
 fails even if the hash coincidentally matched.
@@ -285,9 +298,9 @@ fails the iteration closed, exactly as a throwing `test` does today.
 | both `test` and `execute` | ``EvalTest "<name>" sets both `execute` and its legacy `test` alias — set one. They are two spellings of the case's driver; `execute` may return nothing and lets the evaluators decide.`` |
 | neither | ``Invalid config: must provide 'execute' (or the legacy 'test') function`` |
 | duplicate evaluator id, including against a suite default | ``EvalTest "<name>": duplicate evaluator id "<id>". Evaluator ids must be unique within a case, and suite defaults.evaluators count too — rename one, or use mode "replace" to drop the suite's.`` |
-| `inherit` with a non-empty list | ``EvalTest "<name>" sets evaluators.mode "inherit" with a non-empty list — "inherit" takes the suite's defaults.evaluators only; use "extend" to append or "replace" to override.`` |
 | a widget assertion in a code-first case | ``Assertion <type> needs widget render observations, which only a hosted run captures. Remove it from this code-first evaluator, or move the case to a hosted eval suite.`` |
-| `EvalSuite.run` with no count | ``EvalSuite "<name>" has no iteration count: pass { iterations } to run(), or set defaults.iterations on the suite.`` |
+| `EvalSuite.run` with no count | ``EvalSuite "<name>" has no repetitions count: pass { repetitions } to run(), or set defaults.repetitions on the suite.`` |
+| both spellings of the count | ``Set repetitions or its deprecated alias iterations, not both.`` |
 | both spellings of a bound | ``Set evaluatorConcurrency or its legacy alias scorerConcurrency, not both.`` |
 
 `predicates` alongside `evaluators`, and `scorers` alongside `evaluators`, are **additive** rather
@@ -331,15 +344,18 @@ explicit `null` clear still reaches storage:
 Send <canonical> or <legacy>, not both — they are two spellings of one field.
 ```
 
-Under vocabulary 2 the canonical spellings are `assertions` and `iterations`; the read projection
-renames `checks` to `assertions` and reports the configured count as `iterations`. Under vocabulary 1
+Under vocabulary 2 the canonical spellings are `assertions` and `repetitions`; the read projection
+renames `checks` to `assertions` and reports the configured count as `repetitions`. Under vocabulary 1
 nothing moves. A canonical client must project a GET result into a valid write request rather than
 echoing both spellings back into a PATCH.
 
 The count family is the one place where meaning, not just spelling, differs, because the legacy API
-carries two counts with different semantics on the same object. Under vocabulary 2 `iterations` is
-the configured count; the adapter writes the legacy `runs` and, on a verdict-policy-v2 suite, the v2
-`repetitions` as well, keeping both stored spellings equal.
+carries two counts with different semantics on the same object: `iterations` (a spelling of `runs`)
+and the verdict-policy-v2 `repetitions`. Under vocabulary 1 that object is unchanged, both counts
+included. Under vocabulary 2 `repetitions` is the one configured count and `iterations` and `runs` are
+its legacy spellings; the adapter writes the legacy `runs` and, on a verdict-policy-v2 suite, the v2
+`repetitions` as well, keeping both stored spellings equal. `iterations` never names the configured
+count in vocabulary 2: an iteration is one execution.
 
 ### Capability
 
@@ -350,7 +366,7 @@ vocabulary: {
   version: 2,
   evaluatorKinds: ["assertion", "judge"],
   assertionKinds: PREDICATE_KINDS,
-  fields: { assertions: ["checks", "predicates"], defaultAssertions: ["defaultPredicates"], iterations: ["repetitions", "runs", "iterationOverride"] },
+  fields: { assertions: ["checks", "predicates"], defaultAssertions: ["defaultPredicates"], repetitions: ["iterations", "runs"] },
 }
 ```
 
@@ -360,8 +376,8 @@ a field on an unrelated object.
 
 ## The suite file
 
-Dialect `"2"` uses `assertions` and `iterations`. Dialect `"1"` is untouched — its `repetitions` stays
-required and its published JSON Schema keeps its contract, so an older strict reader can never
+Dialect `"2"` uses `assertions`; the count is `repetitions` in both dialects. Dialect `"1"` is
+untouched — its `repetitions` stays required and its published JSON Schema keeps its contract, so an older strict reader can never
 misread a new file under its existing version.
 
 The loader accepts both. The writer emits the file's own dialect, and a new dialect is written only

--- a/docs/evals-vocabulary-consolidation.md
+++ b/docs/evals-vocabulary-consolidation.md
@@ -351,7 +351,21 @@ Absent means 1, which is byte-for-byte today's contract: the same request fields
 the same response projection. A response that varies by vocabulary sends
 `Vary: x-mcpjam-eval-vocabulary`. Any value other than `"1"` or `"2"` is a 400.
 
-Under **both** vocabularies every spelling of a field is accepted and any two of them together is a
+The header is the **only** thing that decides which spellings a request may use, and vocabulary 1 is
+not widened to meet vocabulary 2 half way:
+
+| | vocabulary 1 (no header) | vocabulary 2 |
+|---|---|---|
+| accepted on a write | exactly today's fields — `checks`, `iterations`, `repetitions`, `defaultPredicates` | those, plus the canonical `assertions`, `defaultAssertions`, `legacyIterations` and the legacy `predicates` and `runs` |
+| refused | `assertions`, `defaultAssertions`, `predicates`, `runs`, `legacyIterations`, as unknown keys | a canonical spelling sent together with a legacy one |
+| read projection | unchanged | `checks` → `assertions`, the configured count → `iterations` |
+
+A headerless request is therefore byte-for-byte today's request, including its refusals: the case
+schemas are `z.strictObject`, so a canonical spelling is an unknown key and a `VALIDATION_ERROR`, not
+a silently dropped field. That is what keeps the negotiation boundary decidable — two implementations
+reading this document cannot disagree about whether the same headerless body is valid.
+
+Under vocabulary 2, where both spellings of one field are accepted, any two of them together is a
 refusal, reported with the conflicting paths and decided by presence rather than truthiness so an
 explicit `null` clear still reaches storage:
 
@@ -359,10 +373,8 @@ explicit `null` clear still reaches storage:
 Send <canonical> or <legacy>, not both — they are two spellings of one field.
 ```
 
-Under vocabulary 2 the canonical spellings are `assertions` and `iterations`; the read projection
-renames `checks` to `assertions` and reports the configured count as `iterations`. Under vocabulary 1
-nothing moves. A canonical client must project a GET result into a valid write request rather than
-echoing both spellings back into a PATCH.
+A canonical client must project a GET result into a valid write request rather than echoing both
+spellings back into a PATCH.
 
 The count family is the one place where meaning, not just spelling, differs, because the legacy API
 carries two counts with different semantics on the same object: `iterations` (a spelling of `runs`,
@@ -377,12 +389,24 @@ the floor leaves it exactly as it was. An unchanged PATCH that also wrote `runs`
 floor of 10 to an exact count of 3 with no authored edit, and rotate the configuration revision,
 which hashes both keys. `runs` is required storage, so a CREATE that names no floor still needs a
 value: it takes the case's `iterations`, which is what the legacy resolver would have floored to
-anyway. Sending
-`iterations` on a legacy-policy suite is the same `VALIDATION_ERROR` naming the upgrade that
+anyway.
+
+A CREATE may legitimately name **neither** count — on a verdict-policy-2 suite the exact count
+inherits the suite default, and on a legacy-policy suite naming it is refused outright — and then
+`runs` is **1**. That is not a new default chosen here: it is the value a headerless create of the
+same body stores today, `Math.max(1, Math.floor(runs ?? 1))` in `createTestCase`
+(`convex/testSuites.ts`). It is deliberately **not** the suite's `verdictPolicyDefaults.repetitions`:
+inlining the suite default would write a different `runs` than vocabulary 1 writes for the same body,
+and `runs` is in the configuration-revision payload, so the two vocabularies would mint different
+revisions for one authored configuration. The v2 override stays absent, which is how a case inherits
+the suite default at run time rather than freezing a copy of it.
+
+Sending `iterations` on a legacy-policy suite is the same `VALIDATION_ERROR` naming the upgrade that
 `repetitions` is today.
 
-The order is the guard. The legacy field is renamed to `legacyIterations` in its own step, with both
-vocabularies accepting it, **before** any adapter reads `iterations` as the configured count. A step
+The order is the guard. The legacy field is renamed to `legacyIterations` in its own step — accepted
+under vocabulary 2, which is the only vocabulary that accepts it at all — **before** any adapter reads
+`iterations` as the configured count. A step
 that makes `iterations` mean the count while the floor field still answers to that name merges two
 counts into one, and the codemod refuses to propose it (`scripts/codemod/evals-vocabulary`,
 "rename target in use").
@@ -396,13 +420,15 @@ vocabulary: {
   version: 2,
   evaluatorKinds: ["assertion", "judge"],
   assertionKinds: PREDICATE_KINDS,
-  fields: { assertions: ["checks", "predicates"], defaultAssertions: ["defaultPredicates"], iterations: ["repetitions"], legacyIterations: ["iterations", "runs"] },
+  fields: { assertions: ["checks", "predicates"], defaultAssertions: ["defaultPredicates"], iterations: ["repetitions"], legacyIterations: ["runs"] },
 }
 ```
 
-`iterations` appears on both sides on purpose: vocabulary 1's `iterations` is vocabulary 2's
-`legacyIterations`. That is exactly why the negotiated vocabulary, never the presence of a field, says
-which one a body means.
+Each list is the legacy spellings a **vocabulary-2** body may use for that field. `iterations` is
+absent from `legacyIterations` on purpose, even though vocabulary 1's `iterations` is what vocabulary 2
+calls `legacyIterations`: under vocabulary 2 that key is the exact count. One key means two things
+across the boundary, which is exactly why the negotiated vocabulary — never the presence of a field —
+says which sense a body means.
 
 `scorers.predicateKinds` is retained for existing consumers. Absence of `vocabulary` selects the
 existing contract. A client reads the capability value; it never infers support from the presence of

--- a/docs/evals-vocabulary-consolidation.md
+++ b/docs/evals-vocabulary-consolidation.md
@@ -29,8 +29,8 @@ Four authoring entry points — `test`, `expectedToolCalls`, `predicates`, `scor
 | suite | cases with shared defaults and an acceptance policy | unchanged |
 | case | an authored scenario with stable identity | unchanged |
 | iteration | one execution instance of a case under one execution variant | the eval sense of `trial` |
-| iterations | the configured number of iterations of a case | `repetitions`, `runs` |
-| legacyIterations | the legacy-policy per-case count, read as a floor | the public API case field `iterations` on a legacy-policy suite |
+| iterations | the configured number of iterations of a case | `repetitions` |
+| legacyIterations | the legacy-policy per-case count, read as a floor | the public API case field `iterations` on a legacy-policy suite, stored as `runs` |
 | trace | captured evidence of that execution | unchanged |
 | evaluator | an assertion or a judge | `Scorer`, `grader`, umbrella uses of `check` |
 | assertion | a deterministic rule | `Predicate`, `check`, matcher-backed rules |
@@ -198,6 +198,12 @@ Tool matching and the legacy boolean are assertions by this rule, which is the i
 are deterministic authored rules. Adding a required `kind` to the definition would change the hash
 payload, which invariant 2 forbids.
 
+Two kinds means a custom non-deterministic evaluator that is not a model-graded rubric reads as
+`judge` — the timeout and concurrency scorers in `sdk/tests/eval-scores.test.ts` are real examples.
+`kind` is therefore a presentation split, and no judge behaviour may branch on it: rubric display,
+reviewer calibration and gate eligibility key off the judge's own definition, its `model` and
+template version, never off `kind`.
+
 ## Authoring
 
 ```ts
@@ -261,8 +267,9 @@ equivalent.
 
 ### Equivalence
 
-The effective assertion list is `config.predicates` followed by the assertions in the resolved
-evaluator list. Ordinals are positions in that combined list. `assertion()` builds its definition
+The effective assertion list is the resolved suite defaults first, then `config.predicates`, then
+the case's own assertions from its `evaluators` list; under `mode: "replace"` no suite defaults are
+in it. Ordinals are positions in that combined list. `assertion()` builds its definition
 through the same `predicateScoreDefinition` the legacy path uses, with the same `{id, ordinal, role}`
 inputs; `judge()` returns `judgeScorer`'s definition unchanged; `execute` reuses the `legacy:test`
 definition. Therefore:
@@ -303,7 +310,7 @@ fails the iteration closed, exactly as a throwing `test` does today.
 |---|---|
 | both `test` and `execute` | ``EvalTest "<name>" sets both `execute` and its legacy `test` alias — set one. They are two spellings of the case's driver; `execute` may return nothing and lets the evaluators decide.`` |
 | neither | ``Invalid config: must provide 'execute' (or the legacy 'test') function`` |
-| duplicate evaluator id, including against a suite default | ``EvalTest "<name>": duplicate evaluator id "<id>". Evaluator ids must be unique within a case, and suite defaults.evaluators count too — rename one, or use mode "replace" to drop the suite's.`` |
+| an evaluator id reused for a DIFFERENT definition, a suite default's included | ``EvalTest "<name>": duplicate evaluator id "<id>" on two different definitions. One id cannot mean two evaluations — rename one, or use mode "replace" to drop the suite's.`` |
 | a widget assertion in a code-first case | ``Assertion <type> needs widget render observations, which only a hosted run captures. Remove it from this code-first evaluator, or move the case to a hosted eval suite.`` |
 | `EvalSuite.run` with no count | ``EvalSuite "<name>" has no iteration count: pass { iterations } to run(), or set defaults.iterations on the suite.`` |
 | both spellings of a bound | ``Set evaluatorConcurrency or its legacy alias scorerConcurrency, not both.`` |
@@ -322,12 +329,15 @@ That collapse is narrower than it sounds, and the order matters. Three cases, th
 | the same id on two definitions that differ | refused by the snapshot builder — one id cannot mean two evaluations |
 | the same id on two IDENTICAL definitions | collapses to one row |
 | an id already owned by a built-in (`legacy:test`, `tool-match`, a positional `predicate:<type>#<n>`) | refused **before** the builder runs, whether or not the content matches |
+| a suite default's id on an identical case definition | collapses to one row, like any other identical pair |
+| a suite default's id on a different case definition | refused, like any other conflict |
 
 The third is the one a reader would otherwise get wrong. `EvalTest` builds its reserved-id set first
 and refuses a custom evaluator that reuses one, because a built-in row minted against the wrong
 definition would carry a hash that joins to nothing — and the gate engine's fail-closed join reads
 an unjoinable row as tampering. So "identical content collapses" holds only outside the reserved
-set, and a suite default counts toward the case's ids for the same reason.
+set. A suite default's id counts toward the case's ids exactly as any other does: an identical
+inherited definition collapses, and a different definition under that id is refused.
 
 ## The wire
 
@@ -360,9 +370,14 @@ which the legacy resolver reads as a floor) and the verdict-policy-v2 `repetitio
 vocabulary 1 that object is unchanged, both counts included.
 
 Under vocabulary 2 the exact configured count is `iterations`, with `repetitions` its legacy spelling.
-The adapter writes the legacy `runs` and, on a verdict-policy-v2 suite, the v2 `repetitions` as well,
-keeping both stored spellings equal. The floor count is `legacyIterations`, and it is not a spelling of
-`iterations`: the two are different fields, so the both-spellings refusal never pairs them. Sending
+A write of `iterations` sets the stored v2 `repetitions`, and nothing else. The floor count is
+`legacyIterations`, stored as `runs`. It is not a spelling of `iterations`: the two are different
+fields, so the both-spellings refusal never pairs them, and a read-modify-write that never mentions
+the floor leaves it exactly as it was. An unchanged PATCH that also wrote `runs` would drop a stored
+floor of 10 to an exact count of 3 with no authored edit, and rotate the configuration revision,
+which hashes both keys. `runs` is required storage, so a CREATE that names no floor still needs a
+value: it takes the case's `iterations`, which is what the legacy resolver would have floored to
+anyway. Sending
 `iterations` on a legacy-policy suite is the same `VALIDATION_ERROR` naming the upgrade that
 `repetitions` is today.
 

--- a/docs/evals-vocabulary-consolidation.md
+++ b/docs/evals-vocabulary-consolidation.md
@@ -297,6 +297,20 @@ makes migration incremental.
 Two evaluators with the same id and identical content collapse into one definition, as the snapshot
 builder already does. That is not an error; it is one definition named once.
 
+That collapse is narrower than it sounds, and the order matters. Three cases, three outcomes:
+
+| Case | Outcome |
+|---|---|
+| the same id on two definitions that differ | refused by the snapshot builder — one id cannot mean two evaluations |
+| the same id on two IDENTICAL definitions | collapses to one row |
+| an id already owned by a built-in (`legacy:test`, `tool-match`, a positional `predicate:<type>#<n>`) | refused **before** the builder runs, whether or not the content matches |
+
+The third is the one a reader would otherwise get wrong. `EvalTest` builds its reserved-id set first
+and refuses a custom evaluator that reuses one, because a built-in row minted against the wrong
+definition would carry a hash that joins to nothing — and the gate engine's fail-closed join reads
+an unjoinable row as tampering. So "identical content collapses" holds only outside the reserved
+set, and a suite default counts toward the case's ids for the same reason.
+
 ## The wire
 
 Requests and responses negotiate with a header rather than a version path:

--- a/docs/evals-vocabulary-consolidation.md
+++ b/docs/evals-vocabulary-consolidation.md
@@ -14,9 +14,10 @@ file since #4774), `predicates` (Convex storage and the SDK's evaluator library)
 contract already disagree with each other.
 
 One configured execution count is spelled three ways: `repetitions` (suite file, CLI flag, Convex
-verdict-policy v2), `runs` (Convex legacy, still required storage), and `iterations` (SDK run options,
-public API case field). And the word for ONE execution is itself split: eval code says `trial` where
-the product already says "iteration".
+verdict-policy v2), `runs` (Convex legacy, still required storage), and `iterations` (SDK run options).
+Worse, the public API case field `iterations` is not that count at all on a legacy-policy suite: the
+legacy resolver reads it as a floor, `max(iterations, minimumIterations)`. And the word for ONE
+execution is itself split: eval code says `trial` where the product already says "iteration".
 
 Four authoring entry points — `test`, `expectedToolCalls`, `predicates`, `scorers` — converge on one
 `ScoreResult`, but an author has to learn all four to know that.
@@ -28,7 +29,8 @@ Four authoring entry points — `test`, `expectedToolCalls`, `predicates`, `scor
 | suite | cases with shared defaults and an acceptance policy | unchanged |
 | case | an authored scenario with stable identity | unchanged |
 | iteration | one execution instance of a case under one execution variant | the eval sense of `trial` |
-| repetitions | the configured number of iterations of a case | `runs`, and `iterations` wherever it names the configured count (SDK run options, public API case field) |
+| iterations | the configured number of iterations of a case | `repetitions`, `runs` |
+| legacyIterations | the legacy-policy per-case count, read as a floor | the public API case field `iterations` on a legacy-policy suite |
 | trace | captured evidence of that execution | unchanged |
 | evaluator | an assertion or a judge | `Scorer`, `grader`, umbrella uses of `check` |
 | assertion | a deterministic rule | `Predicate`, `check`, matcher-backed rules |
@@ -56,7 +58,10 @@ These are the invariants. A PR that trips one has found a defect in itself, not 
    new payload.
 3. **Backend configuration identity.** `convex/lib/evalConfigRevision.ts` keeps serializing the keys
    `predicates`, `defaultPredicates`, `repetitions` and `runs`, and keeps its legacy escape hatch
-   that fires only when all eight suite fields are absent. Canonical arguments are normalized to the
+   that fires only when all eight suite fields are absent. Those four are string literals in the
+   payload, not references to a field's current name: after `repetitions` becomes `iterations` the
+   payload still says `repetitions`, exactly as it still says `predicates` after that rename, so no
+   suite's revision string moves. Canonical arguments are normalized to the
    legacy variables **before** anything hashes them, so an identical configuration authored either
    way produces an identical revision string. The same holds for case fingerprints
    (`convex/lib/testCaseBatch.ts`), rubric and judge-template hashes, and verdict-policy signatures.
@@ -99,8 +104,10 @@ These words mean something else. A codemod that proposes to mutate one fails the
 - **Benchmark and description-experiment `repetitions`** (`convex/schema.ts` benchmark tables,
   `evalDescriptionExperiments.plan.repetitions`).
 - **Description-experiment `iterationOverride`** (`convex/descriptionExperiments.ts`), the experiment's
-  own override beside `maxTrials`. It is not folded into `iteration`. `--max-trials`, `maxTrials` and
-  `plannedTrials` cap the product of cases and repetitions and are out of scope for this program.
+  own override beside `maxTrials`. It is not folded into `iteration`. The `--max-trials` flag becomes
+  `--max-iterations`; the stored `maxTrials` and `plannedTrials` fields are out of scope.
+- **The configuration-identity hash keys** in `convex/lib/evalConfigRevision.ts`: `repetitions`, `runs`,
+  `predicates` and `defaultPredicates` (invariant 3). A rename that reaches that file fails the run.
 - Generic verbs and helpers: `assertValid*`, vitest `expect`, prose "check that", mathematical
   predicates.
 
@@ -127,7 +134,6 @@ SDK. Protect the unrelated identifiers, and review eval imports there by hand.
 | `Predicate`, `PredicateResult`, `PredicateScope` | `Assertion`, `AssertionResult`, `AssertionScope` | type aliases from a new subpath |
 | `@mcpjam/sdk/predicates` | `@mcpjam/sdk/assertions` | new subpath; the old one keeps working |
 | `EvalTestConfig.predicates` / `.scorers` / `.test` | `.evaluators` / `.execute` | additive |
-| `EvalSuite.run({ iterations })` | `EvalSuite.run({ repetitions })` | additive; `iterations` stays as a deprecated alias |
 
 `RECOMMENDED_DEFAULT_PREDICATES` stays declared in `sdk/src/contract/grader-stage.ts`, byte for byte.
 The backend pins it through a whole-file capture of the three `{type, role, severity}` triples
@@ -198,7 +204,7 @@ payload, which invariant 2 forbids.
 const suite = new EvalSuite({
   name: "Support workflows",
   defaults: {
-    repetitions: 5,
+    iterations: 5,
     evaluators: [assertion({ type: "noToolErrors", role: "advisory" })],
   },
 });
@@ -231,9 +237,9 @@ const result = await suite.run(executor);
 
 ```ts
 export type EvaluatorOverride = { mode: "inherit" | "extend" | "replace"; list: Evaluator[] };
-export interface EvalSuiteDefaults { repetitions?: number; evaluators?: Evaluator[] }
+export interface EvalSuiteDefaults { iterations?: number; evaluators?: Evaluator[] }
 // EvalTestConfig gains: execute?, evaluators?: EvaluatorOverride; `test` becomes optional.
-// EvalSuite.run options gain: repetitions?; the existing `iterations` stays as its deprecated alias.
+// EvalSuite.run keeps its existing `iterations` option, which is already the canonical spelling.
 ```
 
 ### Resolution
@@ -299,8 +305,7 @@ fails the iteration closed, exactly as a throwing `test` does today.
 | neither | ``Invalid config: must provide 'execute' (or the legacy 'test') function`` |
 | duplicate evaluator id, including against a suite default | ``EvalTest "<name>": duplicate evaluator id "<id>". Evaluator ids must be unique within a case, and suite defaults.evaluators count too — rename one, or use mode "replace" to drop the suite's.`` |
 | a widget assertion in a code-first case | ``Assertion <type> needs widget render observations, which only a hosted run captures. Remove it from this code-first evaluator, or move the case to a hosted eval suite.`` |
-| `EvalSuite.run` with no count | ``EvalSuite "<name>" has no repetitions count: pass { repetitions } to run(), or set defaults.repetitions on the suite.`` |
-| both spellings of the count | ``Set repetitions or its deprecated alias iterations, not both.`` |
+| `EvalSuite.run` with no count | ``EvalSuite "<name>" has no iteration count: pass { iterations } to run(), or set defaults.iterations on the suite.`` |
 | both spellings of a bound | ``Set evaluatorConcurrency or its legacy alias scorerConcurrency, not both.`` |
 
 `predicates` alongside `evaluators`, and `scorers` alongside `evaluators`, are **additive** rather
@@ -344,18 +349,28 @@ explicit `null` clear still reaches storage:
 Send <canonical> or <legacy>, not both — they are two spellings of one field.
 ```
 
-Under vocabulary 2 the canonical spellings are `assertions` and `repetitions`; the read projection
-renames `checks` to `assertions` and reports the configured count as `repetitions`. Under vocabulary 1
+Under vocabulary 2 the canonical spellings are `assertions` and `iterations`; the read projection
+renames `checks` to `assertions` and reports the configured count as `iterations`. Under vocabulary 1
 nothing moves. A canonical client must project a GET result into a valid write request rather than
 echoing both spellings back into a PATCH.
 
 The count family is the one place where meaning, not just spelling, differs, because the legacy API
-carries two counts with different semantics on the same object: `iterations` (a spelling of `runs`)
-and the verdict-policy-v2 `repetitions`. Under vocabulary 1 that object is unchanged, both counts
-included. Under vocabulary 2 `repetitions` is the one configured count and `iterations` and `runs` are
-its legacy spellings; the adapter writes the legacy `runs` and, on a verdict-policy-v2 suite, the v2
-`repetitions` as well, keeping both stored spellings equal. `iterations` never names the configured
-count in vocabulary 2: an iteration is one execution.
+carries two counts with different semantics on the same object: `iterations` (a spelling of `runs`,
+which the legacy resolver reads as a floor) and the verdict-policy-v2 `repetitions` (exact). Under
+vocabulary 1 that object is unchanged, both counts included.
+
+Under vocabulary 2 the exact configured count is `iterations`, with `repetitions` its legacy spelling.
+The adapter writes the legacy `runs` and, on a verdict-policy-v2 suite, the v2 `repetitions` as well,
+keeping both stored spellings equal. The floor count is `legacyIterations`, and it is not a spelling of
+`iterations`: the two are different fields, so the both-spellings refusal never pairs them. Sending
+`iterations` on a legacy-policy suite is the same `VALIDATION_ERROR` naming the upgrade that
+`repetitions` is today.
+
+The order is the guard. The legacy field is renamed to `legacyIterations` in its own step, with both
+vocabularies accepting it, **before** any adapter reads `iterations` as the configured count. A step
+that makes `iterations` mean the count while the floor field still answers to that name merges two
+counts into one, and the codemod refuses to propose it (`scripts/codemod/evals-vocabulary`,
+"rename target in use").
 
 ### Capability
 
@@ -366,9 +381,13 @@ vocabulary: {
   version: 2,
   evaluatorKinds: ["assertion", "judge"],
   assertionKinds: PREDICATE_KINDS,
-  fields: { assertions: ["checks", "predicates"], defaultAssertions: ["defaultPredicates"], repetitions: ["iterations", "runs"] },
+  fields: { assertions: ["checks", "predicates"], defaultAssertions: ["defaultPredicates"], iterations: ["repetitions"], legacyIterations: ["iterations", "runs"] },
 }
 ```
+
+`iterations` appears on both sides on purpose: vocabulary 1's `iterations` is vocabulary 2's
+`legacyIterations`. That is exactly why the negotiated vocabulary, never the presence of a field, says
+which one a body means.
 
 `scorers.predicateKinds` is retained for existing consumers. Absence of `vocabulary` selects the
 existing contract. A client reads the capability value; it never infers support from the presence of
@@ -376,8 +395,8 @@ a field on an unrelated object.
 
 ## The suite file
 
-Dialect `"2"` uses `assertions`; the count is `repetitions` in both dialects. Dialect `"1"` is
-untouched — its `repetitions` stays required and its published JSON Schema keeps its contract, so an older strict reader can never
+Dialect `"2"` uses `assertions` and `iterations`. A suite file has no floor count, so nothing there
+needs a legacy name first. Dialect `"1"` is untouched — its `repetitions` stays required and its published JSON Schema keeps its contract, so an older strict reader can never
 misread a new file under its existing version.
 
 The loader accepts both. The writer emits the file's own dialect, and a new dialect is written only

--- a/sdk/tests/evaluator-vocabulary-golden.test.ts
+++ b/sdk/tests/evaluator-vocabulary-golden.test.ts
@@ -25,7 +25,7 @@
 import { describe, expect, it } from "vitest";
 import golden from "./fixtures/evaluator-vocabulary-golden.json" with { type: "json" };
 import { EvalTest } from "../src/EvalTest.js";
-import { predicateScorer } from "../src/scorers/index.js";
+import { judgeScorer, predicateScorer } from "../src/scorers/index.js";
 import type { EvaluationConfigSnapshot } from "../src/contract/types.js";
 import type { Predicate } from "../src/predicates/types.js";
 import type { Scorer } from "../src/scorers/types.js";
@@ -58,6 +58,28 @@ const customEvaluator: Scorer = {
     return { kind: "scored" as const, value: 1 };
   },
 };
+
+/**
+ * A REAL judge, not a stand-in.
+ *
+ * `customEvaluator` above carries a fixed `implementationHash` on purpose — it
+ * pins the wiring without pinning a prompt digest. But that left the gate with
+ * a hole a reviewer found: no row exercised `judgeScorer`'s actual derivation,
+ * so a later `judge()` constructor could change the prompt template version or
+ * the hash payload and this suite would stay green while every existing judge's
+ * configuration identity moved underneath it.
+ *
+ * The key is deliberately not a real one. `judgeScorer` builds its provider at
+ * construction but does not authenticate, and the definition it produces is a
+ * function of the rubric, the template version and the model string — none of
+ * which needs a live credential.
+ */
+const JUDGE_OPTIONS = {
+  id: "policy-grounding",
+  model: "anthropic/claude-sonnet-4-6",
+  apiKey: "sk-test-not-a-real-key",
+  rubric: ["The answer is supported by the retrieved policy."],
+} as const;
 
 const twoSameType: Predicate[] = [
   { type: "responseContains", needle: "refund" },
@@ -123,6 +145,22 @@ const legacyBuilders: Record<string, () => EvalTest> = {
       predicates: [{ type: "responseContains", needle: "refund" }],
       scorers: [customEvaluator],
     }),
+
+  "anonymous assertion through scorers — the content-derived id": () =>
+    new EvalTest({
+      id: "c_anonymous",
+      name: "anonymous",
+      test: passing,
+      scorers: [predicateScorer({ type: "responseContains", needle: "refund" })],
+    }),
+
+  "a real judge — the rubric-and-template implementation hash": () =>
+    new EvalTest({
+      id: "c_judge",
+      name: "judge",
+      test: passing,
+      scorers: [judgeScorer(JUDGE_OPTIONS)],
+    }),
 };
 
 describe("evaluation config identity is frozen", () => {
@@ -152,6 +190,99 @@ describe("evaluation config identity is frozen", () => {
     });
   }
 
+  it("refuses a reserved id before the builder can collapse anything", () => {
+    // The distinction the contract now spells out. Identical content collapses
+    // — but only OUTSIDE the reserved set, and this is the case a reader would
+    // otherwise get wrong: a built-in row minted against the wrong definition
+    // carries a hash that joins to nothing, and the gate's fail-closed join
+    // reads an unjoinable row as tampering.
+    expect(
+      () =>
+        new EvalTest({
+          id: "c_reserved",
+          name: "reserved",
+          test: passing,
+          scorers: [
+            predicateScorer({ type: "noToolErrors" }, { id: "tool-match" }),
+          ],
+        }).getEvaluationConfigSnapshot(),
+    ).toThrow(/already used by this test's built-in scorers/);
+  });
+
+  it("refuses one id standing for two different evaluations", () => {
+    expect(
+      () =>
+        new EvalTest({
+          id: "c_conflict",
+          name: "conflict",
+          test: passing,
+          scorers: [
+            predicateScorer({ type: "noToolErrors" }, { id: "same" }),
+            predicateScorer(
+              { type: "finalAssistantMessageNonEmpty" },
+              { id: "same" },
+            ),
+          ],
+        }).getEvaluationConfigSnapshot(),
+    ).toThrow();
+  });
+
+  it("collapses one id standing for one evaluation, named twice", () => {
+    const snapshot = new EvalTest({
+      id: "c_collapse",
+      name: "collapse",
+      test: passing,
+      scorers: [
+        predicateScorer({ type: "noToolErrors" }, { id: "same" }),
+        predicateScorer({ type: "noToolErrors" }, { id: "same" }),
+      ],
+    }).getEvaluationConfigSnapshot();
+
+    expect(
+      snapshot.definitions.filter((d) => d.scorerId === "same"),
+    ).toHaveLength(1);
+  });
+
+  it("pins the content-derived id of an anonymous assertion", () => {
+    const row = goldenCases.find((entry) =>
+      entry.label.startsWith("anonymous assertion"),
+    )!;
+    const generated = row.snapshot.definitions.find(
+      (definition) => definition.idSource === "generated",
+    )!;
+
+    // A standalone evaluator has no position, so its id comes from its rule's
+    // content — the whole digest, because two rules sharing a truncated one
+    // would mint a single id for two definitions. Nothing else in this corpus
+    // covers that path: the `predicates` rows are positional and the other
+    // scorer row is explicitly named.
+    expect(generated.scorerId).toMatch(
+      /^predicate:responseContains#[0-9a-f]{64}$/,
+    );
+    expect(generated.implementationHash).toBe(
+      generated.scorerId.split("#")[1],
+    );
+  });
+
+  it("pins a real judge's rubric-and-template hash", () => {
+    const row = goldenCases.find((entry) =>
+      entry.label.startsWith("a real judge"),
+    )!;
+    const judge = row.snapshot.definitions.find(
+      (definition) => definition.deterministic === false,
+    )!;
+
+    // Derived by `judgeScorer` from the rubric, the prompt TEMPLATE VERSION and
+    // the model. Pinning it is what stops a later constructor from moving the
+    // template while every judge's configuration identity moves with it and
+    // this gate stays green.
+    expect(judge.scorerId).toBe("policy-grounding");
+    expect(judge.idSource).toBe("explicit");
+    expect(judge.passThreshold).toBe(0.7);
+    expect(judge.role).toBe("advisory");
+    expect(judge.implementationHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
   it("pins the generated ids that a later rule insertion would renumber", () => {
     const renumberable = goldenCases
       .flatMap((entry) => entry.snapshot.definitions)
@@ -159,11 +290,15 @@ describe("evaluation config identity is frozen", () => {
       .map((definition) => definition.scorerId);
     // Not an incidental list: these are the ids that are positional by
     // construction, and the reason a gate refuses to select one.
+    // Positional ones first, then the anonymous content-derived id, which is
+    // `generated` for a different reason: content-stable is not author-stable
+    // either, so a gate must not select it.
     expect(renumberable).toEqual([
       "predicate:responseContains#0",
       "predicate:responseContains#1",
       "predicate:noToolErrors#0",
       "predicate:responseContains#0",
+      "predicate:responseContains#1ed825dd8c4484fa231d4b04177afae713ed9ab60de848091d076ea2af8d00e1",
     ]);
   });
 });

--- a/sdk/tests/evaluator-vocabulary-golden.test.ts
+++ b/sdk/tests/evaluator-vocabulary-golden.test.ts
@@ -26,11 +26,16 @@ import { describe, expect, it } from "vitest";
 import golden from "./fixtures/evaluator-vocabulary-golden.json" with { type: "json" };
 import { EvalTest } from "../src/EvalTest.js";
 import { judgeScorer, predicateScorer } from "../src/scorers/index.js";
+import { definitionHash } from "../src/contract/derive.js";
 import type { EvaluationConfigSnapshot } from "../src/contract/types.js";
 import type { Predicate } from "../src/predicates/types.js";
 import type { Scorer } from "../src/scorers/types.js";
 
-type GoldenCase = { label: string; snapshot: EvaluationConfigSnapshot };
+type GoldenCase = {
+  label: string;
+  snapshot: EvaluationConfigSnapshot;
+  definitionHashes: Record<string, string>;
+};
 const goldenCases = (golden as unknown as { cases: GoldenCase[] }).cases;
 
 const passing = async () => true;
@@ -81,6 +86,22 @@ const JUDGE_OPTIONS = {
   rubric: ["The answer is supported by the retrieved policy."],
 } as const;
 
+/**
+ * The same rule, carrying policy.
+ *
+ * Its id digests the WHOLE rule, `role` and `severity` included, while its
+ * `implementationHash` digests the rule with those stripped. The two therefore
+ * differ, and the gate has to pin both or a later constructor could reuse the
+ * implementation hash as the id and renumber every policy-bearing anonymous
+ * evaluator without failing here.
+ */
+const policyBearing: Predicate = {
+  type: "responseContains",
+  needle: "refund",
+  role: "advisory",
+  severity: "warn",
+};
+
 const twoSameType: Predicate[] = [
   { type: "responseContains", needle: "refund" },
   { type: "responseContains", needle: "policy" },
@@ -93,6 +114,9 @@ const twoSameType: Predicate[] = [
  * against the same row — which is what makes "the new facade is the same
  * evaluation" a claim the suite checks rather than a claim the PR body makes.
  */
+const POLICY_LABEL =
+  "anonymous assertion carrying policy — the id keeps it, the implementation hash does not";
+
 const legacyBuilders: Record<string, () => EvalTest> = {
   "bare test — no expectations, no assertions": () =>
     new EvalTest({ id: "c_bare", name: "bare", test: passing }),
@@ -131,7 +155,7 @@ const legacyBuilders: Record<string, () => EvalTest> = {
       scorers: [
         predicateScorer(
           { type: "finalAssistantMessageNonEmpty" },
-          { id: "nonempty-answer" },
+          { id: "nonempty-answer" }
         ),
       ],
     }),
@@ -151,7 +175,17 @@ const legacyBuilders: Record<string, () => EvalTest> = {
       id: "c_anonymous",
       name: "anonymous",
       test: passing,
-      scorers: [predicateScorer({ type: "responseContains", needle: "refund" })],
+      scorers: [
+        predicateScorer({ type: "responseContains", needle: "refund" }),
+      ],
+    }),
+
+  [POLICY_LABEL]: () =>
+    new EvalTest({
+      id: "c_anonymous_policy",
+      name: "anonymous policy",
+      test: passing,
+      scorers: [predicateScorer(policyBearing)],
     }),
 
   "a real judge — the rubric-and-template implementation hash": () =>
@@ -166,25 +200,39 @@ const legacyBuilders: Record<string, () => EvalTest> = {
 describe("evaluation config identity is frozen", () => {
   it("covers every golden row with a builder, and every builder with a row", () => {
     expect(Object.keys(legacyBuilders).sort()).toEqual(
-      goldenCases.map((entry) => entry.label).sort(),
+      goldenCases.map((entry) => entry.label).sort()
     );
   });
 
   for (const entry of goldenCases) {
     describe(entry.label, () => {
       it("produces the pinned snapshot", () => {
-        const built = legacyBuilders[entry.label]!().getEvaluationConfigSnapshot();
+        const built =
+          legacyBuilders[entry.label]!().getEvaluationConfigSnapshot();
         expect(built).toEqual(entry.snapshot);
       });
 
-      it("keeps every evaluator id and id source, in order", () => {
-        const built = legacyBuilders[entry.label]!().getEvaluationConfigSnapshot();
+      it("pins each evaluator's definition hash", () => {
+        // The snapshot carries no `definitionHash`, and the aggregate hash is
+        // computed separately, so without this a change to `definitionHash()`
+        // alone would keep every other assertion green while breaking the
+        // `ScoreResult.definitionHash` joins this contract freezes.
+        const built =
+          legacyBuilders[entry.label]!().getEvaluationConfigSnapshot();
         expect(
-          built.definitions.map((d) => `${d.scorerId} (${d.idSource})`),
+          Object.fromEntries(
+            built.definitions.map((d) => [d.scorerId, definitionHash(d)])
+          )
+        ).toEqual(entry.definitionHashes);
+      });
+
+      it("keeps every evaluator id and id source, in order", () => {
+        const built =
+          legacyBuilders[entry.label]!().getEvaluationConfigSnapshot();
+        expect(
+          built.definitions.map((d) => `${d.scorerId} (${d.idSource})`)
         ).toEqual(
-          entry.snapshot.definitions.map(
-            (d) => `${d.scorerId} (${d.idSource})`,
-          ),
+          entry.snapshot.definitions.map((d) => `${d.scorerId} (${d.idSource})`)
         );
       });
     });
@@ -196,34 +244,32 @@ describe("evaluation config identity is frozen", () => {
     // otherwise get wrong: a built-in row minted against the wrong definition
     // carries a hash that joins to nothing, and the gate's fail-closed join
     // reads an unjoinable row as tampering.
-    expect(
-      () =>
-        new EvalTest({
-          id: "c_reserved",
-          name: "reserved",
-          test: passing,
-          scorers: [
-            predicateScorer({ type: "noToolErrors" }, { id: "tool-match" }),
-          ],
-        }).getEvaluationConfigSnapshot(),
+    expect(() =>
+      new EvalTest({
+        id: "c_reserved",
+        name: "reserved",
+        test: passing,
+        scorers: [
+          predicateScorer({ type: "noToolErrors" }, { id: "tool-match" }),
+        ],
+      }).getEvaluationConfigSnapshot()
     ).toThrow(/already used by this test's built-in scorers/);
   });
 
   it("refuses one id standing for two different evaluations", () => {
-    expect(
-      () =>
-        new EvalTest({
-          id: "c_conflict",
-          name: "conflict",
-          test: passing,
-          scorers: [
-            predicateScorer({ type: "noToolErrors" }, { id: "same" }),
-            predicateScorer(
-              { type: "finalAssistantMessageNonEmpty" },
-              { id: "same" },
-            ),
-          ],
-        }).getEvaluationConfigSnapshot(),
+    expect(() =>
+      new EvalTest({
+        id: "c_conflict",
+        name: "conflict",
+        test: passing,
+        scorers: [
+          predicateScorer({ type: "noToolErrors" }, { id: "same" }),
+          predicateScorer(
+            { type: "finalAssistantMessageNonEmpty" },
+            { id: "same" }
+          ),
+        ],
+      }).getEvaluationConfigSnapshot()
     ).toThrow();
   });
 
@@ -239,16 +285,18 @@ describe("evaluation config identity is frozen", () => {
     }).getEvaluationConfigSnapshot();
 
     expect(
-      snapshot.definitions.filter((d) => d.scorerId === "same"),
+      snapshot.definitions.filter((d) => d.scorerId === "same")
     ).toHaveLength(1);
   });
 
   it("pins the content-derived id of an anonymous assertion", () => {
-    const row = goldenCases.find((entry) =>
-      entry.label.startsWith("anonymous assertion"),
+    const row = goldenCases.find(
+      (entry) =>
+        entry.label ===
+        "anonymous assertion through scorers — the content-derived id"
     )!;
     const generated = row.snapshot.definitions.find(
-      (definition) => definition.idSource === "generated",
+      (definition) => definition.idSource === "generated"
     )!;
 
     // A standalone evaluator has no position, so its id comes from its rule's
@@ -257,19 +305,41 @@ describe("evaluation config identity is frozen", () => {
     // covers that path: the `predicates` rows are positional and the other
     // scorer row is explicitly named.
     expect(generated.scorerId).toMatch(
-      /^predicate:responseContains#[0-9a-f]{64}$/,
+      /^predicate:responseContains#[0-9a-f]{64}$/
+    );
+    // Equal HERE only because this rule carries no policy fields. The row
+    // below is the general case, where they diverge.
+    expect(generated.implementationHash).toBe(generated.scorerId.split("#")[1]);
+  });
+
+  it("pins an anonymous assertion whose rule carries policy", () => {
+    const row = goldenCases.find((entry) => entry.label === POLICY_LABEL)!;
+    const generated = row.snapshot.definitions.find(
+      (definition) => definition.idSource === "generated"
+    )!;
+
+    // The id digests the whole rule; the implementation hash digests it with
+    // `role` and `severity` stripped. Note the implementation hash is the
+    // POLICY-FREE rule's id suffix, which is why asserting the two are equal
+    // in general would have frozen the wrong rule.
+    expect(generated.scorerId).toBe(
+      "predicate:responseContains#f54cf792125b3846651c875cae4d417bb1adf5d6dab0992cca5f661142c6d779"
     );
     expect(generated.implementationHash).toBe(
-      generated.scorerId.split("#")[1],
+      "1ed825dd8c4484fa231d4b04177afae713ed9ab60de848091d076ea2af8d00e1"
     );
+    expect(generated.implementationHash).not.toBe(
+      generated.scorerId.split("#")[1]
+    );
+    expect(generated.role).toBe("advisory");
   });
 
   it("pins a real judge's rubric-and-template hash", () => {
     const row = goldenCases.find((entry) =>
-      entry.label.startsWith("a real judge"),
+      entry.label.startsWith("a real judge")
     )!;
     const judge = row.snapshot.definitions.find(
-      (definition) => definition.deterministic === false,
+      (definition) => definition.deterministic === false
     )!;
 
     // Derived by `judgeScorer` from the rubric, the prompt TEMPLATE VERSION and
@@ -299,6 +369,7 @@ describe("evaluation config identity is frozen", () => {
       "predicate:noToolErrors#0",
       "predicate:responseContains#0",
       "predicate:responseContains#1ed825dd8c4484fa231d4b04177afae713ed9ab60de848091d076ea2af8d00e1",
+      "predicate:responseContains#f54cf792125b3846651c875cae4d417bb1adf5d6dab0992cca5f661142c6d779",
     ]);
   });
 });

--- a/sdk/tests/evaluator-vocabulary-golden.test.ts
+++ b/sdk/tests/evaluator-vocabulary-golden.test.ts
@@ -91,9 +91,9 @@ const JUDGE_OPTIONS = {
  *
  * Its id digests the WHOLE rule, `role` and `severity` included, while its
  * `implementationHash` digests the rule with those stripped. The two therefore
- * differ, and the gate has to pin both or a later constructor could reuse the
- * implementation hash as the id and renumber every policy-bearing anonymous
- * evaluator without failing here.
+ * differ, and the gate has to pin both — otherwise a later constructor could
+ * reuse the implementation hash as the id and renumber every policy-bearing
+ * anonymous evaluator without failing here.
  */
 const policyBearing: Predicate = {
   type: "responseContains",
@@ -155,7 +155,7 @@ const legacyBuilders: Record<string, () => EvalTest> = {
       scorers: [
         predicateScorer(
           { type: "finalAssistantMessageNonEmpty" },
-          { id: "nonempty-answer" }
+          { id: "nonempty-answer" },
         ),
       ],
     }),
@@ -175,9 +175,7 @@ const legacyBuilders: Record<string, () => EvalTest> = {
       id: "c_anonymous",
       name: "anonymous",
       test: passing,
-      scorers: [
-        predicateScorer({ type: "responseContains", needle: "refund" }),
-      ],
+      scorers: [predicateScorer({ type: "responseContains", needle: "refund" })],
     }),
 
   [POLICY_LABEL]: () =>
@@ -200,15 +198,14 @@ const legacyBuilders: Record<string, () => EvalTest> = {
 describe("evaluation config identity is frozen", () => {
   it("covers every golden row with a builder, and every builder with a row", () => {
     expect(Object.keys(legacyBuilders).sort()).toEqual(
-      goldenCases.map((entry) => entry.label).sort()
+      goldenCases.map((entry) => entry.label).sort(),
     );
   });
 
   for (const entry of goldenCases) {
     describe(entry.label, () => {
       it("produces the pinned snapshot", () => {
-        const built =
-          legacyBuilders[entry.label]!().getEvaluationConfigSnapshot();
+        const built = legacyBuilders[entry.label]!().getEvaluationConfigSnapshot();
         expect(built).toEqual(entry.snapshot);
       });
 
@@ -221,18 +218,19 @@ describe("evaluation config identity is frozen", () => {
           legacyBuilders[entry.label]!().getEvaluationConfigSnapshot();
         expect(
           Object.fromEntries(
-            built.definitions.map((d) => [d.scorerId, definitionHash(d)])
-          )
+            built.definitions.map((d) => [d.scorerId, definitionHash(d)]),
+          ),
         ).toEqual(entry.definitionHashes);
       });
 
       it("keeps every evaluator id and id source, in order", () => {
-        const built =
-          legacyBuilders[entry.label]!().getEvaluationConfigSnapshot();
+        const built = legacyBuilders[entry.label]!().getEvaluationConfigSnapshot();
         expect(
-          built.definitions.map((d) => `${d.scorerId} (${d.idSource})`)
+          built.definitions.map((d) => `${d.scorerId} (${d.idSource})`),
         ).toEqual(
-          entry.snapshot.definitions.map((d) => `${d.scorerId} (${d.idSource})`)
+          entry.snapshot.definitions.map(
+            (d) => `${d.scorerId} (${d.idSource})`,
+          ),
         );
       });
     });
@@ -244,32 +242,34 @@ describe("evaluation config identity is frozen", () => {
     // otherwise get wrong: a built-in row minted against the wrong definition
     // carries a hash that joins to nothing, and the gate's fail-closed join
     // reads an unjoinable row as tampering.
-    expect(() =>
-      new EvalTest({
-        id: "c_reserved",
-        name: "reserved",
-        test: passing,
-        scorers: [
-          predicateScorer({ type: "noToolErrors" }, { id: "tool-match" }),
-        ],
-      }).getEvaluationConfigSnapshot()
+    expect(
+      () =>
+        new EvalTest({
+          id: "c_reserved",
+          name: "reserved",
+          test: passing,
+          scorers: [
+            predicateScorer({ type: "noToolErrors" }, { id: "tool-match" }),
+          ],
+        }).getEvaluationConfigSnapshot(),
     ).toThrow(/already used by this test's built-in scorers/);
   });
 
   it("refuses one id standing for two different evaluations", () => {
-    expect(() =>
-      new EvalTest({
-        id: "c_conflict",
-        name: "conflict",
-        test: passing,
-        scorers: [
-          predicateScorer({ type: "noToolErrors" }, { id: "same" }),
-          predicateScorer(
-            { type: "finalAssistantMessageNonEmpty" },
-            { id: "same" }
-          ),
-        ],
-      }).getEvaluationConfigSnapshot()
+    expect(
+      () =>
+        new EvalTest({
+          id: "c_conflict",
+          name: "conflict",
+          test: passing,
+          scorers: [
+            predicateScorer({ type: "noToolErrors" }, { id: "same" }),
+            predicateScorer(
+              { type: "finalAssistantMessageNonEmpty" },
+              { id: "same" },
+            ),
+          ],
+        }).getEvaluationConfigSnapshot(),
     ).toThrow();
   });
 
@@ -285,7 +285,7 @@ describe("evaluation config identity is frozen", () => {
     }).getEvaluationConfigSnapshot();
 
     expect(
-      snapshot.definitions.filter((d) => d.scorerId === "same")
+      snapshot.definitions.filter((d) => d.scorerId === "same"),
     ).toHaveLength(1);
   });
 
@@ -293,10 +293,10 @@ describe("evaluation config identity is frozen", () => {
     const row = goldenCases.find(
       (entry) =>
         entry.label ===
-        "anonymous assertion through scorers — the content-derived id"
+        "anonymous assertion through scorers — the content-derived id",
     )!;
     const generated = row.snapshot.definitions.find(
-      (definition) => definition.idSource === "generated"
+      (definition) => definition.idSource === "generated",
     )!;
 
     // A standalone evaluator has no position, so its id comes from its rule's
@@ -305,41 +305,43 @@ describe("evaluation config identity is frozen", () => {
     // covers that path: the `predicates` rows are positional and the other
     // scorer row is explicitly named.
     expect(generated.scorerId).toMatch(
-      /^predicate:responseContains#[0-9a-f]{64}$/
+      /^predicate:responseContains#[0-9a-f]{64}$/,
     );
     // Equal HERE only because this rule carries no policy fields. The row
-    // below is the general case, where they diverge.
-    expect(generated.implementationHash).toBe(generated.scorerId.split("#")[1]);
+    // below is the general case, where the two diverge.
+    expect(generated.implementationHash).toBe(
+      generated.scorerId.split("#")[1],
+    );
   });
 
   it("pins an anonymous assertion whose rule carries policy", () => {
     const row = goldenCases.find((entry) => entry.label === POLICY_LABEL)!;
     const generated = row.snapshot.definitions.find(
-      (definition) => definition.idSource === "generated"
+      (definition) => definition.idSource === "generated",
     )!;
 
     // The id digests the whole rule; the implementation hash digests it with
-    // `role` and `severity` stripped. Note the implementation hash is the
+    // `role` and `severity` stripped. Note that the implementation hash is the
     // POLICY-FREE rule's id suffix, which is why asserting the two are equal
     // in general would have frozen the wrong rule.
     expect(generated.scorerId).toBe(
-      "predicate:responseContains#f54cf792125b3846651c875cae4d417bb1adf5d6dab0992cca5f661142c6d779"
+      "predicate:responseContains#f54cf792125b3846651c875cae4d417bb1adf5d6dab0992cca5f661142c6d779",
     );
     expect(generated.implementationHash).toBe(
-      "1ed825dd8c4484fa231d4b04177afae713ed9ab60de848091d076ea2af8d00e1"
+      "1ed825dd8c4484fa231d4b04177afae713ed9ab60de848091d076ea2af8d00e1",
     );
     expect(generated.implementationHash).not.toBe(
-      generated.scorerId.split("#")[1]
+      generated.scorerId.split("#")[1],
     );
     expect(generated.role).toBe("advisory");
   });
 
   it("pins a real judge's rubric-and-template hash", () => {
     const row = goldenCases.find((entry) =>
-      entry.label.startsWith("a real judge")
+      entry.label.startsWith("a real judge"),
     )!;
     const judge = row.snapshot.definitions.find(
-      (definition) => definition.deterministic === false
+      (definition) => definition.deterministic === false,
     )!;
 
     // Derived by `judgeScorer` from the rubric, the prompt TEMPLATE VERSION and

--- a/sdk/tests/evaluator-vocabulary-golden.test.ts
+++ b/sdk/tests/evaluator-vocabulary-golden.test.ts
@@ -1,0 +1,169 @@
+/**
+ * The equivalence gate for the evaluator-vocabulary program.
+ *
+ * `sdk/tests/fixtures/evaluator-vocabulary-golden.json` holds the
+ * `EvaluationConfigSnapshot` each authored case produced BEFORE any of the
+ * vocabulary work, captured from unchanged code. Every later step — the
+ * canonical result projection, the `assertion()` / `judge()` constructors, the
+ * `evaluators` list, `execute` in place of `test` — must keep producing these
+ * exact snapshots.
+ *
+ * WHY IT ASSERTS IDS LITERALLY AS WELL AS DEEP-EQUALITY. The aggregate `hash`
+ * sorts its inputs, so two configurations whose definitions were renumbered
+ * against each other could in principle agree on it while disagreeing about
+ * which rule is `#0`. A generated id is positional and documented as unstable
+ * precisely because inserting a rule above it renumbers it — so the ids are the
+ * thing a later reader joins on, and they get their own assertion.
+ *
+ * NEVER regenerate the fixture to make a change pass. A green test bought by
+ * editing both the producer and the expected payload proves nothing at all. If
+ * a change here is genuinely intended, it is an identity change: it resets
+ * baseline comparability for every existing suite and belongs in its own PR
+ * with that consequence stated.
+ */
+
+import { describe, expect, it } from "vitest";
+import golden from "./fixtures/evaluator-vocabulary-golden.json" with { type: "json" };
+import { EvalTest } from "../src/EvalTest.js";
+import { predicateScorer } from "../src/scorers/index.js";
+import type { EvaluationConfigSnapshot } from "../src/contract/types.js";
+import type { Predicate } from "../src/predicates/types.js";
+import type { Scorer } from "../src/scorers/types.js";
+
+type GoldenCase = { label: string; snapshot: EvaluationConfigSnapshot };
+const goldenCases = (golden as unknown as { cases: GoldenCase[] }).cases;
+
+const passing = async () => true;
+
+/**
+ * A custom non-deterministic evaluator with a FIXED `implementationHash`.
+ *
+ * Fixed rather than derived so the fixture pins the wiring — where the
+ * definition lands in the order, what id it keeps — without also pinning the
+ * digest of whatever prompt a real judge would carry.
+ */
+const customEvaluator: Scorer = {
+  definition: {
+    scorerId: "custom:tone",
+    idSource: "explicit",
+    scorerVersion: "1",
+    implementationHash: "fixedhash-tone-v1",
+    label: "tone",
+    deterministic: false,
+    passThreshold: 0.7,
+    role: "advisory",
+    model: "anthropic/claude-sonnet-4-6",
+  },
+  score() {
+    return { kind: "scored" as const, value: 1 };
+  },
+};
+
+const twoSameType: Predicate[] = [
+  { type: "responseContains", needle: "refund" },
+  { type: "responseContains", needle: "policy" },
+];
+
+/**
+ * The legacy authoring of each golden case, keyed by the fixture's label.
+ *
+ * Later steps add a canonical builder beside each of these and assert both
+ * against the same row — which is what makes "the new facade is the same
+ * evaluation" a claim the suite checks rather than a claim the PR body makes.
+ */
+const legacyBuilders: Record<string, () => EvalTest> = {
+  "bare test — no expectations, no assertions": () =>
+    new EvalTest({ id: "c_bare", name: "bare", test: passing }),
+
+  "two assertions of the same type — positional ordinals must differ": () =>
+    new EvalTest({
+      id: "c_two_same_type",
+      name: "two same type",
+      test: passing,
+      predicates: twoSameType,
+    }),
+
+  "assertions plus a custom advisory evaluator": () =>
+    new EvalTest({
+      id: "c_mixed",
+      name: "mixed",
+      test: passing,
+      predicates: [{ type: "noToolErrors" }],
+      scorers: [customEvaluator],
+    }),
+
+  "negative case with no expectations — tool-match is applicable and gating":
+    () =>
+      new EvalTest({
+        id: "c_negative",
+        name: "negative",
+        test: passing,
+        isNegativeTest: true,
+      }),
+
+  "explicit-id assertion through scorers": () =>
+    new EvalTest({
+      id: "c_explicit_id",
+      name: "explicit id",
+      test: passing,
+      scorers: [
+        predicateScorer(
+          { type: "finalAssistantMessageNonEmpty" },
+          { id: "nonempty-answer" },
+        ),
+      ],
+    }),
+
+  "expectations plus assertions — full definition order": () =>
+    new EvalTest({
+      id: "c_full",
+      name: "full",
+      test: passing,
+      expectedToolCalls: [{ toolName: "search_policies", arguments: {} }],
+      predicates: [{ type: "responseContains", needle: "refund" }],
+      scorers: [customEvaluator],
+    }),
+};
+
+describe("evaluation config identity is frozen", () => {
+  it("covers every golden row with a builder, and every builder with a row", () => {
+    expect(Object.keys(legacyBuilders).sort()).toEqual(
+      goldenCases.map((entry) => entry.label).sort(),
+    );
+  });
+
+  for (const entry of goldenCases) {
+    describe(entry.label, () => {
+      it("produces the pinned snapshot", () => {
+        const built = legacyBuilders[entry.label]!().getEvaluationConfigSnapshot();
+        expect(built).toEqual(entry.snapshot);
+      });
+
+      it("keeps every evaluator id and id source, in order", () => {
+        const built = legacyBuilders[entry.label]!().getEvaluationConfigSnapshot();
+        expect(
+          built.definitions.map((d) => `${d.scorerId} (${d.idSource})`),
+        ).toEqual(
+          entry.snapshot.definitions.map(
+            (d) => `${d.scorerId} (${d.idSource})`,
+          ),
+        );
+      });
+    });
+  }
+
+  it("pins the generated ids that a later rule insertion would renumber", () => {
+    const renumberable = goldenCases
+      .flatMap((entry) => entry.snapshot.definitions)
+      .filter((definition) => definition.idSource === "generated")
+      .map((definition) => definition.scorerId);
+    // Not an incidental list: these are the ids that are positional by
+    // construction, and the reason a gate refuses to select one.
+    expect(renumberable).toEqual([
+      "predicate:responseContains#0",
+      "predicate:responseContains#1",
+      "predicate:noToolErrors#0",
+      "predicate:responseContains#0",
+    ]);
+  });
+});

--- a/sdk/tests/fixtures/evaluator-vocabulary-golden.json
+++ b/sdk/tests/fixtures/evaluator-vocabulary-golden.json
@@ -1,0 +1,283 @@
+{
+  "__readme": "Golden EvaluationConfigSnapshots captured from UNCHANGED code before the evaluator-vocabulary program. Each row is an authored case and the snapshot it must keep producing, however it is authored. The test asserts deep equality AND each definition's scorerId/idSource literally, so an ordinal shift fails even when the aggregate hash coincidentally matches. NEVER regenerate this file to make a rename pass — a green test bought by editing both the producer and the expected payload proves nothing.",
+  "cases": [
+    {
+      "label": "bare test — no expectations, no assertions",
+      "snapshot": {
+        "hash": "638a0932bbd19b85fbdf5786ed156198806173fdedc54410667b4ddcb787e433",
+        "definitions": [
+          {
+            "scorerId": "legacy:test",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "4e671f4627b3d66accaebabc6df72885a59c9f9adc9db9e47af371210468015c",
+            "label": "test()",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "tool-match",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "0bc72b69047c95a508d975471f9cb330b2fe2137eea30fcba8e425f087613b74",
+            "label": "expected tool calls",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          }
+        ]
+      }
+    },
+    {
+      "label": "two assertions of the same type — positional ordinals must differ",
+      "snapshot": {
+        "hash": "ebf22fe47e0cf19ddd038ff3f6211aa284bf39d403845af3e85a192eb08fa5dd",
+        "definitions": [
+          {
+            "scorerId": "legacy:test",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "4e671f4627b3d66accaebabc6df72885a59c9f9adc9db9e47af371210468015c",
+            "label": "test()",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "tool-match",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "0bc72b69047c95a508d975471f9cb330b2fe2137eea30fcba8e425f087613b74",
+            "label": "expected tool calls",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "predicate:responseContains#0",
+            "idSource": "generated",
+            "scorerVersion": "1",
+            "implementationHash": "1ed825dd8c4484fa231d4b04177afae713ed9ab60de848091d076ea2af8d00e1",
+            "label": "responseContains",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "predicate:responseContains#1",
+            "idSource": "generated",
+            "scorerVersion": "1",
+            "implementationHash": "4626bace1bf919080f1fe266ead20162809600ea0f82541ad1bc2b5d26170cfa",
+            "label": "responseContains",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          }
+        ]
+      }
+    },
+    {
+      "label": "assertions plus a custom advisory evaluator",
+      "snapshot": {
+        "hash": "72ee7114d35647a999e4c58f3fca08826af51c2d796dc96d5f36e44c44d2882a",
+        "definitions": [
+          {
+            "scorerId": "legacy:test",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "4e671f4627b3d66accaebabc6df72885a59c9f9adc9db9e47af371210468015c",
+            "label": "test()",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "tool-match",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "0bc72b69047c95a508d975471f9cb330b2fe2137eea30fcba8e425f087613b74",
+            "label": "expected tool calls",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "predicate:noToolErrors#0",
+            "idSource": "generated",
+            "scorerVersion": "1",
+            "implementationHash": "c41bce037b27a48947f07b2fa20a96fee23a59c24bc0b82b10c547147289b744",
+            "label": "noToolErrors",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "custom:tone",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "fixedhash-tone-v1",
+            "label": "tone",
+            "deterministic": false,
+            "passThreshold": 0.7,
+            "role": "advisory",
+            "model": "anthropic/claude-sonnet-4-6",
+            "onError": "ignore",
+            "onSkipped": "ignore"
+          }
+        ]
+      }
+    },
+    {
+      "label": "negative case with no expectations — tool-match is applicable and gating",
+      "snapshot": {
+        "hash": "04a19ad1a6c68b6d6741ef8406f16a452b9125dcfedb5bbd76ee4e0806e659a2",
+        "definitions": [
+          {
+            "scorerId": "legacy:test",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "4e671f4627b3d66accaebabc6df72885a59c9f9adc9db9e47af371210468015c",
+            "label": "test()",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "tool-match",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "86df40f091e99985079d0e9abb8b409a59219e8443e26209b88e4421a0732584",
+            "label": "expected tool calls",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          }
+        ]
+      }
+    },
+    {
+      "label": "explicit-id assertion through scorers",
+      "snapshot": {
+        "hash": "f7288a70e1a8987ba28d3180a3af64158c1b5fcf18580ea094751d419ce4a940",
+        "definitions": [
+          {
+            "scorerId": "legacy:test",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "4e671f4627b3d66accaebabc6df72885a59c9f9adc9db9e47af371210468015c",
+            "label": "test()",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "tool-match",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "0bc72b69047c95a508d975471f9cb330b2fe2137eea30fcba8e425f087613b74",
+            "label": "expected tool calls",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "nonempty-answer",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "f86dfa9ba537434b159ed77202eaf1ae197646e371191b32c91a1cb11dbf1ae8",
+            "label": "finalAssistantMessageNonEmpty",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          }
+        ]
+      }
+    },
+    {
+      "label": "expectations plus assertions — full definition order",
+      "snapshot": {
+        "hash": "76eca85134772e209966feebf87c2c5512881e5aab7e8e03331d85e40a42d715",
+        "definitions": [
+          {
+            "scorerId": "legacy:test",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "4e671f4627b3d66accaebabc6df72885a59c9f9adc9db9e47af371210468015c",
+            "label": "test()",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "tool-match",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "cb2b50310076a4af5a83abe0b96ab7f405e013845d464361bf969c98fa84697d",
+            "label": "expected tool calls",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "predicate:responseContains#0",
+            "idSource": "generated",
+            "scorerVersion": "1",
+            "implementationHash": "1ed825dd8c4484fa231d4b04177afae713ed9ab60de848091d076ea2af8d00e1",
+            "label": "responseContains",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "custom:tone",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "fixedhash-tone-v1",
+            "label": "tone",
+            "deterministic": false,
+            "passThreshold": 0.7,
+            "role": "advisory",
+            "model": "anthropic/claude-sonnet-4-6",
+            "onError": "ignore",
+            "onSkipped": "ignore"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sdk/tests/fixtures/evaluator-vocabulary-golden.json
+++ b/sdk/tests/fixtures/evaluator-vocabulary-golden.json
@@ -1,5 +1,5 @@
 {
-  "__readme": "Golden EvaluationConfigSnapshots captured from UNCHANGED code before the evaluator-vocabulary program. Each row is an authored case and the snapshot it must keep producing, however it is authored. The test asserts deep equality AND each definition's scorerId/idSource literally, so an ordinal shift fails even when the aggregate hash coincidentally matches. NEVER regenerate this file to make a rename pass — a green test bought by editing both the producer and the expected payload proves nothing.",
+  "__readme": "Golden EvaluationConfigSnapshots captured from UNCHANGED code before the evaluator-vocabulary program. Each row is an authored case and the snapshot it must keep producing, however it is authored. The test asserts deep equality AND each definition's scorerId/idSource literally, so an ordinal shift fails even when the aggregate hash coincidentally matches. Two rows exist specifically to close holes a reviewer found: an ANONYMOUS assertion, whose id is derived from rule content rather than position, and a REAL judge built through judgeScorer, whose implementationHash covers the rubric, the prompt template version and the model. Without the second, a later judge() could change the template version and leave this whole gate green. NEVER regenerate this file to make a rename pass — a green test bought by editing both the producer and the expected payload proves nothing.",
   "cases": [
     {
       "label": "bare test — no expectations, no assertions",
@@ -269,6 +269,94 @@
             "scorerVersion": "1",
             "implementationHash": "fixedhash-tone-v1",
             "label": "tone",
+            "deterministic": false,
+            "passThreshold": 0.7,
+            "role": "advisory",
+            "model": "anthropic/claude-sonnet-4-6",
+            "onError": "ignore",
+            "onSkipped": "ignore"
+          }
+        ]
+      }
+    },
+    {
+      "label": "anonymous assertion through scorers — the content-derived id",
+      "snapshot": {
+        "hash": "b63baf9e34749dffa1a9ecab0cdf70028f1a6211460ed4b8138b0e27632b623e",
+        "definitions": [
+          {
+            "scorerId": "legacy:test",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "4e671f4627b3d66accaebabc6df72885a59c9f9adc9db9e47af371210468015c",
+            "label": "test()",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "tool-match",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "0bc72b69047c95a508d975471f9cb330b2fe2137eea30fcba8e425f087613b74",
+            "label": "expected tool calls",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "predicate:responseContains#1ed825dd8c4484fa231d4b04177afae713ed9ab60de848091d076ea2af8d00e1",
+            "idSource": "generated",
+            "scorerVersion": "1",
+            "implementationHash": "1ed825dd8c4484fa231d4b04177afae713ed9ab60de848091d076ea2af8d00e1",
+            "label": "responseContains",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          }
+        ]
+      }
+    },
+    {
+      "label": "a real judge — the rubric-and-template implementation hash",
+      "snapshot": {
+        "hash": "f6a6f4dfd7b4bc6a1c3bb9b14ae06b637088e0f5cb4bf53de6542446f598d2fd",
+        "definitions": [
+          {
+            "scorerId": "legacy:test",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "4e671f4627b3d66accaebabc6df72885a59c9f9adc9db9e47af371210468015c",
+            "label": "test()",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "tool-match",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "0bc72b69047c95a508d975471f9cb330b2fe2137eea30fcba8e425f087613b74",
+            "label": "expected tool calls",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "policy-grounding",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "0a46637f7717d8fd081781c851b614d4ef166ad72ee527b644b706d985be1aa1",
             "deterministic": false,
             "passThreshold": 0.7,
             "role": "advisory",

--- a/sdk/tests/fixtures/evaluator-vocabulary-golden.json
+++ b/sdk/tests/fixtures/evaluator-vocabulary-golden.json
@@ -31,6 +31,10 @@
             "onSkipped": "fail"
           }
         ]
+      },
+      "definitionHashes": {
+        "legacy:test": "0f4b9ae5b9454b551b2912b600281d1a775bc44e934e85789aa8900e5663d419",
+        "tool-match": "f5affa564f8de34a4e82babb20f56a103f87e14a9614c89f1a40db58e15bafa8"
       }
     },
     {
@@ -87,6 +91,12 @@
             "onSkipped": "fail"
           }
         ]
+      },
+      "definitionHashes": {
+        "legacy:test": "0f4b9ae5b9454b551b2912b600281d1a775bc44e934e85789aa8900e5663d419",
+        "tool-match": "f5affa564f8de34a4e82babb20f56a103f87e14a9614c89f1a40db58e15bafa8",
+        "predicate:responseContains#0": "da6cd5a26eee784397deb98a0c4cbe32c7b2165f36a34a8bcca0ac39d8a9b6b8",
+        "predicate:responseContains#1": "d3c409bad88cc115bb475276a75cf3f15653da0152144b0d4e913412a0c6dc53"
       }
     },
     {
@@ -144,6 +154,12 @@
             "onSkipped": "ignore"
           }
         ]
+      },
+      "definitionHashes": {
+        "legacy:test": "0f4b9ae5b9454b551b2912b600281d1a775bc44e934e85789aa8900e5663d419",
+        "tool-match": "f5affa564f8de34a4e82babb20f56a103f87e14a9614c89f1a40db58e15bafa8",
+        "predicate:noToolErrors#0": "9fd34dbc6b93d7dc6e875acd4b3780e0750fe089a6b905640a313cd19cd6e761",
+        "custom:tone": "29230ae73e8c4b37d82225c8a58ead849670c264bc1176a73eea68738c177477"
       }
     },
     {
@@ -176,6 +192,10 @@
             "onSkipped": "fail"
           }
         ]
+      },
+      "definitionHashes": {
+        "legacy:test": "0f4b9ae5b9454b551b2912b600281d1a775bc44e934e85789aa8900e5663d419",
+        "tool-match": "e9b710ee70d13190fef7cb2b50e1c1b2ea8b5b65f20eba04e0c1edf1282ea371"
       }
     },
     {
@@ -220,6 +240,11 @@
             "onSkipped": "fail"
           }
         ]
+      },
+      "definitionHashes": {
+        "legacy:test": "0f4b9ae5b9454b551b2912b600281d1a775bc44e934e85789aa8900e5663d419",
+        "tool-match": "f5affa564f8de34a4e82babb20f56a103f87e14a9614c89f1a40db58e15bafa8",
+        "nonempty-answer": "7267a47502b7602592686763bec8bb47f69b3b828bb0c533f9873de3715345bc"
       }
     },
     {
@@ -277,6 +302,12 @@
             "onSkipped": "ignore"
           }
         ]
+      },
+      "definitionHashes": {
+        "legacy:test": "0f4b9ae5b9454b551b2912b600281d1a775bc44e934e85789aa8900e5663d419",
+        "tool-match": "ab68d407a37f43be3561e7107fc19e21482cb0fb171024fe69934d9b207d853f",
+        "predicate:responseContains#0": "da6cd5a26eee784397deb98a0c4cbe32c7b2165f36a34a8bcca0ac39d8a9b6b8",
+        "custom:tone": "29230ae73e8c4b37d82225c8a58ead849670c264bc1176a73eea68738c177477"
       }
     },
     {
@@ -321,6 +352,11 @@
             "onSkipped": "fail"
           }
         ]
+      },
+      "definitionHashes": {
+        "legacy:test": "0f4b9ae5b9454b551b2912b600281d1a775bc44e934e85789aa8900e5663d419",
+        "tool-match": "f5affa564f8de34a4e82babb20f56a103f87e14a9614c89f1a40db58e15bafa8",
+        "predicate:responseContains#1ed825dd8c4484fa231d4b04177afae713ed9ab60de848091d076ea2af8d00e1": "97c28bd1f7bded0043ee80309c4910427ec308692176d7ab78cd38c4d9ce9462"
       }
     },
     {
@@ -365,6 +401,60 @@
             "onSkipped": "ignore"
           }
         ]
+      },
+      "definitionHashes": {
+        "legacy:test": "0f4b9ae5b9454b551b2912b600281d1a775bc44e934e85789aa8900e5663d419",
+        "tool-match": "f5affa564f8de34a4e82babb20f56a103f87e14a9614c89f1a40db58e15bafa8",
+        "policy-grounding": "de56f2e2378b0650e36078dc622e6607f696185be6dda330778ad95a541da0c4"
+      }
+    },
+    {
+      "label": "anonymous assertion carrying policy — the id keeps it, the implementation hash does not",
+      "snapshot": {
+        "hash": "c0aba0445ba5bb9eaea107789b233753ee920a7d20779aaf9ab506fe9c95dd70",
+        "definitions": [
+          {
+            "scorerId": "legacy:test",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "4e671f4627b3d66accaebabc6df72885a59c9f9adc9db9e47af371210468015c",
+            "label": "test()",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "tool-match",
+            "idSource": "explicit",
+            "scorerVersion": "1",
+            "implementationHash": "0bc72b69047c95a508d975471f9cb330b2fe2137eea30fcba8e425f087613b74",
+            "label": "expected tool calls",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "gating",
+            "onError": "fail",
+            "onSkipped": "fail"
+          },
+          {
+            "scorerId": "predicate:responseContains#f54cf792125b3846651c875cae4d417bb1adf5d6dab0992cca5f661142c6d779",
+            "idSource": "generated",
+            "scorerVersion": "1",
+            "implementationHash": "1ed825dd8c4484fa231d4b04177afae713ed9ab60de848091d076ea2af8d00e1",
+            "label": "responseContains",
+            "deterministic": true,
+            "passThreshold": 1,
+            "role": "advisory",
+            "onError": "ignore",
+            "onSkipped": "ignore"
+          }
+        ]
+      },
+      "definitionHashes": {
+        "legacy:test": "0f4b9ae5b9454b551b2912b600281d1a775bc44e934e85789aa8900e5663d419",
+        "tool-match": "f5affa564f8de34a4e82babb20f56a103f87e14a9614c89f1a40db58e15bafa8",
+        "predicate:responseContains#f54cf792125b3846651c875cae4d417bb1adf5d6dab0992cca5f661142c6d779": "ad7d80e1d880145d3a0ca1908d63dd120dfc80754f915631ad192541adffb07b"
       }
     }
   ]


### PR DESCRIPTION
The contract every later step in the evaluator-vocabulary program implements, plus the fixture that stops any of them from changing an identity by accident.

## Why this is a pin, not a proposal

One deterministic grading rule travels under three names: `checks` on the public API and the UI, `predicates` in Convex storage and the SDK, `assertions` in the backend's own suite-file contract — which already disagrees with the SDK's, where `checks` is canonical and `assertions` is the deprecated alias. The configured execution count travels under three: `repetitions`, `runs`, `iterations`; the contract keeps `repetitions` as its canonical name (as #4774 made it for the CLI) and uses `iteration` only for one execution. Four authoring entry points converge on one `ScoreResult` without saying so anywhere.

A stack of PRs across two repositories cannot agree with itself by remembering. `docs/evals-vocabulary-consolidation.md` is what each later step cites instead of re-deciding: the target model, the public symbol map, the `EvaluatorResult` field mapping, the authoring semantics with their exact refusal messages, the wire negotiation, and the compatibility posture.

## The half that matters more than the naming

Most of the document is what may **not** move. Evaluator identities, the eleven-field `definitionHash` payload, `evaluationConfigHash`, the backend's config-revision keys and its eight-field escape hatch, `measurementUnit: "trial"`, the verdict-policy trial counters, and every historical row stay exactly as they are. Canonical names are a projection over those payloads, never a new one.

`RECOMMENDED_DEFAULT_PREDICATES` gets its own paragraph because it is the trap. The backend pins it through a whole-file `capture` of its three `{type, role, severity}` triples, and the checker hashes what the capture matched. Moving the literal to a new file would make that capture match nothing — and a capture that matches nothing hashes to a stable empty string, so the pin goes green forever exactly when it stops watching anything. The stage tables move; the seed stays where it is.

Also written down: the five protected vocabularies this program must not touch. GitHub check runs, protocol and conformance checks, SAML identity assertions, billing trials, and the evaluator-**error** family — which already uses the word this program is adopting, for something else.

## The fixture

`sdk/tests/fixtures/evaluator-vocabulary-golden.json` holds the `EvaluationConfigSnapshot` eight authored cases produce **today**, captured by running unchanged code. Later steps add a canonical builder beside each legacy one and assert both against the same row, which turns "the new facade is the same evaluation" from a claim in a PR body into something the suite checks.

It asserts each evaluator id and id source literally as well as deep-equality. The aggregate hash sorts its inputs, so two configurations renumbered against each other could agree on it while disagreeing about which rule is `#0` — and a generated id is positional by construction, which is why a gate refuses to select one. The ids are what a later reader joins on, so they get their own assertion.

The eight cases cover the corners that would otherwise be found late: a bare test, two assertions of the same type (distinct ordinals), a custom non-deterministic evaluator beside deterministic ones, a negative case where tool-match is applicable with no expectations configured, an explicit-id assertion, the full definition order, an anonymous assertion's content-derived id, and a real judge's hash.

**Regenerating it to make a later change pass proves nothing.** A green test bought by editing the producer and the expected payload together has tested neither. If a change there is ever genuinely intended it is an identity change, it resets baseline comparability for every existing suite, and it belongs in its own PR with that consequence stated.

## Verification

```
npm run test -w @mcpjam/sdk    # 7706 passed, 8 skipped
```

The golden suite is 23 tests over the 8 rows. No source file changes, so no changeset: this is a document and a test.

One thing worth flagging for whoever reviews the rest of the stack. `tests/suite-gate.test.ts` fails on a fresh checkout with `Failed to resolve entry for package "@mcpjam/sdk"` — it imports the bare package, which resolves to `dist`, and nothing in `npm ci` builds it. `npm run build -w @mcpjam/sdk` first. That is not new here and not caused by this PR; it is the trap that will eat the next person's afternoon.

## Could not verify without a deployment

The code changes nothing at runtime, but the contract rests on claims only production can confirm:

- **The measured eval population.** The compatibility posture leans on the eval commands being a ~100-person population with essentially no pinned CI. That is a production usage measurement, not something this branch can check.
- **The public API's preview status.** Deleting old spellings at the end of the rollout assumes the API is still documented and treated as preview when that happens.
- **The cross-repo rollout ordering.** Deploys across the inspector and the backend are not atomic, so the expand, migrate, contract sequence has to be observed in the order the deployments actually land.
- **The `docs/.mintignore` exclusion.** The Mintlify deployment check is skipped on pull requests, so only the next docs deploy from `main` shows `/evals-vocabulary-consolidation` returning 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvZCeGPgmLoWnRyzM3XoCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvZCeGPgmLoWnRyzM3XoCU)_

## Update: `iterations` is the configured count

`repetitions` is the **legacy** spelling. An earlier commit on this branch kept it canonical on a misreading of #4774; `292ae485e6` reverses that. The configured count is `iterations`, the flag `--iterations`, and `--max-trials` becomes `--max-iterations`. `iteration`, singular, still names one execution.

Two guards come with it:

- **The hash key stays frozen.** The literal `repetitions` key inside `convex/lib/evalConfigRevision.ts` keeps its spelling after the rename, like `predicates`, so no suite's revision identity moves (invariant 3, and a new protected-vocabulary entry).
- **Legacy field first.** The public API case field `iterations` already means the legacy per-case count, read as a floor. It becomes `legacyIterations` in its own step **before** `iterations` may mean the configured count. The wire section and the capability field map spell out which name means what under each vocabulary.

The companion scanner change is on #4983.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and regression tests only; no runtime paths change. The contract itself governs future eval API and identity work, which will be higher risk when implemented.
> 
> **Overview**
> Adds the **pinned contract** for the evaluator-vocabulary program (`docs/evals-vocabulary-consolidation.md`) and keeps it off the public docs site via `docs/.mintignore`.
> 
> The document is what later implementation PRs cite: target terms (`iterations` as configured count, `legacyIterations` for the floor, `assertion`/`judge`/`evaluator`), symbol map, wire negotiation (`x-mcpjam-eval-vocabulary`), authoring rules, and **invariants that must not move** (evaluator ids, `definitionHash` payload, frozen Convex revision keys, historical rows).
> 
> Adds an SDK **golden gate**: `evaluator-vocabulary-golden.test.ts` plus a fixture of nine legacy `EvalTest` cases. Current `getEvaluationConfigSnapshot()` output must match exactly—snapshots, per-definition hashes, and literal `scorerId`/ordinals—including reserved-id refusals and judge/content-derived id edge cases. No production or SDK source behavior changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a84bdc4b286270b178f05ca104d3d65b04d03601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the evaluator-vocabulary contract and adds a golden test that enforces it, so the rename stack across both repos cannot change evaluator identities by accident. No runtime behavior changes, so no changeset.

The contract (`docs/evals-vocabulary-consolidation.md`, kept off the docs site via `docs/.mintignore`) fixes the target model: `iterations` is the configured count with `repetitions` and `runs` as legacy spellings, `iteration` is one execution, and a deterministic rule that today travels as `checks`/`predicates`/`assertions` becomes `assertion`.

What a rename may not move is the larger half: evaluator ids, the eleven-field `definitionHash` payload, `evaluationConfigHash`, the frozen `repetitions`/`predicates` config-revision keys, `measurementUnit: "trial"`, verdict-policy trial counters, and every historical row. `RECOMMENDED_DEFAULT_PREDICATES` stays in its file because the backend pins it with a whole-file capture; moving it would make the capture match nothing and hash to a stable empty string.

The golden fixture records the nine `EvaluationConfigSnapshot` rows authored cases produce today, including a real judge, an anonymous assertion (id `predicate:<type>#<sha256>`), and a policy-bearing anonymous assertion whose id digests the whole rule while its implementation hash strips `role`/`severity`. The test asserts each definition hash, evaluator id, and id source literally and deeply, because the aggregate hash sorts inputs and generated ids are positional. Regenerating the fixture to make a change pass proves nothing.

Resolution matches the backend's `resolvePredicates`: no bare-array shorthand, `inherit` ignores the case list, and the effective assertion list is suite defaults, then `config.predicates`, then the case's own.

The wire negotiation is pinned so two implementations cannot disagree on one body: a headerless request is byte-for-byte today's request including its refusals, vocabulary 2 accepts canonical plus legacy spellings but refuses any two together, and a CREATE naming no count stores `runs` as 1 — matching today's `Math.max(1, Math.floor(runs ?? 1))`, not the suite default, so one authored configuration never mints two revisions. `legacyIterations` is the floor field's vocabulary-2 name, accepted nowhere else.

Known pre-existing trap: `tests/suite-gate.test.ts` fails on a fresh checkout with `Failed to resolve entry for package "@mcpjam/sdk"` until you run `npm run build -w @mcpjam/sdk` first.

<sup>Written for commit a84bdc4b286270b178f05ca104d3d65b04d03601. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

