### PR TITLE
Move the sidebar "New" badge from XAA Debugger to WebMCP

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-sections.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-sections.test.ts
@@ -83,6 +83,19 @@ describe("sidebar section grouping", () => {
     ).not.toContain("Acceptance Testing");
   });
 
+  it("points the New pill at WebMCP and nothing else", () => {
+    // The pill is editorial, not structural: it marks whichever surface is
+    // newest, so it has to be moved by hand as tabs age out of being new.
+    // Nothing type-errors when it is left behind on a long-shipped item, or
+    // when a second item quietly picks one up, so assert the whole set.
+    const badged = navigationSections
+      .flatMap((section) => section.items)
+      .filter((item) => item.badge === "New")
+      .map((item) => item.title);
+
+    expect(badged).toEqual(["WebMCP"]);
+  });
+
   it("never lists the same title twice across sections", () => {
     const titles = navigationSections.flatMap((section) =>
       section.items.map((item) => item.title)

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -306,7 +306,6 @@ export const navigationSections: NavSection[] = [
         title: "XAA Debugger",
         url: "/xaa-flow",
         icon: ShieldCheck,
-        badge: "New",
         featureFlag: "xaa",
       },
       {
@@ -361,6 +360,7 @@ export const navigationSections: NavSection[] = [
         title: "WebMCP",
         url: "/webmcp",
         icon: Globe,
+        badge: "New",
         featureFlag: WEBMCP_INSPECTOR_FEATURE_FLAG,
       },
     ],


### PR DESCRIPTION
Moves the `New` pill in the sidebar nav off **XAA Debugger** (Verify) and onto **WebMCP** (Inspect) — XAA Debugger has been shipping for a while, and WebMCP is the newly added tab worth flagging.

One line of data moved in `navigationSections` (`client/src/components/mcp-sidebar.tsx`); no rendering code changed, since `NavItem.badge` already drives the pill for whichever item carries it.

Plus a regression test (`mcp-sidebar-sections.test.ts`), per Codex review: the sidebar tests asserted titles, grouping, and feature flags but never `badge`, so they passed whether the pill sat on WebMCP, stayed behind on XAA Debugger, or vanished. The new test asserts the *whole set* of badged items equals `["WebMCP"]`, so a second item quietly picking up a pill fails too.

Verified:
- `mcp-sidebar-sections.test.ts` + `mcp-sidebar-feature-flags.test.ts` — 29 passed
- The new test fails against the pre-fix code (`- "WebMCP" / + "XAA Debugger"`) and passes once restored, so it genuinely guards the move
- `npm run typecheck:client` — clean
- `prettier --check` (3.9.6, the version this package pins) on both changed files — `mcp-sidebar.tsx` clean; the added test block is clean. Note `mcp-sidebar-sections.test.ts` has pre-existing formatting drift that is already present on `main` and untouched here — no format check runs in `lint.yml`/`test.yml`, which is presumably why it survives. Left alone rather than adding seven unrelated hunks to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcoUP5MHegF4zCX3oQrHYP