### PR TITLE
Warn before an edit that clears a server's saved credentials (MJ-003, client half)

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
@@ -18,6 +18,10 @@ import {
   fetchServerSecretKeys,
   fetchServerSecrets,
 } from "@/lib/apis/server-secrets-api";
+import {
+  credentialClearAcknowledgementKey,
+  type PendingCredentialClear,
+} from "@/lib/credential-origin";
 
 interface EditServerFormContentProps {
   formState: ReturnType<typeof useServerForm>;
@@ -265,6 +269,14 @@ export function EditServerFormContent({
         )}
       </div>
 
+      {formState.pendingCredentialClear && (
+        <CredentialClearWarning
+          pending={formState.pendingCredentialClear}
+          acknowledgedFor={formState.credentialClearAcknowledgedFor}
+          onAcknowledge={formState.acknowledgeCredentialClear}
+        />
+      )}
+
       {formState.type === "http" && (
         <div className="space-y-3 pt-2">
           <AuthenticationSection
@@ -436,6 +448,75 @@ export function EditServerFormContent({
             : {})}
         />
       </div>
+    </div>
+  );
+}
+
+/**
+ * What saving this edit will do to the server's stored credentials (MJ-003).
+ *
+ * Two destinations move: an http server's URL across the origin its
+ * credentials were entered for, and a stdio server's command. The backend
+ * clears the stored credentials in both cases, so both get the same warning
+ * and the same acknowledgement — a save that destroys a credential somebody
+ * else entered should not happen on one click.
+ *
+ * The acknowledgement is keyed to the destination, so typing a different one
+ * after ticking the box re-arms the warning.
+ */
+function CredentialClearWarning({
+  pending,
+  acknowledgedFor,
+  onAcknowledge,
+}: {
+  pending: PendingCredentialClear;
+  acknowledgedFor: string | null;
+  onAcknowledge: (key: string | null) => void;
+}) {
+  const key = credentialClearAcknowledgementKey(pending);
+  return (
+    <div
+      role="alert"
+      className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs space-y-2"
+    >
+      <p className="font-medium">
+        {pending.kind === "url-origin"
+          ? "Saving this URL will clear this server's saved credentials"
+          : "Saving this command will clear this server's saved credentials"}
+      </p>
+      {pending.kind === "url-origin" ? (
+        <p className="text-muted-foreground">
+          This server points at{" "}
+          <span className="font-mono">{pending.previousOrigin}</span>. Everything
+          saved against that host is cleared when it moves: request headers,
+          environment variables, the bearer token, any OAuth access and refresh
+          tokens, and the OAuth client secret. Save it pointing at{" "}
+          <span className="font-mono">{pending.nextOrigin}</span> and all of them
+          go, including credentials other project members added that you cannot
+          see. Someone has to enter them again before this server connects.
+        </p>
+      ) : (
+        <p className="text-muted-foreground">
+          This server runs{" "}
+          <span className="font-mono">{pending.previousCommand}</span>. Its saved
+          environment variables are held for that command and are cleared when it
+          changes. Save it running{" "}
+          <span className="font-mono">{pending.nextCommand}</span> and they go,
+          including values other project members added that you cannot see.
+          Someone has to enter them again before this server connects.
+        </p>
+      )}
+      <label className="flex items-start gap-2">
+        <input
+          type="checkbox"
+          className="mt-0.5"
+          checked={acknowledgedFor === key}
+          onChange={(e) => onAcknowledge(e.target.checked ? key : null)}
+        />
+        <span>
+          I understand the saved credentials for this server will be cleared.
+        </span>
+      </label>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
@@ -477,11 +477,11 @@ function CredentialClearWarning({
   return (
     <div
       role="alert"
-      className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs space-y-2"
+      className="rounded-md border border-warning/40 bg-warning/10 p-3 text-xs space-y-2"
     >
       <p className="font-medium">
         {pending.kind === "url-origin"
-          ? "Saving this URL will clear this server's saved credentials"
+          ? "Saving this URL will clear any saved credentials"
           : "Saving this command will clear this server's saved credentials"}
       </p>
       {pending.kind === "url-origin" ? (

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
 import { toast } from "@/lib/toast";
 import { toastServerConnectionFailure } from "@/lib/server-error-toast";
 import { reportCaught } from "@/lib/error-reporting";
@@ -39,6 +46,7 @@ import { useServerForm } from "./hooks/use-server-form";
 import { ServerInfoContent } from "./ServerInfoContent";
 import { ServerInfoToolsMetadataContent } from "./ServerInfoToolsMetadataContent";
 import { EditServerFormContent } from "./EditServerFormContent";
+import { ServerUrlChangeHistory } from "./ServerUrlChangeHistory";
 import { ServerHistoryContent } from "./ServerHistoryContent";
 import { ServerHistoryDriftChip } from "./ServerHistoryDriftChip";
 import { HostCompatContent } from "@/components/compat/HostCompatContent";
@@ -218,27 +226,37 @@ export function ServerDetailModal({
     },
     []
   );
+  /**
+   * The wire-mode override's own reconnect, flagged in flight so the
+   * configuration Save is blocked for its duration like a user-initiated one.
+   * Both paths below reach it — the reactive watcher and the 1.5s safety net —
+   * because neither goes through `handleConnect`, which is where
+   * `isReconnecting` used to be set. Errors are reported, not toasted: the
+   * toggle owns that.
+   */
+  const reconnectForWireModeOverride = useCallback(async () => {
+    setIsReconnecting(true);
+    try {
+      await onReconnect(server.name, { allowInteractiveOAuthFlow: false });
+    } catch (err) {
+      reportCaught(err, {
+        source: "server_detail_wire_mode_reconnect",
+        level: "warning",
+      });
+    } finally {
+      setIsReconnecting(false);
+    }
+  }, [onReconnect, server.name]);
+
   useEffect(() => {
     const pending = pendingReconnectRef.current;
     if (!pending) return;
     if (currentMcpProtocolVersionOverride !== pending.target) return;
     pendingReconnectRef.current = null;
-    void onReconnect(server.name, { allowInteractiveOAuthFlow: false }).catch(
-      (err) => {
-        // The handler surfaces its own toast; report so a systematically
-        // failing reconnect is visible. Same source/level as the 1.5s
-        // safety-net path below — this is the branch that runs when the
-        // reactive read-back arrives in time, i.e. the common one.
-        reportCaught(err, {
-          source: "server_detail_wire_mode_reconnect",
-          level: "warning",
-        });
-      }
-    );
+    void reconnectForWireModeOverride();
   }, [
     currentMcpProtocolVersionOverride,
-    onReconnect,
-    server.name,
+    reconnectForWireModeOverride,
     pendingReconnectTick,
   ]);
 
@@ -300,17 +318,7 @@ export function ServerDetailModal({
         fallbackReconnectTimerRef.current = null;
         if (pendingReconnectRef.current?.target === next) {
           pendingReconnectRef.current = null;
-          void onReconnect(server.name, {
-            allowInteractiveOAuthFlow: false,
-          }).catch((err) => {
-            // Deliberately not toasted: this is the 1.5s safety-net
-            // reconnect and the toggle has its own error path. Reported so a
-            // systematically failing fallback is visible rather than dropped.
-            reportCaught(err, {
-              source: "server_detail_wire_mode_reconnect",
-              level: "warning",
-            });
-          });
+          void reconnectForWireModeOverride();
         }
       }, 1500);
       // Tick the watcher so it re-evaluates immediately in case the
@@ -522,9 +530,28 @@ export function ServerDetailModal({
   const tabTriggerClass = "min-w-0 flex-1 px-1.5 text-xs sm:px-2 sm:text-sm";
   const isConfigurationTab = activeTab === "configuration";
 
+  /**
+   * The single condition that decides whether this configuration may be saved.
+   *
+   * Extracted because the Save button's `disabled` and the form's submit
+   * handler were two different lists, and Enter in any configuration input
+   * submits the form — so every condition the button enforced was bypassable
+   * from the keyboard. That matters most for MJ-003's credential-clear
+   * acknowledgement, which is there precisely so a destructive save cannot
+   * happen without one, but it was equally true of the duplicate-name check,
+   * the auth-configuration block, and the in-flight reconnect guard.
+   */
+  const saveBlocked =
+    isDuplicateServerName ||
+    isSaving ||
+    isReconnecting ||
+    (!formState.hasChanges && !isConnected) ||
+    formState.authConfigurationBlocksSubmit ||
+    formState.credentialClearBlocksSubmit;
+
   const handleConfigurationSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!isConfigurationTab || isSaving) return;
+    if (!isConfigurationTab || saveBlocked) return;
     void handleSave();
   };
 
@@ -710,6 +737,11 @@ export function ServerDetailModal({
                         : undefined
                     }
                   />
+                  {/* MJ-003 AC 3: where this server has been repointed, and
+                      whether that cleared credentials. Readable on every plan,
+                      unlike the organization audit log. Renders nothing when
+                      there is no history. */}
+                  <ServerUrlChangeHistory serverId={hostedServerId} />
                 </div>
               </TabsContent>
 
@@ -733,13 +765,7 @@ export function ServerDetailModal({
                           })
                       : undefined
                   }
-                  disabled={
-                    isDuplicateServerName ||
-                    isSaving ||
-                    isReconnecting ||
-                    (!formState.hasChanges && !isConnected) ||
-                    formState.authConfigurationBlocksSubmit
-                  }
+                  disabled={saveBlocked}
                   size="sm"
                 >
                   {isSaving || isReconnecting ? (

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -126,7 +126,12 @@ export function ServerDetailModal({
   projectXaaDefaultIdentity = null,
 }: ServerDetailModalProps) {
   const [activeTab, setActiveTab] = useState<ServerDetailTab>(defaultTab);
-  const [isReconnecting, setIsReconnecting] = useState(false);
+  // Reconnects overlap: two quick wire-mode changes start a second one while
+  // the first is still running. A boolean would be cleared by whichever
+  // finished first and let a configuration save through mid-reconnect, so the
+  // guard counts them and lifts only when the last one settles.
+  const [reconnectsInFlight, setReconnectsInFlight] = useState(0);
+  const isReconnecting = reconnectsInFlight > 0;
   const [isSaving, setIsSaving] = useState(false);
   const [isLoadingTools, setIsLoadingTools] = useState(false);
   const [toolsLoadError, setToolsLoadError] = useState<string | null>(null);
@@ -235,7 +240,7 @@ export function ServerDetailModal({
    * toggle owns that.
    */
   const reconnectForWireModeOverride = useCallback(async () => {
-    setIsReconnecting(true);
+    setReconnectsInFlight((count) => count + 1);
     try {
       await onReconnect(server.name, { allowInteractiveOAuthFlow: false });
     } catch (err) {
@@ -244,7 +249,7 @@ export function ServerDetailModal({
         level: "warning",
       });
     } finally {
-      setIsReconnecting(false);
+      setReconnectsInFlight((count) => count - 1);
     }
   }, [onReconnect, server.name]);
 
@@ -481,7 +486,7 @@ export function ServerDetailModal({
     forceOAuthFlow?: boolean;
     allowInteractiveOAuthFlow?: boolean;
   }) => {
-    setIsReconnecting(true);
+    setReconnectsInFlight((count) => count + 1);
     track("server_detail_modal_connect_clicked", {
       location: "server_detail_modal",
       server_id: server.name,
@@ -493,7 +498,7 @@ export function ServerDetailModal({
         error instanceof Error ? error.message : "Unknown error";
       toastServerConnectionFailure(server.name, errorMessage);
     } finally {
-      setIsReconnecting(false);
+      setReconnectsInFlight((count) => count - 1);
     }
   };
 

--- a/mcpjam-inspector/client/src/components/connection/ServerUrlChangeHistory.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerUrlChangeHistory.tsx
@@ -1,0 +1,245 @@
+/**
+ * Where this server has been pointed, and whether that cleared credentials.
+ *
+ * MJ-003 acceptance criterion 3. The backend records the change and reads it
+ * back through `auditEvents:listServerUrlChanges`, which is deliberately NOT
+ * gated on the `auditLog` entitlement — the organization audit log is, and the
+ * member whose saved credential was destroyed by somebody else's edit is
+ * usually on a plan that cannot open it. This is the surface that makes the
+ * record reachable for them.
+ *
+ * Renders nothing when there is no history. A server nobody has repointed
+ * should not carry an empty panel explaining that it has not been repointed.
+ */
+
+import { useQuery } from "convex/react";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { isConvexQueryUnavailable } from "@/lib/convex-error";
+
+/**
+ * Exported so the test can build the exact message the client sees, and so a
+ * rename here cannot drift from the predicate below.
+ */
+export const SERVER_URL_CHANGES_QUERY = "auditEvents:listServerUrlChanges";
+
+const URL_CHANGED_ACTION = "server.url.changed";
+const CREDENTIALS_CLEARED_ACTION = "server.credentials.cleared_on_origin_change";
+
+interface ServerUrlChangeEvent {
+  // `id`, not Convex's `_id`: the query projects the row rather than returning
+  // it, so that the metadata it exposes is a decided list rather than whatever
+  // the audit table happens to hold.
+  id: string;
+  action: string;
+  actorEmail: string | null;
+  timestamp: number;
+  metadata?: {
+    // Which vector moved the destination. Both events carry it.
+    cause?: string | null;
+    previousOrigin?: string | null;
+    nextOrigin?: string | null;
+    clearedOnOriginChange?: boolean;
+    // An http row switched to stdio keeps its `url` and stops reading it. The
+    // url event still fires, so without this the panel would tell somebody
+    // their URL changed when the row still holds the one they can see.
+    viaTransportFlip?: boolean;
+    clearedKinds?: string[];
+  } | null;
+}
+
+/**
+ * Backend category names, in words. Unknown keys fall through unchanged rather
+ * than being dropped: a kind added on the backend should still be visible here
+ * before anyone remembers to update this map.
+ */
+const CLEARED_KIND_LABELS: Record<string, string> = {
+  env: "environment variables",
+  headers: "request headers",
+  legacy_env: "environment variables",
+  legacy_headers: "request headers",
+  client_secret: "OAuth client secret",
+  xaa_dcr: "cross-app client registration",
+  oauth_tokens: "OAuth tokens",
+};
+
+interface ServerUrlChangeHistoryProps {
+  /** The canonical server document id, or null when it is not resolved yet. */
+  serverId: string | null;
+}
+
+function formatWhen(timestamp: number): string {
+  try {
+    return new Date(timestamp).toLocaleString();
+  } catch {
+    return new Date(timestamp).toISOString();
+  }
+}
+
+/**
+ * The failure this panel EXPECTS: the deployment does not serve its query.
+ *
+ * The Inspector half of MJ-003 shipped ahead of the backend half, and
+ * `useQuery` throws during render while the function is missing. That throw
+ * escaped to the route boundary and took the whole Servers page down the
+ * moment anyone opened a hosted server's details (PostHog issue
+ * 01a08999-8c34-77a2-922e-557c0e515919). The boundary below is what keeps a
+ * read-only, renders-nothing-by-default panel from ever doing that again —
+ * still worth having now that the query is deployed, for a browser left open
+ * across a rollback.
+ *
+ * `isConvexQueryUnavailable` alone is not enough here: it names the DEV
+ * shapes ("Could not find public function"), and production redacts every
+ * non-`ConvexError` to `[CONVEX Q(<name>)] [Request ID: …] Server Error`. The
+ * function name in that prefix is the only thing left to match on, so a
+ * redacted failure of THIS query is treated as the dark-ship state. A
+ * `ConvexError` from it (`NOT_FOUND` for a non-member) carries its own
+ * message, matches neither branch, and still reports.
+ */
+export function isServerUrlHistoryUnavailable(error: Error): boolean {
+  const message = typeof error?.message === "string" ? error.message : "";
+  if (!message.includes(`Q(${SERVER_URL_CHANGES_QUERY})`)) return false;
+  return isConvexQueryUnavailable(error) || message.includes("Server Error");
+}
+
+export function ServerUrlChangeHistory({
+  serverId,
+}: ServerUrlChangeHistoryProps) {
+  return (
+    // KEYED by the server: a boundary that has caught stays in its fallback
+    // for the life of the element, so without the key one failure would hide
+    // the history for every server opened after it in the same modal.
+    //
+    // `fallback={null}` is this panel's own contract — nothing to say, draw
+    // nothing. `isExpectedError` suppresses only the telemetry, and only for
+    // the shape the predicate can name; a genuine render bug still reports.
+    <ErrorBoundary
+      key={serverId ?? "no-server"}
+      name="server-url-change-history"
+      fallback={null}
+      isExpectedError={isServerUrlHistoryUnavailable}
+    >
+      <ServerUrlChangeHistoryPanel serverId={serverId} />
+    </ErrorBoundary>
+  );
+}
+
+/**
+ * One line saying what moved, for one event.
+ *
+ * A url repoint writes both actions and a stdio command swap writes only the
+ * clear, so the clear row is a row of its own exactly when it is the only
+ * record of the edit. Otherwise it is dropped: two rows for one edit reads as
+ * two edits, and the url event already carries `clearedKinds`.
+ */
+function isRenderableEvent(event: ServerUrlChangeEvent): boolean {
+  return (
+    event.action === URL_CHANGED_ACTION ||
+    (event.action === CREDENTIALS_CLEARED_ACTION &&
+      event.metadata?.cause === "stdio_target_change")
+  );
+}
+
+function DestinationChange({ event }: { event: ServerUrlChangeEvent }) {
+  const previous = event.metadata?.previousOrigin ?? null;
+  const next = event.metadata?.nextOrigin ?? null;
+
+  if (event.action === CREDENTIALS_CLEARED_ACTION) {
+    // A stdio row. The backend records origins as null for it — a command is
+    // not an origin — and never records the command itself, because it is
+    // the caller's own string.
+    return (
+      <span className="text-muted-foreground">
+        Pointed at a different command
+      </span>
+    );
+  }
+
+  if (event.metadata?.viaTransportFlip === true) {
+    return (
+      <span className="text-muted-foreground">
+        Switched to a local command. The saved URL is no longer used.
+      </span>
+    );
+  }
+
+  if (previous && next && previous !== next) {
+    return (
+      <>
+        <span className="font-mono">{previous}</span>
+        <span className="text-muted-foreground">→</span>
+        <span className="font-mono">{next}</span>
+      </>
+    );
+  }
+
+  return (
+    <span className="text-muted-foreground">
+      URL changed{next ? " within " : ""}
+      {next ? <span className="font-mono">{next}</span> : null}
+    </span>
+  );
+}
+
+function ServerUrlChangeHistoryPanel({
+  serverId,
+}: ServerUrlChangeHistoryProps) {
+  const events = useQuery(
+    SERVER_URL_CHANGES_QUERY as never,
+    serverId ? ({ serverId } as never) : "skip"
+  ) as ServerUrlChangeEvent[] | undefined;
+
+  // `Array.isArray`, not a truthiness-and-length check. `undefined` is still
+  // loading and an empty array is a server nobody has repointed — both render
+  // nothing, because this panel is only interesting when it has something to
+  // say. But the value crosses a boundary this component does not control, and
+  // anything else arriving (a stubbed query in a test, a shape change upstream)
+  // reached `.filter` below and took the whole modal down with a TypeError.
+  // A read from outside gets checked, not assumed.
+  if (!Array.isArray(events) || events.length === 0) return null;
+
+  const changes = events.filter(isRenderableEvent);
+  if (changes.length === 0) return null;
+
+  return (
+    <div className="space-y-2 pt-2">
+      <p className="text-xs font-medium">Destination history</p>
+      <ul className="space-y-1.5">
+        {changes.map((event) => {
+          // The clear event exists only because something was cleared; the url
+          // event fires for same-origin edits too and says so itself.
+          const cleared =
+            event.action === CREDENTIALS_CLEARED_ACTION ||
+            event.metadata?.clearedOnOriginChange === true;
+          const clearedKindLabels = Array.isArray(event.metadata?.clearedKinds)
+            ? event.metadata.clearedKinds
+                .map((kind) => CLEARED_KIND_LABELS[kind] ?? kind)
+                .filter((label, index, all) => all.indexOf(label) === index)
+            : [];
+          return (
+            <li
+              key={event.id}
+              className="rounded-md border border-border px-2.5 py-2 text-xs"
+            >
+              <div className="flex flex-wrap items-baseline gap-x-1.5">
+                <DestinationChange event={event} />
+              </div>
+              <div className="mt-0.5 text-muted-foreground">
+                {event.actorEmail ?? "Unknown user"} ·{" "}
+                {formatWhen(event.timestamp)}
+              </div>
+              {cleared && (
+                <div className="mt-1 text-amber-600 dark:text-amber-500">
+                  Saved credentials were cleared and need re-entering
+                  {clearedKindLabels.length > 0
+                    ? `: ${clearedKindLabels.join(", ")}`
+                    : ""}
+                  .
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/connection/ServerUrlChangeHistory.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerUrlChangeHistory.tsx
@@ -228,7 +228,7 @@ function ServerUrlChangeHistoryPanel({
                 {formatWhen(event.timestamp)}
               </div>
               {cleared && (
-                <div className="mt-1 text-amber-600 dark:text-amber-500">
+                <div className="mt-1 text-warning">
                   Saved credentials were cleared and need re-entering
                   {clearedKindLabels.length > 0
                     ? `: ${clearedKindLabels.join(", ")}`

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ServerWithName } from "@/hooks/use-app-state";
 import type { ListToolsResultWithMetadata } from "@/lib/apis/mcp-tools-api";
@@ -411,6 +418,74 @@ describe("ServerDetailModal", () => {
         },
       });
     });
+  });
+
+  it("keeps Save blocked until the last overlapping wire-mode reconnect settles", async () => {
+    // Two quick override changes run two reconnects at once. A boolean guard
+    // was cleared by whichever finished first, which let a configuration save
+    // through while the other reconnect was still in flight.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      installPointerCaptureMocks();
+      mockUseFeatureFlagEnabled.mockReturnValue(true);
+      // The read-back never reports the new override, so each change reaches
+      // the reconnect through its own 1.5s safety net.
+      mockUseQuery.mockReturnValue({
+        projectId: "jh7abc123def456ghi789jk",
+        serverIds: [],
+        overrides: {},
+      });
+      const settle: Array<() => void> = [];
+      const onReconnect = vi.fn(
+        () => new Promise<void>((resolve) => settle.push(resolve))
+      );
+
+      render(
+        <ServerDetailModal
+          {...defaultProps}
+          onReconnect={onReconnect}
+          projectId="jh7abc123def456ghi789jk"
+          hostedServerId="server_123"
+          hostDefaultMcpProtocolVersion="2026-07-28"
+        />
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: /connection overrides/i })
+      );
+
+      const startReconnectFor = async (version: RegExp) => {
+        await user.click(getProtocolVersionCombobox());
+        await user.click(await screen.findByRole("option", { name: version }));
+        await act(async () => {
+          vi.advanceTimersByTime(1500);
+        });
+      };
+
+      await startReconnectFor(/2025-11-25/);
+      await waitFor(() => expect(onReconnect).toHaveBeenCalledTimes(1));
+      await startReconnectFor(/2026-07-28/);
+      await waitFor(() => expect(onReconnect).toHaveBeenCalledTimes(2));
+
+      // The footer's only button; its label tracks the reconnect, so match it
+      // by position rather than by text.
+      const saveButton = () =>
+        within(screen.getByTestId("modal-footer")).getByRole("button");
+      expect(saveButton()).toBeDisabled();
+
+      await act(async () => {
+        settle[0]();
+      });
+      expect(saveButton()).toBeDisabled();
+
+      await act(async () => {
+        settle[1]();
+      });
+      await waitFor(() => expect(saveButton()).toBeEnabled());
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not fire the fallback reconnect after the modal closes", async () => {

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerUrlChangeHistory.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerUrlChangeHistory.test.tsx
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const { useQueryMock, reportBoundaryError } = vi.hoisted(() => ({
+  useQueryMock: vi.fn(),
+  reportBoundaryError: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+}));
+
+vi.mock("@/lib/error-reporting", () => ({
+  reportBoundaryError,
+  reportCaught: vi.fn(),
+}));
+
+import {
+  SERVER_URL_CHANGES_QUERY,
+  ServerUrlChangeHistory,
+  isServerUrlHistoryUnavailable,
+} from "../ServerUrlChangeHistory";
+
+// The exact string `convex/react` throws from render in PRODUCTION: the
+// server redacts "Could not find public function" to "Server Error", so the
+// function name in the prefix is all the client gets. Copied from the PostHog
+// issue that motivated the boundary.
+const PROD_DARK_SHIP = new Error(
+  `[CONVEX Q(${SERVER_URL_CHANGES_QUERY})] [Request ID: 5eb87f6c9d3ef8d5] Server Error\n  Called by client`
+);
+const DEV_DARK_SHIP = new Error(
+  `[CONVEX Q(${SERVER_URL_CHANGES_QUERY})] [Request ID: abc] Could not find public function for '${SERVER_URL_CHANGES_QUERY}'`
+);
+
+// `auditEvents:listServerUrlChanges` projects the row: `id`, not Convex's
+// `_id`, and a decided metadata list.
+const urlChange = {
+  id: "evt_1",
+  action: "server.url.changed",
+  actorEmail: "editor@example.com",
+  timestamp: Date.UTC(2026, 8, 9, 12, 0, 0),
+  metadata: {
+    cause: "url_origin_change",
+    previousOrigin: "https://old.example.com",
+    nextOrigin: "https://new.example.com",
+    clearedOnOriginChange: true,
+    viaTransportFlip: false,
+    clearedKinds: ["headers", "legacy_headers"],
+  },
+};
+
+// A url repoint writes the clear alongside the url event.
+const urlChangeClear = {
+  id: "evt_1_clear",
+  action: "server.credentials.cleared_on_origin_change",
+  actorEmail: "editor@example.com",
+  timestamp: Date.UTC(2026, 8, 9, 12, 0, 0),
+  metadata: {
+    cause: "url_origin_change",
+    previousOrigin: "https://old.example.com",
+    nextOrigin: "https://new.example.com",
+    clearedKinds: ["headers"],
+  },
+};
+
+describe("ServerUrlChangeHistory", () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    useQueryMock.mockReset();
+    reportBoundaryError.mockReset();
+    // React logs caught boundary errors; keep the suite output readable.
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => consoleError.mockRestore());
+
+  it("renders nothing, and does not report, when production does not serve the query yet", () => {
+    // The Inspector half of MJ-003 deployed before its backend half. That
+    // throw used to escape to the route boundary and take the Servers page
+    // down for anyone opening a hosted server's details.
+    useQueryMock.mockImplementation(() => {
+      throw PROD_DARK_SHIP;
+    });
+
+    const { container } = render(<ServerUrlChangeHistory serverId="srv_1" />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(reportBoundaryError).not.toHaveBeenCalled();
+  });
+
+  it("treats the dev-deployment shape of a missing function the same way", () => {
+    useQueryMock.mockImplementation(() => {
+      throw DEV_DARK_SHIP;
+    });
+
+    const { container } = render(<ServerUrlChangeHistory serverId="srv_1" />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(reportBoundaryError).not.toHaveBeenCalled();
+  });
+
+  it("still renders nothing but DOES report a failure it did not expect", () => {
+    // The predicate is narrow on purpose: a boundary that suppressed
+    // everything would also swallow the real bug it exists to surface.
+    useQueryMock.mockImplementation(() => {
+      throw new Error("kaboom");
+    });
+
+    const { container } = render(<ServerUrlChangeHistory serverId="srv_1" />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(reportBoundaryError).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-probes for the next server after one has failed", () => {
+    // A boundary that has caught stays in its fallback for the life of the
+    // element. Keyed by server, a failure on one does not hide history on
+    // the next one opened in the same modal.
+    //
+    // Persistent, not `Once`: React retries a render that threw concurrently
+    // before handing it to a boundary, and a one-shot throw lets that retry
+    // succeed — which React then reports as an uncaught recovery error.
+    useQueryMock.mockImplementation(() => {
+      throw PROD_DARK_SHIP;
+    });
+    const { rerender } = render(<ServerUrlChangeHistory serverId="srv_1" />);
+    expect(screen.queryByText("Destination history")).not.toBeInTheDocument();
+
+    useQueryMock.mockReset();
+    useQueryMock.mockReturnValue([urlChange]);
+    rerender(<ServerUrlChangeHistory serverId="srv_2" />);
+
+    expect(screen.getByText("Destination history")).toBeInTheDocument();
+  });
+
+  it("renders one row per edit when the backend answers", () => {
+    useQueryMock.mockReturnValue([urlChange, urlChangeClear]);
+
+    render(<ServerUrlChangeHistory serverId="srv_1" />);
+
+    expect(useQueryMock).toHaveBeenCalledWith(SERVER_URL_CHANGES_QUERY, {
+      serverId: "srv_1",
+    });
+    expect(screen.getByText("https://old.example.com")).toBeInTheDocument();
+    expect(screen.getByText("https://new.example.com")).toBeInTheDocument();
+    expect(screen.getByText(/editor@example\.com/)).toBeInTheDocument();
+    // Duplicate labels collapse, and the clear that accompanies a url repoint
+    // does not get a second row — one edit, one row.
+    expect(
+      screen.getByText(/Saved credentials were cleared.*request headers\./)
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(1);
+  });
+
+  it("renders a stdio command swap, which writes no url event at all", () => {
+    // mcpjam-backend#1260. A stdio row's destination is its command, so the
+    // only record of the edit is the clear — filtering to `server.url.changed`
+    // left this vector invisible in the panel.
+    useQueryMock.mockReturnValue([
+      {
+        id: "evt_stdio",
+        action: "server.credentials.cleared_on_origin_change",
+        actorEmail: "editor@example.com",
+        timestamp: Date.UTC(2026, 8, 9, 12, 0, 0),
+        metadata: {
+          cause: "stdio_target_change",
+          previousOrigin: null,
+          nextOrigin: null,
+          clearedKinds: ["env"],
+        },
+      },
+    ]);
+
+    render(<ServerUrlChangeHistory serverId="srv_1" />);
+
+    expect(
+      screen.getByText("Pointed at a different command")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Saved credentials were cleared.*environment variables\./
+      )
+    ).toBeInTheDocument();
+    // No origins to show, and none invented.
+    expect(screen.queryByText("null")).not.toBeInTheDocument();
+  });
+
+  it("does not claim a URL change when the row only stopped using its URL", () => {
+    // A flip to stdio fires the url event with `nextOrigin: null` while the row
+    // KEEPS its url. Reading that as a repoint tells the user their URL moved
+    // while the field in front of them still shows the old one.
+    useQueryMock.mockReturnValue([
+      {
+        ...urlChange,
+        id: "evt_flip",
+        metadata: {
+          ...urlChange.metadata,
+          nextOrigin: null,
+          viaTransportFlip: true,
+          clearedKinds: ["env"],
+        },
+      },
+    ]);
+
+    render(<ServerUrlChangeHistory serverId="srv_1" />);
+
+    expect(
+      screen.getByText(/Switched to a local command/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/URL changed/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("https://old.example.com")
+    ).not.toBeInTheDocument();
+  });
+
+  it("skips the query while the server id is unresolved", () => {
+    useQueryMock.mockReturnValue(undefined);
+
+    const { container } = render(<ServerUrlChangeHistory serverId={null} />);
+
+    expect(useQueryMock).toHaveBeenCalledWith(SERVER_URL_CHANGES_QUERY, "skip");
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("isServerUrlHistoryUnavailable", () => {
+  it("names both dark-ship shapes of THIS query only", () => {
+    expect(isServerUrlHistoryUnavailable(PROD_DARK_SHIP)).toBe(true);
+    expect(isServerUrlHistoryUnavailable(DEV_DARK_SHIP)).toBe(true);
+    // Another query's redacted failure is not this panel's to suppress.
+    expect(
+      isServerUrlHistoryUnavailable(
+        new Error("[CONVEX Q(servers:get)] [Request ID: x] Server Error")
+      )
+    ).toBe(false);
+    // A ConvexError from this query carries its own message and still reports.
+    expect(
+      isServerUrlHistoryUnavailable(
+        new Error(
+          `[CONVEX Q(${SERVER_URL_CHANGES_QUERY})] [Request ID: x] Uncaught ConvexError: Server not found`
+        )
+      )
+    ).toBe(false);
+    expect(isServerUrlHistoryUnavailable(new Error("kaboom"))).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
@@ -1389,3 +1389,110 @@ describe("useServerForm", () => {
     expect(result.current.buildFormData().clientSecret).toBeUndefined();
   });
 });
+
+/**
+ * MJ-003 — the form has to say, before the save, that this edit will destroy
+ * the row's stored credentials. `credential-origin.test.ts` pins the rules;
+ * these pin that the hook feeds them the right values and gates Save on the
+ * acknowledgement.
+ */
+describe("useServerForm credential-clear warning", () => {
+  const httpServer = {
+    name: "Hosted server",
+    config: { url: "https://owner.example.com/mcp" },
+    hasHeaders: true,
+    lastConnectionTime: new Date(),
+    connectionStatus: "disconnected",
+    retryCount: 0,
+    enabled: true,
+  } as any;
+
+  const stdioServer = {
+    name: "Local server",
+    config: {
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-everything"],
+      env: { API_KEY: "secret" },
+    },
+    lastConnectionTime: new Date(),
+    connectionStatus: "disconnected",
+    retryCount: 0,
+    enabled: true,
+  } as any;
+
+  it("warns and blocks Save on a cross-origin URL edit", async () => {
+    const { result } = renderHook(() => useServerForm(httpServer));
+    await waitFor(() => {
+      expect(result.current.url).toBe("https://owner.example.com/mcp");
+    });
+
+    act(() => {
+      result.current.setUrl("https://elsewhere.example.com/mcp");
+    });
+
+    expect(result.current.pendingCredentialClear).toMatchObject({
+      kind: "url-origin",
+      nextOrigin: "https://elsewhere.example.com",
+    });
+    expect(result.current.credentialClearBlocksSubmit).toBe(true);
+  });
+
+  it("warns and blocks Save on a stdio command swap", async () => {
+    // The vector the form was silent about: the row's env secret goes to
+    // whatever process this command names, and the backend clears it.
+    const { result } = renderHook(() => useServerForm(stdioServer));
+    await waitFor(() => {
+      expect(result.current.commandInput).toBe(
+        "npx -y @modelcontextprotocol/server-everything"
+      );
+    });
+
+    act(() => {
+      result.current.setCommandInput("node exfiltrate.js");
+    });
+
+    expect(result.current.pendingCredentialClear).toMatchObject({
+      kind: "stdio-target",
+      previousCommand: "npx -y @modelcontextprotocol/server-everything",
+      nextCommand: "node exfiltrate.js",
+    });
+    expect(result.current.credentialClearBlocksSubmit).toBe(true);
+  });
+
+  it("stays silent on an edit that keeps the destination", async () => {
+    const { result } = renderHook(() => useServerForm(stdioServer));
+    await waitFor(() => {
+      expect(result.current.commandInput).toBe(
+        "npx -y @modelcontextprotocol/server-everything"
+      );
+    });
+
+    act(() => {
+      result.current.setName("Renamed");
+    });
+
+    expect(result.current.pendingCredentialClear).toBeNull();
+    expect(result.current.credentialClearBlocksSubmit).toBe(false);
+  });
+
+  it("releases Save once the destination is acknowledged, and re-arms on a new one", async () => {
+    const { result } = renderHook(() => useServerForm(httpServer));
+    await waitFor(() => {
+      expect(result.current.url).toBe("https://owner.example.com/mcp");
+    });
+
+    act(() => {
+      result.current.setUrl("https://one.example.com/mcp");
+    });
+    act(() => {
+      result.current.acknowledgeCredentialClear("url:https://one.example.com");
+    });
+    expect(result.current.credentialClearBlocksSubmit).toBe(false);
+
+    // Consent was for one destination. Typing another is a new decision.
+    act(() => {
+      result.current.setUrl("https://two.example.com/mcp");
+    });
+    expect(result.current.credentialClearBlocksSubmit).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
@@ -1437,6 +1437,19 @@ describe("useServerForm credential-clear warning", () => {
     expect(result.current.credentialClearBlocksSubmit).toBe(true);
   });
 
+  it("requires acknowledgment when another member's OAuth tokens are absent from runtime state", async () => {
+    const server = {
+      ...httpServer,
+      hasHeaders: false,
+      oauthTokens: undefined,
+      config: { ...httpServer.config, useOAuth: true },
+    };
+    const { result } = renderHook(() => useServerForm(server));
+    await waitFor(() => expect(result.current.url).toBe(httpServer.config.url));
+    act(() => result.current.setUrl("https://elsewhere.example.com/mcp"));
+    expect(result.current.credentialClearBlocksSubmit).toBe(true);
+  });
+
   it("warns and blocks Save on a stdio command swap", async () => {
     // The vector the form was silent about: the row's env secret goes to
     // whatever process this command names, and the backend clears it.
@@ -1532,5 +1545,18 @@ describe("useServerForm credential-clear warning", () => {
 
     expect(result.current.pendingCredentialClear).toBeNull();
     expect(result.current.credentialClearBlocksSubmit).toBe(false);
+  });
+});
+
+describe("pasted command compatibility", () => {
+  it("preserves a pasted Windows path", () => {
+    const { result } = renderHook(() => useServerForm());
+    act(() => {
+      result.current.setType("stdio");
+      result.current.setCommandInput(String.raw`node C:\tools\server.js`);
+    });
+    expect(result.current.buildFormData().args).toEqual([
+      String.raw`C:\tools\server.js`,
+    ]);
   });
 });

--- a/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
@@ -1495,4 +1495,42 @@ describe("useServerForm credential-clear warning", () => {
     });
     expect(result.current.credentialClearBlocksSubmit).toBe(true);
   });
+
+  const spacedStdioServer = {
+    name: "Local server",
+    config: {
+      command: "node",
+      args: ["--inspect", "C:\\Program Files\\mcp\\file name.js", 'say "hi"'],
+      env: { API_KEY: "secret" },
+    },
+    lastConnectionTime: new Date(),
+    connectionStatus: "disconnected",
+    retryCount: 0,
+    enabled: true,
+  } as any;
+
+  it("round-trips stdio arguments that contain whitespace and quotes", async () => {
+    const { result } = renderHook(() => useServerForm(spacedStdioServer));
+    await waitFor(() => {
+      expect(result.current.commandInput).not.toBe("");
+    });
+
+    expect(result.current.buildFormData()).toMatchObject({
+      command: "node",
+      args: ["--inspect", "C:\\Program Files\\mcp\\file name.js", 'say "hi"'],
+    });
+  });
+
+  it("stays silent when a space-bearing stdio target is opened and saved unchanged", async () => {
+    // The user-visible bug: a whitespace split re-reads the stored arguments
+    // as different ones, so the form announces that an untouched row is about
+    // to lose its credentials.
+    const { result } = renderHook(() => useServerForm(spacedStdioServer));
+    await waitFor(() => {
+      expect(result.current.commandInput).not.toBe("");
+    });
+
+    expect(result.current.pendingCredentialClear).toBeNull();
+    expect(result.current.credentialClearBlocksSubmit).toBe(false);
+  });
 });

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -76,13 +76,7 @@ function parseCommandInput(input: string): {
       continue;
     }
 
-    if (char === "\\" && i + 1 < input.length) {
-      current += input[i + 1];
-      i += 1;
-      inPart = true;
-      continue;
-    }
-
+    // Outside quotes, preserve literal backslashes in Windows and UNC paths.
     if (/\s/.test(char)) {
       if (inPart) {
         parts.push(current);
@@ -1234,7 +1228,6 @@ export function useServerForm(
   const pendingCredentialClear: PendingCredentialClear | null =
     type === "http"
       ? pendingCredentialClearForUrlEdit({
-          holdsStoredCredential,
           savedUrl,
           nextUrl: url,
         })

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -19,6 +19,31 @@ import { hasOAuthConfig, getStoredTokens } from "@/lib/oauth/mcp-oauth";
 import { HOSTED_MODE } from "@/lib/config";
 import { XAA_PARTIAL_OVERRIDE_ERROR } from "@/lib/xaa/identity";
 import { useConfidentialCimdCapability } from "@/hooks/use-confidential-cimd-capability";
+import {
+  credentialClearAcknowledgementKey,
+  pendingCredentialClearForStdioTargetEdit,
+  pendingCredentialClearForUrlEdit,
+  rowHoldsStoredCredential,
+  type PendingCredentialClear,
+} from "@/lib/credential-origin";
+
+/**
+ * The command and arguments the stdio branch of `buildFormData` will submit.
+ *
+ * Shared with the credential-clear warning so the two cannot disagree about
+ * what this form is about to send: a warning derived from a different parse
+ * would fire on edits the backend keeps and stay silent on ones it clears.
+ */
+function parseCommandInput(input: string): {
+  command: string;
+  args: string[];
+} {
+  const parts = input
+    .trim()
+    .split(/\s+/)
+    .filter((part) => part.length > 0);
+  return { command: parts[0] || "", args: parts.slice(1) };
+}
 
 interface InitialFormValues {
   name: string;
@@ -145,6 +170,16 @@ export function useServerForm(
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
   const [hasStoredClientSecret, setHasStoredClientSecret] = useState(false);
+  // Where the row POINTS as saved, kept beside the editable fields so the form
+  // can tell a destination change from an edit that keeps the credentials
+  // (MJ-003) — a cross-origin repoint, or a stdio row pointed at a different
+  // process.
+  const [savedUrl, setSavedUrl] = useState<string | null>(null);
+  const [savedCommand, setSavedCommand] = useState<string | null>(null);
+  const [savedArgs, setSavedArgs] = useState<string[]>([]);
+  // The destination the user has explicitly accepted losing credentials for.
+  const [credentialClearAcknowledgedFor, setCredentialClearAcknowledgedFor] =
+    useState<string | null>(null);
   const [clearClientSecret, setClearClientSecret] = useState(false);
   const [bearerToken, setBearerToken] = useState("");
   // True when the server has a saved bearer token whose value was stripped
@@ -407,7 +442,11 @@ export function useServerForm(
       setName(server.name);
       setType(serverType);
       setUrl(serverUrl);
+      setSavedUrl(serverUrl || null);
       setCommandInput(fullCommand);
+      setSavedCommand(server.config.command ?? null);
+      setSavedArgs(server.config.args ? [...server.config.args] : []);
+      setCredentialClearAcknowledgedFor(null);
 
       // Don't set a default scope for existing servers - use what's configured
       // Only set default for new servers
@@ -836,13 +875,7 @@ export function useServerForm(
 
     // Handle stdio-specific data
     if (type === "stdio") {
-      // Parse commandInput to extract command and args
-      const parts = commandInput
-        .trim()
-        .split(/\s+/)
-        .filter((part) => part.length > 0);
-      const command = parts[0] || "";
-      const args = parts.slice(1);
+      const { command, args } = parseCommandInput(commandInput);
 
       // Build environment variables
       const env: Record<string, string> = {};
@@ -1020,6 +1053,10 @@ export function useServerForm(
     setType("http");
     setCommandInput("");
     setUrl("");
+    setSavedUrl(null);
+    setSavedCommand(null);
+    setSavedArgs([]);
+    setCredentialClearAcknowledgedFor(null);
     setOauthScopesInput("");
     setOauthProtocolMode(DEFAULT_OAUTH_PROTOCOL_MODE);
     setOauthRegistrationMode(DEFAULT_OAUTH_REGISTRATION_MODE);
@@ -1117,6 +1154,34 @@ export function useServerForm(
     (type === "http" &&
       authType === "xaa" &&
       confidentialCimdBlockReason !== null);
+  // MJ-003. Moving where a credential-bearing row POINTS makes the backend wipe
+  // its stored credentials, including ones this user never entered and cannot
+  // see. Two vectors, decided by which transport the form is submitting: an
+  // http url that crosses its credentials' origin, and a stdio `command`/`args`
+  // swap. Which rows count is `rowHoldsStoredCredential`'s business.
+  const holdsStoredCredential = rowHoldsStoredCredential(server);
+  const nextStdioTarget = parseCommandInput(commandInput);
+  const pendingCredentialClear: PendingCredentialClear | null =
+    type === "http"
+      ? pendingCredentialClearForUrlEdit({
+          holdsStoredCredential,
+          savedUrl,
+          nextUrl: url,
+        })
+      : pendingCredentialClearForStdioTargetEdit({
+          holdsStoredCredential,
+          savedCommand,
+          savedArgs,
+          nextCommand: nextStdioTarget.command,
+          nextArgs: nextStdioTarget.args,
+        });
+  // Blocked until acknowledged, following `authConfigurationBlocksSubmit`. A
+  // destructive side effect on somebody else's credential should not happen on
+  // a single Save click.
+  const credentialClearBlocksSubmit =
+    pendingCredentialClear !== null &&
+    credentialClearAcknowledgedFor !==
+      credentialClearAcknowledgementKey(pendingCredentialClear);
   const oauthAuthorizationHeaderWarning =
     type === "http" &&
     authType === "oauth" &&
@@ -1129,6 +1194,10 @@ export function useServerForm(
     hasChanges,
     preregisteredOauthBlocksSubmit,
     authConfigurationBlocksSubmit,
+    pendingCredentialClear,
+    credentialClearBlocksSubmit,
+    credentialClearAcknowledgedFor,
+    acknowledgeCredentialClear: setCredentialClearAcknowledgedFor,
 
     // Form data
     name,

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -33,16 +33,87 @@ import {
  * Shared with the credential-clear warning so the two cannot disagree about
  * what this form is about to send: a warning derived from a different parse
  * would fire on edits the backend keeps and stay silent on ones it clears.
+ *
+ * Quoting is the exact inverse of `formatCommandInput`. A plain whitespace
+ * split loses the boundaries of a saved argument that contains a space — it
+ * reads `["file name.js"]` back as two arguments — which warns that an
+ * untouched row is about to lose its credentials and then saves arguments the
+ * user never typed.
  */
 function parseCommandInput(input: string): {
   command: string;
   args: string[];
 } {
-  const parts = input
-    .trim()
-    .split(/\s+/)
-    .filter((part) => part.length > 0);
+  const parts: string[] = [];
+  let current = "";
+  let inPart = false;
+  let quote: '"' | "'" | null = null;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+
+    if (quote === "'") {
+      if (char === "'") quote = null;
+      else current += char;
+      continue;
+    }
+
+    if (quote === '"') {
+      if (char === "\\" && (input[i + 1] === '"' || input[i + 1] === "\\")) {
+        current += input[i + 1];
+        i += 1;
+      } else if (char === '"') {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      inPart = true;
+      continue;
+    }
+
+    if (char === "\\" && i + 1 < input.length) {
+      current += input[i + 1];
+      i += 1;
+      inPart = true;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (inPart) {
+        parts.push(current);
+        current = "";
+        inPart = false;
+      }
+      continue;
+    }
+
+    current += char;
+    inPart = true;
+  }
+
+  if (inPart) parts.push(current);
+
   return { command: parts[0] || "", args: parts.slice(1) };
+}
+
+/**
+ * The single command line the edit form shows for a stored stdio target, and
+ * the inverse of `parseCommandInput` — the form holds one text input, so the
+ * round trip through it is what keeps the warning honest.
+ */
+function formatCommandInput(command: string, args: readonly string[]): string {
+  if (!command) return "";
+  return [command, ...args].map(quoteCommandToken).join(" ");
+}
+
+function quoteCommandToken(token: string): string {
+  if (token !== "" && !/[\s"'\\]/.test(token)) return token;
+  return `"${token.replace(/(["\\])/g, "\\$1")}"`;
 }
 
 interface InitialFormValues {
@@ -379,11 +450,10 @@ export function useServerForm(
         ? "stdio"
         : "http";
       const serverUrl = isHttpServer && config.url ? config.url.toString() : "";
-      const fullCommand = server.config.command
-        ? [server.config.command, ...(server.config.args || [])]
-            .filter(Boolean)
-            .join(" ")
-        : "";
+      const fullCommand = formatCommandInput(
+        server.config.command ?? "",
+        server.config.args ?? []
+      );
       const authorizationHeader = isHttpServer
         ? getAuthorizationHeaderValue(
             config.requestInit?.headers as Record<string, unknown> | undefined

--- a/mcpjam-inspector/client/src/lib/__tests__/credential-origin.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/credential-origin.test.ts
@@ -40,7 +40,6 @@ describe("credentialOriginOf", () => {
 
 describe("pendingCredentialClearForUrlEdit", () => {
   const base = {
-    holdsStoredCredential: true,
     savedUrl: "https://owner.example.com/mcp",
   };
 
@@ -89,14 +88,13 @@ describe("pendingCredentialClearForUrlEdit", () => {
     ).not.toBeNull();
   });
 
-  it("stays silent when the row holds no stored credential", () => {
+  it("warns even when this browser cannot see stored OAuth credentials", () => {
     expect(
       pendingCredentialClearForUrlEdit({
-        holdsStoredCredential: false,
         savedUrl: "https://owner.example.com/mcp",
         nextUrl: "https://elsewhere.example.com/mcp",
-      })
-    ).toBeNull();
+      }),
+    ).not.toBeNull();
   });
 
   it("stays silent while the URL is still being typed", () => {
@@ -113,7 +111,6 @@ describe("pendingCredentialClearForUrlEdit", () => {
   it("stays silent on a new server with nothing saved yet", () => {
     expect(
       pendingCredentialClearForUrlEdit({
-        holdsStoredCredential: true,
         savedUrl: null,
         nextUrl: "https://elsewhere.example.com/mcp",
       })

--- a/mcpjam-inspector/client/src/lib/__tests__/credential-origin.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/credential-origin.test.ts
@@ -1,0 +1,319 @@
+/**
+ * MJ-003 — when the edit form must warn that saving will destroy credentials.
+ *
+ * Two failure modes, opposite and both bad: warning on the common harmless edit
+ * teaches people to click through, so it is not there when it matters; not
+ * warning on a destination change means the backend silently wipes a credential
+ * somebody else entered. The cases below pin both edges, for both vectors the
+ * backend clears on — a cross-origin url, and a stdio `command`/`args` swap.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  credentialClearAcknowledgementKey,
+  credentialOriginOf,
+  pendingCredentialClearForStdioTargetEdit,
+  pendingCredentialClearForUrlEdit,
+  rowHoldsStoredCredential,
+} from "../credential-origin";
+
+describe("credentialOriginOf", () => {
+  it.each([
+    ["https://a.example.com/mcp", "https://a.example.com"],
+    ["https://a.example.com:443/mcp", "https://a.example.com"],
+    ["http://a.example.com:80/mcp", "http://a.example.com"],
+    ["https://a.example.com:8443/mcp", "https://a.example.com:8443"],
+    ["https://A.Example.COM/mcp", "https://a.example.com"],
+    ["https://a.example.com./mcp", "https://a.example.com"],
+  ])("%s -> %s", (input, expected) => {
+    expect(credentialOriginOf(input)).toBe(expected);
+  });
+
+  it.each([[""], ["   "], ["not a url"], ["/mcp"], ["file:///etc/passwd"]])(
+    "%s is unusable",
+    (input) => {
+      expect(credentialOriginOf(input)).toBeNull();
+    }
+  );
+});
+
+describe("pendingCredentialClearForUrlEdit", () => {
+  const base = {
+    holdsStoredCredential: true,
+    savedUrl: "https://owner.example.com/mcp",
+  };
+
+  it("warns on a cross-origin move, naming both hosts", () => {
+    expect(
+      pendingCredentialClearForUrlEdit({
+        ...base,
+        nextUrl: "https://elsewhere.example.com/mcp",
+      })
+    ).toEqual({
+      kind: "url-origin",
+      previousOrigin: "https://owner.example.com",
+      nextOrigin: "https://elsewhere.example.com",
+    });
+  });
+
+  it("stays silent on a same-origin path edit", () => {
+    // The common legitimate edit. A warning here is the one that gets
+    // click-trained away.
+    expect(
+      pendingCredentialClearForUrlEdit({
+        ...base,
+        nextUrl: "https://owner.example.com/mcp/v2",
+      })
+    ).toBeNull();
+  });
+
+  it("stays silent on a re-save that changes nothing", () => {
+    expect(
+      pendingCredentialClearForUrlEdit({ ...base, nextUrl: base.savedUrl })
+    ).toBeNull();
+  });
+
+  it("warns on a scheme downgrade and on a port change", () => {
+    expect(
+      pendingCredentialClearForUrlEdit({
+        ...base,
+        nextUrl: "http://owner.example.com/mcp",
+      })
+    ).not.toBeNull();
+    expect(
+      pendingCredentialClearForUrlEdit({
+        ...base,
+        nextUrl: "https://owner.example.com:8443/mcp",
+      })
+    ).not.toBeNull();
+  });
+
+  it("stays silent when the row holds no stored credential", () => {
+    expect(
+      pendingCredentialClearForUrlEdit({
+        holdsStoredCredential: false,
+        savedUrl: "https://owner.example.com/mcp",
+        nextUrl: "https://elsewhere.example.com/mcp",
+      })
+    ).toBeNull();
+  });
+
+  it("stays silent while the URL is still being typed", () => {
+    // Fires on almost every keystroke otherwise. The form's own validation owns
+    // an unparseable URL; this is not the place to report it.
+    // Not `https://part`: that parses to a real, different origin, so warning
+    // on it is correct — a half-typed HOSTNAME is indistinguishable from a
+    // deliberate one, and staying silent would mean no warning on the save.
+    for (const nextUrl of ["", "https://", "htt", "example.com/mcp"]) {
+      expect(pendingCredentialClearForUrlEdit({ ...base, nextUrl })).toBeNull();
+    }
+  });
+
+  it("stays silent on a new server with nothing saved yet", () => {
+    expect(
+      pendingCredentialClearForUrlEdit({
+        holdsStoredCredential: true,
+        savedUrl: null,
+        nextUrl: "https://elsewhere.example.com/mcp",
+      })
+    ).toBeNull();
+  });
+});
+
+/**
+ * The vector the form said nothing about until now: a stdio row's `command` is
+ * where its env secret gets delivered, so swapping it is the same exfiltration
+ * as a repoint. The backend clears on it (mcpjam-backend#1260) and did so with
+ * no warning at all on this side.
+ */
+describe("pendingCredentialClearForStdioTargetEdit", () => {
+  const base = {
+    holdsStoredCredential: true,
+    savedCommand: "npx",
+    savedArgs: ["-y", "@modelcontextprotocol/server-everything"],
+  };
+
+  it("warns on a command swap, naming both invocations in full", () => {
+    expect(
+      pendingCredentialClearForStdioTargetEdit({
+        ...base,
+        nextCommand: "node",
+        nextArgs: ["exfiltrate.js"],
+      })
+    ).toEqual({
+      kind: "stdio-target",
+      previousCommand: "npx -y @modelcontextprotocol/server-everything",
+      nextCommand: "node exfiltrate.js",
+    });
+  });
+
+  it("warns when only an argument changes", () => {
+    // `npx → npx` would be a useless warning, so the whole invocation is what
+    // gets named.
+    expect(
+      pendingCredentialClearForStdioTargetEdit({
+        ...base,
+        nextCommand: "npx",
+        nextArgs: ["-y", "@attacker/collector"],
+      })
+    ).toMatchObject({
+      nextCommand: "npx -y @attacker/collector",
+    });
+  });
+
+  it("stays silent on a re-save that changes nothing", () => {
+    expect(
+      pendingCredentialClearForStdioTargetEdit({
+        ...base,
+        nextCommand: "npx",
+        nextArgs: ["-y", "@modelcontextprotocol/server-everything"],
+      })
+    ).toBeNull();
+  });
+
+  it("treats absent args and [] as the same invocation", () => {
+    // The backend compares args element-wise and reads absent as empty, so a
+    // row that never stored args being written `[]` is not a change and must
+    // not warn about a clear that will not happen.
+    expect(
+      pendingCredentialClearForStdioTargetEdit({
+        holdsStoredCredential: true,
+        savedCommand: "run-server",
+        savedArgs: undefined,
+        nextCommand: "run-server",
+        nextArgs: [],
+      })
+    ).toBeNull();
+  });
+
+  it("counts a reordering of the same arguments as a change", () => {
+    expect(
+      pendingCredentialClearForStdioTargetEdit({
+        holdsStoredCredential: true,
+        savedCommand: "server",
+        savedArgs: ["--a", "--b"],
+        nextCommand: "server",
+        nextArgs: ["--b", "--a"],
+      })
+    ).not.toBeNull();
+  });
+
+  it("stays silent when the row holds no stored credential", () => {
+    // The backend gates this trigger on the row holding something, unlike the
+    // origin one. Warning here would be crying wolf on an ordinary edit.
+    expect(
+      pendingCredentialClearForStdioTargetEdit({
+        ...base,
+        holdsStoredCredential: false,
+        nextCommand: "node",
+        nextArgs: [],
+      })
+    ).toBeNull();
+  });
+
+  it("stays silent while the command is being retyped from empty", () => {
+    expect(
+      pendingCredentialClearForStdioTargetEdit({
+        ...base,
+        nextCommand: "",
+        nextArgs: [],
+      })
+    ).toBeNull();
+  });
+
+  it("stays silent on a row with no saved command", () => {
+    expect(
+      pendingCredentialClearForStdioTargetEdit({
+        holdsStoredCredential: true,
+        savedCommand: null,
+        savedArgs: [],
+        nextCommand: "node",
+        nextArgs: [],
+      })
+    ).toBeNull();
+  });
+});
+
+describe("credentialClearAcknowledgementKey", () => {
+  it("changes with the destination, so consent does not carry across", () => {
+    const first = credentialClearAcknowledgementKey({
+      kind: "url-origin",
+      previousOrigin: "https://owner.example.com",
+      nextOrigin: "https://one.example.com",
+    });
+    const second = credentialClearAcknowledgementKey({
+      kind: "url-origin",
+      previousOrigin: "https://owner.example.com",
+      nextOrigin: "https://two.example.com",
+    });
+    expect(first).not.toBe(second);
+  });
+
+  it("keeps the two vectors apart", () => {
+    expect(
+      credentialClearAcknowledgementKey({
+        kind: "stdio-target",
+        previousCommand: "npx a",
+        nextCommand: "node b",
+      })
+    ).not.toBe(
+      credentialClearAcknowledgementKey({
+        kind: "url-origin",
+        previousOrigin: "npx a",
+        nextOrigin: "node b",
+      })
+    );
+  });
+});
+
+/**
+ * The review found `holdsStoredCredential` under-reporting in two ways, both of
+ * which meant a save silently destroyed credentials with no warning. The
+ * predicate now reads the ROW, so these pin the shapes it has to recognise.
+ */
+describe("which rows count as holding a stored credential", () => {
+  it.each([
+    ["hasEnv", { hasEnv: true }],
+    ["hasHeaders", { hasHeaders: true }],
+    ["hasBearerToken", { hasBearerToken: true }],
+    ["hasClientSecret", { hasClientSecret: true }],
+    // The backend clears every hostedOAuthCredentials row on an origin change,
+    // and an OAuth-connected server may hold nothing else. There is no
+    // `hasOAuthTokens` redaction flag, so the tokens themselves are the signal.
+    ["stored OAuth tokens", { oauthTokens: { access_token: "x" } }],
+    // Visible plaintext headers, the local path where nothing is redacted.
+    // `hasHeaders` is false for these BY DESIGN — it means "stored and hidden"
+    // — so keying the warning off it missed a row that genuinely holds
+    // credentials the backend will wipe.
+    [
+      "plaintext headers on the row",
+      { config: { requestInit: { headers: { "X-Api-Key": "value" } } } },
+    ],
+    // Same for env, and this is the shape the stdio warning lives or dies on:
+    // a local stdio row keeps its environment in the clear.
+    ["plaintext env on the row", { config: { env: { API_KEY: "value" } } }],
+  ])("%s alone counts", (_label, server) => {
+    expect(rowHoldsStoredCredential(server)).toBe(true);
+  });
+
+  it.each([
+    ["nothing stored", {}],
+    ["flags explicitly false", { hasEnv: false, hasHeaders: false }],
+    ["an empty header record", { config: { requestInit: { headers: {} } } }],
+    [
+      "a header present but empty",
+      { config: { requestInit: { headers: { "X-Api-Key": "" } } } },
+    ],
+    ["an empty env record", { config: { env: {} } }],
+    ["oauthTokens null", { oauthTokens: null }],
+    // A non-record `headers` is not a credential. The mirrored copy this suite
+    // used to run answered `true` here, which is the drift that made it useless.
+    [
+      "a header array rather than a record",
+      { config: { requestInit: { headers: ["x"] } } },
+    ],
+  ])("%s does not count", (_label, server) => {
+    expect(rowHoldsStoredCredential(server)).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/credential-origin.ts
+++ b/mcpjam-inspector/client/src/lib/credential-origin.ts
@@ -1,0 +1,239 @@
+/**
+ * Will saving this edit throw away the server's stored credentials? (MJ-003)
+ *
+ * The backend clears a row's saved headers, env, OAuth tokens and client secret
+ * when the row's DESTINATION moves — a `url` change that crosses their origin,
+ * or a `command`/`args` swap on a stdio row. Either one is the same primitive:
+ * anyone who can edit a project points a server somewhere they control and has
+ * the Inspector deliver somebody else's credential to it.
+ *
+ * That is the right behaviour and a genuinely surprising one — it destroys data
+ * the person saving may not have entered and cannot see. So the edit form has
+ * to say so before the save, which is what this is for.
+ *
+ * ORIGIN, NOT URL. Editing `…/mcp` to `…/mcp/v2` keeps the credentials, and the
+ * warning must not fire for it: a warning on the common harmless edit is one
+ * people learn to click through, and then it is not there when it matters. The
+ * stdio trigger is held to the same standard — an `args` value that was absent
+ * and is now `[]` runs the same process, so it is not a change.
+ *
+ * These rules mirror `convex/lib/serverSecretOrigin.ts` in the backend. A copy
+ * rather than an import because the renderer cannot import backend code. If the
+ * rules diverge, this warns about the wrong saves — either crying wolf, or
+ * staying silent while the backend wipes a credential.
+ */
+
+/**
+ * The http(s) origin a credential is bound to, or `null` for anything that
+ * cannot be reduced to one.
+ *
+ * The trailing dot is stripped because `host.example.com.` and
+ * `host.example.com` are one name to a resolver and two strings to a
+ * comparison. Non-http schemes are rejected rather than passed through:
+ * `URL.origin` answers the opaque string `"null"` for them, which would make
+ * two unrelated URLs compare equal.
+ */
+export function credentialOriginOf(
+  url: string | null | undefined
+): string | null {
+  if (typeof url !== "string" || !url.trim()) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return null;
+  }
+  const host = parsed.hostname.toLowerCase().replace(/\.+$/, "");
+  if (!host) return null;
+  parsed.protocol = parsed.protocol.toLowerCase();
+  parsed.hostname = host;
+  return parsed.origin;
+}
+
+/**
+ * Does this record carry at least one non-empty VALUE?
+ *
+ * A redacted config has the names stripped and a `has*` flag instead, so this
+ * only ever answers true for the plaintext case — which is exactly the case the
+ * redaction flags miss.
+ */
+function hasNonEmptyStringRecord(record: unknown): boolean {
+  if (!record || typeof record !== "object" || Array.isArray(record)) {
+    return false;
+  }
+  return Object.values(record as Record<string, unknown>).some(
+    (value) => typeof value === "string" && value.length > 0
+  );
+}
+
+/**
+ * Does this row hold a credential a destination change would destroy?
+ *
+ * Read off the ROW, not off the form's `hasStored*` flags. Those mean "stored
+ * AND HIDDEN from me" — `hasStoredHeaders` carries a trailing
+ * `headersArray.length === 0`, so a row whose headers arrive as plaintext (the
+ * local path, where nothing is redacted) reports `false` while genuinely
+ * holding headers the backend will wipe. `server.has*` are the backend's own
+ * answers to the question actually being asked, and the plaintext `env` /
+ * `headers` records cover the rows where nothing was redacted at all.
+ *
+ * Plaintext `env` matters most for the stdio trigger: a local stdio row keeps
+ * its environment in `config.env` in the clear, so without it the command
+ * warning would never fire on exactly the rows it exists for.
+ *
+ * `oauthTokens` is in the list because the backend clears every
+ * `hostedOAuthCredentials` row for the server on an origin change, and an
+ * OAuth-connected server may hold nothing else; there is no `hasOAuthTokens`
+ * redaction flag.
+ */
+export function rowHoldsStoredCredential(
+  server:
+    | {
+        hasEnv?: boolean;
+        hasHeaders?: boolean;
+        hasBearerToken?: boolean;
+        hasClientSecret?: boolean;
+        oauthTokens?: unknown;
+        config?: { env?: unknown; requestInit?: { headers?: unknown } };
+      }
+    | null
+    | undefined
+): boolean {
+  return Boolean(
+    server?.hasEnv === true ||
+      server?.hasHeaders === true ||
+      server?.hasBearerToken === true ||
+      server?.hasClientSecret === true ||
+      server?.oauthTokens != null ||
+      hasNonEmptyStringRecord(server?.config?.env) ||
+      hasNonEmptyStringRecord(server?.config?.requestInit?.headers)
+  );
+}
+
+/** A repoint of an http row across the origin its credentials are bound to. */
+export interface PendingUrlOriginClear {
+  kind: "url-origin";
+  previousOrigin: string;
+  nextOrigin: string;
+}
+
+/**
+ * A stdio row being pointed at a different process.
+ *
+ * The two commands are whole invocations, `command` and `args` together, so an
+ * edit that changes only an argument does not render as `npx → npx`.
+ */
+export interface PendingStdioTargetClear {
+  kind: "stdio-target";
+  previousCommand: string;
+  nextCommand: string;
+}
+
+export type PendingCredentialClear =
+  | PendingUrlOriginClear
+  | PendingStdioTargetClear;
+
+/**
+ * What the user has to have accepted for THIS destination.
+ *
+ * A key rather than a boolean, so acknowledging one destination and then typing
+ * a different one re-arms the warning instead of carrying consent across.
+ */
+export function credentialClearAcknowledgementKey(
+  pending: PendingCredentialClear
+): string {
+  return pending.kind === "url-origin"
+    ? `url:${pending.nextOrigin}`
+    : `stdio:${pending.nextCommand}`;
+}
+
+/**
+ * The warning for a URL edit, or `null` for a save that keeps the credentials.
+ *
+ * Returns `null` when either URL cannot be parsed at all: the form's own
+ * validation owns that, and a "your credentials will be cleared" warning on a
+ * half-typed URL would fire on almost every keystroke.
+ */
+export function pendingCredentialClearForUrlEdit(args: {
+  /** `true` when the row holds any credential a repoint would invalidate. */
+  holdsStoredCredential: boolean;
+  /** The URL as saved on the server row. */
+  savedUrl: string | null | undefined;
+  /** The URL currently in the form. */
+  nextUrl: string | null | undefined;
+}): PendingUrlOriginClear | null {
+  if (!args.holdsStoredCredential) return null;
+  const previousOrigin = credentialOriginOf(args.savedUrl);
+  const nextOrigin = credentialOriginOf(args.nextUrl);
+  if (previousOrigin === null || nextOrigin === null) return null;
+  if (previousOrigin === nextOrigin) return null;
+  return { kind: "url-origin", previousOrigin, nextOrigin };
+}
+
+/**
+ * Do these two argument vectors run the same invocation?
+ *
+ * Absent and `[]` are the same invocation, so a row that never stored `args`
+ * being written `[]` is not a change. Order matters — reordering a command's
+ * arguments changes what it does — so this is an element-wise compare.
+ *
+ * Mirrors `sameStoredArgsValue` in the backend; the warning has to fire on
+ * exactly the edits the backend clears on.
+ */
+function sameArgsValue(
+  a: readonly string[] | null | undefined,
+  b: readonly string[] | null | undefined
+): boolean {
+  const left = a ?? [];
+  const right = b ?? [];
+  return left.length === right.length && left.every((v, i) => v === right[i]);
+}
+
+/**
+ * The warning for a stdio `command`/`args` edit, or `null` for a save that
+ * keeps the credentials.
+ *
+ * A stdio row has no origin, so the URL rule above answers `null` for every one
+ * of these — and the row's decrypted env secret is handed to whatever process
+ * the `command` names. That is the same exfiltration primitive as a repoint,
+ * and it is the one the form said nothing about.
+ *
+ * Gated on the row holding a credential, matching the backend: without that,
+ * retyping the command of a server that stores no secret would warn about a
+ * destruction that is not going to happen.
+ *
+ * Returns `null` for an empty next command for the same reason the URL rule
+ * returns `null` for an unparseable URL — the form's own validation rejects it,
+ * and warning mid-deletion is noise.
+ */
+export function pendingCredentialClearForStdioTargetEdit(args: {
+  /** `true` when the row holds any credential the swap would invalidate. */
+  holdsStoredCredential: boolean;
+  /** The command as saved on the server row. */
+  savedCommand: string | null | undefined;
+  /** The arguments as saved on the server row. */
+  savedArgs: readonly string[] | null | undefined;
+  /** The command the form will submit. */
+  nextCommand: string;
+  /** The arguments the form will submit. */
+  nextArgs: readonly string[];
+}): PendingStdioTargetClear | null {
+  if (!args.holdsStoredCredential) return null;
+  const previousCommand = args.savedCommand?.trim() ?? "";
+  const nextCommand = args.nextCommand.trim();
+  if (!previousCommand || !nextCommand) return null;
+  if (
+    previousCommand === nextCommand &&
+    sameArgsValue(args.savedArgs, args.nextArgs)
+  ) {
+    return null;
+  }
+  return {
+    kind: "stdio-target",
+    previousCommand: [previousCommand, ...(args.savedArgs ?? [])].join(" "),
+    nextCommand: [nextCommand, ...args.nextArgs].join(" "),
+  };
+}

--- a/mcpjam-inspector/client/src/lib/credential-origin.ts
+++ b/mcpjam-inspector/client/src/lib/credential-origin.ts
@@ -158,14 +158,14 @@ export function credentialClearAcknowledgementKey(
  * half-typed URL would fire on almost every keystroke.
  */
 export function pendingCredentialClearForUrlEdit(args: {
-  /** `true` when the row holds any credential a repoint would invalidate. */
-  holdsStoredCredential: boolean;
   /** The URL as saved on the server row. */
   savedUrl: string | null | undefined;
   /** The URL currently in the form. */
   nextUrl: string | null | undefined;
 }): PendingUrlOriginClear | null {
-  if (!args.holdsStoredCredential) return null;
+  // Hosted OAuth credentials belong to individual subjects and may be absent
+  // from this browser's runtime state. Every origin change invalidates them,
+  // so an absent local credential flag must never suppress acknowledgment.
   const previousOrigin = credentialOriginOf(args.savedUrl);
   const nextOrigin = credentialOriginOf(args.nextUrl);
   if (previousOrigin === null || nextOrigin === null) return null;


### PR DESCRIPTION
Warns before a server destination edit clears saved credentials and shows a read-only destination history (MJ-003 client surfacing).

Cross-origin HTTP edits always require acknowledgment, including after a fresh page load or when another member's hosted OAuth credentials are absent from this browser's runtime state. The copy says “any saved credentials”; determining whether a shared credential exists is not delegated to browser token state. Same-origin path edits stay silent. Stdio command/argument changes warn when the row carries a credential.

The form shares its Save-button and submit-handler guard, so Enter cannot bypass acknowledgment. Command formatting round-trips saved quoted arguments; unquoted backslashes remain literal so pasted Windows paths survive unchanged. Warning colors use design-system role tokens.

The history panel handles URL changes, stdio credential clears, and transport-flip history, with an error boundary for unavailable backend queries. The form's existing transport-flip warning gap remains outside this change.

## Validation

- Focused client suites passed, covering warning detection, acknowledgment, command round trips, history rendering, and Save behavior.
- Added regression coverage for pasted Windows paths and credentials absent from browser runtime state.
- Client typecheck and design drift/spec checks passed (design lint has existing warnings).

This PR adds user-facing warnings, not credential enforcement; #4989 owns enforcement.
