### PR TITLE
Publish MCPJam's UI tools to browser-native WebMCP agents

### DIFF
--- a/.changeset/webmcp-native-ui-tools.md
+++ b/.changeset/webmcp-native-ui-tools.md
@@ -1,0 +1,44 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Publish MCPJam's own inspector tools to browser-native WebMCP agents.
+
+The `ui_*` catalog — navigate, select a server, prefill and run a tool in the
+playground — was reachable only through Ask MCPJam. The same tools are now also
+registered on `document.modelContext` (with the deprecated
+`navigator.modelContext` as a capability-checked fallback), so a browser agent
+discovers and drives the inspector without anyone opening the side panel.
+
+One catalog, one execution path. `ui-tool-execution.ts` resolves the name
+against the registry, validates the arguments, runs the registered handler and
+returns a bounded, JSON-serializable result — for both agents, so neither can
+grow a second answer to what a tool does. Everything that only exists because
+there is a conversation stays in the Ask MCPJam adapter: the approval pill, the
+transcript, duplicate-call suppression, the side-panel handoff. A native call
+creates no conversation and opens no panel.
+
+- **Eligibility is explicit, per definition.** `nativePublication` says
+  publish or internal-with-a-reason, and an absent decision reads as internal,
+  so a new tool is never published by accident. `ui_ask_user` and the scoped
+  eval-authoring tools stay internal: each needs an MCPJam conversation that a
+  native call does not have.
+- **Each agent owns its approvals.** Ask MCPJam keeps its Tool Approval
+  setting; an external agent's browser runs its own confirmation, informed by
+  the hints Chrome's secure-tools guidance asks for — `readOnlyHint`, an
+  explicit `untrustedContentHint` for results that quote a third party, and
+  `consequentialHint` for destructive or externally-reaching actions. Both
+  still pass through MCPJam's own billing gates and in-app confirmations,
+  because both run the same handler. Tools are never exposed to other origins.
+- **Built around what the pinned Chromium actually does.** A duplicate name is
+  rejected, so work for one name is serialized: retire, wait for the platform,
+  re-register. Unregistering during a call is only safe for in-flight
+  executions from Chrome 153, so a registration with an accepted call stays
+  standing until that call settles — marked dead meanwhile, so anything new
+  through it is refused.
+
+Browser support remains a prerequisite: WebMCP ships behind an origin trial, so
+where the API is absent nothing is published and MCPJam's own agent is
+unaffected. The Playground still receives no automatic `uiTools` snapshot, and
+the standalone scenario chat publishes nothing at all. See
+`mcpjam-inspector/docs/webmcp-native-tools.md`.

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -174,6 +174,7 @@ import {
 } from "./lib/inspector-command-handlers";
 import { resolveUiNavigationTarget } from "./lib/webmcp/ui-actions";
 import { useRegisterUiTools } from "./lib/webmcp/use-register-ui-tools";
