### PR TITLE
Send an SDK user-agent by default, and record the caller's

### DIFF
--- a/.changeset/sdk-default-user-agent.md
+++ b/.changeset/sdk-default-user-agent.md
@@ -1,5 +1,5 @@
 ---
-"@mcpjam/sdk": patch
+"@mcpjam/sdk": minor
 "@mcpjam/inspector": patch
 ---
 
@@ -11,12 +11,23 @@ version?". That is not a gap in the telemetry: Axiom carries every request. It
 is a field nobody populated, and the cost is that decisions about this surface
 get argued from reasoning instead of settled from data.
 
-The client now sends `mcpjam-sdk/<version>` by default. A caller's own token is
-prefixed rather than replaced, so the CLI identifies as
-`mcpjam-cli/5.7.1 mcpjam-sdk/8.7.1` — which program is calling and which SDK it
-links. Losing the second was the problem; losing the first would trade one blind
-spot for another. A consumer that bundles the SDK from source with no version
-injected reports `mcpjam-sdk/unknown`, which is the honest answer.
+Outside a browser, `PlatformApiClient` now sends `mcpjam-sdk/<version>` by
+default, and the new `DEFAULT_PLATFORM_USER_AGENT` export holds that value.
+
+**This changes what goes on the wire for callers that already set `userAgent`.**
+` mcpjam-sdk/<version>` is now appended to the value they supply, so the CLI
+sends `mcpjam-cli/5.7.1 mcpjam-sdk/8.7.1` instead of `mcpjam-cli/5.7.1`, and the
+MCP worker sends `mcpjam-mcp-worker/0.2.0 mcpjam-sdk/8.7.1` instead of
+`mcpjam-mcp-worker/0.2.0`. Any filter that matches the old string exactly, or
+anchors it at the end, stops matching. A consumer that bundles the SDK from
+source with no version injected reports `mcpjam-sdk/unknown`.
+
+In a browser page (a global `window` and `document`) nothing changes: no default
+is sent, and a supplied `userAgent` goes out unchanged. Chromium drops a
+script-set `User-Agent`, but Firefox sends it, and a page usually bundles the
+SDK from source, so a default there would log browser users as
+`mcpjam-sdk/unknown`. Node, Bun, Deno and Cloudflare Workers still send the
+default; they have `navigator` but no `document`.
 
 The inspector records the header on its request-log rows, sanitized and capped
 at 256 characters. It is a log field and nothing may branch on it: a user-agent

--- a/.changeset/sdk-default-user-agent.md
+++ b/.changeset/sdk-default-user-agent.md
@@ -1,0 +1,24 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/inspector": patch
+---
+
+Identify the SDK in every platform request, and record the caller's user-agent.
+
+The SDK sent a `user-agent` only when the caller supplied one, and most callers
+do not — so the request logs cannot answer "who is on the SDK, and on which
+version?". That is not a gap in the telemetry: Axiom carries every request. It
+is a field nobody populated, and the cost is that decisions about this surface
+get argued from reasoning instead of settled from data.
+
+The client now sends `mcpjam-sdk/<version>` by default. A caller's own token is
+prefixed rather than replaced, so the CLI identifies as
+`mcpjam-cli/5.7.1 mcpjam-sdk/8.7.1` — which program is calling and which SDK it
+links. Losing the second was the problem; losing the first would trade one blind
+spot for another. A consumer that bundles the SDK from source with no version
+injected reports `mcpjam-sdk/unknown`, which is the honest answer.
+
+The inspector records the header on its request-log rows, sanitized and capped
+at 256 characters. It is a log field and nothing may branch on it: a user-agent
+is caller-supplied text, and this server already removed UA-derived attribution
+once for exactly that reason.

--- a/mcpjam-inspector/server/middleware/__tests__/request-log-context.middleware.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/request-log-context.middleware.test.ts
@@ -59,6 +59,84 @@ describe("requestLogContextMiddleware", () => {
     expect(capturedCtx.environment).toBeDefined();
   });
 
+  it("records the caller's user-agent", async () => {
+    const app = createTestApp();
+    let capturedCtx: any;
+    app.get("/api/web/test", (c) => {
+      capturedCtx = c.var.requestLogContext;
+      return c.json({ ok: true });
+    });
+
+    await app.request("/api/web/test", {
+      headers: { "user-agent": "mcpjam-cli/5.7.1 mcpjam-sdk/8.7.1" },
+    });
+
+    expect(capturedCtx.userAgent).toBe("mcpjam-cli/5.7.1 mcpjam-sdk/8.7.1");
+  });
+
+  it("omits the field when the caller sent no user-agent", async () => {
+    const app = createTestApp();
+    let capturedCtx: any;
+    app.get("/api/web/test", (c) => {
+      capturedCtx = c.var.requestLogContext;
+      return c.json({ ok: true });
+    });
+
+    await app.request("/api/web/test", { method: "GET" });
+
+    // Omitted, not defaulted: a caller who sent none is not an "unknown
+    // client", and a row that says so would be counted as one.
+    expect(capturedCtx).not.toHaveProperty("userAgent");
+  });
+
+  it("flattens tabs and whitespace runs into single spaces", async () => {
+    const app = createTestApp();
+    let capturedCtx: any;
+    app.get("/api/web/test", (c) => {
+      capturedCtx = c.var.requestLogContext;
+      return c.json({ ok: true });
+    });
+
+    // Tabs are legal in a header value, so they are what actually reaches the
+    // sanitizer. NUL and CRLF — the characters that would forge a log line —
+    // are rejected by the HTTP parser before this middleware runs, which is
+    // why there is no test for them here: it could only assert that the
+    // platform still does its job.
+    await app.request("/api/web/test", {
+      headers: { "user-agent": "agent/1.0\t\tbuild   42" },
+    });
+
+    expect(capturedCtx.userAgent).toBe("agent/1.0 build 42");
+  });
+
+  it("caps an unbounded user-agent rather than indexing all of it", async () => {
+    const app = createTestApp();
+    let capturedCtx: any;
+    app.get("/api/web/test", (c) => {
+      capturedCtx = c.var.requestLogContext;
+      return c.json({ ok: true });
+    });
+
+    await app.request("/api/web/test", {
+      headers: { "user-agent": "a".repeat(4096) },
+    });
+
+    expect(capturedCtx.userAgent).toHaveLength(256);
+  });
+
+  it("treats a blank user-agent as none at all", async () => {
+    const app = createTestApp();
+    let capturedCtx: any;
+    app.get("/api/web/test", (c) => {
+      capturedCtx = c.var.requestLogContext;
+      return c.json({ ok: true });
+    });
+
+    await app.request("/api/web/test", { headers: { "user-agent": "   " } });
+
+    expect(capturedCtx).not.toHaveProperty("userAgent");
+  });
+
   it("sets x-request-id response header via c.header()", async () => {
     const app = createTestApp();
     app.get("/api/web/test", (c) => c.json({ ok: true }));

--- a/mcpjam-inspector/server/middleware/request-log-context.ts
+++ b/mcpjam-inspector/server/middleware/request-log-context.ts
@@ -34,6 +34,34 @@ function isHealthPath(path: string): boolean {
 // mint a fresh UUID.
 const REQUEST_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
 
+/**
+ * Make a caller-supplied user-agent safe to put in a log row.
+ *
+ * Two hazards and a distinction, the same shape as the `x-request-id` guard
+ * above. An unbounded string bloats every row and the backend's index with it —
+ * real agents send a few dozen characters, and a four-kilobyte tail is either a
+ * bug or an attempt. Tabs and whitespace runs make one agent read as several in
+ * a group-by, which is the whole reason to record the field. And an empty
+ * header is not a user-agent; it is a caller who sent none, which the row says
+ * by omitting the field rather than by carrying a blank one.
+ *
+ * The control-character strip is the SECOND line, not the only one: NUL and
+ * CRLF — the characters that would let a caller forge a log line — are rejected
+ * by the HTTP parser before this middleware ever runs. It stays because a
+ * sanitizer that depends on an upstream layer staying strict is one deploy away
+ * from being wrong.
+ */
+function sanitizeUserAgent(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const cleaned = raw
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 256);
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
 function isStreaming(c: Context): boolean {
   const ct = c.res.headers.get("content-type") ?? "";
   if (ct.includes("text/event-stream")) return true;
@@ -48,6 +76,7 @@ export async function requestLogContextMiddleware(c: Context, next: Next) {
   }
 
   const startedAt = Date.now();
+  const userAgent = sanitizeUserAgent(c.req.header("user-agent"));
   const inboundRequestId = c.req.header("x-request-id");
   const requestId =
     inboundRequestId && REQUEST_ID_PATTERN.test(inboundRequestId)
@@ -65,6 +94,7 @@ export async function requestLogContextMiddleware(c: Context, next: Next) {
     route: "pending",
     method: c.req.method,
     authType: "unknown",
+    ...(userAgent ? { userAgent } : {}),
   };
 
   c.set("requestLogContext", baseContext);

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -75,6 +75,19 @@ export interface RequestLogContext extends CommonLogContext {
   requestId: string;
   route: string;
   method: string;
+  /**
+   * The caller's `user-agent`, sanitized and capped.
+   *
+   * A LOG FIELD, never an identity. It is caller-supplied text: this server
+   * already removed UA-derived attribution once because a client can write
+   * whatever it likes there, and re-introducing it here is only safe while
+   * nothing branches on it.
+   *
+   * Omitted rather than defaulted when the header is absent — a row with no
+   * user-agent is a caller that sent none, which is not the same claim as
+   * "unknown client" and should not be counted as one.
+   */
+  userAgent?: string;
 }
 
 export interface SystemLogContext extends CommonLogContext {

--- a/sdk/src/conformance-profile.ts
+++ b/sdk/src/conformance-profile.ts
@@ -43,44 +43,13 @@
 
 import { sha256 } from "@noble/hashes/sha2.js";
 import { bytesToHex, utf8ToBytes } from "@noble/hashes/utils.js";
+import { readSdkVersion } from "./sdk-version.js";
 import { MCP_CHECK_IDS, type MCPCheckId } from "./mcp-conformance/types.js";
 import {
   MCP_TASKS_CHECK_IDS,
   type MCPTasksCheckId,
 } from "./tasks-conformance/types.js";
 
-/** Injected by tsup/vitest `define` (see `sdk/tsup.config.ts`). */
-declare const __MCPJAM_SDK_VERSION__: string;
-
-/**
- * Read the injected version WITHOUT assuming the injection happened.
- *
- * This module is reachable from the browser entry, and the inspector's Vite
- * build aliases `@mcpjam/sdk/browser` straight to `src/browser.ts` — so it
- * compiles this file from SOURCE, with no `define` of its own. A bare
- * `__MCPJAM_SDK_VERSION__` reference then survives into the client bundle as an
- * undeclared global and throws `ReferenceError` at module init, which takes the
- * whole app down before React mounts. (It did: every Playwright smoke test
- * failed on a missing app shell.)
- *
- * `typeof` on an undeclared identifier is the one read that cannot throw, so a
- * consumer that bundles this from source degrades to `"unknown"` instead of
- * crashing. `"unknown"` is deliberate rather than a plausible-looking version:
- * a stamp claiming a version nobody injected would be worse than one admitting
- * it does not know.
- */
-function readSdkVersion(): string {
-  return typeof __MCPJAM_SDK_VERSION__ === "string"
-    ? __MCPJAM_SDK_VERSION__
-    : "unknown";
-}
-
-/**
- * The build that produced a result. Distinct from the profile version on
- * purpose: a patch that fixes a check's ASSERTION moves this and not the
- * profile, and that difference is exactly what a reader needs to tell "the
- * server changed" from "we fixed a false positive".
- */
 export const CONFORMANCE_CHECKER_VERSION = readSdkVersion();
 
 /**

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -173,7 +173,14 @@ export interface PlatformApiClientOptions {
    * A token naming the calling PROGRAM, prefixed onto this client's own
    * `mcpjam-sdk/<version>` rather than replacing it — see
    * {@link DEFAULT_PLATFORM_USER_AGENT}. Omit it and the SDK still identifies
-   * itself. Ignored by browsers, where the header is forbidden.
+   * itself outside a browser.
+   *
+   * In a browser (a global `window` and `document`) neither the suffix nor the
+   * default is added, and a value given here is sent as-is. Browsers disagree
+   * on the header: Chromium silently drops a script-set `User-Agent`, but
+   * Firefox sends it, because the Fetch spec no longer forbids it. A page
+   * usually bundles the SDK from source, where the version is `unknown`, so a
+   * default there would only log browser users as `mcpjam-sdk/unknown`.
    */
   userAgent?: string;
   /**
@@ -518,6 +525,21 @@ function stripTrailingSlashes(url: string): string {
  */
 export const DEFAULT_PLATFORM_USER_AGENT = `mcpjam-sdk/${readSdkVersion()}`;
 
+/**
+ * Whether this client is running in a browser page, where the default
+ * user-agent must not be sent (see {@link PlatformApiClientOptions.userAgent}).
+ *
+ * Keyed on `window` AND `document`, never on `navigator`: Node 21+, Deno, Bun
+ * and Cloudflare Workers all define `navigator` (in Workers its `userAgent` is
+ * `"Cloudflare-Workers"`), and none of them has a `document`. Requiring both
+ * also keeps Deno 1.x, which defined `window` but no `document`, on the
+ * server side.
+ */
+function isBrowserPage(): boolean {
+  const scope = globalThis as { window?: unknown; document?: unknown };
+  return scope.window !== undefined && scope.document !== undefined;
+}
+
 export class PlatformApiClient {
   private readonly baseUrl: string;
   private readonly getAuth: () => string | Promise<string>;
@@ -545,9 +567,11 @@ export class PlatformApiClient {
     // client instance, which throws "Illegal invocation" in Workers/browsers.
     this.fetchFn = options.fetch ?? fetch.bind(globalThis);
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    this.userAgent = options.userAgent
-      ? `${options.userAgent} ${DEFAULT_PLATFORM_USER_AGENT}`
-      : DEFAULT_PLATFORM_USER_AGENT;
+    this.userAgent = isBrowserPage()
+      ? options.userAgent
+      : options.userAgent
+        ? `${options.userAgent} ${DEFAULT_PLATFORM_USER_AGENT}`
+        : DEFAULT_PLATFORM_USER_AGENT;
     this.launchHeaders = buildLaunchHeaders(options);
     // Lower-cased at construction so `request` cannot end up with two spellings
     // of one header — HTTP names are case-insensitive, but a plain object's

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -1,6 +1,7 @@
 import type { PlatformSessionBrowserBodies, PlatformSessionBrowserResults } from "./types.js";
 import type { PlatformSessionBrowserInput, PlatformSessionBrowserOperation, PlatformSessionBrowserOpened, PlatformBrowserToolPolicy } from "./types.js";
 import { PlatformApiError } from "./errors.js";
+import { readSdkVersion } from "../sdk-version.js";
 import type {
   PlatformScenarioSummary,
   PlatformScenarioDetail,
@@ -168,7 +169,12 @@ export interface PlatformApiClientOptions {
   fetch?: typeof fetch;
   /** Per-request timeout. */
   timeoutMs?: number;
-  /** Optional User-Agent; ignored by browsers (forbidden header). */
+  /**
+   * A token naming the calling PROGRAM, prefixed onto this client's own
+   * `mcpjam-sdk/<version>` rather than replacing it — see
+   * {@link DEFAULT_PLATFORM_USER_AGENT}. Omit it and the SDK still identifies
+   * itself. Ignored by browsers, where the header is forbidden.
+   */
   userAgent?: string;
   /**
    * Extra headers sent on every request — for a deployment that sits behind an
@@ -490,6 +496,28 @@ function stripTrailingSlashes(url: string): string {
   return url.slice(0, end);
 }
 
+/**
+ * What this client calls itself when the caller says nothing.
+ *
+ * It used to say nothing at all, which is why the question "who is on the SDK,
+ * and on which version?" has no answer in the request logs: the header was set
+ * only when a caller supplied one, and most callers do not. That absence is not
+ * a gap in the telemetry — Axiom carries every request — it is a field nobody
+ * populated, and the cost of it is that decisions about this surface get argued
+ * from reasoning rather than settled from data.
+ *
+ * A caller's own token is PREFIXED rather than replaced, so `mcpjam-cli/5.7.1
+ * mcpjam-sdk/8.7.1` says both which program is calling and which SDK it links.
+ * Losing the second was the whole problem; losing the first would trade one
+ * blind spot for another.
+ *
+ * NOT an identity claim, and nothing may treat it as one. A user-agent is
+ * caller-supplied text, this repository already removed UA-derived attribution
+ * once for exactly that reason, and re-introducing it as a log field is only
+ * safe while it stays a log field.
+ */
+export const DEFAULT_PLATFORM_USER_AGENT = `mcpjam-sdk/${readSdkVersion()}`;
+
 export class PlatformApiClient {
   private readonly baseUrl: string;
   private readonly getAuth: () => string | Promise<string>;
@@ -517,7 +545,9 @@ export class PlatformApiClient {
     // client instance, which throws "Illegal invocation" in Workers/browsers.
     this.fetchFn = options.fetch ?? fetch.bind(globalThis);
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    this.userAgent = options.userAgent;
+    this.userAgent = options.userAgent
+      ? `${options.userAgent} ${DEFAULT_PLATFORM_USER_AGENT}`
+      : DEFAULT_PLATFORM_USER_AGENT;
     this.launchHeaders = buildLaunchHeaders(options);
     // Lower-cased at construction so `request` cannot end up with two spellings
     // of one header — HTTP names are case-insensitive, but a plain object's

--- a/sdk/src/platform/index.ts
+++ b/sdk/src/platform/index.ts
@@ -18,6 +18,7 @@ export {
 
 export {
   DEFAULT_PLATFORM_API_BASE_URL,
+  DEFAULT_PLATFORM_USER_AGENT,
   PlatformApiClient,
   RUN_LAUNCH_HEADERS,
   type PlatformApiClientOptions,

--- a/sdk/src/sdk-version.ts
+++ b/sdk/src/sdk-version.ts
@@ -1,0 +1,25 @@
+/** Injected by tsup/vitest `define` (see `sdk/tsup.config.ts`). */
+declare const __MCPJAM_SDK_VERSION__: string;
+
+/**
+ * Read the injected version WITHOUT assuming the injection happened.
+ *
+ * Modules that call this are reachable from the browser entry, and the
+ * inspector's Vite build aliases `@mcpjam/sdk/browser` straight to
+ * `src/browser.ts` — so it compiles them from SOURCE, with no `define` of its
+ * own. A bare `__MCPJAM_SDK_VERSION__` reference then survives into the client
+ * bundle as an undeclared global and throws `ReferenceError` at module init,
+ * which takes the whole app down before React mounts. (It did: every Playwright
+ * smoke test failed on a missing app shell.)
+ *
+ * `typeof` on an undeclared identifier is the one read that cannot throw, so a
+ * consumer that bundles this from source degrades to `"unknown"` instead of
+ * crashing. `"unknown"` is deliberate rather than a plausible-looking version:
+ * a stamp claiming a version nobody injected would be worse than one admitting
+ * it does not know.
+ */
+export function readSdkVersion(): string {
+  return typeof __MCPJAM_SDK_VERSION__ === "string"
+    ? __MCPJAM_SDK_VERSION__
+    : "unknown";
+}

--- a/sdk/tests/platform/client.test.ts
+++ b/sdk/tests/platform/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_PLATFORM_API_BASE_URL,
   DEFAULT_PLATFORM_USER_AGENT,
@@ -398,6 +398,59 @@ describe("PlatformApiClient", () => {
     expect(header(0)).toBe(DEFAULT_PLATFORM_USER_AGENT);
     // Prefixed, not replaced: which program is calling AND which SDK it links.
     expect(header(1)).toBe(`mcpjam-cli/1.0 ${DEFAULT_PLATFORM_USER_AGENT}`);
+  });
+
+  describe("in a browser", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    const header = (fetchMock: FetchMock) =>
+      new Headers(requestOf(fetchMock, 0).init.headers as HeadersInit).get(
+        "user-agent"
+      );
+
+    it("sets no default user-agent where a page could send it", async () => {
+      // Firefox lets a script set `User-Agent` (the Fetch spec no longer
+      // forbids it), and the inspector bundles the SDK from source, where the
+      // version is `unknown` — so a default here would log every Firefox user
+      // as `mcpjam-sdk/unknown`.
+      vi.stubGlobal("window", {});
+      vi.stubGlobal("document", {});
+      const fetchMock = vi.fn(async () => jsonResponse({}));
+      await makeClient(fetchMock).getMe();
+
+      expect(header(fetchMock)).toBeNull();
+    });
+
+    it("still sends a caller's own user-agent unchanged", async () => {
+      vi.stubGlobal("window", {});
+      vi.stubGlobal("document", {});
+      const fetchMock = vi.fn(async () => jsonResponse({}));
+      await makeClient(fetchMock, { userAgent: "mcpjam-cli/1.0" }).getMe();
+
+      expect(header(fetchMock)).toBe("mcpjam-cli/1.0");
+    });
+
+    it("does not mistake a Workers runtime, which has only `navigator`, for one", async () => {
+      vi.stubGlobal("window", undefined);
+      vi.stubGlobal("document", undefined);
+      vi.stubGlobal("navigator", { userAgent: "Cloudflare-Workers" });
+      const fetchMock = vi.fn(async () => jsonResponse({}));
+      await makeClient(fetchMock).getMe();
+
+      expect(header(fetchMock)).toBe(DEFAULT_PLATFORM_USER_AGENT);
+    });
+
+    it("sends the default in Node", async () => {
+      expect(typeof (globalThis as { window?: unknown }).window).toBe(
+        "undefined"
+      );
+      const fetchMock = vi.fn(async () => jsonResponse({}));
+      await makeClient(fetchMock).getMe();
+
+      expect(header(fetchMock)).toBe(DEFAULT_PLATFORM_USER_AGENT);
+    });
   });
 
   it("names a version rather than claiming one it was not given", () => {

--- a/sdk/tests/platform/client.test.ts
+++ b/sdk/tests/platform/client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_PLATFORM_API_BASE_URL,
+  DEFAULT_PLATFORM_USER_AGENT,
   PlatformApiClient,
   PlatformApiError,
 } from "../../src/platform/index.js";
@@ -382,21 +383,30 @@ describe("PlatformApiClient", () => {
     expect(suiteRuns.searchParams.get("limit")).toBe("10");
   });
 
-  it("sets a user-agent header only when configured", async () => {
+  it("identifies the SDK by default, and keeps the caller's own token", async () => {
     const fetchMock = vi.fn(async () => jsonResponse({}));
     await makeClient(fetchMock).getMe();
     await makeClient(fetchMock, { userAgent: "mcpjam-cli/1.0" }).getMe();
 
-    expect(
-      new Headers(requestOf(fetchMock, 0).init.headers as HeadersInit).get(
+    const header = (index: number) =>
+      new Headers(requestOf(fetchMock, index).init.headers as HeadersInit).get(
         "user-agent"
-      )
-    ).toBeNull();
-    expect(
-      new Headers(requestOf(fetchMock, 1).init.headers as HeadersInit).get(
-        "user-agent"
-      )
-    ).toBe("mcpjam-cli/1.0");
+      );
+
+    // It used to send nothing here, which is why "who is on the SDK, and on
+    // which version?" had no answer in the request logs.
+    expect(header(0)).toBe(DEFAULT_PLATFORM_USER_AGENT);
+    // Prefixed, not replaced: which program is calling AND which SDK it links.
+    expect(header(1)).toBe(`mcpjam-cli/1.0 ${DEFAULT_PLATFORM_USER_AGENT}`);
+  });
+
+  it("names a version rather than claiming one it was not given", () => {
+    // `unknown` is the honest answer when a consumer bundles the SDK from
+    // source with no `define` — a stamp asserting a version nobody injected
+    // would be worse than one admitting it does not know.
+    expect(DEFAULT_PLATFORM_USER_AGENT).toMatch(
+      /^mcpjam-sdk\/(unknown|\d+\.\d+\.\d+.*)$/
+    );
   });
 
   it("maps wire error envelopes onto PlatformApiError", async () => {


### PR DESCRIPTION
The SDK set a `user-agent` only when the caller supplied one, and most callers do not. So the request logs cannot answer "who is on the SDK, and on which version?".

That is not a gap in the telemetry — Axiom carries every request. It is a field nobody populated, and the cost is that decisions about this surface get argued from reasoning instead of settled from data. The evaluator-vocabulary program is one of those decisions right now; the next one should not have to be.

Independent of that program and mergeable on its own.

## The SDK identifies itself

Outside a browser page, `PlatformApiClient` sends `mcpjam-sdk/<version>` by default. A caller's own token is **prefixed, not replaced**, so the CLI identifies as `mcpjam-cli/5.7.1 mcpjam-sdk/8.7.1` — which program is calling *and* which SDK it links. Losing the second was the whole problem; losing the first would trade one blind spot for another.

In a browser page (a global `window` and `document`) no default is added and a supplied `userAgent` goes out unchanged: Firefox sends a script-set `User-Agent`, and the inspector bundles the SDK from source, so a default there would log Firefox users as `mcpjam-sdk/unknown`. Node, Bun, Deno and Cloudflare Workers have `navigator` but no `document`, so they still send it.

A consumer that bundles the SDK from source with no version injected reports `mcpjam-sdk/unknown`. That is the honest answer, and it is why the existing `typeof __MCPJAM_SDK_VERSION__` guard moved into a module both callers share rather than staying a comment in one of them. The guard's reasoning is worth keeping intact: the inspector's Vite build aliases `@mcpjam/sdk/browser` straight to source with no `define`, and a bare reference to that global survives into the client bundle and throws at module init — which took the whole app down once already.

## The inspector records it

`RequestLogContext` gains `userAgent`, sanitized and capped at 256 characters. It is **omitted** when the caller sent none: a caller who sent no user-agent is not an "unknown client", and a row that said so would be counted as one.

**It is a log field and nothing may branch on it.** A user-agent is caller-supplied text; this server already removed UA-derived attribution once for exactly that reason, and re-introducing it here is only safe while it stays a log field.

## One test that changed shape mid-write, and why

The first version of the sanitizer test injected a NUL byte to prove control characters get stripped. It failed — `Headers.append` rejects the value before the middleware ever sees it. So the test was asserting an attack the platform already blocks, which is a test that can only ever report on someone else's job.

What actually reaches the sanitizer is tabs and whitespace runs, and those matter for a different reason: they make one agent read as several in a group-by, which is the entire point of recording the field. The test asserts that, and the code comment now says the control-character strip is the second line rather than the only one — it stays because a sanitizer that depends on an upstream layer staying strict is one deploy away from being wrong.

## Verification

```
npm run build -w @mcpjam/sdk
npm run test -w @mcpjam/sdk            # 339 files, 7757 passed
npm run test:packaging:assert -w @mcpjam/sdk
npm run test:fast -w @mcpjam/cli       # 1308 passed, 0 failed
npm run test:fast -w @mcpjam/mcp       # 10 files passed
npm run typecheck -w @mcpjam/sdk
npm run typecheck:client -w @mcpjam/inspector
npx vitest run --project server .../request-log-context.middleware.test.ts   # 39 passed
```

Changeset: `@mcpjam/sdk` minor (new `DEFAULT_PLATFORM_USER_AGENT` export, and callers that set `userAgent` now send a longer string), `@mcpjam/inspector` patch.

## Could not verify without a deployment

That the new field survives production log-scrubbing configuration and lands in Axiom as a queryable column. The middleware test proves it reaches the log context; nothing here can prove what the sink does with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvZCeGPgmLoWnRyzM3XoCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvZCeGPgmLoWnRyzM3XoCU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SDK changes outbound User-Agent for most non-browser clients (including prefixed values for CLI/workers), which can break exact-match filters; inspector only adds a log field with no branching shown in this diff.
> 
> **Overview**
> **Platform requests now carry SDK identity in `User-Agent`, and the inspector logs that header on HTTP request rows.**
> 
> Outside a real browser page (`window` + `document`), `PlatformApiClient` sends `mcpjam-sdk/<version>` by default via new export `DEFAULT_PLATFORM_USER_AGENT`. Callers that set `userAgent` get the SDK token **appended** (e.g. `mcpjam-cli/5.7.1 mcpjam-sdk/8.7.1`), which is a **wire-format change** for anything that matched the old value exactly. Browser pages still send no default; an explicit `userAgent` there is unchanged. Version comes from shared `readSdkVersion()` in `sdk-version.ts` (moved out of conformance-profile), falling back to `unknown` when not injected at build time.
> 
> **Inspector:** `request-log-context` middleware adds optional `userAgent` on `RequestLogContext`—sanitized (whitespace/control chars), capped at 256 chars, and **omitted** when the header is missing or blank. Documented as telemetry only, not for auth or routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16e5c41a23599b14876a001d5aa105fca3b959fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The SDK now sends `mcpjam-sdk/<version>` as a `user-agent` on platform requests outside browser pages, and the inspector records the caller's user-agent in request logs. Before, the header was set only when a caller supplied one, so most requests carried no client identification.

**New Features**
- A caller-supplied `userAgent` is prefixed, not replaced, so custom values now go out as `<custom> mcpjam-sdk/<version>`; exact-match or end-anchored filters on the old value stop matching.
- In browsers (a global `window` and `document`) no default is sent and a supplied `userAgent` goes out unchanged.
- Source-built SDK consumers without an injected version report `mcpjam-sdk/unknown` instead of crashing.
- `RequestLogContext` gains a sanitized, 256-char-capped `userAgent` field, omitted when the caller sent none; it is a log field only, and nothing branches on it.

**Refactors**
- Moved the guarded `__MCPJAM_SDK_VERSION__` read into `sdk/src/sdk-version.ts` so both the conformance checker and platform client share it.

<sup>Written for commit 16e5c41a23599b14876a001d5aa105fca3b959fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