+import { usePublishNativeUiTools } from "./lib/webmcp/use-publish-native-ui-tools";
 import { waitForUiCommit } from "./lib/wait-for-ui-commit";
 import { subscribeToOAuthDebuggerRequests } from "./lib/oauth/oauth-debugger-navigation";
 import {
@@ -3156,13 +3157,18 @@ export default function App() {
     [appState],
   );
   useInspectorCommandBus({ onScopeStepUp: handleInspectorScopeStepUp });
-  // MCPJam UI tools: registered in both modes for the in-app "Ask MCPJam"
-  // agent (the registry's only consumer); the always-available side panel
-  // drives whichever inspector surface is open, so registration lives at the
-  // App root. Never exposed to browser-native agents. Disabled on the
-  // standalone scenario chat route: its end user is not the inspector
-  // operator, so inspector-driving tools must not exist on that page.
+  // MCPJam UI tools: registered in both modes; the always-available side
+  // panel drives whichever inspector surface is open, so registration lives
+  // at the App root. Disabled on the standalone scenario chat route: its end
+  // user is not the inspector operator, so inspector-driving tools must not
+  // exist on that page — for either agent below.
   useRegisterUiTools({ enabled: !isScenarioChatRoute });
+  // The same tools, published to whatever WebMCP agent the browser is running
+  // (`document.modelContext`), so an external agent can operate the inspector
+  // without anyone opening Ask MCPJam. Subscribes to the registry, so a
+  // surface's mount-scoped tools follow their screen. A no-op where the
+  // browser has no WebMCP API.
+  usePublishNativeUiTools({ enabled: !isScenarioChatRoute });
   // One-time migration from legacy localStorage state to Convex. No-op in
   // hosted mode and after the first successful run; safe to keep in the tree.
   useLocalStateMigration({

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
@@ -507,10 +507,14 @@ describe("useChatSession hosted mode", () => {
   });
 
   it("never ships WebMCP ui_* tools from the generic hook", async () => {
-    // MCPJam UI tools are agent-surface-only: even with a non-empty internal
-    // registry, the generic chat body must not carry a `uiTools` field on any
-    // surface. The only sender is agent-chat-instances.ts
-    // (/api/web/mcpjam-agent).
+    // The Playground and every other generic chat surface stay isolated from
+    // the UI-tool catalog: even with a non-empty registry, the body must not
+    // carry a `uiTools` field on any surface. The only sender is
+    // agent-chat-instances.ts (/api/web/mcpjam-agent). A user who explicitly
+    // opts a turn into an open WebMCP session's `pageTools` still gets those
+    // — this is about the automatic snapshot, not about page tools. (The
+    // catalog ALSO reaches browser-native agents now, but through
+    // `document.modelContext`, which never touches this request body.)
     const unregister = useUiToolsRegistry.getState().registerUiTool({
       name: "ui_navigate",
       description: "Navigate the MCPJam inspector",

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-mcpjam-agent-session.uitools.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-mcpjam-agent-session.uitools.test.tsx
@@ -203,10 +203,11 @@ describe("useMcpjamAgentSession — WebMCP UI tools", () => {
     });
 
     // The context carries this session's id, which is what lets a parked
-    // `ui_ask_user` be cancelled per conversation.
+    // `ui_ask_user` be cancelled per conversation — and names Ask MCPJam as
+    // the caller, which is what a browser-native call never is.
     expect(def.execute).toHaveBeenCalledWith(
       { target: "playground" },
-      { toolCallId: "tc-1", scope: SESSION_ID },
+      { toolCallId: "tc-1", caller: "ask_mcpjam", scope: SESSION_ID },
     );
     expect(mockState.addToolOutput).toHaveBeenCalledWith({
       tool: "ui_navigate",

--- a/mcpjam-inspector/client/src/lib/__tests__/agent-tool-coverage.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/agent-tool-coverage.test.ts
@@ -204,6 +204,47 @@ describe("tool hygiene: global catalog + every group", () => {
     }
   });
 
+  it("every tool states whether browser-native agents get it", () => {
+    // `shouldPublishNatively` defaults to NO, so a tool that forgets this is
+    // simply invisible to an external agent rather than dangerous — which is
+    // exactly why it needs a test: a silent omission reads as a working
+    // decision. Say it outright, at the definition.
+    for (const { label, tool } of allTools) {
+      const publication = tool.nativePublication;
+      expect(
+        publication,
+        `${label}/${tool.name} must declare nativePublication (PUBLISH_NATIVE, PUBLISH_NATIVE_UNTRUSTED, or nativeInternal("why"))`,
+      ).toBeDefined();
+      if (publication?.kind === "publish") {
+        expect(
+          typeof publication.untrustedContent,
+          `${label}/${tool.name} must say whether its result can carry third-party content`,
+        ).toBe("boolean");
+      } else {
+        expect(
+          publication?.reason?.length ?? 0,
+          `${label}/${tool.name} stays internal — say why`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("only conversation-bound tools are kept off the native surface", () => {
+    // The internal set is small and deliberate: tools whose meaning depends
+    // on an Ask MCPJam conversation. Anything else an external agent should
+    // be able to drive, so growing this list is a conscious edit here.
+    const internal = allTools
+      .filter(({ tool }) => tool.nativePublication?.kind !== "publish")
+      .map(({ tool }) => tool.name)
+      .sort();
+    expect(internal).toEqual([
+      "ui_ask_user",
+      "ui_eval_context",
+      "ui_eval_propose_cases",
+      "ui_eval_question",
+    ]);
+  });
+
   it("catalog + the largest group fit the snapshot budget with headroom", () => {
     // 56 = 8 headroom under the server's 64-entry snapshot cap, assuming a
     // single surface is mounted at a time (one group live alongside the

--- a/mcpjam-inspector/client/src/lib/webmcp/ADDING_SURFACE_TOOLS.md
+++ b/mcpjam-inspector/client/src/lib/webmcp/ADDING_SURFACE_TOOLS.md
@@ -1,5 +1,19 @@
 # Adding agent tools for a surface
 
+Three things share the word "WebMCP" in this repo; the tools you are about to
+add are the first:
+
+1. **MCPJam's own `ui_*` tools** — this document. Actions that drive the
+   inspector, resolved in the page. Two agents reach them: Ask MCPJam over
+   MCPJam's transport, and a browser-native agent over `document.modelContext`
+   (see [`docs/webmcp-native-tools.md`](../../../../docs/webmcp-native-tools.md)).
+2. **Native publishing** — the mirror of (1) onto the browser's WebMCP API.
+   You decide per tool whether yours is published; see "Native publication"
+   below. It is a field on the definition, not a separate registration.
+3. **The WebMCP Inspector** — the opposite direction entirely: a managed
+   browser pointed at somebody else's page, listing the `page_*` tools THAT
+   page registers. Nothing you add here goes near it.
+
 Every screen manifest in `shared/app-surfaces.ts` carries a REQUIRED
 `agentTools` decision, so a new surface cannot ship without one — the client
 typecheck fails on a missing field, and `agent-tool-coverage.test.ts` fails
@@ -62,17 +76,50 @@ replace the pill; both apply. Read-only tools never gate — so they must
 genuinely be side-effect-free (`ui_snapshot_app` errors rather than
 auto-opening a surface).
 
+### Native publication
+
+Every definition states whether a browser-native WebMCP agent gets it, using
+the helpers in `groups/shared.ts`:
+
+```ts
+nativePublication: PUBLISH_NATIVE,            // an ordinary inspector action
+nativePublication: PUBLISH_NATIVE_UNTRUSTED,  // …whose RESULT quotes a third party
+nativePublication: nativeInternal("why not"), // Ask MCPJam only
+```
+
+Default is internal, so a tool that says nothing is simply invisible to
+external agents — which is why the coverage test insists you say. Publish
+unless the tool cannot mean anything without an MCPJam conversation: the two
+exceptions today are `ui_ask_user` (paints a card into a transcript and parks
+that turn) and the eval-authoring group (reads a scope pinned to one
+conversation). "It is destructive" is NOT a reason to withhold a tool — the
+hints below are how that gets handled.
+
+Pick `PUBLISH_NATIVE_UNTRUSTED` when the result can carry bytes MCPJam did not
+author: an MCP server's tool output, a registry listing, an OAuth server's
+metadata, a snapshot of a screen showing any of those. It becomes WebMCP's
+`untrustedContentHint`, telling the agent to treat the payload as data rather
+than instructions. Over-claiming costs nothing; under-claiming is the mistake
+that matters.
+
+You do not set `consequentialHint` — it is derived from the annotations above
+(destructive, or mutating-and-open-world), so the two can never disagree. Get
+the annotations right and the native hints follow.
+
 ### Billing gates
 
 Handlers must call the SAME gated callbacks the buttons use — eval quota,
 swarm 402 handling, the computer daily cap, the `assertMayCreateServer`
 precedent on the Connect screen. An agent tool that bypasses a billing gate
-is a billing bug, not a convenience.
+is a billing bug, not a convenience. This is load bearing for published tools:
+an external agent's approval flow belongs to its browser, so the handler's own
+gates and confirmations are the only ones MCPJam still controls.
 
 ### Transcript safety
 
-Tool inputs, tool outputs, and snapshots all land in the chat transcript
-(and cross to the server). No secrets or credentials in input schemas — the
+Tool inputs, tool outputs, and snapshots all land in the chat transcript (and
+cross to the server) — and, for a published tool, cross to an agent MCPJam
+does not control. No secrets or credentials in input schemas — the
 server-draft tools take no env/headers for exactly this reason (the
 no-env/no-headers precedent). Snapshot providers report STATE, not payloads,
 and redact tokens, keys, and PII.

--- a/mcpjam-inspector/client/src/lib/webmcp/ADDING_SURFACE_TOOLS.md
+++ b/mcpjam-inspector/client/src/lib/webmcp/ADDING_SURFACE_TOOLS.md
@@ -132,12 +132,17 @@ gates and confirmations are the only ones MCPJam still controls.
 
 ### Transcript safety
 
-Tool inputs, tool outputs, and snapshots all land in the chat transcript (and
-cross to the server) — and, for a published tool, cross to an agent MCPJam
-does not control. No secrets or credentials in input schemas — the
-server-draft tools take no env/headers for exactly this reason (the
-no-env/no-headers precedent). Snapshot providers report STATE, not payloads,
-and redact tokens, keys, and PII.
+Whatever a tool takes and returns leaves your control, by one of two routes.
+An **Ask MCPJam** call lands in that conversation's transcript and crosses to
+the server with it. A **native** call touches neither: it creates no
+conversation, and is executed in the page and answered straight to a browser
+agent MCPJam does not control.
+
+The rule is the same either way, because both ends are outside this app. No
+secrets or credentials in input schemas — the server-draft tools take no
+env/headers for exactly this reason (the no-env/no-headers precedent).
+Snapshot providers report STATE, not payloads, and redact tokens, keys, and
+PII.
 
 ### Prefill over commit
 

--- a/mcpjam-inspector/client/src/lib/webmcp/ADDING_SURFACE_TOOLS.md
+++ b/mcpjam-inspector/client/src/lib/webmcp/ADDING_SURFACE_TOOLS.md
@@ -102,9 +102,24 @@ metadata, a snapshot of a screen showing any of those. It becomes WebMCP's
 than instructions. Over-claiming costs nothing; under-claiming is the mistake
 that matters.
 
-You do not set `consequentialHint` — it is derived from the annotations above
-(destructive, or mutating-and-open-world), so the two can never disagree. Get
-the annotations right and the native hints follow.
+`consequentialHint` is normally derived from the annotations above
+(destructive, or mutating-and-open-world), so the two cannot drift: get the
+annotations right and the native hint follows. The exception is real, though,
+because the two hints ask different questions — MCP's `destructiveHint` is
+about irreversibility, Chrome's `consequentialHint` is about whether a browser
+agent should confirm first. A tool that only CREATES can still commit the
+organization to something. Say so outright there, with the reason at the call
+site:
+
+```ts
+// `access: "link_guests"` opens this to signed-out visitors, funded by the org.
+nativePublication: publishNativeConsequential({ untrustedContent: false }),
+```
+
+That widens only what the browser is told; the MCP annotations and Ask
+MCPJam's approval behaviour stay as they are. It is not a way around getting
+`destructiveHint` right — if an action really is irreversible, annotate it
+destructive.
 
 ### Billing gates
 

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/bounded-size.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/bounded-size.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { boundedJsonByteLength } from "../bounded-size";
+import {
+  boundedJsonByteLength,
+  boundedJsonString,
+  MAX_RESULT_CHARS,
+} from "../bounded-size";
 
 describe("boundedJsonByteLength", () => {
   it("reports an approximate size for a small value without truncating", () => {
@@ -35,5 +39,64 @@ describe("boundedJsonByteLength", () => {
     cyclic.self = cyclic;
     // JSON.stringify throws on cycles; the helper must swallow that, not crash.
     expect(() => boundedJsonByteLength(cyclic)).not.toThrow();
+  });
+});
+
+describe("boundedJsonString", () => {
+  it("returns a small value unchanged, and parses", () => {
+    const text = boundedJsonString({ a: "hello", n: 1, flag: true });
+    expect(text).not.toBeNull();
+    expect(JSON.parse(text!)).toEqual({ a: "hello", n: 1, flag: true });
+  });
+
+  it("refuses a value whose OUTPUT exceeds the cap, even with no scalar bytes", () => {
+    // The hole a payload-only budget leaves: 100,000 `null`s carry nothing a
+    // scalar counter would see, sit inside the node budget, and serialize to
+    // roughly half a megabyte. Whatever this returns, it is never over the
+    // cap it was given.
+    const nullHeavy = new Array(100_000).fill(null);
+    expect(boundedJsonString(nullHeavy)).toBeNull();
+    expect(JSON.stringify(nullHeavy).length).toBeGreaterThan(MAX_RESULT_CHARS);
+  });
+
+  it("counts property names, which are output too", () => {
+    // 400 keys of 200 characters: 80 KB of pure key, and not one byte of it
+    // is a value.
+    const wideKeys = Object.fromEntries(
+      Array.from({ length: 400 }, (_, i) => [`${"k".repeat(200)}${i}`, 0]),
+    );
+    expect(boundedJsonString(wideKeys)).toBeNull();
+  });
+
+  it("truncates one oversized string rather than giving up on the value", () => {
+    // A single huge scalar is one node: the node budget cannot catch it, so
+    // the replacer cuts it to what is left of the cap.
+    const text = boundedJsonString({ body: "x".repeat(MAX_RESULT_CHARS * 4) });
+    expect(text).not.toBeNull();
+    expect(text!.length).toBeLessThanOrEqual(MAX_RESULT_CHARS);
+    expect(JSON.parse(text!).body).toMatch(/x+…$/);
+  });
+
+  it("never returns more than the cap, whatever the shape", () => {
+    const cap = 256;
+    const shapes: unknown[] = [
+      new Array(5_000).fill(null),
+      new Array(5_000).fill({}),
+      Array.from({ length: 200 }, (_, i) => ({ [`key${i}`]: i })),
+      { nested: { deep: { deeper: "y".repeat(5_000) } } },
+      '"'.repeat(5_000),
+      Array.from({ length: 500 }, (_, i) => 1e300 + i),
+    ];
+    for (const shape of shapes) {
+      const text = boundedJsonString(shape, cap);
+      if (text !== null) expect(text.length).toBeLessThanOrEqual(cap);
+    }
+  });
+
+  it("returns null for what cannot be serialized at all", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(boundedJsonString(cyclic)).toBeNull();
+    expect(boundedJsonString(undefined)).toBeNull();
   });
 });

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/native-model-context.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/native-model-context.test.ts
@@ -1,0 +1,210 @@
+/**
+ * The browser seam: where the WebMCP API is found, when it counts as present,
+ * and what MCPJam claims about a tool once it publishes one.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  nativeAnnotationsFor,
+  nativeDescriptorFor,
+  resolveNativeModelContext,
+} from "../native-model-context";
+import type { UiToolDefinition } from "../ui-tools-registry";
+
+function defineModelContext(host: Document | Navigator, value: unknown): void {
+  Object.defineProperty(host, "modelContext", { configurable: true, value });
+}
+
+function clearModelContexts(): void {
+  delete (document as { modelContext?: unknown }).modelContext;
+  delete (navigator as { modelContext?: unknown }).modelContext;
+}
+
+function makeDef(extra?: Partial<UiToolDefinition>): UiToolDefinition {
+  return {
+    name: "ui_navigate",
+    description: "Navigate",
+    readOnly: false,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    nativePublication: { kind: "publish", untrustedContent: false },
+    execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+    ...extra,
+  };
+}
+
+describe("resolveNativeModelContext", () => {
+  afterEach(clearModelContexts);
+
+  it("returns null on a browser without the API", () => {
+    expect(resolveNativeModelContext()).toBeNull();
+  });
+
+  it("prefers document.modelContext", () => {
+    const documentApi = { registerTool: () => {} };
+    const navigatorApi = { registerTool: () => {} };
+    defineModelContext(document, documentApi);
+    defineModelContext(navigator, navigatorApi);
+
+    expect(resolveNativeModelContext()).toEqual({
+      api: documentApi,
+      home: "document",
+    });
+  });
+
+  it("falls back to the deprecated navigator alias", () => {
+    const navigatorApi = { registerTool: () => {} };
+    defineModelContext(navigator, navigatorApi);
+
+    expect(resolveNativeModelContext()).toEqual({
+      api: navigatorApi,
+      home: "navigator",
+    });
+  });
+
+  it("ignores a home whose API cannot register a tool", () => {
+    // A capability check, not a presence check: the property has already been
+    // one shape and then another, and a stub is not an API.
+    defineModelContext(document, { registerTool: "not a function" });
+    const navigatorApi = { registerTool: () => {} };
+    defineModelContext(navigator, navigatorApi);
+
+    expect(resolveNativeModelContext()?.home).toBe("navigator");
+
+    defineModelContext(navigator, {});
+    clearModelContexts();
+    defineModelContext(document, {});
+    expect(resolveNativeModelContext()).toBeNull();
+  });
+});
+
+describe("nativeAnnotationsFor", () => {
+  it("copies readOnlyHint and states untrustedContent from the definition", () => {
+    expect(
+      nativeAnnotationsFor(
+        makeDef({
+          readOnly: true,
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+          },
+          nativePublication: { kind: "publish", untrustedContent: true },
+        }),
+      ),
+    ).toEqual({
+      readOnlyHint: true,
+      untrustedContentHint: true,
+      consequentialHint: false,
+    });
+  });
+
+  it("marks destructive actions consequential", () => {
+    expect(
+      nativeAnnotationsFor(
+        makeDef({
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: false,
+          },
+        }),
+      ).consequentialHint,
+    ).toBe(true);
+  });
+
+  it("marks a mutating open-world action consequential", () => {
+    // Connecting a server or running one of its tools reaches something
+    // outside this browser; that is a real-world consequence.
+    expect(
+      nativeAnnotationsFor(
+        makeDef({
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: true,
+          },
+        }),
+      ).consequentialHint,
+    ).toBe(true);
+  });
+
+  it("never marks a read-only tool consequential, even across the network", () => {
+    // ui_read_resource / ui_get_prompt: open-world reads. Gating those would
+    // spend the user's attention on the prompts that do not matter.
+    expect(
+      nativeAnnotationsFor(
+        makeDef({
+          readOnly: true,
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: true,
+          },
+        }),
+      ),
+    ).toEqual({
+      readOnlyHint: true,
+      untrustedContentHint: false,
+      consequentialHint: false,
+    });
+  });
+
+  it("reads an unannotated tool pessimistically", () => {
+    // The protocol's default: an absent destructiveHint means destructive,
+    // and a definition that never declared its publication is treated as
+    // carrying content MCPJam cannot vouch for.
+    expect(
+      nativeAnnotationsFor({
+        name: "ui_mystery",
+        description: "?",
+        readOnly: false,
+        execute: async () => ({ content: [] }),
+      }),
+    ).toEqual({
+      readOnlyHint: false,
+      untrustedContentHint: true,
+      consequentialHint: true,
+    });
+  });
+});
+
+describe("nativeDescriptorFor", () => {
+  it("carries name, description, schema and annotations", () => {
+    const execute = async () => ({ content: [] });
+    const descriptor = nativeDescriptorFor(
+      makeDef({ inputSchema: { type: "object", properties: { a: {} } } }),
+      execute,
+    );
+
+    expect(descriptor).toEqual({
+      name: "ui_navigate",
+      description: "Navigate",
+      inputSchema: { type: "object", properties: { a: {} } },
+      annotations: {
+        readOnlyHint: false,
+        untrustedContentHint: false,
+        consequentialHint: false,
+      },
+      execute,
+    });
+  });
+
+  it("substitutes an empty object schema when a tool declares none", () => {
+    // Blink derives the agent-facing parameter list from the schema; absent
+    // is not the same as "takes nothing".
+    expect(
+      nativeDescriptorFor(makeDef({ inputSchema: undefined }), async () => ({
+        content: [],
+      })).inputSchema,
+    ).toEqual({ type: "object", properties: {} });
+  });
+});

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/native-model-context.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/native-model-context.test.ts
@@ -158,6 +158,35 @@ describe("nativeAnnotationsFor", () => {
     });
   });
 
+  it("honors an explicit consequence declaration over the derivation", () => {
+    // MCP's destructiveHint asks whether something is irreversible; Chrome's
+    // consequentialHint asks whether a browser agent should confirm. A tool
+    // that only creates can still answer yes to the second
+    // (`ui_publish_scenario` opening an org-funded link to signed-out
+    // visitors), and deriving alone would under-claim exactly there.
+    expect(
+      nativeAnnotationsFor(
+        makeDef({
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+          },
+          nativePublication: {
+            kind: "publish",
+            untrustedContent: false,
+            consequential: true,
+          },
+        }),
+      ),
+    ).toEqual({
+      readOnlyHint: false,
+      untrustedContentHint: false,
+      consequentialHint: true,
+    });
+  });
+
   it("reads an unannotated tool pessimistically", () => {
     // The protocol's default: an absent destructiveHint means destructive,
     // and a definition that never declared its publication is treated as

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/native-tool-publisher.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/native-tool-publisher.test.ts
@@ -665,6 +665,45 @@ describe("startNativeUiToolPublisher", () => {
       publisher.stop();
     });
 
+    it("retires a call that settles before queued teardown runs", async () => {
+      let release!: () => void;
+      const running = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const def = makeTool("ui_execute_tool", {
+        execute: vi.fn(async () => {
+          await running;
+          return { content: [{ type: "text" as const, text: "finished" }] };
+        }),
+      });
+      register(def, "global");
+      const first = startNativeUiToolPublisher();
+      await first.whenSettled();
+      const call = fake.invoke("ui_execute_tool", {});
+      // Keep teardown queued while the accepted call settles.
+      for (let i = 0; i < 20; i += 1) {
+        useUiToolsRegistry.setState({ shippedNames: new Set() });
+      }
+      first.stop();
+      const second = startNativeUiToolPublisher();
+      release();
+      await call;
+      await second.whenSettled();
+      expect(fake.names()).toEqual(["ui_execute_tool"]);
+      expect(
+        trackMock.mock.calls.filter(
+          ([event]) => event === "ui_tool_native_registration_failed",
+        ),
+      ).toEqual([]);
+      await expect(fake.invoke("ui_execute_tool", {})).resolves.toEqual({
+        content: [{ type: "text", text: "finished" }],
+      });
+      expect(def.execute).toHaveBeenCalledTimes(2);
+      second.stop();
+      await second.whenSettled();
+      expect(fake.names()).toEqual([]);
+    });
+
     it("republishes the tool when a remount lands mid-call", async () => {
       // The collision the two rules above make between them: the outgoing
       // publisher must leave a registration standing while its call runs

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/native-tool-publisher.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/native-tool-publisher.test.ts
@@ -458,8 +458,9 @@ describe("startNativeUiToolPublisher", () => {
 
       first.stop();
       const second = startNativeUiToolPublisher();
-      await second.whenSettled();
-      // Only now does the first publisher's registration get its answer.
+      // Only now does the first publisher's registration get its answer. The
+      // replacement is queued BEHIND it — settling `second` first would wait
+      // on work this test is deliberately holding shut.
       release();
       await first.whenSettled();
       await second.whenSettled();
@@ -662,6 +663,61 @@ describe("startNativeUiToolPublisher", () => {
       await publisher.whenSettled();
       expect(fake.names()).toEqual([]);
       publisher.stop();
+    });
+
+    it("republishes the tool when a remount lands mid-call", async () => {
+      // The collision the two rules above make between them: the outgoing
+      // publisher must leave a registration standing while its call runs
+      // (race 3), and the browser rejects the replacement's claim on a name
+      // it still holds (race 1). Nothing retries a rejected registration, so
+      // a replacement that did not wait would leave the tool published by
+      // NOBODY for the rest of the page — the agent silently loses it.
+      let release!: () => void;
+      const running = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const def = makeTool("ui_execute_tool", {
+        execute: vi.fn(async () => {
+          await running;
+          return { content: [{ type: "text" as const, text: "finished" }] };
+        }),
+      });
+      register(def, "global");
+      const first = startNativeUiToolPublisher();
+      await first.whenSettled();
+      const call = fake.invoke("ui_execute_tool", {});
+
+      // The remount: cleanup stops the old publisher, setup starts the new
+      // one, both while the agent's call is still running.
+      first.stop();
+      const second = startNativeUiToolPublisher();
+      // Every chance to collide, and it must not take it: while the outgoing
+      // registration is still standing for its call, the name is not free.
+      for (let tick = 0; tick < 5; tick += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      expect(fake.attempts).toEqual(["ui_execute_tool"]);
+
+      release();
+      await expect(call).resolves.toEqual({
+        content: [{ type: "text", text: "finished" }],
+      });
+      await second.whenSettled();
+
+      // Published again, by the publisher that is actually live…
+      expect(fake.names()).toEqual(["ui_execute_tool"]);
+      expect(
+        trackMock.mock.calls.filter(
+          ([event]) => event === "ui_tool_native_registration_failed",
+        ),
+      ).toEqual([]);
+      // …and it works: the new registration reaches the handler rather than
+      // answering for a tool that has gone away.
+      await expect(fake.invoke("ui_execute_tool", {})).resolves.toEqual({
+        content: [{ type: "text", text: "finished" }],
+      });
+      expect(def.execute).toHaveBeenCalledTimes(2);
+      second.stop();
     });
   });
 });

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/native-tool-publisher.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/native-tool-publisher.test.ts
@@ -1,0 +1,667 @@
+/**
+ * Publishing MCPJam's UI tools to a browser-native WebMCP agent.
+ *
+ * `FakeModelContext` below is not a convenient stub: it encodes what the
+ * pinned Chromium 151.0.7922.34 actually does, as probed while this was
+ * written — `registerTool` is async, a duplicate name REJECTS, aborting the
+ * registration's signal is the only unregister and removes only that
+ * registration, and an invocation for an unregistered name is rejected by the
+ * browser rather than reaching the page. A test that passed against a friendlier
+ * fake would prove nothing about the browser people use.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const trackMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/analytics", () => ({ track: trackMock }));
+
+import { startNativeUiToolPublisher } from "../native-tool-publisher";
+import type { NativeToolDescriptor } from "../native-model-context";
+import { buildUiToolsCatalog } from "../ui-tools-catalog";
+import { listDeferredUiToolCalls } from "../ui-tool-executor";
+import {
+  useUiToolsRegistry,
+  type UiToolDefinition,
+} from "../ui-tools-registry";
+
+class FakeModelContext {
+  /** Live registrations, exactly as the browser would hold them. */
+  readonly tools = new Map<string, NativeToolDescriptor>();
+  /** Every registerTool call, in order, including the ones that reject. */
+  readonly attempts: string[] = [];
+  /** Registrations held open until the test releases them, by name. */
+  private readonly gates = new Map<string, Promise<void>>();
+
+  /** Make the next registration of `name` pend until the returned fn runs. */
+  gate(name: string): () => void {
+    let release!: () => void;
+    this.gates.set(
+      name,
+      new Promise<void>((resolve) => {
+        release = resolve;
+      }),
+    );
+    return release;
+  }
+
+  async registerTool(
+    descriptor: NativeToolDescriptor,
+    options?: { signal?: AbortSignal },
+  ): Promise<void> {
+    this.attempts.push(descriptor.name);
+    const gate = this.gates.get(descriptor.name);
+    if (gate) {
+      this.gates.delete(descriptor.name);
+      await gate;
+    }
+    // Aborted before the platform got to it: nothing is registered.
+    if (options?.signal?.aborted) return;
+    if (this.tools.has(descriptor.name)) {
+      const error = new Error("Duplicate tool name");
+      error.name = "InvalidStateError";
+      throw error;
+    }
+    this.tools.set(descriptor.name, descriptor);
+    options?.signal?.addEventListener(
+      "abort",
+      () => {
+        // Only THIS registration is removed — a later registration of the
+        // same name survives its predecessor's teardown.
+        if (this.tools.get(descriptor.name) === descriptor) {
+          this.tools.delete(descriptor.name);
+        }
+      },
+      { once: true },
+    );
+  }
+
+  names(): string[] {
+    return [...this.tools.keys()].sort();
+  }
+
+  /** What an external agent does: invoke a tool the browser has. */
+  invoke(
+    name: string,
+    args: unknown,
+    ctx?: { signal?: AbortSignal },
+  ): Promise<unknown> {
+    const descriptor = this.tools.get(name);
+    if (!descriptor) return Promise.reject(new Error("Tool not found"));
+    return descriptor.execute(args, ctx);
+  }
+}
+
+function installModelContext(fake: unknown, home: "document" | "navigator") {
+  Object.defineProperty(
+    home === "document" ? document : navigator,
+    "modelContext",
+    {
+      configurable: true,
+      value: fake,
+    },
+  );
+}
+
+function clearModelContexts(): void {
+  delete (document as { modelContext?: unknown }).modelContext;
+  delete (navigator as { modelContext?: unknown }).modelContext;
+}
+
+function resetRegistry(): void {
+  useUiToolsRegistry.setState({
+    tools: new Map(),
+    globalNames: new Set(),
+    ownerTokens: new Map(),
+    shippedNames: new Set(),
+  });
+}
+
+function makeTool(
+  name: string,
+  extra?: Partial<UiToolDefinition>,
+): UiToolDefinition {
+  return {
+    name,
+    description: `Test tool ${name}`,
+    inputSchema: { type: "object", properties: { a: { type: "string" } } },
+    readOnly: false,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    nativePublication: { kind: "publish", untrustedContent: false },
+    execute: vi.fn(async () => ({
+      content: [{ type: "text" as const, text: `ran ${name}` }],
+    })),
+    ...extra,
+  };
+}
+
+/** Let queued microtasks and timers run until `predicate` holds. */
+async function waitUntil(
+  predicate: () => boolean,
+  label = "condition",
+): Promise<void> {
+  for (let tick = 0; tick < 200; tick += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+const register = (def: UiToolDefinition, scope?: "global" | "surface") =>
+  useUiToolsRegistry
+    .getState()
+    .registerUiTool(def, scope ? { scope } : undefined);
+
+describe("startNativeUiToolPublisher", () => {
+  let fake: FakeModelContext;
+
+  beforeEach(() => {
+    trackMock.mockClear();
+    resetRegistry();
+    fake = new FakeModelContext();
+    installModelContext(fake, "document");
+  });
+
+  afterEach(clearModelContexts);
+
+  describe("when the browser has no WebMCP API", () => {
+    it("publishes nothing and leaves the in-app agent working", async () => {
+      clearModelContexts();
+      const def = makeTool("ui_navigate");
+      register(def);
+
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+
+      expect(publisher.home).toBeNull();
+      expect(fake.attempts).toEqual([]);
+      // The registry — Ask MCPJam's source of truth — is untouched.
+      expect(useUiToolsRegistry.getState().resolve("ui_navigate")).toBe(def);
+      expect(() => publisher.stop()).not.toThrow();
+    });
+  });
+
+  it("publishes through the navigator alias when that is the only home", async () => {
+    clearModelContexts();
+    const navigatorFake = new FakeModelContext();
+    installModelContext(navigatorFake, "navigator");
+    register(makeTool("ui_navigate"));
+
+    const publisher = startNativeUiToolPublisher();
+    await publisher.whenSettled();
+
+    expect(publisher.home).toBe("navigator");
+    expect(navigatorFake.names()).toEqual(["ui_navigate"]);
+    publisher.stop();
+  });
+
+  describe("eligibility", () => {
+    it("publishes tools that opt in and skips the ones that do not", async () => {
+      register(makeTool("ui_navigate"));
+      register(
+        makeTool("ui_ask_user", {
+          nativePublication: {
+            kind: "internal",
+            reason: "needs an Ask MCPJam conversation",
+          },
+        }),
+      );
+      // A definition that never declared anything: default-deny.
+      register(makeTool("ui_undeclared", { nativePublication: undefined }));
+
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+
+      expect(fake.names()).toEqual(["ui_navigate"]);
+      publisher.stop();
+    });
+
+    it("publishes the real catalog's inspector actions and no conversation-only tool", async () => {
+      for (const def of buildUiToolsCatalog()) register(def, "global");
+
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+
+      const published = fake.names();
+      // The ordinary inspector actions an external agent should be able to
+      // drive.
+      expect(published).toEqual(
+        expect.arrayContaining([
+          "ui_navigate",
+          "ui_select_server",
+          "ui_snapshot_app",
+          "ui_open_playground",
+          "ui_execute_tool",
+          "ui_add_server",
+        ]),
+      );
+      // The tools that only mean something inside an MCPJam conversation.
+      expect(published).not.toContain("ui_ask_user");
+      expect(published.filter((n) => n.startsWith("ui_eval_"))).toEqual([]);
+      publisher.stop();
+    });
+
+    it("states all three WebMCP hints on every published tool", async () => {
+      register(
+        makeTool("ui_execute_tool", {
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: true,
+          },
+          nativePublication: { kind: "publish", untrustedContent: true },
+        }),
+      );
+
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+
+      expect(fake.tools.get("ui_execute_tool")?.annotations).toEqual({
+        readOnlyHint: false,
+        untrustedContentHint: true,
+        consequentialHint: true,
+      });
+      publisher.stop();
+    });
+
+    it("reports the publication once, with counts only", async () => {
+      register(makeTool("ui_navigate"));
+      register(makeTool("ui_select_server"));
+
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+      // A later registry change must not re-announce.
+      register(makeTool("ui_snapshot_app"), "surface");
+      await publisher.whenSettled();
+
+      const announcements = trackMock.mock.calls.filter(
+        (call) => call[0] === "ui_tool_native_published",
+      );
+      expect(announcements).toHaveLength(1);
+      expect(announcements[0]?.[1]).toEqual(
+        expect.objectContaining({ api_home: "document", tool_count: 2 }),
+      );
+      publisher.stop();
+    });
+
+    it("says nothing on a page that publishes nothing", async () => {
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+
+      expect(
+        trackMock.mock.calls.filter(
+          (call) => call[0] === "ui_tool_native_published",
+        ),
+      ).toEqual([]);
+      publisher.stop();
+    });
+
+    it("never exposes tools to other origins", async () => {
+      const spy = vi.spyOn(fake, "registerTool");
+      register(makeTool("ui_navigate"));
+
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+
+      for (const call of spy.mock.calls) {
+        expect(call[1]).not.toHaveProperty("exposedTo");
+      }
+      publisher.stop();
+    });
+  });
+
+  describe("following the registry", () => {
+    it("registers a surface's tools on mount and removes them on unmount", async () => {
+      register(makeTool("ui_navigate"), "global");
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+      expect(fake.names()).toEqual(["ui_navigate"]);
+
+      // The user navigates to a screen with a tool group.
+      const unregister = register(makeTool("ui_run_eval_suite"), "surface");
+      await publisher.whenSettled();
+      expect(fake.names()).toEqual(["ui_navigate", "ui_run_eval_suite"]);
+
+      // …and leaves it. The global tool survives the navigation.
+      unregister();
+      await publisher.whenSettled();
+      expect(fake.names()).toEqual(["ui_navigate"]);
+      publisher.stop();
+    });
+
+    it("re-registers a name whose definition changed", async () => {
+      const first = makeTool("ui_navigate", { description: "First" });
+      register(first);
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+      expect(fake.tools.get("ui_navigate")?.description).toBe("First");
+
+      // A remount builds a fresh definition object for the same name.
+      useUiToolsRegistry.getState().unregisterUiTool("ui_navigate");
+      register(makeTool("ui_navigate", { description: "Second" }));
+      await publisher.whenSettled();
+
+      expect(fake.tools.get("ui_navigate")?.description).toBe("Second");
+      expect(fake.names()).toEqual(["ui_navigate"]);
+      publisher.stop();
+    });
+
+    it("retires everything on stop", async () => {
+      register(makeTool("ui_navigate"));
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+
+      publisher.stop();
+      await publisher.whenSettled();
+
+      expect(fake.names()).toEqual([]);
+    });
+  });
+
+  describe("registration failures", () => {
+    it("catches one refused tool without losing the rest", async () => {
+      const failing = makeTool("ui_navigate");
+      register(failing);
+      register(makeTool("ui_select_server"));
+      const original = fake.registerTool.bind(fake);
+      vi.spyOn(fake, "registerTool").mockImplementation(
+        async (descriptor, options) => {
+          if (descriptor.name === "ui_navigate") {
+            const error = new Error("Duplicate tool name");
+            error.name = "InvalidStateError";
+            throw error;
+          }
+          return original(descriptor, options);
+        },
+      );
+
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+
+      expect(fake.names()).toEqual(["ui_select_server"]);
+      expect(trackMock).toHaveBeenCalledWith(
+        "ui_tool_native_registration_failed",
+        expect.objectContaining({
+          tool_name: "ui_navigate",
+          error_code: "InvalidStateError",
+        }),
+      );
+      publisher.stop();
+    });
+
+    it("reports only the error's name, never its message", async () => {
+      register(makeTool("ui_navigate"));
+      vi.spyOn(fake, "registerTool").mockImplementation(async () => {
+        const error = new Error("secret: https://internal.example/token=abc");
+        error.name = "NotAllowedError";
+        throw error;
+      });
+
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+
+      const failure = trackMock.mock.calls.find(
+        (call) => call[0] === "ui_tool_native_registration_failed",
+      );
+      expect(JSON.stringify(failure)).not.toContain("internal.example");
+      publisher.stop();
+    });
+  });
+
+  describe("ownership across remounts", () => {
+    it("a registration that settles after its publisher stopped removes only itself", async () => {
+      // StrictMode: setup, cleanup, setup. The first publisher's registration
+      // is still in flight when the second one makes its own.
+      register(makeTool("ui_navigate"));
+      const release = fake.gate("ui_navigate");
+      const first = startNativeUiToolPublisher();
+      first.stop();
+
+      const second = startNativeUiToolPublisher();
+      release();
+      await first.whenSettled();
+      await second.whenSettled();
+
+      // The replacement survives; nothing was left behind or double-removed.
+      expect(fake.names()).toEqual(["ui_navigate"]);
+      expect(
+        trackMock.mock.calls.filter(
+          (call) => call[0] === "ui_tool_native_registration_failed",
+        ),
+      ).toEqual([]);
+      second.stop();
+    });
+
+    it("a registration still pending when its publisher stops never lands", async () => {
+      // The sharp version of the remount race: publisher one is mid-
+      // `registerTool` when it is torn down and publisher two claims the same
+      // name. If the late registration were allowed to land it would hit the
+      // browser's duplicate-name rejection — or take the live registration's
+      // place.
+      register(makeTool("ui_navigate", { description: "First" }));
+      const first = startNativeUiToolPublisher();
+      await first.whenSettled();
+      const attemptsBefore = fake.attempts.length;
+
+      // Force a re-registration and hold it open inside the platform.
+      const release = fake.gate("ui_navigate");
+      useUiToolsRegistry.getState().unregisterUiTool("ui_navigate");
+      register(makeTool("ui_navigate", { description: "Second" }));
+      await waitUntil(
+        () => fake.attempts.length > attemptsBefore,
+        "the replacement registration to reach the platform",
+      );
+
+      first.stop();
+      const second = startNativeUiToolPublisher();
+      await second.whenSettled();
+      // Only now does the first publisher's registration get its answer.
+      release();
+      await first.whenSettled();
+      await second.whenSettled();
+
+      expect(fake.names()).toEqual(["ui_navigate"]);
+      expect(fake.tools.get("ui_navigate")?.description).toBe("Second");
+      expect(
+        trackMock.mock.calls.filter(
+          (call) => call[0] === "ui_tool_native_registration_failed",
+        ),
+      ).toEqual([]);
+      second.stop();
+    });
+
+    it("a remount ends with exactly one registration per name", async () => {
+      for (const def of buildUiToolsCatalog()) register(def, "global");
+      const first = startNativeUiToolPublisher();
+      await first.whenSettled();
+      first.stop();
+      await first.whenSettled();
+
+      const second = startNativeUiToolPublisher();
+      await second.whenSettled();
+
+      expect(new Set(fake.names()).size).toBe(fake.names().length);
+      expect(fake.names()).toContain("ui_navigate");
+      second.stop();
+    });
+  });
+
+  describe("invoking a published tool", () => {
+    it("routes the call through shared execution without touching the chat", async () => {
+      const def = makeTool("ui_navigate");
+      register(def);
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+
+      const result = await fake.invoke("ui_navigate", { a: "playground" });
+
+      expect(result).toEqual({
+        content: [{ type: "text", text: "ran ui_navigate" }],
+      });
+      expect(def.execute).toHaveBeenCalledTimes(1);
+      expect(def.execute).toHaveBeenCalledWith(
+        { a: "playground" },
+        expect.objectContaining({ caller: "native_webmcp" }),
+      );
+      // No conversation: nothing is deferred for an approval pill, and no
+      // chat-side telemetry is emitted.
+      expect(listDeferredUiToolCalls()).toEqual([]);
+      expect(def.execute).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ scope: expect.anything() }),
+      );
+      expect(
+        trackMock.mock.calls.filter((call) =>
+          String(call[0]).startsWith("ui_tool_call_"),
+        ),
+      ).toEqual([]);
+      expect(trackMock).toHaveBeenCalledWith(
+        "ui_tool_native_call_completed",
+        expect.objectContaining({ tool_name: "ui_navigate", status: "ok" }),
+      );
+      publisher.stop();
+    });
+
+    it("returns a readable error for malformed arguments", async () => {
+      const def = makeTool("ui_navigate");
+      register(def);
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+
+      const result = await fake.invoke("ui_navigate", "garbage");
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "ui_navigate: Arguments must be a JSON object, got a string.",
+          },
+        ],
+        isError: true,
+      });
+      expect(def.execute).not.toHaveBeenCalled();
+      publisher.stop();
+    });
+
+    it("honors the agent's cancellation signal", async () => {
+      const def = makeTool("ui_navigate");
+      register(def);
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+      const controller = new AbortController();
+      controller.abort();
+
+      const result = (await fake.invoke(
+        "ui_navigate",
+        {},
+        {
+          signal: controller.signal,
+        },
+      )) as { content: Array<{ text: string }>; isError?: boolean };
+
+      expect(def.execute).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain("nothing was executed");
+      publisher.stop();
+    });
+
+    it("refuses a call through a registration that has been replaced", async () => {
+      // The name is still live — a NEW definition owns it — but the agent is
+      // holding the descriptor of the registration that was replaced. Running
+      // the replacement through a dead registration would act on a tool the
+      // page has already taken down.
+      const first = makeTool("ui_navigate", { description: "First" });
+      register(first);
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+      const staleDescriptor = fake.tools.get("ui_navigate")!;
+
+      useUiToolsRegistry.getState().unregisterUiTool("ui_navigate");
+      const second = makeTool("ui_navigate", { description: "Second" });
+      register(second);
+      await publisher.whenSettled();
+
+      const result = (await staleDescriptor.execute({}, undefined)) as {
+        content: Array<{ text: string }>;
+        isError?: boolean;
+      };
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain("no longer available");
+      expect(first.execute).not.toHaveBeenCalled();
+      expect(second.execute).not.toHaveBeenCalled();
+      publisher.stop();
+    });
+
+    it("refuses a stale call for a tool that has gone away", async () => {
+      // The registration the agent holds can outlive the tool: the screen
+      // unmounted, or the publisher is mid-teardown.
+      const def = makeTool("ui_run_eval_suite");
+      const unregister = register(def, "surface");
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+      const descriptor = fake.tools.get("ui_run_eval_suite");
+      expect(descriptor).toBeDefined();
+
+      unregister();
+      await publisher.whenSettled();
+
+      const result = (await descriptor!.execute({}, undefined)) as {
+        content: Array<{ text: string }>;
+        isError?: boolean;
+      };
+      expect(def.execute).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain("no longer available");
+      publisher.stop();
+    });
+  });
+
+  describe("unregistering while a call is running", () => {
+    it("lets the accepted call finish, then tears the registration down", async () => {
+      // Chrome only promises that unregistering leaves in-flight executions
+      // alone from 153; the pin is 151, so the teardown waits instead.
+      let release!: () => void;
+      const running = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const def = makeTool("ui_execute_tool", {
+        execute: vi.fn(async () => {
+          await running;
+          return { content: [{ type: "text" as const, text: "finished" }] };
+        }),
+      });
+      const unregister = register(def, "surface");
+      const publisher = startNativeUiToolPublisher();
+      await publisher.whenSettled();
+      const descriptor = fake.tools.get("ui_execute_tool")!;
+
+      const call = descriptor.execute({}, undefined);
+      unregister();
+      await Promise.resolve();
+
+      // Still registered: the call it accepted has not finished.
+      expect(fake.names()).toEqual(["ui_execute_tool"]);
+      // …but the tool is dead to anything new.
+      const second = (await descriptor.execute({}, undefined)) as {
+        content: Array<{ text: string }>;
+        isError?: boolean;
+      };
+      expect(second.isError).toBe(true);
+      expect(second.content[0]?.text).toContain("no longer available");
+      expect(def.execute).toHaveBeenCalledTimes(1);
+
+      release();
+      await expect(call).resolves.toEqual({
+        content: [{ type: "text", text: "finished" }],
+      });
+      await publisher.whenSettled();
+      expect(fake.names()).toEqual([]);
+      publisher.stop();
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-approval.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-approval.test.ts
@@ -86,7 +86,7 @@ describe("createUiAwareApprovalResponseHandler", () => {
 
     expect(def.execute).toHaveBeenCalledWith(
       { target: "servers" },
-      { toolCallId: "tc-1" },
+      { toolCallId: "tc-1", caller: "ask_mcpjam" },
     );
     expect(addToolOutput).toHaveBeenCalledWith(
       expect.objectContaining({ tool: "ui_navigate", toolCallId: "tc-1" }),

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-execution.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-execution.test.ts
@@ -314,6 +314,64 @@ describe("executeUiToolCall", () => {
       expect(text.endsWith("[truncated]")).toBe(true);
     });
 
+    it("bounds the WHOLE result, not each part on its own", async () => {
+      // `content` can hold any number of parts. A per-part cap bounds nothing:
+      // 50 parts at the cap is 50x the cap, and the total is the number both
+      // transports actually have to carry.
+      useUiToolsRegistry.getState().registerUiTool(
+        makeTool({
+          execute: async () => ({
+            content: Array.from({ length: 50 }, () => ({
+              type: "text" as const,
+              text: "x".repeat(MAX_RESULT_CHARS),
+            })),
+          }),
+        }),
+      );
+
+      const outcome = await executeUiToolCall({
+        toolName: "ui_navigate",
+        input: {},
+        caller: "native_webmcp",
+        invocationId: "native-1",
+      });
+
+      const total = outcome.result.content.reduce(
+        (sum, part) => sum + part.text.length,
+        0,
+      );
+      // The budget, plus the one short line saying what did not fit.
+      expect(total).toBeLessThanOrEqual(MAX_RESULT_CHARS + 200);
+      const last = outcome.result.content.at(-1)?.text ?? "";
+      expect(last).toContain("more result part(s) omitted");
+    });
+
+    it("reports an oversized foreign part instead of rendering it", async () => {
+      // The danger is not only the output: stringify-then-truncate would
+      // materialize the whole value first.
+      useUiToolsRegistry.getState().registerUiTool(
+        makeTool({
+          execute: async () =>
+            ({
+              content: [
+                { type: "image", data: "d".repeat(MAX_RESULT_CHARS * 4) },
+              ],
+            }) as never,
+        }),
+      );
+
+      const outcome = await executeUiToolCall({
+        toolName: "ui_navigate",
+        input: {},
+        caller: "native_webmcp",
+        invocationId: "native-1",
+      });
+
+      const text = outcome.result.content[0]?.text ?? "";
+      expect(text.length).toBeLessThanOrEqual(MAX_RESULT_CHARS + 32);
+      expect(outcome.status).toBe("ok");
+    });
+
     it("serializes a foreign result shape rather than shipping it raw", async () => {
       useUiToolsRegistry.getState().registerUiTool(
         makeTool({

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-execution.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-execution.test.ts
@@ -291,6 +291,84 @@ describe("executeUiToolCall", () => {
   });
 
   describe("result bounding", () => {
+    it.each(["ask_mcpjam", "native_webmcp"] as const)(
+      "bounds serialized empty-part envelopes for %s",
+      async (caller) => {
+        useUiToolsRegistry.getState().registerUiTool(
+          makeTool({
+            execute: async () => ({
+              content: Array.from({ length: 100_000 }, () => ({
+                type: "text" as const,
+                text: "",
+              })),
+              isError: true,
+            }),
+          }),
+        );
+        const { result } = await executeUiToolCall({
+          toolName: "ui_navigate",
+          input: {},
+          caller,
+          invocationId: "bounded",
+        });
+        expect(JSON.stringify(result).length).toBeLessThanOrEqual(
+          MAX_RESULT_CHARS,
+        );
+        expect(result.isError).toBe(true);
+        expect(result.content.at(-1)?.text).toContain(
+          "more result part(s) omitted",
+        );
+      },
+    );
+
+    it("includes JSON escaping in the result budget", async () => {
+      useUiToolsRegistry.getState().registerUiTool(
+        makeTool({
+          execute: async () => ({
+            content: [
+              {
+                type: "text",
+                text: String.fromCharCode(0, 34, 92).repeat(MAX_RESULT_CHARS),
+              },
+            ],
+          }),
+        }),
+      );
+      const { result } = await executeUiToolCall({
+        toolName: "ui_navigate",
+        input: {},
+        caller: "native_webmcp",
+        invocationId: "escaped",
+      });
+      expect(JSON.stringify(result).length).toBeLessThanOrEqual(
+        MAX_RESULT_CHARS,
+      );
+      expect(result.content[0].text).toContain("[truncated]");
+    });
+
+    it("bounds serialized errors from throwing handlers", async () => {
+      useUiToolsRegistry.getState().registerUiTool(
+        makeTool({
+          execute: async () => {
+            throw new Error(
+              String.fromCharCode(0).repeat(MAX_RESULT_CHARS * 2),
+            );
+          },
+        }),
+      );
+      const outcome = await executeUiToolCall({
+        toolName: "ui_navigate",
+        input: {},
+        caller: "native_webmcp",
+        invocationId: "error",
+      });
+      expect(outcome.status).toBe("threw");
+      expect(outcome.result.isError).toBe(true);
+      expect(JSON.stringify(outcome.result).length).toBeLessThanOrEqual(
+        MAX_RESULT_CHARS,
+      );
+    });
+
     it("clamps oversized text", async () => {
       useUiToolsRegistry.getState().registerUiTool(
         makeTool({

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-execution.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-execution.test.ts
@@ -1,0 +1,378 @@
+/**
+ * The transport-independent half of a UI tool call.
+ *
+ * The point of these tests is that there is exactly ONE answer to "what does
+ * this tool do?": Ask MCPJam and a browser-native WebMCP agent resolve the
+ * same registry, validate arguments the same way, and get back the same
+ * bounded result. Everything that differs between them lives in their
+ * adapters and is tested there.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { executeUiToolCall } from "../ui-tool-execution";
+import { MAX_RESULT_CHARS } from "../bounded-size";
+import {
+  useUiToolsRegistry,
+  type UiToolDefinition,
+} from "../ui-tools-registry";
+
+function makeTool(extra?: Partial<UiToolDefinition>): UiToolDefinition {
+  return {
+    name: "ui_navigate",
+    description: "Navigate",
+    readOnly: false,
+    execute: vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "navigated" }],
+    })),
+    ...extra,
+  };
+}
+
+function resetRegistry() {
+  useUiToolsRegistry.setState({
+    tools: new Map(),
+    globalNames: new Set(),
+    ownerTokens: new Map(),
+    shippedNames: new Set(),
+  });
+}
+
+describe("executeUiToolCall", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetRegistry();
+  });
+
+  it("resolves the tool, runs it, and reports the outcome", async () => {
+    const def = makeTool();
+    useUiToolsRegistry.getState().registerUiTool(def);
+
+    const outcome = await executeUiToolCall({
+      toolName: "ui_navigate",
+      input: { target: "playground" },
+      caller: "ask_mcpjam",
+      invocationId: "tc-1",
+      scope: "session-a",
+    });
+
+    expect(outcome).toEqual({
+      result: { content: [{ type: "text", text: "navigated" }] },
+      status: "ok",
+    });
+    expect(def.execute).toHaveBeenCalledWith(
+      { target: "playground" },
+      { toolCallId: "tc-1", caller: "ask_mcpjam", scope: "session-a" },
+    );
+  });
+
+  it("produces equivalent results for both callers", async () => {
+    // The whole premise of the shared seam: an external agent driving
+    // ui_navigate gets what Ask MCPJam gets, from the same handler.
+    const def = makeTool({
+      execute: vi.fn(async (args) => ({
+        content: [{ type: "text" as const, text: JSON.stringify(args) }],
+      })),
+    });
+    useUiToolsRegistry.getState().registerUiTool(def);
+
+    const internal = await executeUiToolCall({
+      toolName: "ui_navigate",
+      input: { target: "evals" },
+      caller: "ask_mcpjam",
+      invocationId: "tc-internal",
+    });
+    const native = await executeUiToolCall({
+      toolName: "ui_navigate",
+      input: { target: "evals" },
+      caller: "native_webmcp",
+      invocationId: "native-1",
+    });
+
+    expect(native.result).toEqual(internal.result);
+    expect(native.status).toBe(internal.status);
+    // The ONE difference the handler can see: who asked, and whether there is
+    // a conversation behind it.
+    expect(def.execute).toHaveBeenNthCalledWith(1, expect.anything(), {
+      toolCallId: "tc-internal",
+      caller: "ask_mcpjam",
+    });
+    expect(def.execute).toHaveBeenNthCalledWith(2, expect.anything(), {
+      toolCallId: "native-1",
+      caller: "native_webmcp",
+    });
+  });
+
+  it("executes the handler exactly once per call", async () => {
+    const def = makeTool();
+    useUiToolsRegistry.getState().registerUiTool(def);
+
+    await executeUiToolCall({
+      toolName: "ui_navigate",
+      input: {},
+      caller: "native_webmcp",
+      invocationId: "native-1",
+    });
+
+    expect(def.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an unregistered tool instead of throwing", async () => {
+    const outcome = await executeUiToolCall({
+      toolName: "ui_navigate",
+      input: {},
+      caller: "native_webmcp",
+      invocationId: "native-1",
+    });
+
+    expect(outcome.status).toBe("unavailable");
+    expect(outcome.errorCode).toBe("tool_unavailable");
+    expect(outcome.result).toEqual({
+      content: [
+        { type: "text", text: 'UI tool "ui_navigate" is no longer available.' },
+      ],
+      isError: true,
+    });
+  });
+
+  it.each([
+    ["a string", "garbage", "a string"],
+    ["a number", 42, "a number"],
+    ["an array", [1, 2], "an array"],
+  ])("rejects %s as arguments", async (_label, input, described) => {
+    const def = makeTool();
+    useUiToolsRegistry.getState().registerUiTool(def);
+
+    const outcome = await executeUiToolCall({
+      toolName: "ui_navigate",
+      input,
+      caller: "native_webmcp",
+      invocationId: "native-1",
+    });
+
+    expect(outcome.status).toBe("invalid_input");
+    expect(outcome.errorCode).toBe("invalid_input");
+    expect(outcome.result.content[0]?.text).toBe(
+      `ui_navigate: Arguments must be a JSON object, got ${described}.`,
+    );
+    expect(def.execute).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, null])(
+    "treats %s as a no-argument call",
+    async (input) => {
+      const def = makeTool();
+      useUiToolsRegistry.getState().registerUiTool(def);
+
+      const outcome = await executeUiToolCall({
+        toolName: "ui_navigate",
+        input,
+        caller: "native_webmcp",
+        invocationId: "native-1",
+      });
+
+      expect(outcome.status).toBe("ok");
+      expect(def.execute).toHaveBeenCalledWith({}, expect.anything());
+    },
+  );
+
+  it("turns a throwing handler into an error result", async () => {
+    useUiToolsRegistry.getState().registerUiTool(
+      makeTool({
+        execute: async () => {
+          throw new Error("router exploded");
+        },
+      }),
+    );
+
+    const outcome = await executeUiToolCall({
+      toolName: "ui_navigate",
+      input: {},
+      caller: "native_webmcp",
+      invocationId: "native-1",
+    });
+
+    expect(outcome.status).toBe("threw");
+    expect(outcome.errorCode).toBe("tool_threw");
+    expect(outcome.result).toEqual({
+      content: [{ type: "text", text: "UI tool failed: router exploded" }],
+      isError: true,
+    });
+  });
+
+  it("extracts a structured error code from a command-bus failure", async () => {
+    useUiToolsRegistry.getState().registerUiTool(
+      makeTool({
+        execute: async () => ({
+          content: [
+            { type: "text" as const, text: "unknown_server: no such server" },
+          ],
+          isError: true,
+        }),
+      }),
+    );
+
+    const outcome = await executeUiToolCall({
+      toolName: "ui_navigate",
+      input: {},
+      caller: "ask_mcpjam",
+      invocationId: "tc-1",
+    });
+
+    expect(outcome.status).toBe("error");
+    expect(outcome.errorCode).toBe("unknown_server");
+  });
+
+  it("never reports a free-text message as an error code", async () => {
+    useUiToolsRegistry.getState().registerUiTool(
+      makeTool({
+        execute: async () => ({
+          content: [{ type: "text" as const, text: "Something: went wrong" }],
+          isError: true,
+        }),
+      }),
+    );
+
+    const outcome = await executeUiToolCall({
+      toolName: "ui_navigate",
+      input: {},
+      caller: "native_webmcp",
+      invocationId: "native-1",
+    });
+
+    expect(outcome.status).toBe("error");
+    expect(outcome.errorCode).toBeUndefined();
+  });
+
+  describe("cancellation", () => {
+    it("refuses a call whose signal is already aborted, without running it", async () => {
+      const def = makeTool();
+      useUiToolsRegistry.getState().registerUiTool(def);
+      const controller = new AbortController();
+      controller.abort();
+
+      const outcome = await executeUiToolCall({
+        toolName: "ui_navigate",
+        input: {},
+        caller: "native_webmcp",
+        invocationId: "native-1",
+        signal: controller.signal,
+      });
+
+      expect(outcome.status).toBe("cancelled");
+      expect(def.execute).not.toHaveBeenCalled();
+      // The wording must not suggest anything was rolled back.
+      expect(outcome.result.content[0]?.text).toContain("nothing was executed");
+    });
+
+    it("hands the signal to the handler and keeps a completed result", async () => {
+      // A late abort does not un-navigate a page. Once the handler has run,
+      // its result is the truth about the world.
+      const controller = new AbortController();
+      const def = makeTool({
+        execute: vi.fn(async (_args, ctx) => {
+          expect(ctx?.signal).toBe(controller.signal);
+          controller.abort();
+          return { content: [{ type: "text" as const, text: "navigated" }] };
+        }),
+      });
+      useUiToolsRegistry.getState().registerUiTool(def);
+
+      const outcome = await executeUiToolCall({
+        toolName: "ui_navigate",
+        input: {},
+        caller: "native_webmcp",
+        invocationId: "native-1",
+        signal: controller.signal,
+      });
+
+      expect(outcome.status).toBe("ok");
+      expect(outcome.result.content[0]?.text).toBe("navigated");
+    });
+  });
+
+  describe("result bounding", () => {
+    it("clamps oversized text", async () => {
+      useUiToolsRegistry.getState().registerUiTool(
+        makeTool({
+          execute: async () => ({
+            content: [
+              { type: "text" as const, text: "x".repeat(MAX_RESULT_CHARS * 3) },
+            ],
+          }),
+        }),
+      );
+
+      const outcome = await executeUiToolCall({
+        toolName: "ui_navigate",
+        input: {},
+        caller: "native_webmcp",
+        invocationId: "native-1",
+      });
+
+      const text = outcome.result.content[0]?.text ?? "";
+      expect(text.length).toBeLessThanOrEqual(MAX_RESULT_CHARS + 32);
+      expect(text.endsWith("[truncated]")).toBe(true);
+    });
+
+    it("serializes a foreign result shape rather than shipping it raw", async () => {
+      useUiToolsRegistry.getState().registerUiTool(
+        makeTool({
+          execute: async () =>
+            ({
+              content: [{ type: "image", data: "abc" }],
+            }) as never,
+        }),
+      );
+
+      const outcome = await executeUiToolCall({
+        toolName: "ui_navigate",
+        input: {},
+        caller: "native_webmcp",
+        invocationId: "native-1",
+      });
+
+      expect(outcome.result.content).toEqual([
+        { type: "text", text: '{"type":"image","data":"abc"}' },
+      ]);
+    });
+
+    it("says so when a handler returns nothing at all", async () => {
+      useUiToolsRegistry
+        .getState()
+        .registerUiTool(makeTool({ execute: async () => undefined as never }));
+
+      const outcome = await executeUiToolCall({
+        toolName: "ui_navigate",
+        input: {},
+        caller: "native_webmcp",
+        invocationId: "native-1",
+      });
+
+      expect(outcome.status).toBe("ok");
+      expect(outcome.result.content).toEqual([
+        { type: "text", text: "The tool returned no content." },
+      ]);
+    });
+  });
+
+  it("keeps the eval-scope restriction on the shared path", async () => {
+    // A conversation whose eval scope cannot be read must not execute
+    // anything, whichever transport asked. (No native call carries a scope,
+    // so this only ever fires for Ask MCPJam — it is the backstop for the
+    // gate the chat adapter applies before it claims the call.)
+    const def = makeTool();
+    useUiToolsRegistry.getState().registerUiTool(def);
+
+    const outcome = await executeUiToolCall({
+      toolName: "ui_navigate",
+      input: {},
+      caller: "ask_mcpjam",
+      invocationId: "tc-1",
+      scope: "eval-missing-scope",
+    });
+
+    expect(outcome.status).toBe("threw");
+    expect(def.execute).not.toHaveBeenCalled();
+    expect(outcome.result.isError).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-execution.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-execution.test.ts
@@ -372,6 +372,36 @@ describe("executeUiToolCall", () => {
       expect(outcome.status).toBe("ok");
     });
 
+    it("bounds a foreign part that is huge in SHAPE rather than in payload", async () => {
+      // 100,000 `null`s: no scalar bytes to count, well inside any traversal
+      // budget, and half a megabyte once serialized. A budget that only adds
+      // up strings and numbers waves this straight through into the agent's
+      // context.
+      useUiToolsRegistry.getState().registerUiTool(
+        makeTool({
+          execute: async () =>
+            ({
+              content: [
+                { type: "sparse", rows: new Array(100_000).fill(null) },
+              ],
+            }) as never,
+        }),
+      );
+
+      const outcome = await executeUiToolCall({
+        toolName: "ui_navigate",
+        input: {},
+        caller: "native_webmcp",
+        invocationId: "native-1",
+      });
+
+      const total = outcome.result.content.reduce(
+        (sum, part) => sum + part.text.length,
+        0,
+      );
+      expect(total).toBeLessThanOrEqual(MAX_RESULT_CHARS + 200);
+    });
+
     it("serializes a foreign result shape rather than shipping it raw", async () => {
       useUiToolsRegistry.getState().registerUiTool(
         makeTool({

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.test.ts
@@ -47,7 +47,7 @@ describe("handleUiToolCall", () => {
     expect(handled).toBe(true);
     expect(def.execute).toHaveBeenCalledWith(
       { target: "playground" },
-      { toolCallId: "tc-1" }
+      { toolCallId: "tc-1", caller: "ask_mcpjam" },
     );
     expect(addToolOutput).toHaveBeenCalledWith({
       tool: "ui_navigate",
@@ -73,7 +73,7 @@ describe("handleUiToolCall", () => {
 
     expect(def.execute).toHaveBeenCalledWith(
       { target: "playground" },
-      { toolCallId: "tc-scoped", scope: "session-a" }
+      { toolCallId: "tc-scoped", caller: "ask_mcpjam", scope: "session-a" },
     );
   });
 
@@ -211,7 +211,7 @@ describe("handleUiToolCall", () => {
     expect(def.execute).toHaveBeenCalledTimes(1);
     expect(def.execute).toHaveBeenCalledWith(
       { target: "servers" },
-      { toolCallId: "tc-appr" }
+      { toolCallId: "tc-appr", caller: "ask_mcpjam" },
     );
     expect(addToolOutput).toHaveBeenCalledTimes(1);
     expect(listDeferredUiToolCalls()).toEqual([]);
@@ -233,10 +233,10 @@ describe("handleUiToolCall", () => {
 
     expect(def.execute).toHaveBeenCalledWith(
       { target: "evals" },
-      { toolCallId: "tc-reload" }
+      { toolCallId: "tc-reload", caller: "ask_mcpjam" },
     );
     expect(addToolOutput).toHaveBeenCalledWith(
-      expect.objectContaining({ toolCallId: "tc-reload" })
+      expect.objectContaining({ toolCallId: "tc-reload" }),
     );
   });
 
@@ -317,23 +317,57 @@ describe("handleUiToolCall", () => {
     expect(handled).toBe(true);
     expect(def.execute).toHaveBeenCalled();
     expect(addToolOutput).toHaveBeenCalledWith(
-      expect.objectContaining({ toolCallId: "tc-throw" })
+      expect.objectContaining({ toolCallId: "tc-throw" }),
     );
   });
 
-  it("coerces non-object input to empty args", async () => {
+  it("rejects non-object input instead of substituting empty args", async () => {
+    // Shared execution validates the arguments (`ui-tool-execution.ts`), so
+    // both transports say the same thing about a malformed call. Silently
+    // running with `{}` used to report whichever required field went missing
+    // — an error about the wrong problem.
     const def = makeTool();
     useUiToolsRegistry.getState().registerUiTool(def);
+    const addToolOutput = vi.fn();
 
     await handleUiToolCall({
       toolName: "ui_navigate",
       toolCallId: "tc-1",
       input: "garbage",
+      addToolOutput,
+    });
+
+    expect(def.execute).not.toHaveBeenCalled();
+    expect(addToolOutput).toHaveBeenCalledWith({
+      tool: "ui_navigate",
+      toolCallId: "tc-1",
+      output: {
+        content: [
+          {
+            type: "text",
+            text: "ui_navigate: Arguments must be a JSON object, got a string.",
+          },
+        ],
+        isError: true,
+      },
+    });
+  });
+
+  it("treats a missing payload as a no-argument call", async () => {
+    // `ui_snapshot_app` and friends legitimately take nothing.
+    const def = makeTool();
+    useUiToolsRegistry.getState().registerUiTool(def);
+
+    await handleUiToolCall({
+      toolName: "ui_navigate",
+      toolCallId: "tc-empty",
+      input: undefined,
       addToolOutput: vi.fn(),
     });
+
     expect(def.execute).toHaveBeenCalledWith(
       {},
-      { toolCallId: "tc-1" }
+      { toolCallId: "tc-empty", caller: "ask_mcpjam" },
     );
   });
 
@@ -385,7 +419,10 @@ describe("handleUiToolCall", () => {
       toolCallId: "tc-1",
       output: {
         content: [
-          { type: "text", text: 'UI tool "ui_navigate" is no longer available.' },
+          {
+            type: "text",
+            text: 'UI tool "ui_navigate" is no longer available.',
+          },
         ],
         isError: true,
       },
@@ -402,7 +439,7 @@ describe("handleUiToolCall", () => {
         toolName,
         toolCallId: "tc-1",
         input: {},
-          addToolOutput,
+        addToolOutput,
       });
       expect(handled).toBe(false);
     }

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/use-publish-native-ui-tools.test.tsx
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/use-publish-native-ui-tools.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * The App-root hook that publishes MCPJam's UI tools to browser-native WebMCP
+ * agents: what an inspector page exposes, what the standalone scenario chat
+ * must not, and what a StrictMode double-mount leaves behind.
+ *
+ * This is the test that replaced the old "the catalog makes zero native
+ * registerTool calls" guard. Zero is no longer the contract — the contract is
+ * WHICH tools, and it has two halves that have to hold together: the ordinary
+ * inspector actions are published, and the tools that only mean something
+ * inside an MCPJam conversation are not.
+ */
+import { render } from "@testing-library/react";
+import { StrictMode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRegisterUiTools } from "../use-register-ui-tools";
+import { usePublishNativeUiTools } from "../use-publish-native-ui-tools";
+import type { NativeToolDescriptor } from "../native-model-context";
+import { useUiToolsRegistry } from "../ui-tools-registry";
+
+/** The measured Chromium 151 contract, in miniature — see the publisher test. */
+class FakeModelContext {
+  readonly tools = new Map<string, NativeToolDescriptor>();
+  readonly failures: string[] = [];
+
+  async registerTool(
+    descriptor: NativeToolDescriptor,
+    options?: { signal?: AbortSignal },
+  ): Promise<void> {
+    if (options?.signal?.aborted) return;
+    if (this.tools.has(descriptor.name)) {
+      this.failures.push(descriptor.name);
+      const error = new Error("Duplicate tool name");
+      error.name = "InvalidStateError";
+      throw error;
+    }
+    this.tools.set(descriptor.name, descriptor);
+    options?.signal?.addEventListener(
+      "abort",
+      () => {
+        if (this.tools.get(descriptor.name) === descriptor) {
+          this.tools.delete(descriptor.name);
+        }
+      },
+      { once: true },
+    );
+  }
+
+  names(): string[] {
+    return [...this.tools.keys()].sort();
+  }
+}
+
+function InspectorPage({ enabled }: { enabled: boolean }) {
+  useRegisterUiTools({ enabled });
+  usePublishNativeUiTools({ enabled });
+  return null;
+}
+
+/** Let the publisher's per-name chains drain. */
+async function settle(): Promise<void> {
+  for (let tick = 0; tick < 20; tick += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("usePublishNativeUiTools", () => {
+  let fake: FakeModelContext;
+
+  beforeEach(() => {
+    useUiToolsRegistry.setState({
+      tools: new Map(),
+      globalNames: new Set(),
+      ownerTokens: new Map(),
+      shippedNames: new Set(),
+    });
+    fake = new FakeModelContext();
+    Object.defineProperty(document, "modelContext", {
+      configurable: true,
+      value: fake,
+    });
+  });
+
+  afterEach(() => {
+    delete (document as { modelContext?: unknown }).modelContext;
+    vi.restoreAllMocks();
+  });
+
+  it("publishes the eligible catalog and unpublishes it on unmount", async () => {
+    const view = render(<InspectorPage enabled />);
+    await settle();
+
+    expect(fake.names()).toEqual(
+      expect.arrayContaining([
+        "ui_navigate",
+        "ui_select_server",
+        "ui_set_app_context",
+        "ui_snapshot_app",
+        "ui_open_playground",
+        "ui_select_tool",
+        "ui_execute_tool",
+        "ui_open_server_form",
+        "ui_add_server",
+        "ui_connect_server",
+        "ui_disconnect_server",
+        "ui_remove_server",
+      ]),
+    );
+
+    view.unmount();
+    await settle();
+    expect(fake.names()).toEqual([]);
+  });
+
+  it("never publishes a tool that needs an MCPJam conversation", async () => {
+    // `ui_ask_user` renders a card into a transcript and parks that turn; the
+    // eval-authoring tools read a scope pinned to one conversation. A native
+    // agent has neither, so publishing these would advertise capabilities
+    // that can only answer "open Ask MCPJam first".
+    const view = render(<InspectorPage enabled />);
+    await settle();
+
+    const published = fake.names();
+    expect(published).not.toContain("ui_ask_user");
+    expect(published.filter((name) => name.startsWith("ui_eval_"))).toEqual([]);
+    // …while the very same tools ARE available to Ask MCPJam.
+    expect(useUiToolsRegistry.getState().resolve("ui_ask_user")).not.toBeNull();
+    expect(
+      useUiToolsRegistry.getState().resolve("ui_eval_context"),
+    ).not.toBeNull();
+
+    view.unmount();
+  });
+
+  it("publishes nothing on the standalone scenario chat route", async () => {
+    // `enabled: false` is how App excludes that route. Its end user is not
+    // the inspector operator, so inspector-driving tools must not exist on
+    // the page for EITHER agent.
+    const view = render(<InspectorPage enabled={false} />);
+    await settle();
+
+    expect(fake.names()).toEqual([]);
+    expect(useUiToolsRegistry.getState().tools.size).toBe(0);
+
+    view.unmount();
+  });
+
+  it("survives StrictMode's double mount without duplicate registrations", async () => {
+    const view = render(
+      <StrictMode>
+        <InspectorPage enabled />
+      </StrictMode>,
+    );
+    await settle();
+
+    const published = fake.names();
+    expect(published).toContain("ui_navigate");
+    expect(new Set(published).size).toBe(published.length);
+    // The browser rejects a duplicate name outright; a single one of those
+    // would mean a tool silently missing from the published set.
+    expect(fake.failures).toEqual([]);
+
+    view.unmount();
+    await settle();
+    expect(fake.names()).toEqual([]);
+  });
+
+  it("is inert on a browser with no WebMCP API", async () => {
+    delete (document as { modelContext?: unknown }).modelContext;
+
+    const view = render(<InspectorPage enabled />);
+    await settle();
+
+    // Nothing published, nothing thrown — and Ask MCPJam's registry is full.
+    expect(fake.names()).toEqual([]);
+    expect(useUiToolsRegistry.getState().resolve("ui_navigate")).not.toBeNull();
+
+    view.unmount();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/use-register-ui-tools.test.tsx
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/use-register-ui-tools.test.tsx
@@ -1,10 +1,14 @@
 /**
- * Mount/It gating for the catalog registration hook: the registry must be
- * empty on surfaces where the end user is not the inspector operator — the
+ * Mount gating for the catalog registration hook: the registry must be empty
+ * on surfaces where the end user is not the inspector operator — the
  * standalone scenario chat route passes `enabled: false` — and must follow
- * `enabled` toggles across rerenders. Also guards the removal of the
- * browser-native WebMCP mirror: registering the catalog must never touch
- * `document.modelContext` / `navigator.modelContext`.
+ * `enabled` toggles across rerenders.
+ *
+ * This hook fills the REGISTRY and nothing else. Which of those tools reach a
+ * browser-native WebMCP agent is the publisher's decision, tested in
+ * `use-publish-native-ui-tools.test.tsx` and `native-tool-publisher.test.ts`;
+ * the test below only holds the two apart, so registering the catalog can
+ * never become a native side effect of its own.
  */
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -43,14 +47,13 @@ describe("useRegisterUiTools", () => {
     unmount();
   });
 
-  describe("browser-native WebMCP exposure (removed)", () => {
+  describe("registration is not publication", () => {
     const documentRegisterTool = vi.fn();
     const navigatorRegisterTool = vi.fn();
 
     beforeEach(() => {
-      // Fake native WebMCP surfaces on BOTH homes (`document.modelContext`
-      // preferred, `navigator.modelContext` the deprecated fallback). If any
-      // mirroring code is reintroduced, one of these spies records a call.
+      // Fake WebMCP surfaces on BOTH homes (`document.modelContext`
+      // preferred, `navigator.modelContext` the deprecated alias).
       Object.defineProperty(document, "modelContext", {
         configurable: true,
         value: { registerTool: documentRegisterTool },
@@ -66,14 +69,15 @@ describe("useRegisterUiTools", () => {
       delete (navigator as { modelContext?: unknown }).modelContext;
     });
 
-    it("registering the catalog makes zero native registerTool calls", () => {
+    it("filling the registry publishes nothing by itself", () => {
+      // Publication is `usePublishNativeUiTools`, mounted separately at the
+      // App root, so a surface that registers tools without it (or with it
+      // disabled) stays internal-only.
       const { unmount } = renderHook(() => useRegisterUiTools());
       expect(useUiToolsRegistry.getState().tools.size).toBeGreaterThan(0);
       expect(documentRegisterTool).not.toHaveBeenCalled();
       expect(navigatorRegisterTool).not.toHaveBeenCalled();
       unmount();
-      expect(documentRegisterTool).not.toHaveBeenCalled();
-      expect(navigatorRegisterTool).not.toHaveBeenCalled();
     });
   });
 });

--- a/mcpjam-inspector/client/src/lib/webmcp/bounded-size.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/bounded-size.ts
@@ -61,3 +61,51 @@ export function clampText(text: string): string {
   if (text.length <= MAX_RESULT_CHARS) return text;
   return `${text.slice(0, MAX_RESULT_CHARS)}… [truncated]`;
 }
+
+/**
+ * `JSON.stringify` that CANNOT build a string bigger than `cap`, and cannot
+ * walk more than `nodeBudget` values getting there.
+ *
+ * The difference from stringify-then-truncate: that materializes the whole
+ * thing first, so a handler returning a 100 MB object costs 100 MB before a
+ * single character is thrown away. Here long strings are cut down inside the
+ * replacer, and a value that blows either budget aborts the walk and returns
+ * `null` — the caller substitutes a marker rather than a head of JSON no
+ * reader could parse anyway.
+ */
+export function boundedJsonString(
+  value: unknown,
+  cap = MAX_RESULT_CHARS,
+  nodeBudget = DEFAULT_NODE_BUDGET,
+): string | null {
+  let emitted = 0;
+  let nodes = 0;
+  const OVER = Symbol("over-budget");
+  try {
+    const text = JSON.stringify(value, (_key, v) => {
+      nodes += 1;
+      if (nodes > nodeBudget) throw OVER;
+      // Everything below counts what this node will COST in the output, and
+      // gives up the moment the total would exceed the cap.
+      if (typeof v === "string") {
+        const room = cap - emitted;
+        if (room <= 0) throw OVER;
+        emitted += Math.min(v.length, room);
+        // Truncate IN the replacer: one multi-megabyte scalar is a single
+        // node, so no node budget would catch it.
+        return v.length > room ? `${v.slice(0, room)}…` : v;
+      }
+      if (typeof v === "number" || typeof v === "boolean") {
+        emitted += 8;
+        if (emitted > cap) throw OVER;
+      }
+      return v;
+    });
+    return text ?? null;
+  } catch {
+    // Over budget, or a value that cannot be serialized at all (a cycle, a
+    // throwing `toJSON`). Both mean the same thing to the caller: there is
+    // nothing safe to render here.
+    return null;
+  }
+}

--- a/mcpjam-inspector/client/src/lib/webmcp/bounded-size.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/bounded-size.ts
@@ -42,7 +42,22 @@ export function boundedJsonByteLength(
     });
     return { bytes: emitted, truncated: false };
   } catch (e) {
-    if (e === OVER) return { bytes: Math.min(emitted, cap) || cap, truncated: true };
+    if (e === OVER)
+      return { bytes: Math.min(emitted, cap) || cap, truncated: true };
     return { bytes: 0, truncated: false };
   }
+}
+
+/**
+ * The per-result text budget for a `ui_*` tool, shared by the group helpers
+ * that build results (`groups/shared.ts`) and the executor that bounds
+ * whatever a handler returns (`ui-tool-execution.ts`). One definition,
+ * because a result clamped to one number and checked against another is a
+ * silent truncation bug.
+ */
+export const MAX_RESULT_CHARS = 16 * 1024;
+
+export function clampText(text: string): string {
+  if (text.length <= MAX_RESULT_CHARS) return text;
+  return `${text.slice(0, MAX_RESULT_CHARS)}… [truncated]`;
 }

--- a/mcpjam-inspector/client/src/lib/webmcp/bounded-size.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/bounded-size.ts
@@ -63,7 +63,7 @@ export function clampText(text: string): string {
 }
 
 /**
- * `JSON.stringify` that CANNOT build a string bigger than `cap`, and cannot
+ * `JSON.stringify` that CANNOT return a string bigger than `cap`, and cannot
  * walk more than `nodeBudget` values getting there.
  *
  * The difference from stringify-then-truncate: that materializes the whole
@@ -72,6 +72,14 @@ export function clampText(text: string): string {
  * replacer, and a value that blows either budget aborts the walk and returns
  * `null` — the caller substitutes a marker rather than a head of JSON no
  * reader could parse anyway.
+ *
+ * The running total counts what each node costs in the OUTPUT — its
+ * separator, and inside an object its quoted key — not just its scalar
+ * payload. Under a payload-only total, `null`s, `{}`s and long property names
+ * are free: an array of 100,000 `null`s stays inside every budget and still
+ * serializes to half a megabyte. The `text.length` check at the end is the
+ * guarantee, because escaping can widen a string past the length it was
+ * measured at; the accounting only decides how early the walk gives up.
  */
 export function boundedJsonString(
   value: unknown,
@@ -82,26 +90,30 @@ export function boundedJsonString(
   let nodes = 0;
   const OVER = Symbol("over-budget");
   try {
-    const text = JSON.stringify(value, (_key, v) => {
+    // A `function`, not an arrow: `this` is the holder, which is how an array
+    // element (a bare comma) is told apart from an object member (a key).
+    const text = JSON.stringify(value, function (this: unknown, key, v) {
       nodes += 1;
       if (nodes > nodeBudget) throw OVER;
-      // Everything below counts what this node will COST in the output, and
-      // gives up the moment the total would exceed the cap.
+      emitted += Array.isArray(this) ? 1 : key.length + 4;
       if (typeof v === "string") {
-        const room = cap - emitted;
+        const room = cap - emitted - 2;
         if (room <= 0) throw OVER;
-        emitted += Math.min(v.length, room);
+        emitted += Math.min(v.length, room) + 2;
         // Truncate IN the replacer: one multi-megabyte scalar is a single
         // node, so no node budget would catch it.
         return v.length > room ? `${v.slice(0, room)}…` : v;
       }
-      if (typeof v === "number" || typeof v === "boolean") {
-        emitted += 8;
-        if (emitted > cap) throw OVER;
+      if (v === null) emitted += 4;
+      else if (typeof v === "object") emitted += 2;
+      else if (typeof v === "number" || typeof v === "boolean") {
+        emitted += String(v).length;
       }
+      if (emitted > cap) throw OVER;
       return v;
     });
-    return text ?? null;
+    if (text === undefined) return null;
+    return text.length > cap ? null : text;
   } catch {
     // Over budget, or a value that cannot be serialized at all (a cycle, a
     // throwing `toJSON`). Both mean the same thing to the caller: there is

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/__tests__/scenarios.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/__tests__/scenarios.test.ts
@@ -65,6 +65,25 @@ describe("buildScenariosUiTools", () => {
     }
   });
 
+  it("tells a BROWSER agent that publishing is consequential", () => {
+    // The two hints answer different questions. `destructiveHint` stays false
+    // above — publishing destroys nothing and re-publishing converges, so Ask
+    // MCPJam's approval behaviour is unchanged. But `access: "link_guests"`
+    // opens the scenario to signed-out visitors funded by this organization,
+    // which is exactly the kind of commitment Chrome's `consequentialHint`
+    // exists to put a confirmation in front of.
+    expect(getTool("ui_publish_scenario").nativePublication).toEqual({
+      kind: "publish",
+      untrustedContent: false,
+      consequential: true,
+    });
+    // Deleting is destructive, so it derives consequential without saying so.
+    expect(getTool("ui_delete_scenario").nativePublication).toEqual({
+      kind: "publish",
+      untrustedContent: false,
+    });
+  });
+
   it("gates exactly delete behind the destructive approval pill", () => {
     const destructive = buildScenariosUiTools()
       .filter((tool) => tool.annotations?.destructiveHint === true)

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/computer.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/computer.ts
@@ -32,7 +32,7 @@ import {
   commandResponseToActionResult,
   dispatchInspectorCommand,
 } from "../ui-actions";
-import { fromActionResult } from "./shared";
+import { PUBLISH_NATIVE, fromActionResult } from "./shared";
 
 const EMPTY_SCHEMA = {
   type: "object",
@@ -58,6 +58,7 @@ export function buildComputerUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: true,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async () => {
         const response = await dispatchInspectorCommand({
           type: "startComputer",
@@ -79,6 +80,7 @@ export function buildComputerUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async () => {
         const response = await dispatchInspectorCommand({
           type: "hibernateComputer",
@@ -100,6 +102,7 @@ export function buildComputerUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async () => {
         const response = await dispatchInspectorCommand({
           type: "resetComputer",
@@ -121,6 +124,7 @@ export function buildComputerUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async () => {
         const response = await dispatchInspectorCommand({
           type: "deleteComputer",

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/core.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/core.ts
@@ -19,10 +19,13 @@ import {
   selectServerAction,
 } from "../ui-actions";
 import {
+  PUBLISH_NATIVE,
+  PUBLISH_NATIVE_UNTRUSTED,
   asOptionalString,
   ensurePlaygroundOpen,
   errorResult,
   fromActionResult,
+  nativeInternal,
   okResult,
 } from "./shared";
 import {
@@ -168,6 +171,7 @@ export function buildCoreUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       mayNavigate: true,
       execute: async (args) => {
         const target = asOptionalString(args.target);
@@ -194,6 +198,7 @@ export function buildCoreUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         const serverName = asOptionalString(args.serverName);
         if (!serverName) {
@@ -235,6 +240,7 @@ export function buildCoreUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       // Auto-opens the playground when its handler isn't mounted — from a
       // non-playground route that is a navigation.
       mayNavigate: true,
@@ -293,6 +299,7 @@ export function buildCoreUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE_UNTRUSTED,
       execute: async (args) => {
         const surface = asOptionalString(args.surface);
         const response = await dispatchInspectorCommand({
@@ -350,10 +357,19 @@ export function buildCoreUiTools(): UiToolDefinition[] {
         readOnlyHint: true,
         destructiveHint: false,
         // NOT idempotent: each call paints a new card and demands the user's
-        // attention. A native agent retrying freely would nag.
+        // attention. An agent retrying freely would nag.
         idempotentHint: false,
         openWorldHint: false,
       },
+      // The one core tool browser-native agents do NOT get. Everything it
+      // does happens inside an MCPJam conversation: it paints a card into
+      // that transcript and parks the turn on the answer. A native agent has
+      // no transcript to paint into and no turn to park, so publishing this
+      // would advertise a question nobody could be asked — an external agent
+      // asks its own user in its own UI instead.
+      nativePublication: nativeInternal(
+        "Renders a question card into the Ask MCPJam transcript and parks that turn until the user answers — a native call has neither.",
+      ),
       execute: async (args, ctx) => {
         // The card resolves the parked promise by tool-call id, so a call
         // that arrived without one can never be answered — fail it now

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/eval-authoring.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/eval-authoring.ts
@@ -13,6 +13,7 @@ import {
   useEvalGeneration,
   evalSuiteKey,
 } from "@/lib/mcpjam-agent/eval-workspace";
+import { nativeInternal } from "./shared";
 
 const revision = {
   type: "string",
@@ -88,6 +89,15 @@ export function buildEvalAuthoringTools(): UiToolDefinition[] {
       idempotentHint: spec.name === "ui_eval_context",
       openWorldHint: false,
     },
+    // Never published to browser-native agents. Each of these reads or writes
+    // the eval scope PINNED TO ONE Ask MCPJam conversation (`context.scope`)
+    // and refuses outright without it — see the guard in `execute` below. A
+    // native call has no conversation, so the whole group would be an
+    // advertised capability whose only answer is "open Ask MCPJam from the
+    // eval workspace first".
+    nativePublication: nativeInternal(
+      "Reads and writes the eval scope pinned to one Ask MCPJam conversation; refuses without that session.",
+    ),
     inputSchema: {
       type: "object",
       properties: spec.properties,

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/evals.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/evals.ts
@@ -22,7 +22,12 @@ import {
   commandResponseToActionResult,
   dispatchInspectorCommand,
 } from "../ui-actions";
-import { asOptionalString, errorResult, fromActionResult } from "./shared";
+import {
+  PUBLISH_NATIVE,
+  asOptionalString,
+  errorResult,
+  fromActionResult,
+} from "./shared";
 
 const SUITE_PROPERTY = {
   type: "string",
@@ -58,6 +63,7 @@ export function buildEvalsUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       // Opens the /evals/create route (the dialog) on the Evaluate screen.
       mayNavigate: true,
       execute: async (args) => {
@@ -91,6 +97,7 @@ export function buildEvalsUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: true,
       },
+      nativePublication: PUBLISH_NATIVE,
       // A successful single-host launch lands on the new run's detail page.
       mayNavigate: true,
       execute: async (args) => {
@@ -130,6 +137,7 @@ export function buildEvalsUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         const runId = asOptionalString(args.runId);
         if (!runId) {
@@ -162,6 +170,7 @@ export function buildEvalsUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: true,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         const suite = requireSuite(args.suite);
         if (!suite) {
@@ -214,6 +223,7 @@ export function buildEvalsUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         const prompt = asOptionalString(args.prompt);
         if (args.prompt !== undefined && prompt === undefined) {
@@ -297,6 +307,7 @@ export function buildEvalsUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         const suite = requireSuite(args.suite);
         if (!suite) {

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/hosts.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/hosts.ts
@@ -28,7 +28,12 @@ import {
   commandResponseToActionResult,
   dispatchInspectorCommand,
 } from "../ui-actions";
-import { asOptionalString, errorResult, fromActionResult } from "./shared";
+import {
+  PUBLISH_NATIVE,
+  asOptionalString,
+  errorResult,
+  fromActionResult,
+} from "./shared";
 
 const HOST_PROPERTY = {
   type: "string",
@@ -81,6 +86,7 @@ export function buildHostsUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       // A successful create opens the new host's editor.
       mayNavigate: true,
       execute: async (args) => {
@@ -120,6 +126,7 @@ export function buildHostsUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       mayNavigate: true,
       execute: async (args) => {
         const host = asOptionalString(args.host);
@@ -160,6 +167,7 @@ export function buildHostsUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         const host = asOptionalString(args.host);
         if (!host) {
@@ -197,6 +205,7 @@ export function buildHostsUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         const host = asOptionalString(args.host);
         if (!host) {
@@ -233,6 +242,7 @@ export function buildHostsUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       // A successful duplicate opens the copy's editor.
       mayNavigate: true,
       execute: async (args) => {

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/oauth-flow.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/oauth-flow.ts
@@ -30,7 +30,13 @@ import {
   commandResponseToActionResult,
   dispatchInspectorCommand,
 } from "../ui-actions";
-import { asOptionalString, errorResult, fromActionResult } from "./shared";
+import {
+  PUBLISH_NATIVE,
+  PUBLISH_NATIVE_UNTRUSTED,
+  asOptionalString,
+  errorResult,
+  fromActionResult,
+} from "./shared";
 
 const REGISTRATION_MODES = ["preregistered", "dcr", "cimd"] as const;
 
@@ -70,6 +76,7 @@ export function buildOAuthFlowUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         const serverName = asOptionalString(args.serverName);
         if (args.serverName !== undefined && serverName === undefined) {
@@ -132,6 +139,7 @@ export function buildOAuthFlowUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: true,
       },
+      nativePublication: PUBLISH_NATIVE_UNTRUSTED,
       execute: async () => {
         const response = await dispatchInspectorCommand({
           type: "advanceOauthFlow",
@@ -158,6 +166,7 @@ export function buildOAuthFlowUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async () => {
         const response = await dispatchInspectorCommand({
           type: "resetOauthFlow",

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/playground.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/playground.ts
@@ -18,6 +18,8 @@ import {
   openPlaygroundAction,
 } from "../ui-actions";
 import {
+  PUBLISH_NATIVE,
+  PUBLISH_NATIVE_UNTRUSTED,
   asOptionalString,
   ensurePlaygroundOpen,
   errorResult,
@@ -55,6 +57,7 @@ export function buildPlaygroundUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       mayNavigate: true,
       execute: async (args) =>
         fromActionResult(
@@ -90,6 +93,7 @@ export function buildPlaygroundUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       // Auto-opens the playground when its handler isn't mounted — from a
       // non-playground route that is a navigation.
       mayNavigate: true,
@@ -145,6 +149,7 @@ export function buildPlaygroundUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: true,
       },
+      nativePublication: PUBLISH_NATIVE_UNTRUSTED,
       // Auto-opens the playground when its handler isn't mounted — from a
       // non-playground route that is a navigation.
       mayNavigate: true,
@@ -192,6 +197,7 @@ export function buildPlaygroundUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       mayNavigate: true,
       execute: async (args) => {
         const model = asOptionalString(args.model);
@@ -231,6 +237,7 @@ export function buildPlaygroundUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       mayNavigate: true,
       execute: async (args) => {
         // Free text, so accept it verbatim — including the empty string, which
@@ -269,6 +276,7 @@ export function buildPlaygroundUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       mayNavigate: true,
       execute: async () => {
         const notOpen = await ensurePlaygroundOpen("resetChat");
@@ -297,6 +305,7 @@ export function buildPlaygroundUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       mayNavigate: true,
       execute: async () => {
         const notOpen = await ensurePlaygroundOpen("stopGeneration");

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/prompts.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/prompts.ts
@@ -22,6 +22,7 @@ import {
   dispatchInspectorCommand,
 } from "../ui-actions";
 import {
+  PUBLISH_NATIVE_UNTRUSTED,
   asOptionalString,
   asStringRecord,
   errorResult,
@@ -61,6 +62,7 @@ export function buildPromptsUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: true,
       },
+      nativePublication: PUBLISH_NATIVE_UNTRUSTED,
       execute: async (args) => {
         const prompt = asOptionalString(args.prompt);
         if (!prompt) {

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/registry.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/registry.ts
@@ -15,7 +15,13 @@ import {
   commandResponseToActionResult,
   dispatchInspectorCommand,
 } from "../ui-actions";
-import { asOptionalString, errorResult, fromActionResult } from "./shared";
+import {
+  PUBLISH_NATIVE,
+  PUBLISH_NATIVE_UNTRUSTED,
+  asOptionalString,
+  errorResult,
+  fromActionResult,
+} from "./shared";
 
 const SERVER_NAME_PROPERTY = {
   type: "string",
@@ -61,6 +67,7 @@ export function buildRegistryUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: true,
       },
+      nativePublication: PUBLISH_NATIVE_UNTRUSTED,
       // A successful quick-connect auto-redirects to the playground.
       mayNavigate: true,
       execute: async (args) => {
@@ -106,6 +113,7 @@ export function buildRegistryUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: true,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         const serverName = asOptionalString(args.serverName);
         if (!serverName) {
@@ -151,6 +159,7 @@ export function buildRegistryUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         const serverName = asOptionalString(args.serverName);
         if (!serverName) {
@@ -203,6 +212,7 @@ export function buildRegistryUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE_UNTRUSTED,
       execute: async (args) => {
         const query = asOptionalString(args.query);
         const tier = asOptionalString(args.tier);

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/resources.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/resources.ts
@@ -23,6 +23,7 @@ import {
   dispatchInspectorCommand,
 } from "../ui-actions";
 import {
+  PUBLISH_NATIVE_UNTRUSTED,
   asOptionalString,
   asStringRecord,
   errorResult,
@@ -62,6 +63,7 @@ export function buildResourcesUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: true,
       },
+      nativePublication: PUBLISH_NATIVE_UNTRUSTED,
       execute: async (args) => {
         const resource = asOptionalString(args.resource);
         if (!resource) {

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/scenarios.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/scenarios.ts
@@ -39,6 +39,7 @@ import {
   asOptionalString,
   errorResult,
   fromActionResult,
+  publishNativeConsequential,
 } from "./shared";
 
 const ACCESS_VALUES = ["invited_only", "link_guests", "project"] as const;
@@ -83,7 +84,17 @@ export function buildScenariosUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
-      nativePublication: PUBLISH_NATIVE,
+      // Consequential for a BROWSER agent even though it is not destructive
+      // for MCP, and the two are different questions. `access: "link_guests"`
+      // opens the scenario to anyone with the link — signed-out visitors
+      // included — with their sessions funded by this organization. Nothing is
+      // destroyed and re-publishing converges, so `destructiveHint` stays
+      // false and Ask MCPJam's approval behaviour is unchanged; an external
+      // agent's browser is told to confirm first, which is the one place that
+      // spend would otherwise happen with nobody looking.
+      nativePublication: publishNativeConsequential({
+        untrustedContent: false,
+      }),
       execute: async (args) => {
         // Validate strictly here, loosely in the schema (Chrome): the errors
         // are what let the model correct itself on the next turn.

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/scenarios.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/scenarios.ts
@@ -34,7 +34,12 @@ import {
   commandResponseToActionResult,
   dispatchInspectorCommand,
 } from "../ui-actions";
-import { asOptionalString, errorResult, fromActionResult } from "./shared";
+import {
+  PUBLISH_NATIVE,
+  asOptionalString,
+  errorResult,
+  fromActionResult,
+} from "./shared";
 
 const ACCESS_VALUES = ["invited_only", "link_guests", "project"] as const;
 type AccessValue = (typeof ACCESS_VALUES)[number];
@@ -78,6 +83,7 @@ export function buildScenariosUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         // Validate strictly here, loosely in the schema (Chrome): the errors
         // are what let the model correct itself on the next turn.
@@ -132,6 +138,7 @@ export function buildScenariosUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         const scenario = asOptionalString(args.scenario);
         if (!scenario) {

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/servers.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/servers.ts
@@ -13,7 +13,13 @@ import {
   dispatchInspectorCommand,
   navigateAction,
 } from "../ui-actions";
-import { asOptionalString, errorResult, fromActionResult } from "./shared";
+import {
+  PUBLISH_NATIVE,
+  PUBLISH_NATIVE_UNTRUSTED,
+  asOptionalString,
+  errorResult,
+  fromActionResult,
+} from "./shared";
 
 /**
  * The Connect screen owns `openServerForm` (the Add-server modal's open
@@ -134,6 +140,7 @@ function connectScreenServerTool(config: {
   commandType: "connectServer" | "disconnectServer" | "removeServer";
   verb: string;
   annotations: NonNullable<UiToolDefinition["annotations"]>;
+  nativePublication: NonNullable<UiToolDefinition["nativePublication"]>;
 }): UiToolDefinition {
   return {
     name: config.name,
@@ -151,6 +158,7 @@ function connectScreenServerTool(config: {
     },
     readOnly: false,
     annotations: config.annotations,
+    nativePublication: config.nativePublication,
     mayNavigate: true,
     execute: async (args) => {
       const serverName = asOptionalString(args.serverName);
@@ -182,6 +190,7 @@ export function buildServersUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       mayNavigate: true,
       execute: async (args) => {
         const notOpen = await ensureConnectOpen("openServerForm");
@@ -209,6 +218,7 @@ export function buildServersUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       mayNavigate: true,
       execute: async (args) => {
         const draft = readServerDraft(args);
@@ -237,6 +247,7 @@ export function buildServersUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: true,
       },
+      nativePublication: PUBLISH_NATIVE_UNTRUSTED,
     }),
     connectScreenServerTool({
       name: "ui_disconnect_server",
@@ -251,6 +262,7 @@ export function buildServersUiTools(): UiToolDefinition[] {
         idempotentHint: true,
         openWorldHint: true,
       },
+      nativePublication: PUBLISH_NATIVE,
     }),
     connectScreenServerTool({
       name: "ui_remove_server",
@@ -266,6 +278,7 @@ export function buildServersUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
     }),
   ];
 }

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/shared.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/shared.ts
@@ -42,6 +42,23 @@ export const PUBLISH_NATIVE_UNTRUSTED: UiToolNativePublication = {
 };
 
 /**
+ * Publish, and tell the browser to confirm this one even though MCP's
+ * `destructiveHint` is false — for an action that creates rather than
+ * destroys, yet commits the organization to something a person should see
+ * first. The MCP annotations stay as they are; this only widens what the
+ * BROWSER is told. State the reason at the call site.
+ */
+export function publishNativeConsequential(options: {
+  untrustedContent: boolean;
+}): UiToolNativePublication {
+  return {
+    kind: "publish",
+    untrustedContent: options.untrustedContent,
+    consequential: true,
+  };
+}
+
+/**
  * Keep this tool off the native surface, with the reason stated. Reserved for
  * tools whose meaning depends on an MCPJam conversation — there is no
  * conversation behind a native call, so publishing one would advertise a

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/shared.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/shared.ts
@@ -5,21 +5,63 @@
 
 import { hasInspectorCommandHandler } from "@/lib/inspector-command-handlers";
 import type { InspectorCommandType } from "@/shared/inspector-command.js";
-import type { UiToolResult } from "../ui-tools-registry";
+import type {
+  UiToolNativePublication,
+  UiToolResult,
+} from "../ui-tools-registry";
 import { openPlaygroundAction, type UiActionResult } from "../ui-actions";
+import { clampText, MAX_RESULT_CHARS } from "../bounded-size";
 
-/** Keep serialized results well under context-bloating sizes. */
-export const MAX_RESULT_CHARS = 16 * 1024;
+// --- Native publication (browser-native WebMCP agents) -----------------
+//
+// Every first-party definition states one of these. Shared constants rather
+// than inline literals so the decision reads as a decision at each tool, and
+// so the whole published set is one grep away.
+
+/**
+ * Publish this tool to browser-native WebMCP agents. Its result is MCPJam's
+ * own reporting — a command outcome, a status, an id — so nothing in it came
+ * from a third party.
+ */
+export const PUBLISH_NATIVE: UiToolNativePublication = {
+  kind: "publish",
+  untrustedContent: false,
+};
+
+/**
+ * Publish, and say that the RESULT can carry somebody else's bytes: an MCP
+ * server's tool output, a registry listing, an OAuth server's metadata, a
+ * snapshot of a screen showing any of those. Chrome's guidance is to label
+ * such payloads so an agent treats them as data rather than instructions
+ * (https://developer.chrome.com/docs/ai/webmcp/secure-tools) — over-claiming
+ * here is cheap, under-claiming is the failure that matters.
+ */
+export const PUBLISH_NATIVE_UNTRUSTED: UiToolNativePublication = {
+  kind: "publish",
+  untrustedContent: true,
+};
+
+/**
+ * Keep this tool off the native surface, with the reason stated. Reserved for
+ * tools whose meaning depends on an MCPJam conversation — there is no
+ * conversation behind a native call, so publishing one would advertise a
+ * capability that cannot work.
+ */
+export function nativeInternal(reason: string): UiToolNativePublication {
+  return { kind: "internal", reason };
+}
+
+/**
+ * Keep serialized results well under context-bloating sizes. Defined in
+ * `bounded-size.ts` and re-exported here because both the builders below and
+ * `ui-tool-execution.ts`'s backstop must clamp to the SAME number.
+ */
+export { MAX_RESULT_CHARS, clampText } from "../bounded-size";
 // Stop serializing well before we've built a multi-megabyte string: a tool
 // result can carry arbitrary provider content (e.g. a large resource read).
 // The replacer throws once the running length passes this budget, so we never
 // materialize the whole thing just to clamp it afterwards.
 const SERIALIZE_BUDGET = MAX_RESULT_CHARS * 2;
-
-export function clampText(text: string): string {
-  if (text.length <= MAX_RESULT_CHARS) return text;
-  return `${text.slice(0, MAX_RESULT_CHARS)}… [truncated]`;
-}
 
 /** JSON.stringify that aborts once it has emitted more than SERIALIZE_BUDGET. */
 function budgetedStringify(value: unknown): string {

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/swarms.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/swarms.ts
@@ -30,7 +30,12 @@ import {
   commandResponseToActionResult,
   dispatchInspectorCommand,
 } from "../ui-actions";
-import { asOptionalString, errorResult, fromActionResult } from "./shared";
+import {
+  PUBLISH_NATIVE,
+  asOptionalString,
+  errorResult,
+  fromActionResult,
+} from "./shared";
 
 const PERSONA_PROPERTY = {
   type: "string",
@@ -77,6 +82,7 @@ export function buildSwarmsUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         const name = asOptionalString(args.name);
         const role = asOptionalString(args.role);
@@ -121,6 +127,7 @@ export function buildSwarmsUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: false,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         const persona = asOptionalString(args.persona);
         if (args.persona !== undefined && persona === undefined) {
@@ -162,6 +169,7 @@ export function buildSwarmsUiTools(): UiToolDefinition[] {
         idempotentHint: false,
         openWorldHint: true,
       },
+      nativePublication: PUBLISH_NATIVE,
       execute: async (args) => {
         const journey = asOptionalString(args.journey);
         if (!journey) {

--- a/mcpjam-inspector/client/src/lib/webmcp/native-model-context.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/native-model-context.ts
@@ -118,7 +118,7 @@ export function resolveNativeModelContext(): ResolvedNativeModelContext | null {
  * server's tool output. A definition that somehow reaches here without saying
  * gets `true`, the cautious reading.
  *
- * `consequentialHint` IS derived, from the annotations the catalog already
+ * `consequentialHint` is derived, from the annotations the catalog already
  * curates: destructive actions (delete something, spend quota, consume billed
  * infrastructure), plus mutating actions that reach an external system
  * (`openWorldHint`) — connecting a server, running one of its tools. A
@@ -127,6 +127,13 @@ export function resolveNativeModelContext(): ResolvedNativeModelContext | null {
  * teach the user to click through the prompts that matter. An absent
  * `destructiveHint` counts as destructive, matching the protocol's pessimistic
  * default and the approval floor MCPJam already applies.
+ *
+ * A definition can also declare `consequential` outright, and that wins. The
+ * two hints ask different questions — MCP's `destructiveHint` is about
+ * irreversibility, Chrome's `consequentialHint` is about whether a browser
+ * agent should confirm — and a tool that only creates can still commit the
+ * organization to something (`ui_publish_scenario` opening an org-funded link
+ * to signed-out visitors). Deriving alone would under-claim exactly there.
  */
 export function nativeAnnotationsFor(
   def: UiToolDefinition,
@@ -134,13 +141,15 @@ export function nativeAnnotationsFor(
   const readOnly = def.annotations?.readOnlyHint ?? def.readOnly;
   const destructive = def.annotations?.destructiveHint !== false;
   const openWorld = def.annotations?.openWorldHint === true;
+  const publication =
+    def.nativePublication?.kind === "publish" ? def.nativePublication : null;
   return {
     readOnlyHint: readOnly,
-    untrustedContentHint:
-      def.nativePublication?.kind === "publish"
-        ? def.nativePublication.untrustedContent
-        : true,
-    consequentialHint: destructive || (openWorld && !readOnly),
+    untrustedContentHint: publication ? publication.untrustedContent : true,
+    consequentialHint:
+      publication?.consequential === true ||
+      destructive ||
+      (openWorld && !readOnly),
   };
 }
 

--- a/mcpjam-inspector/client/src/lib/webmcp/native-model-context.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/native-model-context.ts
@@ -1,0 +1,161 @@
+/**
+ * The browser's WebMCP page API, as much of it as MCPJam actually uses.
+ *
+ * One narrow seam so the rest of the publisher never touches a global: where
+ * the API lives, whether this browser has it at all, and how an MCPJam tool
+ * definition becomes a WebMCP descriptor.
+ *
+ * MEASURED, not assumed. Everything asserted below was probed against the
+ * pinned Chromium 151.0.7922.34 (the same build the CDP contract suite in
+ * `server/services/webmcp-inspector/__tests__/webmcp-cdp.spike.test.ts` pins):
+ *
+ *   - `document.modelContext` is the current home; `navigator.modelContext`
+ *     is the deprecated alias and is the SAME object at this pin. We read the
+ *     documented one and fall back rather than requiring both.
+ *   - `registerTool(descriptor, { signal })` returns a Promise that resolves
+ *     to `undefined`. There is no `unregisterTool` and no `provideContext`:
+ *     aborting the signal passed at registration IS the unregister.
+ *   - Registering a name that is already registered REJECTS
+ *     (`InvalidStateError: Duplicate tool name`), so a replacement must tear
+ *     the old registration down first and wait for it.
+ *   - The `execute` callback receives NO second argument at this pin. The
+ *     spec'd `(args, { signal })` shape arrives in a later Chromium, so we
+ *     read it defensively and use it when it shows up.
+ *
+ * WebMCP ships behind an origin trial / feature flag, so on a stock profile
+ * none of this exists — `resolveNativeModelContext` returns null and MCPJam's
+ * own agent is unaffected. See `docs/webmcp-native-tools.md`.
+ */
+
+import type { UiToolDefinition } from "./ui-tools-registry";
+
+/**
+ * The three hints Chrome's secure-tools guidance asks a page to publish
+ * (https://developer.chrome.com/docs/ai/webmcp/secure-tools). All three are
+ * stated explicitly on every tool MCPJam publishes: an omitted hint reads as
+ * `false`, and "we never said" is not the same claim as "no".
+ */
+export interface NativeToolAnnotations {
+  readOnlyHint: boolean;
+  untrustedContentHint: boolean;
+  consequentialHint: boolean;
+}
+
+export interface NativeToolDescriptor {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations: NativeToolAnnotations;
+  execute: (args: unknown, ctx?: { signal?: AbortSignal }) => Promise<unknown>;
+}
+
+export interface NativeRegisterToolOptions {
+  /** Aborting this is how a tool is unregistered. */
+  signal?: AbortSignal;
+  /**
+   * Deliberately never set. `exposedTo` hands a tool to OTHER origins'
+   * agents; MCPJam's tools drive the user's own inspector session and have no
+   * business being callable from someone else's page.
+   */
+  exposedTo?: never;
+}
+
+export interface NativeModelContext {
+  registerTool(
+    descriptor: NativeToolDescriptor,
+    options?: NativeRegisterToolOptions,
+  ): Promise<unknown> | unknown;
+}
+
+export type NativeModelContextHome = "document" | "navigator";
+
+export interface ResolvedNativeModelContext {
+  api: NativeModelContext;
+  home: NativeModelContextHome;
+}
+
+function readCandidate(host: unknown): NativeModelContext | null {
+  const candidate = (host as { modelContext?: unknown } | null | undefined)
+    ?.modelContext;
+  if (!candidate || typeof candidate !== "object") return null;
+  // CAPABILITY check, not a presence check: `navigator.modelContext` has
+  // already been one shape and then another, and some environments define the
+  // property as a stub. The only thing that matters is whether we can
+  // register a tool through it.
+  const { registerTool } = candidate as { registerTool?: unknown };
+  if (typeof registerTool !== "function") return null;
+  return candidate as NativeModelContext;
+}
+
+/**
+ * The page's WebMCP API, or null when this browser has none.
+ *
+ * Null is a completely normal answer — no WebMCP build, the origin trial not
+ * activated, a non-Chromium browser, a test environment, SSR. Callers publish
+ * nothing and say nothing; MCPJam's in-app agent keeps working through its
+ * own transport either way.
+ */
+export function resolveNativeModelContext(): ResolvedNativeModelContext | null {
+  if (typeof globalThis === "undefined") return null;
+  const documentApi =
+    typeof document === "undefined" ? null : readCandidate(document);
+  if (documentApi) return { api: documentApi, home: "document" };
+  const navigatorApi =
+    typeof navigator === "undefined" ? null : readCandidate(navigator);
+  if (navigatorApi) return { api: navigatorApi, home: "navigator" };
+  return null;
+}
+
+/**
+ * MCP tool annotations → the WebMCP hints, per tool.
+ *
+ * `readOnlyHint` is a straight copy. The other two are the interesting ones:
+ *
+ * `untrustedContentHint` is NOT derived — it is read off the definition's own
+ * `nativePublication`, because "can this result contain somebody else's
+ * bytes?" is not answerable from the MCP hints: `ui_snapshot_app` is
+ * read-only, closed-world, and still returns a screen showing a third-party
+ * server's tool output. A definition that somehow reaches here without saying
+ * gets `true`, the cautious reading.
+ *
+ * `consequentialHint` IS derived, from the annotations the catalog already
+ * curates: destructive actions (delete something, spend quota, consume billed
+ * infrastructure), plus mutating actions that reach an external system
+ * (`openWorldHint`) — connecting a server, running one of its tools. A
+ * read-only tool is never consequential even when it reads across the network:
+ * Chrome's guidance is about real-world consequences, and gating reads would
+ * teach the user to click through the prompts that matter. An absent
+ * `destructiveHint` counts as destructive, matching the protocol's pessimistic
+ * default and the approval floor MCPJam already applies.
+ */
+export function nativeAnnotationsFor(
+  def: UiToolDefinition,
+): NativeToolAnnotations {
+  const readOnly = def.annotations?.readOnlyHint ?? def.readOnly;
+  const destructive = def.annotations?.destructiveHint !== false;
+  const openWorld = def.annotations?.openWorldHint === true;
+  return {
+    readOnlyHint: readOnly,
+    untrustedContentHint:
+      def.nativePublication?.kind === "publish"
+        ? def.nativePublication.untrustedContent
+        : true,
+    consequentialHint: destructive || (openWorld && !readOnly),
+  };
+}
+
+/** The descriptor for one tool, minus the callback the publisher supplies. */
+export function nativeDescriptorFor(
+  def: UiToolDefinition,
+  execute: NativeToolDescriptor["execute"],
+): NativeToolDescriptor {
+  return {
+    name: def.name,
+    description: def.description,
+    // Blink derives the agent-facing parameter list from this, and a missing
+    // schema is not the same as "no parameters".
+    inputSchema: def.inputSchema ?? { type: "object", properties: {} },
+    annotations: nativeAnnotationsFor(def),
+    execute,
+  };
+}

--- a/mcpjam-inspector/client/src/lib/webmcp/native-tool-publisher.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/native-tool-publisher.ts
@@ -84,7 +84,16 @@ interface NativeRegistration {
   name: string;
   /** The exact definition object this registration was built from. */
   def: UiToolDefinition;
-  /** Aborting this unregisters the tool. Never aborted while a call runs. */
+  /**
+   * The REGISTRATION's lifetime, not any call's. Aborting it unregisters the
+   * tool, which is why it is never aborted while a call this registration
+   * accepted is still running, and why it is deliberately NOT forwarded to a
+   * running handler: "your registration went away" is not "stop what you are
+   * doing", and cancelling the call we chose to let finish would undo the one
+   * accommodation the pinned browser needs. Per-invocation cancellation is the
+   * agent's own signal, which arrives through `ctx.signal` (see
+   * `buildExecute`) on a Chromium that supplies one.
+   */
   controller: AbortController;
   /** Resolves when the platform has accepted or refused. Never rejects. */
   settled: Promise<void>;

--- a/mcpjam-inspector/client/src/lib/webmcp/native-tool-publisher.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/native-tool-publisher.ts
@@ -273,8 +273,10 @@ export function startNativeUiToolPublisher(): NativeUiToolPublisher {
   async function awaitRetired(entry: NativeRegistration): Promise<void> {
     if (entry.inFlight > 0) {
       await whenIdle(entry);
-      entry.controller.abort();
     }
+    // The call may have settled after markRetired but before this queued
+    // task started. Retirement must abort even when there is no wait left.
+    entry.controller.abort();
     // Wait for the platform to finish with this registration before the name
     // can be claimed again — an overlapping claim is the duplicate-name
     // rejection this whole chain exists to avoid.

--- a/mcpjam-inspector/client/src/lib/webmcp/native-tool-publisher.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/native-tool-publisher.ts
@@ -1,0 +1,419 @@
+/**
+ * The NATIVE adapter: MCPJam's `ui_*` tools, published to whatever WebMCP
+ * agent the browser is running.
+ *
+ * The other adapter is `ui-tool-executor.ts` (Ask MCPJam). Both execute
+ * through `ui-tool-execution.ts`, so an external agent and the in-app one
+ * drive the same inspector actions with the same arguments and get the same
+ * results. What is different is everything around the call: an external agent
+ * discovers these tools without anyone opening the MCPJam sidebar, its own
+ * browser owns its approval flow, and a native call NEVER creates a
+ * conversation or opens a panel.
+ *
+ * ## What it does
+ *
+ * Subscribes to the UI tools registry and keeps the browser's registrations in
+ * step with it — global tools stay up across navigation, a surface's tools
+ * appear when its screen mounts and go when it leaves. Only definitions that
+ * say `nativePublication: { kind: "publish" }` are mirrored; the tools that
+ * need an MCPJam conversation (`ui_ask_user`, the eval-authoring group) are
+ * internal and stay internal.
+ *
+ * ## The three races this is built around
+ *
+ * 1. **Duplicate names.** Chromium rejects `registerTool` for a name it
+ *    already holds, so a replacement CANNOT overlap its predecessor. Work for
+ *    one name is therefore serialized on a per-name chain: retire, wait for
+ *    the platform to acknowledge, then register.
+ *
+ * 2. **Registration results that arrive late.** `registerTool` is async, and
+ *    StrictMode, HMR and a fast navigation can all replace a registration
+ *    while its promise is still pending. `live` is the ownership map and each
+ *    entry carries its own AbortController: the moment an entry stops being
+ *    the owner it is marked dead and — unless it has a call to protect —
+ *    aborted on the spot, so a pending registration never lands after its
+ *    publisher is gone. Because the abort belongs to that one registration,
+ *    a late teardown can only ever remove its own, never the replacement.
+ *
+ * 3. **Unregistering during a call.** Chrome only guarantees that
+ *    unregistering leaves in-flight executions alone from 153 onward, and the
+ *    pinned Chromium is 151. So a registration with an accepted call is left
+ *    standing until that call settles, while being marked dead so any further
+ *    call through it is refused rather than executed.
+ *
+ * ## What it never does
+ *
+ * Retry a failed call (a UI tool can add a server or spend quota — a silent
+ * second attempt is a second action), expose tools to other origins
+ * (`exposedTo` is never set), or report a tool's arguments or results: the
+ * diagnostics below carry names, counts, statuses and durations only.
+ */
+
+import { track } from "@/lib/analytics";
+import {
+  nativeDescriptorFor,
+  resolveNativeModelContext,
+  type NativeModelContextHome,
+  type NativeToolDescriptor,
+} from "./native-model-context";
+import {
+  executeUiToolCall,
+  uiToolErrorResult,
+  uiToolUnavailableResult,
+} from "./ui-tool-execution";
+import {
+  shouldPublishNatively,
+  useUiToolsRegistry,
+  type UiToolDefinition,
+} from "./ui-tools-registry";
+
+/**
+ * How long a teardown waits for an accepted call before aborting the
+ * registration anyway.
+ *
+ * The deferral exists so a call in progress is not cut off mid-flight; it is
+ * not a promise to wait forever. A handler that never settles would otherwise
+ * pin a dead tool to the page for the rest of the session — including
+ * blocking the replacement registration that a remount is waiting to make.
+ * Well past the inspector command bus's own timeouts, so a real call reaches
+ * its own failure long before this fires.
+ */
+const TEARDOWN_GRACE_MS = 30_000;
+
+interface NativeRegistration {
+  name: string;
+  /** The exact definition object this registration was built from. */
+  def: UiToolDefinition;
+  /** Aborting this unregisters the tool. Never aborted while a call runs. */
+  controller: AbortController;
+  /** Resolves when the platform has accepted or refused. Never rejects. */
+  settled: Promise<void>;
+  /** No longer the live owner: refuse calls that still arrive through it. */
+  disposed: boolean;
+  inFlight: number;
+  /** Resolvers waiting for `inFlight` to reach zero. */
+  idleWaiters: Array<() => void>;
+}
+
+export interface NativeUiToolPublisher {
+  /**
+   * Retire every registration and stop following the registry. In-flight
+   * calls are still allowed to finish (see TEARDOWN_GRACE_MS).
+   */
+  stop(): void;
+  /** Where the API was found — for diagnostics and tests. */
+  readonly home: NativeModelContextHome | null;
+  /**
+   * Settles once the work queued so far has been applied. Tests await this;
+   * nothing in the app does.
+   */
+  whenSettled(): Promise<void>;
+}
+
+type DiagnosticEvent =
+  | "ui_tool_native_published"
+  | "ui_tool_native_registration_failed"
+  | "ui_tool_native_call_completed";
+
+function report(event: DiagnosticEvent, props: Record<string, unknown>): void {
+  try {
+    track(event, { location: "webmcp", ...props });
+  } catch {
+    // Diagnostics must never break a tool call or a registration.
+  }
+}
+
+/** An error's NAME only — messages can quote a page or a server. */
+function errorCodeOf(error: unknown): string {
+  if (error && typeof error === "object" && "name" in error) {
+    const name = (error as { name?: unknown }).name;
+    if (typeof name === "string" && name.length > 0 && name.length <= 64) {
+      return name;
+    }
+  }
+  return "unknown";
+}
+
+let invocationCounter = 0;
+function mintInvocationId(name: string): string {
+  invocationCounter += 1;
+  return `native-${name}-${invocationCounter}`;
+}
+
+function publishableTools(): Map<string, UiToolDefinition> {
+  const out = new Map<string, UiToolDefinition>();
+  for (const def of useUiToolsRegistry.getState().tools.values()) {
+    if (shouldPublishNatively(def)) out.set(def.name, def);
+  }
+  return out;
+}
+
+/**
+ * Start mirroring the registry onto the browser's WebMCP surface.
+ *
+ * Returns a publisher even when the browser has no WebMCP API: it publishes
+ * nothing, reports nothing, and `stop()` is a no-op — MCPJam's own agent is
+ * unaffected, which is the whole point of the capability check.
+ */
+export function startNativeUiToolPublisher(): NativeUiToolPublisher {
+  const resolved = resolveNativeModelContext();
+  if (!resolved) {
+    return {
+      stop: () => {},
+      home: null,
+      whenSettled: () => Promise.resolve(),
+    };
+  }
+  const { api, home } = resolved;
+
+  const live = new Map<string, NativeRegistration>();
+  /** Per-name serialization: see race 1 in the module comment. */
+  const chains = new Map<string, Promise<void>>();
+  let stopped = false;
+  let announced = false;
+
+  /** Queue work for ONE name behind whatever is already queued for it. */
+  function onName(name: string, task: () => Promise<void>): Promise<void> {
+    const previous = chains.get(name) ?? Promise.resolve();
+    // `.then(task, task)` rather than `.then(task)`: a rejected predecessor
+    // must not strand every later change to this name.
+    const next = previous.then(task, task).catch(() => {});
+    chains.set(name, next);
+    return next;
+  }
+
+  function releaseInFlight(entry: NativeRegistration): void {
+    entry.inFlight = Math.max(0, entry.inFlight - 1);
+    if (entry.inFlight > 0) return;
+    const waiters = entry.idleWaiters.splice(0);
+    for (const resolve of waiters) resolve();
+  }
+
+  function whenIdle(entry: NativeRegistration): Promise<void> {
+    if (entry.inFlight === 0) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      let done = false;
+      const settle = () => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(settle, TEARDOWN_GRACE_MS);
+      entry.idleWaiters.push(settle);
+    });
+  }
+
+  /**
+   * The DECISION that a registration is over, taken synchronously at the
+   * moment it is made rather than whenever the name's chain gets to it.
+   *
+   * Two things have to happen immediately. The entry is dead, so a call the
+   * browser still routes through it is refused instead of executed. And when
+   * nothing has been accepted yet, the registration is aborted right here —
+   * including while `registerTool` is still pending, which is what stops a
+   * torn-down publisher's late registration from colliding with the one that
+   * replaced it (StrictMode's second mount, a hot reload).
+   *
+   * The one case that does NOT abort now is the one the deferral exists for:
+   * a call this registration already accepted is still running.
+   */
+  function markRetired(entry: NativeRegistration): void {
+    entry.disposed = true;
+    if (entry.inFlight === 0) entry.controller.abort();
+  }
+
+  /** The WAIT, on the name's chain: let the platform finish with it. */
+  async function awaitRetired(entry: NativeRegistration): Promise<void> {
+    if (entry.inFlight > 0) {
+      await whenIdle(entry);
+      entry.controller.abort();
+    }
+    // Wait for the platform to finish with this registration before the name
+    // can be claimed again — an overlapping claim is the duplicate-name
+    // rejection this whole chain exists to avoid.
+    await entry.settled;
+  }
+
+  function buildExecute(
+    entry: NativeRegistration,
+  ): NativeToolDescriptor["execute"] {
+    return async (args, ctx) => {
+      if (entry.disposed || stopped) {
+        // The underlying tool is gone (its screen unmounted, the page is
+        // tearing down) but the platform still holds this registration while
+        // an earlier call finishes. Refuse — never act on a dead tool.
+        return uiToolUnavailableResult(entry.name);
+      }
+      entry.inFlight += 1;
+      const startedAt = Date.now();
+      try {
+        const outcome = await executeUiToolCall({
+          toolName: entry.name,
+          input: args,
+          caller: "native_webmcp",
+          invocationId: mintInvocationId(entry.name),
+          // The agent's own cancellation, when the browser supplies one (not
+          // at the pinned Chromium — see `native-model-context.ts`). Shared
+          // execution checks it before dispatch and hands it to the handler;
+          // an abort never un-does an action that already happened.
+          ...(ctx?.signal ? { signal: ctx.signal } : {}),
+        });
+        report("ui_tool_native_call_completed", {
+          tool_name: entry.name,
+          status: outcome.status,
+          duration_ms: Date.now() - startedAt,
+          ...(outcome.errorCode ? { error_code: outcome.errorCode } : {}),
+        });
+        return outcome.result;
+      } catch (error) {
+        // `executeUiToolCall` is written not to throw; if it ever does, the
+        // agent still gets a readable result instead of an opaque rejection.
+        report("ui_tool_native_call_completed", {
+          tool_name: entry.name,
+          status: "threw",
+          duration_ms: Date.now() - startedAt,
+          error_code: errorCodeOf(error),
+        });
+        return uiToolErrorResult(
+          `UI tool "${entry.name}" failed before it could report a result.`,
+        );
+      } finally {
+        releaseInFlight(entry);
+      }
+    };
+  }
+
+  async function registerOne(
+    name: string,
+    def: UiToolDefinition,
+  ): Promise<void> {
+    const controller = new AbortController();
+    const entry: NativeRegistration = {
+      name,
+      def,
+      controller,
+      settled: Promise.resolve(),
+      disposed: false,
+      inFlight: 0,
+      idleWaiters: [],
+    };
+    live.set(name, entry);
+    // Assigned before the first await inside, so `awaitRetired` can never
+    // observe the placeholder and conclude the platform is already done.
+    entry.settled = (async () => {
+      try {
+        await api.registerTool(nativeDescriptorFor(def, buildExecute(entry)), {
+          signal: controller.signal,
+        });
+        // Nothing to reconcile after the await, deliberately. If this entry
+        // stopped being the owner while its registration was pending,
+        // `markRetired` already aborted this controller — the platform then
+        // either never registered it or dropped it, and because the abort
+        // belongs to THIS registration it cannot touch the one that replaced
+        // it. That is the whole ownership story; a second check here would be
+        // a branch no sequence of events can reach.
+      } catch (error) {
+        // Individually awaited and individually caught: one refused tool must
+        // not take the rest of the catalog with it.
+        entry.disposed = true;
+        if (live.get(name) === entry) live.delete(name);
+        report("ui_tool_native_registration_failed", {
+          tool_name: name,
+          error_code: errorCodeOf(error),
+        });
+      }
+    })();
+    await entry.settled;
+  }
+
+  /** Bring ONE name to its desired state. Runs on that name's chain. */
+  function applyName(name: string): Promise<void> {
+    return onName(name, async () => {
+      const current = live.get(name);
+      const desired = stopped ? undefined : publishableTools().get(name);
+      // Same definition object: the registry has not changed this tool, so
+      // the browser's copy is already right.
+      if (current && current.def === desired) return;
+      if (current) {
+        live.delete(name);
+        markRetired(current);
+        await awaitRetired(current);
+      }
+      // Re-read: the registry can have moved on while we waited for an
+      // in-flight call, and the desired state is whatever it says NOW.
+      const target = stopped ? undefined : publishableTools().get(name);
+      if (!target) return;
+      await registerOne(name, target);
+    });
+  }
+
+  function reconcile(): void {
+    const desired = publishableTools();
+    const names = new Set<string>([...desired.keys(), ...live.keys()]);
+    for (const name of names) void applyName(name);
+    scheduleAnnouncement();
+  }
+
+  /**
+   * One adoption signal per page, once something is actually published: how
+   * many tools this browser accepted and which home the API was found at.
+   * Re-armed on every reconcile until a pass ends with tools live, so a page
+   * whose catalog mounts after the publisher does still reports.
+   */
+  function scheduleAnnouncement(): void {
+    if (announced || stopped) return;
+    void whenSettled().then(() => {
+      if (announced || stopped || live.size === 0) return;
+      announced = true;
+      report("ui_tool_native_published", {
+        api_home: home,
+        tool_count: live.size,
+      });
+    });
+  }
+
+  const unsubscribe = useUiToolsRegistry.subscribe(() => {
+    if (stopped) return;
+    reconcile();
+  });
+
+  reconcile();
+
+  /**
+   * Drain the per-name chains until a full pass queues nothing new. Bounded
+   * so a pathological loop cannot hang a caller; `chains` itself is bounded
+   * by the number of distinct tool names this page ever registers.
+   */
+  async function whenSettled(): Promise<void> {
+    for (let pass = 0; pass < 10; pass += 1) {
+      const pending = [...chains.values()];
+      await Promise.all(pending);
+      const after = [...chains.values()];
+      if (
+        after.length === pending.length &&
+        after.every((promise, index) => promise === pending[index])
+      ) {
+        return;
+      }
+    }
+  }
+
+  return {
+    home,
+    whenSettled,
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      unsubscribe();
+      for (const [name, entry] of [...live]) {
+        live.delete(name);
+        // Marked dead NOW — the queued wait below may sit behind a pending
+        // registration, and neither a late call nor a late registration may
+        // outlive this publisher.
+        markRetired(entry);
+        void onName(name, () => awaitRetired(entry));
+      }
+    },
+  };
+}

--- a/mcpjam-inspector/client/src/lib/webmcp/native-tool-publisher.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/native-tool-publisher.ts
@@ -24,7 +24,11 @@
  * 1. **Duplicate names.** Chromium rejects `registerTool` for a name it
  *    already holds, so a replacement CANNOT overlap its predecessor. Work for
  *    one name is therefore serialized on a per-name chain: retire, wait for
- *    the platform to acknowledge, then register.
+ *    the platform to acknowledge, then register. The chains belong to the
+ *    model context, not to a publisher, because the namespace they protect
+ *    does: a publisher that stops while one of its tools is mid-call leaves
+ *    that registration standing (race 3), and its replacement has to queue
+ *    behind that retirement rather than collide with it.
  *
  * 2. **Registration results that arrive late.** `registerTool` is async, and
  *    StrictMode, HMR and a fast navigation can all replace a registration
@@ -53,6 +57,7 @@ import { track } from "@/lib/analytics";
 import {
   nativeDescriptorFor,
   resolveNativeModelContext,
+  type NativeModelContext,
   type NativeModelContextHome,
   type NativeToolDescriptor,
 } from "./native-model-context";
@@ -79,6 +84,34 @@ import {
  * its own failure long before this fires.
  */
 const TEARDOWN_GRACE_MS = 30_000;
+
+/**
+ * Per-name work queues, keyed by the model context that owns the tool names.
+ *
+ * Keyed by the API object rather than held per publisher, because a name is
+ * unique to the browser's registry and not to whoever registered it. Two
+ * publishers overlap whenever one is torn down while a call it accepted is
+ * still running: the old registration is deliberately left standing until
+ * that call settles, so a replacement that registered the same name straight
+ * away would be rejected as a duplicate and — nothing retries a registration
+ * — the tool would be missing for the rest of the page's life. Sharing the
+ * chain makes the replacement wait for the retirement instead.
+ *
+ * Weak so a discarded context (a test's fake, a torn-down document) takes its
+ * queues with it.
+ */
+const chainsByContext = new WeakMap<
+  NativeModelContext,
+  Map<string, Promise<void>>
+>();
+
+function chainsFor(api: NativeModelContext): Map<string, Promise<void>> {
+  const existing = chainsByContext.get(api);
+  if (existing) return existing;
+  const created = new Map<string, Promise<void>>();
+  chainsByContext.set(api, created);
+  return created;
+}
 
 interface NativeRegistration {
   name: string;
@@ -176,8 +209,12 @@ export function startNativeUiToolPublisher(): NativeUiToolPublisher {
   const { api, home } = resolved;
 
   const live = new Map<string, NativeRegistration>();
-  /** Per-name serialization: see race 1 in the module comment. */
-  const chains = new Map<string, Promise<void>>();
+  /**
+   * Per-name serialization: see race 1 in the module comment. Shared with any
+   * other publisher on this same model context, so a remount queues behind
+   * the outgoing publisher's retirements instead of racing them.
+   */
+  const chains = chainsFor(api);
   let stopped = false;
   let announced = false;
 

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-execution.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-execution.ts
@@ -24,7 +24,7 @@
 
 import { assertEvalToolAllowed } from "@/lib/mcpjam-agent/eval-scope";
 import type { InspectorCommandErrorCode } from "@/shared/inspector-command.js";
-import { boundedJsonString, clampText, MAX_RESULT_CHARS } from "./bounded-size";
+import { boundedJsonString, MAX_RESULT_CHARS } from "./bounded-size";
 import {
   useUiToolsRegistry,
   type UiToolCaller,
@@ -116,10 +116,10 @@ export function structuredErrorCode(output: UiToolResult): string | undefined {
 }
 
 export function uiToolErrorResult(message: string): UiToolResult {
-  return {
-    content: [{ type: "text", text: clampText(message) }],
+  return boundedResult({
+    content: [{ type: "text", text: message }],
     isError: true,
-  };
+  });
 }
 
 /** The message an unresolvable name gets, identical on both transports. */
@@ -152,12 +152,9 @@ function readArguments(
 /**
  * Force a handler's return value into the wire shape, under ONE budget.
  *
- * The first-party handlers already return bounded text (`okResult` /
- * `errorResult` in `groups/shared.ts`), so for every tool in the catalog this
- * is a pass-through that rebuilds an equal object. It exists for the value
- * that ISN'T one of those: a future handler returning a foreign shape, a
- * `content` array holding non-text parts, or text long enough to bloat an
- * agent's context.
+ * Ordinary small results pass through unchanged. Even handlers that bound
+ * their text still need this final envelope budget: part wrappers and JSON
+ * escaping consume space too. Foreign parts are converted to bounded text.
  *
  * The budget is AGGREGATE, across the whole result. A per-part cap bounds
  * nothing — `content` can hold any number of parts, so N parts at the cap is
@@ -169,28 +166,61 @@ function boundedResult(value: unknown): UiToolResult {
   const source = value as Partial<UiToolResult> | undefined;
   const parts = Array.isArray(source?.content) ? source.content : [];
   const content: UiToolResult["content"] = [];
-  let remaining = MAX_RESULT_CHARS;
+  const result: UiToolResult = source?.isError
+    ? { content, isError: true }
+    : { content };
+  const omittedPart = (count: number) => ({
+    type: "text" as const,
+    text: `… [${count} more result part(s) omitted: the result is over ${MAX_RESULT_CHARS} characters]`,
+  });
+  // Reserve the envelope and a final omission notice. Every part costs its
+  // serialized size plus a comma, even when its text is empty. The notice's
+  // actual count cannot be longer than the total count reserved here.
+  let remaining =
+    MAX_RESULT_CHARS -
+    JSON.stringify(result).length -
+    JSON.stringify(omittedPart(parts.length)).length -
+    1;
 
   for (const [index, part] of parts.entries()) {
-    if (remaining <= 0) {
-      content.push({
-        type: "text",
-        text: `… [${parts.length - index} more result part(s) omitted: the result is over ${MAX_RESULT_CHARS} characters]`,
-      });
+    if (remaining < 64) {
+      content.push(omittedPart(parts.length - index));
       break;
     }
     const text = boundedPartText(part, remaining);
-    remaining -= text.length;
-    content.push({ type: "text", text });
+    const fitted = fitSerializedText(text, remaining - 1);
+    remaining -= JSON.stringify(fitted).length + 1;
+    content.push(fitted);
   }
 
   if (content.length === 0) {
     content.push({ type: "text", text: "The tool returned no content." });
   }
-  return source?.isError ? { content, isError: true } : { content };
+  return result;
 }
 
-/** One part's text, never longer than `budget`. */
+/** Include JSON escaping and the part wrapper in the remaining budget. */
+function fitSerializedText(
+  text: string,
+  budget: number,
+): { type: "text"; text: string } {
+  const part = (value: string) => ({ type: "text" as const, text: value });
+  if (JSON.stringify(part(text)).length <= budget) return part(text);
+  const suffix = "… [truncated]";
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if (JSON.stringify(part(text.slice(0, mid) + suffix)).length <= budget) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return part(text.slice(0, low) + suffix);
+}
+
+/** Bound the text before measuring JSON escaping; may add a short notice. */
 function boundedPartText(part: unknown, budget: number): string {
   if (
     part &&

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-execution.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-execution.ts
@@ -24,7 +24,7 @@
 
 import { assertEvalToolAllowed } from "@/lib/mcpjam-agent/eval-scope";
 import type { InspectorCommandErrorCode } from "@/shared/inspector-command.js";
-import { clampText } from "./bounded-size";
+import { boundedJsonString, clampText, MAX_RESULT_CHARS } from "./bounded-size";
 import {
   useUiToolsRegistry,
   type UiToolCaller,
@@ -150,43 +150,66 @@ function readArguments(
 }
 
 /**
- * Force a handler's return value into the wire shape, bounded.
+ * Force a handler's return value into the wire shape, under ONE budget.
  *
  * The first-party handlers already return bounded text (`okResult` /
  * `errorResult` in `groups/shared.ts`), so for every tool in the catalog this
  * is a pass-through that rebuilds an equal object. It exists for the value
  * that ISN'T one of those: a future handler returning a foreign shape, a
- * `content` array holding non-text parts, or a string long enough to bloat an
- * agent's context. Both transports serialize what comes back — Ask MCPJam
- * into a transcript, WebMCP across the browser boundary — so neither can
- * accept "whatever the handler felt like returning".
+ * `content` array holding non-text parts, or text long enough to bloat an
+ * agent's context.
+ *
+ * The budget is AGGREGATE, across the whole result. A per-part cap bounds
+ * nothing — `content` can hold any number of parts, so N parts at the cap is
+ * N times the cap — and the number the two transports actually have to carry
+ * is the total. Parts are filled from the remaining budget until it runs out,
+ * and what did not fit is reported rather than dropped in silence.
  */
 function boundedResult(value: unknown): UiToolResult {
   const source = value as Partial<UiToolResult> | undefined;
   const parts = Array.isArray(source?.content) ? source.content : [];
   const content: UiToolResult["content"] = [];
-  for (const part of parts) {
-    if (part && typeof part === "object" && part.type === "text") {
-      content.push({ type: "text", text: clampText(String(part.text ?? "")) });
-      continue;
+  let remaining = MAX_RESULT_CHARS;
+
+  for (const [index, part] of parts.entries()) {
+    if (remaining <= 0) {
+      content.push({
+        type: "text",
+        text: `… [${parts.length - index} more result part(s) omitted: the result is over ${MAX_RESULT_CHARS} characters]`,
+      });
+      break;
     }
-    // A non-text part still has to cross a JSON boundary; carry what can be
-    // serialized and never throw on what can't.
-    let text: string;
-    try {
-      text = JSON.stringify(part) ?? String(part);
-    } catch {
-      text = "[unserializable tool result part]";
-    }
-    content.push({ type: "text", text: clampText(text) });
+    const text = boundedPartText(part, remaining);
+    remaining -= text.length;
+    content.push({ type: "text", text });
   }
+
   if (content.length === 0) {
-    content.push({
-      type: "text",
-      text: "The tool returned no content.",
-    });
+    content.push({ type: "text", text: "The tool returned no content." });
   }
   return source?.isError ? { content, isError: true } : { content };
+}
+
+/** One part's text, never longer than `budget`. */
+function boundedPartText(part: unknown, budget: number): string {
+  if (
+    part &&
+    typeof part === "object" &&
+    (part as { type?: unknown }).type === "text"
+  ) {
+    const text = String((part as { text?: unknown }).text ?? "");
+    return text.length > budget
+      ? `${text.slice(0, budget)}… [truncated]`
+      : text;
+  }
+  // A non-text part still has to cross a JSON boundary. `boundedJsonString`
+  // never materializes the whole value — a part too big for the remaining
+  // budget is reported, not rendered — and never throws on what cannot be
+  // serialized at all.
+  return (
+    boundedJsonString(part, budget) ??
+    "[result part omitted: not serializable, or over the size budget]"
+  );
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-execution.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-execution.ts
@@ -1,0 +1,285 @@
+/**
+ * Executing ONE MCPJam UI tool call, for whoever asked.
+ *
+ * The seam between the two agents that can reach the `ui_*` catalog and the
+ * handlers themselves:
+ *   - Ask MCPJam, through `ui-tool-executor.ts` (approval pill, transcript,
+ *     duplicate-call suppression, conversation scope), and
+ *   - a browser-native WebMCP agent, through `native-tool-publisher.ts` (the
+ *     browser owns that agent's approval flow; there is no conversation).
+ *
+ * Everything in here is what BOTH must do identically: resolve the name
+ * against the registry, validate the arguments, run the registered handler,
+ * and hand back a bounded, JSON-serializable result plus a machine-readable
+ * status. Everything a single transport does — approvals, transcripts,
+ * telemetry, navigation handoff, conversation state — stays in that
+ * transport's adapter, which is why neither can quietly grow a second answer
+ * to "what does this tool do?".
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO: retry. A UI tool call can add a server,
+ * run a tool against somebody's live MCP server, or spend eval quota, and
+ * nothing here knows which failures were side-effect-free. A caller that
+ * wants another attempt asks for one.
+ */
+
+import { assertEvalToolAllowed } from "@/lib/mcpjam-agent/eval-scope";
+import type { InspectorCommandErrorCode } from "@/shared/inspector-command.js";
+import { clampText } from "./bounded-size";
+import {
+  useUiToolsRegistry,
+  type UiToolCaller,
+  type UiToolResult,
+} from "./ui-tools-registry";
+
+/**
+ * What happened, in one machine-readable token. Adapters map these onto their
+ * own vocabulary (chat telemetry, native diagnostics) rather than re-deriving
+ * the outcome from the result text.
+ */
+export type UiToolExecutionStatus =
+  /** The handler ran and reported success. */
+  | "ok"
+  /** The handler ran and reported failure (`isError`). */
+  | "error"
+  /** No such tool is registered right now (unmounted, HMR, never existed). */
+  | "unavailable"
+  /** The arguments were not a JSON object. */
+  | "invalid_input"
+  /** The caller's signal was already aborted; the handler never ran. */
+  | "cancelled"
+  /** The handler threw instead of returning a result. */
+  | "threw";
+
+export interface UiToolExecutionRequest {
+  /** Registry name (`ui_*`). Resolved here, not by the caller. */
+  toolName: string;
+  /** Raw arguments as the agent sent them. Validated, never trusted. */
+  input: unknown;
+  /** Which agent is asking. */
+  caller: UiToolCaller;
+  /**
+   * Identity of THIS invocation: the streamed tool-call id for Ask MCPJam, a
+   * minted id for a native call. Handed to the tool, which may key parked
+   * state on it.
+   */
+  invocationId: string;
+  /**
+   * The Ask MCPJam conversation this call belongs to, when there is one. It
+   * carries the eval scope and scopes cancellation of parked tools. A native
+   * call has no conversation and passes nothing.
+   */
+  scope?: string;
+  /**
+   * Cancellation, when the transport has any. Checked before the handler runs
+   * and forwarded to it; an abort NEVER un-does work already done.
+   */
+  signal?: AbortSignal;
+}
+
+export interface UiToolExecutionOutcome {
+  /** Bounded, JSON-serializable, always present — even for a failure. */
+  result: UiToolResult;
+  status: UiToolExecutionStatus;
+  /**
+   * Low-cardinality error code for diagnostics, when one can be established:
+   * a structured inspector-command code, or one of this module's own
+   * (`tool_unavailable`, `invalid_input`, `tool_threw`, `cancelled`). Never
+   * free text — error messages can contain a server's own words.
+   */
+  errorCode?: string;
+}
+
+/**
+ * Structured error codes only: the leading `code:` prefix of a command-bus
+ * error (see `commandResponseToActionResult`), validated against the CLOSED
+ * `InspectorCommandErrorCode` set so a free-text message can never be
+ * reported. Unrecognized error texts produce no code at all.
+ */
+const INSPECTOR_COMMAND_ERROR_CODES = new Set<string>([
+  "no_active_client",
+  "unknown_server",
+  "disconnected_server",
+  "unknown_tool",
+  "unknown_command_id",
+  "timeout",
+  "unsupported_in_mode",
+  "invalid_request",
+  "execution_failed",
+] satisfies InspectorCommandErrorCode[]);
+
+export function structuredErrorCode(output: UiToolResult): string | undefined {
+  if (!output.isError) return undefined;
+  const first = output.content?.[0];
+  const text = first?.type === "text" ? first.text : "";
+  const code = text.split(":", 1)[0]?.trim();
+  return code && INSPECTOR_COMMAND_ERROR_CODES.has(code) ? code : undefined;
+}
+
+export function uiToolErrorResult(message: string): UiToolResult {
+  return {
+    content: [{ type: "text", text: clampText(message) }],
+    isError: true,
+  };
+}
+
+/** The message an unresolvable name gets, identical on both transports. */
+export function uiToolUnavailableResult(toolName: string): UiToolResult {
+  return uiToolErrorResult(`UI tool "${toolName}" is no longer available.`);
+}
+
+/**
+ * Arguments as the handlers expect them, or a rejection.
+ *
+ * A missing or null payload is a legitimate no-argument call (`ui_snapshot_app`
+ * takes nothing). Anything else that is not a plain object — a bare string, a
+ * number, an array — is a malformed call, and saying so is far more useful
+ * than silently substituting `{}` and reporting whichever required field went
+ * missing as a result.
+ */
+function readArguments(
+  input: unknown,
+): { ok: true; args: Record<string, unknown> } | { ok: false; error: string } {
+  if (input === undefined || input === null) return { ok: true, args: {} };
+  if (typeof input !== "object" || Array.isArray(input)) {
+    return {
+      ok: false,
+      error: `Arguments must be a JSON object, got ${Array.isArray(input) ? "an array" : `a ${typeof input}`}.`,
+    };
+  }
+  return { ok: true, args: input as Record<string, unknown> };
+}
+
+/**
+ * Force a handler's return value into the wire shape, bounded.
+ *
+ * The first-party handlers already return bounded text (`okResult` /
+ * `errorResult` in `groups/shared.ts`), so for every tool in the catalog this
+ * is a pass-through that rebuilds an equal object. It exists for the value
+ * that ISN'T one of those: a future handler returning a foreign shape, a
+ * `content` array holding non-text parts, or a string long enough to bloat an
+ * agent's context. Both transports serialize what comes back — Ask MCPJam
+ * into a transcript, WebMCP across the browser boundary — so neither can
+ * accept "whatever the handler felt like returning".
+ */
+function boundedResult(value: unknown): UiToolResult {
+  const source = value as Partial<UiToolResult> | undefined;
+  const parts = Array.isArray(source?.content) ? source.content : [];
+  const content: UiToolResult["content"] = [];
+  for (const part of parts) {
+    if (part && typeof part === "object" && part.type === "text") {
+      content.push({ type: "text", text: clampText(String(part.text ?? "")) });
+      continue;
+    }
+    // A non-text part still has to cross a JSON boundary; carry what can be
+    // serialized and never throw on what can't.
+    let text: string;
+    try {
+      text = JSON.stringify(part) ?? String(part);
+    } catch {
+      text = "[unserializable tool result part]";
+    }
+    content.push({ type: "text", text: clampText(text) });
+  }
+  if (content.length === 0) {
+    content.push({
+      type: "text",
+      text: "The tool returned no content.",
+    });
+  }
+  return source?.isError ? { content, isError: true } : { content };
+}
+
+/**
+ * The answer for a call the caller abandoned before the handler ran.
+ *
+ * Worded carefully, and used for every pre-dispatch cancellation check so the
+ * wording cannot drift: an abort is not a rollback, and an agent told
+ * "cancelled" about work that already happened would act on a false picture
+ * of the world.
+ */
+function cancelledOutcome(toolName: string): UiToolExecutionOutcome {
+  return {
+    result: uiToolErrorResult(
+      `UI tool "${toolName}" was cancelled before it ran; nothing was executed.`,
+    ),
+    status: "cancelled",
+    errorCode: "cancelled",
+  };
+}
+
+/**
+ * Resolve, validate, run.
+ *
+ * Never throws: every failure — unknown tool, bad arguments, a handler that
+ * threw, a call cancelled before it started — comes back as an error result
+ * with a status, because both transports owe their caller an answer and a
+ * thrown exception would strand a paused stream or a pending native
+ * invocation.
+ */
+export async function executeUiToolCall(
+  request: UiToolExecutionRequest,
+): Promise<UiToolExecutionOutcome> {
+  const { toolName, input, caller, invocationId, scope, signal } = request;
+
+  // Cancellation, before anything is resolved or dispatched.
+  if (signal?.aborted) return cancelledOutcome(toolName);
+
+  const def = useUiToolsRegistry.getState().resolve(toolName);
+  if (!def) {
+    return {
+      result: uiToolUnavailableResult(toolName),
+      status: "unavailable",
+      errorCode: "tool_unavailable",
+    };
+  }
+
+  const args = readArguments(input);
+  if (!args.ok) {
+    return {
+      result: uiToolErrorResult(`${toolName}: ${args.error}`),
+      status: "invalid_input",
+      errorCode: "invalid_input",
+    };
+  }
+
+  // Again between the lookups above and the dispatch below: resolving and
+  // validating are the last cheap moments to notice the caller walked away.
+  if (signal?.aborted) return cancelledOutcome(toolName);
+
+  let output: UiToolResult;
+  try {
+    // Eval scope is re-asserted HERE, inside the try, so an out-of-scope call
+    // fails like any other handler failure rather than escaping as an
+    // exception. Ask MCPJam also gates earlier, before it claims the call;
+    // this is the backstop that holds for every transport.
+    assertEvalToolAllowed(scope, toolName);
+    output = boundedResult(
+      await def.execute(args.args, {
+        toolCallId: invocationId,
+        caller,
+        ...(scope !== undefined ? { scope } : {}),
+        ...(signal !== undefined ? { signal } : {}),
+      }),
+    );
+  } catch (error) {
+    return {
+      result: uiToolErrorResult(
+        `UI tool failed: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`,
+      ),
+      status: "threw",
+      errorCode: "tool_threw",
+    };
+  }
+
+  // Deliberately NOT re-checked against `signal` here. The handler ran; a
+  // late abort does not un-navigate a page or un-run a tool.
+  if (!output.isError) return { result: output, status: "ok" };
+  const errorCode = structuredErrorCode(output);
+  return {
+    result: output,
+    status: "error",
+    ...(errorCode ? { errorCode } : {}),
+  };
+}

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
@@ -1,6 +1,15 @@
 /**
- * Client-side fulfillment for WebMCP UI tool calls streamed back by the
- * server (which registered them as no-execute AI SDK tools).
+ * The ASK MCPJAM adapter: client-side fulfillment for `ui_*` tool calls
+ * streamed back by the server (which registered them as no-execute AI SDK
+ * tools).
+ *
+ * One of two adapters over `ui-tool-execution.ts` — the other is
+ * `native-tool-publisher.ts`, which serves browser-native WebMCP agents. What
+ * lives HERE is everything that only exists because there is a conversation:
+ * the approval pill handshake, the transcript output, duplicate-call
+ * suppression, outcome telemetry, and the navigation handoff to the side
+ * panel. A native call creates no conversation and opens no panel, so none of
+ * it runs for one.
  *
  * Called first from each chat surface's `useChat.onToolCall`; returns `false`
  * for names that aren't ours so the app-tool and server-tool paths run
@@ -21,12 +30,14 @@
 
 import { assertEvalToolAllowed } from "@/lib/mcpjam-agent/eval-scope";
 import { uiToolCallNeedsApproval } from "@/shared/client-fulfilled-tools.js";
-import type { InspectorCommandErrorCode } from "@/shared/inspector-command.js";
 import { track } from "@/lib/analytics";
 import { pathnameToActiveTab } from "@/lib/app-navigation";
 import {
+  executeUiToolCall,
+  uiToolUnavailableResult,
+} from "./ui-tool-execution";
+import {
   useUiToolsRegistry,
-  type UiToolDefinition,
   type UiToolResult,
 } from "./ui-tools-registry";
 
@@ -298,31 +309,6 @@ function completeUiToolCallTelemetry(
   });
 }
 
-/**
- * Structured error codes only: the leading `code:` prefix of a command-bus
- * error (see `commandResponseToActionResult`), validated against the CLOSED
- * `InspectorCommandErrorCode` set so a free-text message can never be
- * emitted. Unrecognized error texts emit no code at all.
- */
-const INSPECTOR_COMMAND_ERROR_CODES = new Set<string>([
-  "no_active_client",
-  "unknown_server",
-  "disconnected_server",
-  "unknown_tool",
-  "unknown_command_id",
-  "timeout",
-  "unsupported_in_mode",
-  "invalid_request",
-  "execution_failed",
-] satisfies InspectorCommandErrorCode[]);
-
-function structuredErrorCode(output: UiToolResult): string | undefined {
-  if (!output.isError) return undefined;
-  const first = output.content?.[0];
-  const text = first?.type === "text" ? first.text : "";
-  const code = text.split(":", 1)[0]?.trim();
-  return code && INSPECTOR_COMMAND_ERROR_CODES.has(code) ? code : undefined;
-}
 // --- End outcome telemetry ---------------------------------------------
 
 /** Deferred calls, for the orphaned-defer fallback (see ui-tool-approval). */
@@ -374,8 +360,17 @@ export function settleDeniedUiToolCall(
   completeUiToolCallTelemetry(toolCallId, "denied", "denied");
 }
 
+/**
+ * Run a claimed call and settle its transcript entry + telemetry.
+ *
+ * Takes the NAME, not the definition the caller resolved: shared execution
+ * looks the tool up again at dispatch time, so an approval the user clicks
+ * minutes later runs whatever is registered then rather than a stale closure
+ * (and reports "no longer available" when the answer is nothing). Identity of
+ * the call and the conversation scope travel with it — the tools that park on
+ * user input key their state on both.
+ */
 async function executeResolvedUiTool(
-  def: UiToolDefinition,
   opts: Pick<
     HandleUiToolCallOptions,
     "toolName" | "toolCallId" | "input" | "addToolOutput" | "telemetryScope"
@@ -385,56 +380,27 @@ async function executeResolvedUiTool(
   const { toolName, toolCallId, input, addToolOutput } = opts;
   settledOrInFlightToolCallIds.add(toolCallId);
   deferredUiToolCalls.delete(toolCallId);
-  let output: UiToolResult;
-  let threw = false;
-  try {
-    assertEvalToolAllowed(opts.telemetryScope, toolName);
-    const args =
-      input && typeof input === "object" && !Array.isArray(input)
-        ? (input as Record<string, unknown>)
-        : {};
-    // Identity of the call, not just its arguments: tools that park on user
-    // input (`ui_ask_user`) key their pending state on the tool-call id, and
-    // scope cancellation to the asking conversation.
-    output = await def.execute(args, {
-      toolCallId,
-      ...(opts.telemetryScope !== undefined
-        ? { scope: opts.telemetryScope }
-        : {}),
-    });
-  } catch (error) {
-    threw = true;
-    output = {
-      content: [
-        {
-          type: "text",
-          text: `UI tool failed: ${
-            error instanceof Error ? error.message : "Unknown error"
-          }`,
-        },
-      ],
-      isError: true,
-    };
-  }
-  addToolOutput({ tool: toolName, toolCallId, output });
+  const { result, status, errorCode } = await executeUiToolCall({
+    toolName,
+    input,
+    caller: "ask_mcpjam",
+    invocationId: toolCallId,
+    ...(opts.telemetryScope !== undefined
+      ? { scope: opts.telemetryScope }
+      : {}),
+  });
+  addToolOutput({ tool: toolName, toolCallId, output: result });
   completeUiToolCallTelemetry(
     toolCallId,
-    output.isError ? "error" : "success",
+    status === "ok" ? "success" : "error",
     approval,
-    threw ? "tool_threw" : structuredErrorCode(output),
+    errorCode,
   );
 }
 
+/** Same wording on both transports — see `ui-tool-execution.ts`. */
 function unavailableOutput(toolName: string): UiToolResult {
-  return {
-    content: [
-      {
-        type: "text",
-        text: `UI tool "${toolName}" is no longer available.`,
-      },
-    ],
-    isError: true,
-  };
+  return uiToolUnavailableResult(toolName);
 }
 
 /**
@@ -462,12 +428,28 @@ export async function handleUiToolCall(
   // re-stash.
   if (deferredUiToolCalls.has(toolCallId)) return true;
 
-  try { assertEvalToolAllowed(opts.telemetryScope, toolName); } catch (error) {
+  try {
+    assertEvalToolAllowed(opts.telemetryScope, toolName);
+  } catch (error) {
     settledOrInFlightToolCallIds.add(toolCallId);
-    addToolOutput({ tool: toolName, toolCallId, output: { isError: true, content: [{ type: "text", text: error instanceof Error ? error.message : "Tool is outside eval scope." }] } });
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      output: {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text:
+              error instanceof Error
+                ? error.message
+                : "Tool is outside eval scope.",
+          },
+        ],
+      },
+    });
     return true;
   }
-
 
   if (!def) {
     // The name was advertised to the server in an earlier snapshot but the
@@ -526,8 +508,10 @@ export async function handleUiToolCall(
   }
 
   if (def.mayNavigate) {
-    try { assertEvalToolAllowed(opts.telemetryScope, toolName); } catch {
-      await executeResolvedUiTool(def, { ...opts, toolName, input }, "not_required");
+    try {
+      assertEvalToolAllowed(opts.telemetryScope, toolName);
+    } catch {
+      await executeResolvedUiTool({ ...opts, toolName, input }, "not_required");
       return true;
     }
     try {
@@ -542,7 +526,6 @@ export async function handleUiToolCall(
   }
 
   await executeResolvedUiTool(
-    def,
     {
       toolName,
       toolCallId,
@@ -610,8 +593,21 @@ export async function fulfillApprovedUiToolCall(opts: {
   }
 
   if (def.mayNavigate) {
-    try { assertEvalToolAllowed(opts.telemetryScope ?? stashed?.telemetryScope, toolName); } catch {
-      await executeResolvedUiTool(def, { ...opts, toolName, input, telemetryScope: opts.telemetryScope ?? stashed?.telemetryScope }, "approved");
+    try {
+      assertEvalToolAllowed(
+        opts.telemetryScope ?? stashed?.telemetryScope,
+        toolName,
+      );
+    } catch {
+      await executeResolvedUiTool(
+        {
+          ...opts,
+          toolName,
+          input,
+          telemetryScope: opts.telemetryScope ?? stashed?.telemetryScope,
+        },
+        "approved",
+      );
       return;
     }
     try {
@@ -625,7 +621,6 @@ export async function fulfillApprovedUiToolCall(opts: {
   }
 
   await executeResolvedUiTool(
-    def,
     {
       toolName,
       toolCallId,

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-catalog.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-catalog.ts
@@ -1,6 +1,7 @@
 /**
- * The v1 `ui_*` catalog: hand-curated tools the in-app agent resolves in the
- * browser. Mostly tools that DRIVE the MCPJam inspector; `ui_ask_user` is the
+ * The v1 `ui_*` catalog: hand-curated tools resolved in the browser — by the
+ * in-app "Ask MCPJam" agent and, for the eligible ones, by whatever
+ * browser-native WebMCP agent the user is running. Mostly tools that DRIVE the MCPJam inspector; `ui_ask_user` is the
  * exception that collects input from it instead, which is why the namespace
  * means "the browser fulfills this" rather than "this moves the UI" (see
  * `shared/client-fulfilled-tools.ts`). Thin wrappers over the command bus —
@@ -21,6 +22,12 @@
  * Tool names live in the reserved `ui_` namespace (see
  * `shared/client-fulfilled-tools.ts`) and must satisfy the server-side
  * `validateUiToolEntries` boundary.
+ *
+ * PUBLICATION — every definition here states, in `nativePublication`,
+ * whether a browser-native WebMCP agent gets it. The ordinary inspector
+ * actions do; `ui_ask_user` does not, because the card it paints and the turn
+ * it parks only exist inside an Ask MCPJam conversation. Same for the
+ * eval-authoring group. See `../native-tool-publisher.ts`.
  *
  * REGISTRATION POLICY — this catalog is global, deliberately NOT contextual.
  * Chrome's WebMCP guidance suggests registering tools only when useful in

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
@@ -1,24 +1,32 @@
 /**
- * MCPJam `ui_*` tools registry — the in-app agent's browser-side tool set.
+ * MCPJam `ui_*` tools registry — the browser-side tool set for MCPJam's own
+ * inspector actions.
  *
- * Holds the tools the in-app "Ask MCPJam" agent resolves IN THE PAGE rather
- * than on the server. Two kinds, and the name covers both:
+ * Holds the tools that are resolved IN THE PAGE rather than on the server.
+ * Two kinds, and the name covers both:
  *   - driving the inspector UI — navigate, select servers, run a tool in the
  *     playground — where the user watches the action happen, and
  *   - collecting input from it — `ui_ask_user` paints a question card and
  *     parks the turn until the user answers.
  *
- * WebMCP-*shaped*, but not WebMCP: these are deliberately NOT exposed to
- * browser-native agents (`document.modelContext` / `navigator.modelContext`).
- * The shared shape buys familiarity and a clean annotations contract, nothing
- * more. The registry is the enumerable source of truth for the agent's
- * transport and executor — its sole consumer.
+ * TWO ACCESS PATHS, ONE CATALOG. The registry is the single source of truth
+ * for both agents that can reach these tools:
+ *   - the in-app "Ask MCPJam" agent, over MCPJam's own transport
+ *     (`snapshotForChatBody()` at chat POST time, `resolve()` from the chat
+ *     executor), and
+ *   - a browser-native WebMCP agent, over `document.modelContext`
+ *     (`native-tool-publisher.ts` subscribes here and mirrors the eligible
+ *     tools out; both paths execute through `ui-tool-execution.ts`).
  *
- * The registry serves two callers, mirroring `app-tools-registry.ts`:
- *   - `snapshotForChatBody()` — drained at chat POST time so the server can
- *     register no-execute AI SDK tools that the model can pick.
- *   - `resolve(name)` — looked up by `useChat.onToolCall` (via
- *     `ui-tool-executor.ts`) to execute the tool in-page.
+ * Eligibility is per definition and explicit: `nativePublication`. Tools that
+ * need an MCPJam conversation to mean anything (`ui_ask_user`, the scoped
+ * eval-authoring tools) stay internal; ordinary inspector actions publish.
+ * Absent metadata is read as INTERNAL — a new tool is never published by
+ * accident.
+ *
+ * NOT the same thing as the `page_*` namespace: those are tools a real
+ * third-party page registered, which MCPJam INSPECTS over CDP (see
+ * `shared/client-fulfilled-tools.ts`). `ui_*` is what MCPJam itself offers.
  *
  * Dispatch is gated on registry membership (`resolve`) — never on the `ui_`
  * prefix alone — so a genuine MCP server tool that happens to be named
@@ -39,25 +47,73 @@ export interface UiToolResult {
 }
 
 /**
- * Per-call context handed to `execute`, for the few tools that need to know
- * WHICH call they are rather than just their arguments.
+ * Which agent asked for this call.
+ *
+ * Load bearing rather than decorative: `ask_mcpjam` calls carry a
+ * conversation (a transcript to render into, a session to scope a parked
+ * question to, MCPJam's own approval pill), and `native_webmcp` calls carry
+ * none of that — the browser owns that agent's approval flow, and there is no
+ * conversation to create. A tool that needs one reads this instead of
+ * guessing from the absence of a `scope`.
+ */
+export type UiToolCaller = "ask_mcpjam" | "native_webmcp";
+
+/**
+ * Per-call context handed to `execute`, for the tools that need to know WHICH
+ * call they are — and on whose behalf — rather than just their arguments.
  *
  * Optional on the signature so the catalog's ordinary tools — and the tests
- * that invoke them directly — keep working with a single argument. Only the
- * executor supplies it.
+ * that invoke them directly — keep working with a single argument. Only
+ * `executeUiToolCall` (`ui-tool-execution.ts`) supplies it, for both
+ * transports.
  */
 export interface UiToolExecuteContext {
   /**
-   * The streamed tool-call id. Required by tools that park on user input
-   * (`ui_ask_user`): it's the key the rendered card resolves against.
+   * This invocation's identity: the streamed tool-call id for an Ask MCPJam
+   * call, a minted id for a native one. Required by tools that park on user
+   * input (`ui_ask_user`): it's the key the rendered card resolves against.
    */
   toolCallId: string;
   /**
-   * The caller's chatSessionId. Lets a parked tool be cancelled per
-   * conversation instead of globally.
+   * The caller's chatSessionId — Ask MCPJam only. Lets a parked tool be
+   * cancelled per conversation instead of globally, and carries the eval
+   * scope. A native call has no conversation, so it has no scope.
    */
   scope?: string;
+  /** Which agent asked. */
+  caller: UiToolCaller;
+  /**
+   * Cancellation for this call, when the transport has any. Today only the
+   * native publisher supplies one (it aborts when the tool's registration is
+   * torn down). Handlers that reach something cancellable should forward it;
+   * aborting NEVER un-does an action that already happened.
+   */
+  signal?: AbortSignal;
 }
+
+/**
+ * Whether a tool definition may be published to browser-native WebMCP agents
+ * (`document.modelContext`), and — when it is — whether its RESULT can carry
+ * content MCPJam did not author.
+ *
+ * Explicit per definition, and shaped like the surface manifest's
+ * `agentTools` opt-out, for the same reason: staying out of a channel is a
+ * decision with a reason, not an omission. Absent metadata is read as
+ * internal by `shouldPublishNatively`, so a new tool is never published by
+ * accident.
+ */
+export type UiToolNativePublication =
+  | {
+      readonly kind: "publish";
+      /**
+       * True when the result can contain bytes from somewhere else — a
+       * third-party MCP server's tool output, a registry listing, a page.
+       * Published as WebMCP's `untrustedContentHint` so an external agent
+       * knows to treat the payload as data rather than instructions.
+       */
+      readonly untrustedContent: boolean;
+    }
+  | { readonly kind: "internal"; readonly reason: string };
 
 export interface UiToolDefinition {
   /** Model-facing tool name. Must match `UI_TOOL_NAME_REGEX` (`ui_*`). */
@@ -87,6 +143,14 @@ export interface UiToolDefinition {
    * it to the server.
    */
   mayNavigate?: boolean;
+  /**
+   * Whether browser-native WebMCP agents get this tool, and why not when they
+   * don't. Client-only metadata — `snapshotForChatBody` never ships it to the
+   * server. Absent reads as internal (see `shouldPublishNatively`); the
+   * agent-tool coverage test requires every first-party definition to state
+   * it outright.
+   */
+  nativePublication?: UiToolNativePublication;
   execute: (
     args: Record<string, unknown>,
     ctx?: UiToolExecuteContext,
@@ -293,3 +357,16 @@ export const useUiToolsRegistry = create<UiToolsRegistryState>((set, get) => ({
 
   wasShipped: (name) => get().shippedNames.has(name),
 }));
+
+/**
+ * Whether a definition is eligible for browser-native publication.
+ *
+ * Default-deny: a definition that says nothing stays internal. The cost of
+ * that default is a tool an external agent cannot see until someone declares
+ * it; the cost of the other default is a conversation-only tool published to
+ * an agent that has no conversation, which fails at the far end of a call the
+ * user cannot see. The first is a missing feature, the second is a bug.
+ */
+export function shouldPublishNatively(def: UiToolDefinition): boolean {
+  return def.nativePublication?.kind === "publish";
+}

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
@@ -112,6 +112,20 @@ export type UiToolNativePublication =
        * knows to treat the payload as data rather than instructions.
        */
       readonly untrustedContent: boolean;
+      /**
+       * Force `consequentialHint: true` for the browser, when WebMCP's
+       * question and MCP's are not the same question.
+       *
+       * `consequentialHint` normally follows the MCP annotations (see
+       * `nativeAnnotationsFor`), and for nearly every tool that is right.
+       * They do diverge: MCP's `destructiveHint` asks "is this irreversible,
+       * does it destroy something?", while Chrome's `consequentialHint` asks
+       * "should a browser agent confirm this with its user first?" — a tool
+       * that only CREATES can still answer yes, if what it creates commits
+       * the organization to something. Set this there, with the reason at the
+       * call site; never as a way to avoid getting the MCP annotations right.
+       */
+      readonly consequential?: true;
     }
   | { readonly kind: "internal"; readonly reason: string };
 

--- a/mcpjam-inspector/client/src/lib/webmcp/use-publish-native-ui-tools.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/use-publish-native-ui-tools.ts
@@ -1,0 +1,37 @@
+/**
+ * Mount-scoped publication of MCPJam's UI tools to browser-native WebMCP
+ * agents.
+ *
+ * Mounted ONCE at the App root, beside `useRegisterUiTools`, in both local
+ * and hosted modes. The two are deliberately separate hooks: one fills the
+ * registry with the always-on catalog, this one mirrors whatever the registry
+ * holds — catalog plus whichever surface group is mounted — onto
+ * `document.modelContext`. That is why this hook subscribes rather than
+ * registering a fixed list: a surface's tools have to appear and disappear
+ * with its screen without the App root knowing anything about surfaces.
+ *
+ * `enabled: false` is the same exclusion the internal registration uses: on
+ * the standalone scenario chat route the end user is not the inspector
+ * operator, so inspector-driving tools must not exist on that page — for
+ * either agent.
+ *
+ * No opt-in beyond that, and no MCPJam approval prompt: where the browser has
+ * the API, the tools are published; where it does not, nothing happens and
+ * Ask MCPJam is unaffected.
+ */
+
+import { useEffect } from "react";
+import { startNativeUiToolPublisher } from "./native-tool-publisher";
+
+export function usePublishNativeUiTools(options?: { enabled?: boolean }): void {
+  const enabled = options?.enabled ?? true;
+  useEffect(() => {
+    if (!enabled) return;
+    const publisher = startNativeUiToolPublisher();
+    // StrictMode runs setup/cleanup/setup: stop() retires this publisher's
+    // registrations and the second setup makes fresh ones. The publisher's
+    // per-name serialization is what keeps that from colliding with the
+    // browser's duplicate-name rejection.
+    return () => publisher.stop();
+  }, [enabled]);
+}

--- a/mcpjam-inspector/client/src/lib/webmcp/use-register-ui-tools.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/use-register-ui-tools.ts
@@ -1,11 +1,13 @@
 /**
- * Mount-scoped registration of the WebMCP UI tool catalog.
+ * Mount-scoped registration of the always-on `ui_*` tool catalog.
  *
  * Mounted once near the App root (beside the inspector command handlers, in
- * BOTH local and hosted modes). Registration feeds a single consumer: the UI
- * tools registry, whose snapshot/executor serve the in-app "Ask MCPJam"
- * agent. Tools are never exposed to browser-native agents. Cleanup aborts
- * everything.
+ * BOTH local and hosted modes). Registration feeds ONE destination: the UI
+ * tools registry. Who reads the registry is not this hook's business — today
+ * that is Ask MCPJam's snapshot/executor and the native publisher
+ * (`use-publish-native-ui-tools.ts`), which mirrors the publishable entries
+ * onto `document.modelContext`. Cleanup aborts everything, which removes the
+ * tools from both.
  *
  * Pass `enabled: false` on surfaces whose end user is not the inspector
  * operator (the standalone scenario chat route): inspector-driving tools must

--- a/mcpjam-inspector/docs/webmcp-inspector.md
+++ b/mcpjam-inspector/docs/webmcp-inspector.md
@@ -3,6 +3,12 @@
 A managed browser pointed at a page, so the WebMCP tools that page registers can
 be listed, invoked, watched across navigations, and handed to a model.
 
+This is WebMCP pointed OUTWARD, at somebody else's page. The other direction —
+the `ui_*` tools MCPJam itself publishes, so a browser agent can drive the
+inspector — is [`webmcp-native-tools.md`](./webmcp-native-tools.md). The two
+share a protocol and nothing else: page tools are third-party and never
+trusted to describe themselves, MCPJam's own are first-party and curated.
+
 Visibility follows `local-browser-enabled` in Node/Electron and
 `hosted-browser-enabled` in hosted deployments.
 

--- a/mcpjam-inspector/docs/webmcp-native-tools.md
+++ b/mcpjam-inspector/docs/webmcp-native-tools.md
@@ -1,0 +1,155 @@
+# MCPJam's own tools, published to browser agents
+
+MCPJam's inspector actions — navigate, select a server, run a tool in the
+playground — exist as a catalog of `ui_*` tools that run in the page. Two
+agents can reach them:
+
+- **Ask MCPJam**, the in-app agent, over MCPJam's own transport.
+- **Any browser-native WebMCP agent**, over `document.modelContext`.
+
+Both drive the same handlers, so an external agent operates the inspector the
+same way the built-in one does — without anyone opening the Ask MCPJam side
+panel.
+
+Not to be confused with the **[WebMCP Inspector](./webmcp-inspector.md)**,
+which is the other direction: a managed browser pointed at somebody else's
+page, so the tools *that* page registers can be listed and invoked. This
+document is about the tools MCPJam itself offers.
+
+## Shape
+
+```
+client/src/lib/webmcp/
+  ├ groups/                     the tool definitions, by surface
+  ├ ui-tools-registry.ts        the catalog + `nativePublication` metadata
+  ├ ui-tool-execution.ts        resolve → validate → run (both transports)
+  ├ ui-tool-executor.ts         the Ask MCPJam adapter (approvals, transcript)
+  ├ native-model-context.ts     the browser API seam + the WebMCP hints
+  ├ native-tool-publisher.ts    the NATIVE adapter (registry → the browser)
+  └ use-publish-native-ui-tools.ts   one mount at the App root
+```
+
+`ui-tool-execution.ts` is the seam. It resolves the name against the registry,
+validates the arguments, runs the registered handler and returns a bounded,
+JSON-serializable result with a status. Everything that exists only because
+there is a conversation — the approval pill, the transcript, duplicate-call
+suppression, the side-panel handoff — lives in the Ask MCPJam adapter, so a
+native call creates no conversation and opens no panel.
+
+## Which tools are published
+
+Per definition, explicitly:
+
+```ts
+nativePublication: PUBLISH_NATIVE,            // ordinary inspector action
+nativePublication: PUBLISH_NATIVE_UNTRUSTED,  // …whose result quotes a third party
+nativePublication: nativeInternal("why not"), // Ask MCPJam only
+```
+
+Absent metadata reads as **internal**, so a new tool is never published by
+accident; `agent-tool-coverage.test.ts` fails on a definition that does not
+state its decision.
+
+Internal today, and the only things that should be:
+
+| Tool | Why |
+| --- | --- |
+| `ui_ask_user` | Paints a question card into the Ask MCPJam transcript and parks that turn on the answer. A native agent has neither. |
+| `ui_eval_question`, `ui_eval_propose_cases`, `ui_eval_context` | Read and write the eval scope pinned to one Ask MCPJam conversation; they refuse without it. |
+
+Everything else is an inspector action an external agent should be able to
+drive.
+
+## What MCPJam claims about a tool
+
+Chrome's [secure tools
+guidance](https://developer.chrome.com/docs/ai/webmcp/secure-tools) asks a page
+to publish three hints. MCPJam states all three on every tool it publishes,
+because an omitted hint reads as `false` and "we never said" is a different
+claim from "no":
+
+- **`readOnlyHint`** — copied from the tool's MCP annotations.
+- **`untrustedContentHint`** — from the definition's own `nativePublication`.
+  Not derivable from the MCP hints: `ui_snapshot_app` is read-only and
+  closed-world and still returns a screen showing a third-party server's tool
+  output.
+- **`consequentialHint`** — derived: destructive actions (delete something,
+  spend quota, consume billed infrastructure) plus mutating actions that reach
+  an external system. Read-only tools are never consequential, even when they
+  read across the network — gating reads teaches people to click through the
+  prompts that matter.
+
+`exposedTo` is never set: these tools drive the user's own inspector session
+and have no business being callable from another origin's page.
+
+## Approvals
+
+Each agent owns its own approval flow. Ask MCPJam keeps its Tool Approval
+setting and its confirmation pill; an external agent's browser runs whatever
+confirmation IT applies, which is what the hints above are for. Neither
+bypasses MCPJam's ordinary application authorization: billing gates, quota
+checks and the in-app confirmations a handler already performs apply to both,
+because both run the same handler.
+
+Failed calls are reported, never retried automatically — a UI tool can add a
+server, run somebody's MCP tool, or spend quota, and a silent second attempt
+is a second action.
+
+## Browser support is a prerequisite
+
+WebMCP ships as a Chrome origin trial. On a stock profile
+`document.modelContext` does not exist, the publisher resolves nothing, and
+MCPJam's own agent is unaffected — no error, no prompt, no degraded mode. To
+see the tools published you need a browser where the API is live:
+
+- **Chrome/Chromium with the feature flag:** launch with
+  `--enable-features=WebMCP` (the minimal switch — see
+  `server/services/webmcp-inspector/launch-args.ts` for why not the broader
+  ones), or
+- **an origin trial token** for the origin serving the inspector, or
+- **MCPJam's own WebMCP Inspector**, which launches its browser with that
+  switch already set. Pointing it at a running inspector lists MCPJam's tools
+  like any other page's.
+
+Everything asserted about the API was measured against the pinned Chromium
+(151.0.7922.34, the build `webmcp-cdp.spike.test.ts` pins). The two facts the
+publisher is built around:
+
+1. **A duplicate name is rejected** (`InvalidStateError`), so a replacement
+   registration cannot overlap its predecessor — work for one name is
+   serialized.
+2. **Unregistering during a call** is only guaranteed safe for in-flight
+   executions from Chrome 153. So a registration with an accepted call stays
+   standing until that call settles, marked dead meanwhile so anything new
+   through it is refused.
+
+## Testing
+
+```bash
+npx vitest run client/src/lib/webmcp client/src/lib/__tests__/agent-tool-coverage.test.ts
+npx playwright test e2e/webmcp-native-tools.spec.ts   # real Chromium
+```
+
+The unit fake in `native-tool-publisher.test.ts` encodes the measured browser
+behaviour rather than a convenient one; the Playwright spec drives the real
+thing — discover MCPJam's tools over CDP in a Chromium with WebMCP on, invoke
+`ui_navigate`, check the sidebar moved, then invoke a tool on the destination
+and check its answer against the browser's own URL.
+
+### By hand, through MCPJam itself
+
+The one check no suite here can make for you, because the `/webmcp` workspace
+sits behind a rollout flag and a device consent that a headless run cannot
+resolve: point MCPJam's own WebMCP Inspector at a running MCPJam.
+
+1. `npm run start` (or `npm run electron:dev`) and open the inspector.
+2. WebMCP tab → In app → the inspector's own URL (`http://localhost:6274/`).
+3. The tool list should fill with `ui_navigate`, `ui_snapshot_app`,
+   `ui_execute_tool` and the rest — and with no `ui_ask_user` and no
+   `ui_eval_*`.
+4. Invoke `ui_navigate` with `{"target": "playground"}` and watch the embedded
+   MCPJam move. Invoke `ui_snapshot_app` and check its `activeTab` against
+   what the pane is showing.
+
+Any browser agent that speaks WebMCP sees exactly this list; the inspector is
+just the copy of one you already have.

--- a/mcpjam-inspector/docs/webmcp-native-tools.md
+++ b/mcpjam-inspector/docs/webmcp-native-tools.md
@@ -44,6 +44,9 @@ Per definition, explicitly:
 nativePublication: PUBLISH_NATIVE,            // ordinary inspector action
 nativePublication: PUBLISH_NATIVE_UNTRUSTED,  // …whose result quotes a third party
 nativePublication: nativeInternal("why not"), // Ask MCPJam only
+// …and, for an action the browser should confirm even though MCP does not
+// call it destructive:
+nativePublication: publishNativeConsequential({ untrustedContent: false }),
 ```
 
 Absent metadata reads as **internal**, so a new tool is never published by
@@ -77,7 +80,11 @@ claim from "no":
   spend quota, consume billed infrastructure) plus mutating actions that reach
   an external system. Read-only tools are never consequential, even when they
   read across the network — gating reads teaches people to click through the
-  prompts that matter.
+  prompts that matter. A definition can also declare it outright, and that
+  wins: the two hints ask different questions, and a tool that only creates
+  can still commit the organization to something. `ui_publish_scenario` is the
+  live case — nothing is destroyed, but `access: "link_guests"` opens the
+  scenario to signed-out visitors funded by the organization.
 
 `exposedTo` is never set: these tools drive the user's own inspector session
 and have no business being callable from another origin's page.

--- a/mcpjam-inspector/e2e/webmcp-native-tools.spec.ts
+++ b/mcpjam-inspector/e2e/webmcp-native-tools.spec.ts
@@ -1,0 +1,262 @@
+/**
+ * A browser agent driving MCPJam, in a real browser.
+ *
+ * Everything else about native publication is tested against a fake
+ * (`client/src/lib/webmcp/__tests__/native-tool-publisher.test.ts`). This spec
+ * is the one that uses the actual platform: a Chromium with WebMCP enabled,
+ * the built app, and the CDP `WebMCP` domain standing in for the external
+ * agent — the same surface Chrome's own tool inspector and any browser agent
+ * see. It answers the questions a fake cannot: are MCPJam's tools really
+ * advertised to an agent nobody wired up, does invoking one really move the
+ * UI, and are the conversation-only tools really absent?
+ *
+ * Requires the pinned Chromium (WebMCP is Chromium 151+ behind
+ * `--enable-features=WebMCP`). Locally, a browser without it skips; in CI it
+ * fails, because a silent skip there would mean the only real-browser test of
+ * this feature quietly stopped running.
+ */
+import { expect, test, type CDPSession, type Page } from "@playwright/test";
+
+test.use({ launchOptions: { args: ["--enable-features=WebMCP"] } });
+
+/**
+ * Local build only, like the NUX spec. A hosted deployment puts a WorkOS
+ * sign-in in front of the inspector chrome this drives, so a run against
+ * `PLAYWRIGHT_BASE_URL` would report a product failure for a screen that is
+ * correctly behind auth. Publication itself is not mode-specific — the App
+ * root mounts the publisher in both — so the local build covers it.
+ */
+test.skip(
+  !!process.env.PLAYWRIGHT_BASE_URL,
+  "drives the inspector chrome, which a deployed target puts behind auth",
+);
+
+interface ToolPayload {
+  name: string;
+  description: string;
+  inputSchema?: Record<string, unknown>;
+  annotations?: {
+    readOnly?: boolean;
+    untrustedContent?: boolean;
+    consequential?: boolean;
+  };
+  frameId: string;
+}
+
+interface RespondedPayload {
+  invocationId: string;
+  status: "Completed" | "Canceled" | "Error";
+  output?: { content?: Array<{ type: string; text?: string }> };
+  exception?: { description?: string };
+}
+
+/** The agent's view of the page: what it can see, and how it calls it. */
+class BrowserAgent {
+  private readonly added: ToolPayload[] = [];
+  private readonly removed: Array<{ name: string }> = [];
+  private readonly responded: RespondedPayload[] = [];
+  private frameId = "";
+
+  private constructor(
+    private readonly page: Page,
+    private readonly cdp: CDPSession,
+  ) {}
+
+  static async attach(page: Page): Promise<BrowserAgent> {
+    const cdp = await page.context().newCDPSession(page);
+    const agent = new BrowserAgent(page, cdp);
+    cdp.on("WebMCP.toolsAdded", (event) =>
+      agent.added.push(...((event as { tools: ToolPayload[] }).tools ?? [])),
+    );
+    cdp.on("WebMCP.toolsRemoved", (event) =>
+      agent.removed.push(
+        ...((event as { tools: Array<{ name: string }> }).tools ?? []),
+      ),
+    );
+    cdp.on("WebMCP.toolResponded", (event) =>
+      agent.responded.push(event as RespondedPayload),
+    );
+    await cdp.send("WebMCP.enable" as never);
+    return agent;
+  }
+
+  async resolveFrame(): Promise<void> {
+    const { frameTree } = (await this.cdp.send(
+      "Page.getFrameTree" as never,
+    )) as {
+      frameTree: { frame: { id: string } };
+    };
+    this.frameId = frameTree.frame.id;
+  }
+
+  /** Tools currently advertised to this agent. */
+  discover(): string[] {
+    const gone = new Set(this.removed.map((tool) => tool.name));
+    return [...new Set(this.added.map((tool) => tool.name))]
+      .filter((name) => !gone.has(name))
+      .sort();
+  }
+
+  tool(name: string): ToolPayload {
+    const found = this.added.find((entry) => entry.name === name);
+    if (!found) throw new Error(`the page never published "${name}"`);
+    return found;
+  }
+
+  async waitForTool(name: string, timeoutMs = 30_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (this.discover().includes(name)) return;
+      await this.page.waitForTimeout(100);
+    }
+    throw new Error(`"${name}" was never published (waited ${timeoutMs}ms)`);
+  }
+
+  async invoke(
+    toolName: string,
+    input: Record<string, unknown>,
+  ): Promise<RespondedPayload> {
+    const { invocationId } = (await this.cdp.send(
+      "WebMCP.invokeTool" as never,
+      { frameId: this.frameId, toolName, input } as never,
+    )) as { invocationId: string };
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline) {
+      const done = this.responded.find(
+        (entry) => entry.invocationId === invocationId,
+      );
+      if (done) return done;
+      await this.page.waitForTimeout(50);
+    }
+    throw new Error(`"${toolName}" never answered`);
+  }
+
+  /** The browser's own rejection for a name it does not hold. */
+  async invokeExpectingRejection(toolName: string): Promise<string> {
+    try {
+      await this.cdp.send(
+        "WebMCP.invokeTool" as never,
+        { frameId: this.frameId, toolName, input: {} } as never,
+      );
+      return "";
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error);
+    }
+  }
+}
+
+/** The JSON payload MCPJam's tools answer with. */
+function readResult(response: RespondedPayload): unknown {
+  expect(
+    response.status,
+    `invocation failed: ${response.exception?.description ?? ""}`,
+  ).toBe("Completed");
+  const text = response.output?.content?.[0]?.text ?? "";
+  return JSON.parse(text);
+}
+
+test("a browser agent discovers MCPJam's tools, navigates, and reads the screen it landed on", async ({
+  page,
+}) => {
+  // A returning user: no first-run redirect racing the agent's navigation.
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "mcp-onboarding-state",
+      JSON.stringify({ status: "completed", completedAt: 1 }),
+    );
+  });
+
+  const agent = await BrowserAgent.attach(page);
+  await page.goto("/");
+  await expect(page.getByTestId("app-shell")).toBeVisible({ timeout: 30_000 });
+  await agent.resolveFrame();
+
+  const webMcpAvailable = await page.evaluate(
+    "!!(document.modelContext ?? navigator.modelContext)",
+  );
+  test.skip(
+    !webMcpAvailable && !process.env.CI,
+    "WebMCP needs Chromium 151+ with --enable-features=WebMCP; install the pinned Playwright browser",
+  );
+  expect(
+    webMcpAvailable,
+    "the pinned Chromium must expose the WebMCP page API",
+  ).toBe(true);
+
+  // 1. DISCOVERY. Nobody opened Ask MCPJam; the tools are simply there.
+  await agent.waitForTool("ui_navigate");
+  const published = agent.discover();
+  expect(published).toEqual(
+    expect.arrayContaining([
+      "ui_navigate",
+      "ui_select_server",
+      "ui_snapshot_app",
+      "ui_open_playground",
+      "ui_execute_tool",
+      "ui_add_server",
+    ]),
+  );
+
+  // …and the conversation-only tools are not, in the only way that counts:
+  // the browser does not have them to invoke.
+  expect(published).not.toContain("ui_ask_user");
+  expect(published.filter((name) => name.startsWith("ui_eval_"))).toEqual([]);
+  expect(await agent.invokeExpectingRejection("ui_ask_user")).toContain(
+    "Tool not found",
+  );
+
+  // 2. WHAT MCPJAM CLAIMS. Chromium 151 reports `readOnlyHint` and
+  // `untrustedContentHint` under bare names and does not carry
+  // `consequentialHint` through at all — so a tool whose result quotes an MCP
+  // server says so, here, in the browser's own vocabulary.
+  expect(agent.tool("ui_execute_tool").annotations).toMatchObject({
+    readOnly: false,
+    untrustedContent: true,
+  });
+  expect(agent.tool("ui_navigate").annotations).toMatchObject({
+    readOnly: false,
+    untrustedContent: false,
+  });
+
+  // 3. NAVIGATION, invoked by the agent — and visible on screen.
+  const navigated = readResult(
+    await agent.invoke("ui_navigate", { target: "oauth-flow" }),
+  );
+  expect(navigated).toMatchObject({
+    ok: true,
+    data: { activeTab: "oauth-flow" },
+  });
+  await page.waitForURL("**/oauth-flow", { timeout: 15_000 });
+  // The sidebar marks the screen the user is looking at. This is the "the
+  // user sees the page change" half of every navigation tool's description.
+  await expect(
+    page.getByRole("button", { name: "OAuth Debugger" }),
+  ).toHaveAttribute("data-active", "true", { timeout: 15_000 });
+
+  // 4. THE DESTINATION'S TOOLS. Discovery survives the navigation — this is a
+  // single-page app, so the registrations the agent holds must still be the
+  // live ones rather than stale entries from the previous screen.
+  await agent.waitForTool("ui_snapshot_app");
+  expect(agent.discover()).toEqual(expect.arrayContaining(["ui_snapshot_app"]));
+
+  // 5. INVOKE ONE, AND CHECK IT AGAINST WHAT IS ON SCREEN. `ui_snapshot_app`
+  // reports what the user currently sees, so its answer and the browser's own
+  // URL have to agree — if the agent were talking to a stale registration,
+  // this is where it would show.
+  const snapshot = readResult(await agent.invoke("ui_snapshot_app", {})) as {
+    ok: boolean;
+    data: { path: string; activeTab: string };
+  };
+  expect(snapshot.ok).toBe(true);
+  expect(snapshot.data.activeTab).toBe("oauth-flow");
+  expect(new URL(page.url()).pathname).toBe(snapshot.data.path);
+
+  // 6. A MALFORMED CALL gets a usable answer rather than a hang or a crash.
+  const rejected = await agent.invoke("ui_navigate", {
+    target: "not-a-real-screen",
+  });
+  expect(rejected.status).toBe("Completed");
+  expect(rejected.output?.content?.[0]?.text).toContain(
+    'Unknown navigation target "not-a-real-screen"',
+  );
+});

--- a/mcpjam-inspector/e2e/webmcp-native-tools.spec.ts
+++ b/mcpjam-inspector/e2e/webmcp-native-tools.spec.ts
@@ -52,10 +52,17 @@ interface RespondedPayload {
 
 /** The agent's view of the page: what it can see, and how it calls it. */
 class BrowserAgent {
-  private readonly added: ToolPayload[] = [];
-  private readonly removed: Array<{ name: string }> = [];
+  /**
+   * The tools the page currently offers, by name — a live map rather than an
+   * add-log, because the publisher legitimately removes and re-adds a name
+   * (a replaced registration, a remount). Reading an append-only array there
+   * hides the restored tool and hands back its dead descriptor.
+   */
+  private readonly tools = new Map<string, ToolPayload>();
   private readonly responded: RespondedPayload[] = [];
   private frameId = "";
+  /** False when this browser has no WebMCP domain at all. */
+  domainAvailable = false;
 
   private constructor(
     private readonly page: Page,
@@ -65,18 +72,30 @@ class BrowserAgent {
   static async attach(page: Page): Promise<BrowserAgent> {
     const cdp = await page.context().newCDPSession(page);
     const agent = new BrowserAgent(page, cdp);
-    cdp.on("WebMCP.toolsAdded", (event) =>
-      agent.added.push(...((event as { tools: ToolPayload[] }).tools ?? [])),
-    );
-    cdp.on("WebMCP.toolsRemoved", (event) =>
-      agent.removed.push(
-        ...((event as { tools: Array<{ name: string }> }).tools ?? []),
-      ),
-    );
+    cdp.on("WebMCP.toolsAdded", (event) => {
+      for (const tool of (event as { tools: ToolPayload[] }).tools ?? []) {
+        agent.tools.set(tool.name, tool);
+      }
+    });
+    cdp.on("WebMCP.toolsRemoved", (event) => {
+      for (const tool of (event as { tools: Array<{ name: string }> }).tools ??
+        []) {
+        agent.tools.delete(tool.name);
+      }
+    });
     cdp.on("WebMCP.toolResponded", (event) =>
       agent.responded.push(event as RespondedPayload),
     );
-    await cdp.send("WebMCP.enable" as never);
+    try {
+      await cdp.send("WebMCP.enable" as never);
+      agent.domainAvailable = true;
+    } catch {
+      // A Chromium without the experimental domain rejects the command
+      // outright. Caught here so the availability check below can SKIP rather
+      // than this line erroring the run — the check is still needed either
+      // way, because `WebMCP.enable` also resolves on a browser where the
+      // feature is merely switched off (see webmcp-cdp.spike.test.ts).
+    }
     return agent;
   }
 
@@ -91,15 +110,12 @@ class BrowserAgent {
 
   /** Tools currently advertised to this agent. */
   discover(): string[] {
-    const gone = new Set(this.removed.map((tool) => tool.name));
-    return [...new Set(this.added.map((tool) => tool.name))]
-      .filter((name) => !gone.has(name))
-      .sort();
+    return [...this.tools.keys()].sort();
   }
 
   tool(name: string): ToolPayload {
-    const found = this.added.find((entry) => entry.name === name);
-    if (!found) throw new Error(`the page never published "${name}"`);
+    const found = this.tools.get(name);
+    if (!found) throw new Error(`the page is not publishing "${name}"`);
     return found;
   }
 
@@ -171,9 +187,11 @@ test("a browser agent discovers MCPJam's tools, navigates, and reads the screen 
   await expect(page.getByTestId("app-shell")).toBeVisible({ timeout: 30_000 });
   await agent.resolveFrame();
 
-  const webMcpAvailable = await page.evaluate(
-    "!!(document.modelContext ?? navigator.modelContext)",
-  );
+  const webMcpAvailable =
+    agent.domainAvailable &&
+    (await page.evaluate(
+      "!!(document.modelContext ?? navigator.modelContext)",
+    ));
   test.skip(
     !webMcpAvailable && !process.env.CI,
     "WebMCP needs Chromium 151+ with --enable-features=WebMCP; install the pinned Playwright browser",

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -452,6 +452,25 @@ export const ANALYTICS_EVENTS = {
   ui_tool_call_completed: { source: "client" },
   ui_tool_call_started: { source: "client" },
 
+  // --- The same `ui_*` tools, published to browser-native WebMCP agents ---
+  // Diagnostics for `native-tool-publisher.ts`. Same hard rule as the events
+  // above and then some: a native call is made by software MCPJam does not
+  // control, so its ARGUMENTS AND RESULTS NEVER RIDE AN EVENT — only tool
+  // names (first-party, curated), statuses, counts and durations.
+  // ui_tool_native_published: one page's publication landed. Props: api_home
+  //   (document | navigator), tool_count. The adoption signal — how many
+  //   sessions actually have a browser with the WebMCP API.
+  // ui_tool_native_registration_failed: one tool the browser refused. Props:
+  //   tool_name, error_code (the DOMException NAME only, e.g.
+  //   InvalidStateError — never its message).
+  // ui_tool_native_call_completed: one native invocation settled. Props:
+  //   tool_name, status (the shared execution status: ok | error |
+  //   unavailable | invalid_input | cancelled | threw), duration_ms, and the
+  //   structured error_code when there is one.
+  ui_tool_native_published: { source: "client" },
+  ui_tool_native_registration_failed: { source: "client" },
+  ui_tool_native_call_completed: { source: "client" },
+
   // --- Home: shared Slack Connect channel card ---
   // Flag-dark (`shared-slack-channel-enabled`). Props: location ("home"),
   // state (none | provisioning | invite_sent | pending_admin_approval |

--- a/mcpjam-inspector/shared/client-fulfilled-tools.ts
+++ b/mcpjam-inspector/shared/client-fulfilled-tools.ts
@@ -9,7 +9,9 @@
  *     advertised.
  *   - `ui_*` — MCPJam's own browser-fulfilled tools, hand-named in the
  *     client catalog (`client/src/lib/webmcp/ui-tools-catalog.ts`) and
- *     validated server-side by `validateUiToolEntries`.
+ *     validated server-side by `validateUiToolEntries`. This namespace is the
+ *     Ask MCPJam wire format; the same tools reach browser-native agents by a
+ *     different route entirely (see below).
  *   - `page_<8hex>` — WebMCP Inspector page tools: tools a real third-party
  *     WEB PAGE registered, which the inspector's browser session invokes over
  *     CDP. Minted per (session, tool) by the inspector store and validated
@@ -17,17 +19,23 @@
  *
  * WHAT THE `ui_` PREFIX ASSERTS: only that the BROWSER resolves the call.
  * Not that the tool drives a screen — `ui_ask_user` renders a card and waits
- * for an answer — and NOT that it is a WebMCP tool: the catalog is
- * WebMCP-*shaped* but deliberately never exposed to browser-native agents
- * (`document.modelContext` / `navigator.modelContext`). Tools that ARE
- * browser-native WebMCP live under `page_` instead, and the two must not be
- * confused: `ui_` is first-party and curated, `page_` is third-party — and
- * never trusted to describe itself, whatever its annotations claim, though
- * whether a call pauses is the user's Tool Approval switch to decide (see
- * `pageToolCallNeedsApproval`). The prefixes are load bearing because they are this
- * narrow: they are the token the server's skip gate and pause predicate key
- * on, so a browser-fulfilled tool named anything else would either be executed
- * server-side or leave the stream waiting on a result nobody will send.
+ * for an answer — and not that THIS route is how it was reached. Most of the
+ * catalog is also published to browser-native WebMCP agents through
+ * `document.modelContext` (`client/src/lib/webmcp/native-tool-publisher.ts`),
+ * which never touches this wire format at all: a native call is executed in
+ * the page and answered there.
+ *
+ * `ui_` and `page_` must not be confused. `ui_` is MCPJam's OWN first-party,
+ * curated catalog — the tools this app offers, whoever is asking. `page_` is
+ * the opposite direction: tools a third-party WEB PAGE registered, which
+ * MCPJam inspects over CDP, and which are never trusted to describe
+ * themselves whatever their annotations claim — though whether a call pauses
+ * is the user's Tool Approval switch to decide (see
+ * `pageToolCallNeedsApproval`). The prefixes are load bearing because they are
+ * this narrow: they are the token the server's skip gate and pause predicate
+ * key on, so a browser-fulfilled tool named anything else would either be
+ * executed server-side or leave the stream waiting on a result nobody will
+ * send.
  *
  * Both the skip gate (`isSkippableClientFulfilledToolCall` in
  * `http-tool-calls.ts`) and the pause predicate


### PR DESCRIPTION
The `ui_*` catalog — navigate, select a server, prefill and run a tool in the playground — was reachable only through Ask MCPJam. The same tools are now also registered on `document.modelContext` (with the deprecated `navigator.modelContext` as a capability-checked fallback), so a browser agent discovers and drives the inspector without anyone opening the side panel.

## One catalog, one execution path

`ui-tool-execution.ts` resolves the name against the registry, validates the arguments, runs the registered handler and returns a bounded, JSON-serializable result — for both agents, so neither can grow a second answer to what a tool does. Everything that only exists because there is a conversation stays in the Ask MCPJam adapter: the approval pill, the transcript, duplicate-call suppression, the side-panel handoff. **A native call creates no conversation and opens no panel.**

```
client/src/lib/webmcp/
  ├ ui-tool-execution.ts        resolve → validate → run (both transports)
  ├ ui-tool-executor.ts         the Ask MCPJam adapter (approvals, transcript)
  ├ native-model-context.ts     the browser API seam + the WebMCP hints
  ├ native-tool-publisher.ts    the NATIVE adapter (registry → the browser)
  └ use-publish-native-ui-tools.ts   one mount at the App root
```

## Which tools, and why

Eligibility is explicit per definition (`nativePublication`), and an absent decision reads as **internal**, so a new tool is never published by accident. Two things stay internal, because each needs an MCPJam conversation a native call does not have:

| Tool | Why |
| --- | --- |
| `ui_ask_user` | Paints a question card into the Ask MCPJam transcript and parks that turn on the answer. |
| `ui_eval_question` / `ui_eval_propose_cases` / `ui_eval_context` | Read and write the eval scope pinned to one conversation; they refuse without it. |

The coverage test fails on a definition that says nothing, and on any growth of that list.

## Approvals

Each agent owns its own flow. Ask MCPJam keeps its Tool Approval setting and its pill; an external agent's browser runs its own confirmation, informed by the hints Chrome's [secure-tools guidance](https://developer.chrome.com/docs/ai/webmcp/secure-tools) asks for — `readOnlyHint`, an explicit `untrustedContentHint` for results that quote a third party, and `consequentialHint` for destructive or externally-reaching actions. Both still pass through MCPJam's billing gates and in-app confirmations, because both run the same handler. Tools are never exposed to other origins (`exposedTo` is never set), and a failed call is reported, never retried.

## Built on what the browser actually does

Probed against the pinned Chromium 151.0.7922.34 rather than assumed:

- **A duplicate name is rejected** (`InvalidStateError`), so work for one name is serialized: retire, wait for the platform, re-register.
- **A registration that stops being the owner is aborted on the spot** — including mid-`registerTool` — so a torn-down publisher's late registration cannot collide with the one that replaced it (StrictMode's second mount, a hot reload).
- **Unregistering during a call** is only guaranteed safe for in-flight executions from Chrome 153, so a registration with an accepted call stays standing until that call settles — marked dead meanwhile, so anything new through it is refused.
- The `execute` callback gets no per-invocation signal at this pin; the code reads one defensively for the Chromium that supplies it.

## Boundaries kept

The Playground still receives no automatic `uiTools` snapshot (its explicitly selected WebMCP page tools are unaffected), and the standalone scenario chat publishes nothing at all — the same exclusion the internal registration already applies. Where the browser has no WebMCP API, nothing is published and Ask MCPJam is unaffected: browser support / origin-trial activation stays a prerequisite, documented in `mcpjam-inspector/docs/webmcp-native-tools.md`.

## Testing

- **Shared execution**: equivalence across callers, invalid input, cancellation before dispatch, result bounding, eval-scope backstop.
- **The publisher**, against a fake that encodes the *measured* browser contract: missing API, `navigator` fallback, eligibility, hints, individually-caught registration failures, replacement ownership, remounts, surface mount/unmount, stale and refused calls, deferred teardown during a call.
- **The App mount**: eligible publication, conversation-only exclusion, scenario-chat exclusion, StrictMode, and inertness with no WebMCP API. This replaces the old "the catalog makes zero native `registerTool` calls" guard.
- **A real browser** (`e2e/webmcp-native-tools.spec.ts`): a Chromium with WebMCP on, discovering MCPJam's tools over CDP, confirming `ui_ask_user` is not even invocable, invoking `ui_navigate`, checking the sidebar moved, then reading the destination back with `ui_snapshot_app` and matching it against the browser's own URL.

`npx vitest run client/src/lib client/src/hooks client/src/components/__tests__` (5652 passed), `--project shared` (1031 passed), `npm run test:checks`, `typecheck:client`, and the Playwright spec all pass locally.

One verification could not run in this sandbox: pointing MCPJam's own WebMCP Inspector at a running MCPJam. `/webmcp` sits behind a PostHog rollout flag and a device consent that an offline run cannot resolve (the same reason `webmcp-frame-stream.spec.ts` skips when gated). The by-hand steps are written up in the new doc; the CDP path it would use is the one the Playwright spec already drives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HaZahg9fbJwdbXtYm9Jxi

---
_Generated by [Claude Code](https://claude.ai/code/session_018HaZahg9fbJwdbXtYm9Jxi)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> External browser agents gain a new path to drive inspector mutations (servers, playground, billing-gated actions) through the same handlers; risk is bounded by opt-in publication, conversation-only exclusions, and unchanged in-app gates, but the control surface is materially wider than Ask MCPJam alone.
> 
> **Overview**
> MCPJam’s **`ui_*` inspector catalog** is no longer Ask MCPJam–only: eligible tools are mirrored onto **`document.modelContext`** (with a capability-checked **`navigator.modelContext`** fallback) via a new App-root hook **`usePublishNativeUiTools`**, so an external browser WebMCP agent can navigate, connect servers, and run playground actions without opening the side panel.
> 
> **One registry, one execution path.** New **`ui-tool-execution.ts`** resolves tools, validates args (malformed non-objects are rejected instead of coerced to `{}`), runs handlers with a **`caller`** of `ask_mcpjam` or `native_webmcp`, and returns **aggregate-bounded** JSON results; **`native-tool-publisher.ts`** syncs registrations to the browser with Chromium-aware retire/re-register logic. Ask MCPJam keeps approvals, transcript, and deferral in **`ui-tool-executor.ts`**; native calls skip all of that.
> 
> **Per-tool `nativePublication`** (default internal) decides what ships; **`ui_ask_user`** and **`ui_eval_*`** stay internal. Published tools carry WebMCP secure-tool hints (`untrustedContent`, derived or explicit **`consequential`** e.g. for **`ui_publish_scenario`**). Scenario chat and missing WebMCP API still publish nothing; Playground chat bodies still omit automatic **`uiTools`** snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f870cc589ae73697848a3d932aea7286556133e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes MCPJam's `ui_*` inspector tools — navigate, select a server, prefill and run a tool in the playground — to browser-native WebMCP agents via `document.modelContext` (with `navigator.modelContext` as a capability-checked fallback). Previously only Ask MCPJam could reach the catalog; now a browser agent can discover and drive the inspector without anyone opening the side panel.

Both transports run through one shared execution path (`ui-tool-execution.ts`) — resolve, validate, execute, return a bounded JSON result — with handlers receiving a `caller` field to tell the transports apart. The result budget is aggregate and counts what the value serializes to, not just its scalar payload, so shape-heavy output can't slip past the cap. Conversation-only concerns — the approval pill, transcript, duplicate-call suppression, and side-panel handoff — stay in the Ask MCPJam adapter; a native call creates no conversation and opens no panel.

**Behavior and boundaries**
- Eligibility is declared per tool (`nativePublication`); a missing decision keeps a tool internal, so new tools are never published by accident. `ui_ask_user` and the eval-authoring tools stay internal because they need a conversation.
- Each agent keeps its own approval flow; native calls expose Chrome's secure-tools hints (`readOnlyHint`, `untrustedContentHint`, `consequentialHint`). `ui_publish_scenario` declares `consequential` explicitly because its `link_guests` mode opens the scenario to signed-out visitors — the hint widens only what the browser is told, not approval behavior.
- Publisher behavior follows the measured Chromium 151 contract: duplicate names are rejected, torn-down registrations are aborted on the spot, and a registration with an in-flight call stays standing until that call settles, with a replacement publisher queueing behind it instead of colliding as a duplicate.
- The Playground still receives no automatic `uiTools` snapshot, and the standalone scenario chat publishes nothing. Where the browser lacks WebMCP, nothing publishes and Ask MCPJam is unaffected.

<sup>Written for commit f870cc589ae73697848a3d932aea7286556133e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

