### PR TITLE
fix(findings): render the summary as one paragraph, not stacked lines (BB-146)

### DIFF
--- a/mcpjam-inspector/client/src/components/scenarios/findings/scenario-findings-summary.ts
+++ b/mcpjam-inspector/client/src/components/scenarios/findings/scenario-findings-summary.ts
@@ -1,5 +1,8 @@
 /**
- * The Findings summary card's lines for User Testing.
+ * The Findings summary card's sentences for User Testing.
+ *
+ * Returned separately and joined into one paragraph by the card, same as the
+ * swarm composer.
  *
  * The swarm composer answers "which goal broke, for which authored persona, at
  * which stage". This surface cannot answer the stage half yet, and its personas
@@ -14,7 +17,7 @@ import type { PersonaFindingsModel } from "@/components/swarms/findings/findings
 import type { ScenarioFindingsModel } from "./scenario-findings-derivation";
 
 /**
- * How a persona's sessions ENDED, as the lead line says it. Keyed on the pill
+ * How a persona's sessions ENDED, as the lead sentence says it. Keyed on the pill
  * label this module's derivation sets, so the two stay in step.
  *
  * `gave_up` gets a clause rather than an adjective: the backend only admits it

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/findings-summary-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/findings-summary-card.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { FindingsSummaryCard } from "../findings/findings-summary-card";
+
+/**
+ * The card takes SENTENCES and renders ONE PARAGRAPH.
+ *
+ * Both composers keep answering the four questions as separate strings, so
+ * each answer stays assertable on its own; the joining lives here. Vignesh
+ * asked for one flowing paragraph rather than the stacked lines this card used
+ * to render (standup, 2026-09-12), and these are the cases where "joined" and
+ * "stacked" would otherwise look the same in a test.
+ */
+
+describe("FindingsSummaryCard", () => {
+  it("joins the sentences into a single paragraph element", () => {
+    render(
+      <FindingsSummaryCard
+        sessionCount={3}
+        summary={["First sentence.", "Second sentence.", "Third sentence."]}
+        footnotes={[]}
+      />
+    );
+    // One element holding all three. Rendering them as siblings would satisfy
+    // the card's own text but not this.
+    expect(screen.getByTestId("findings-headline").textContent).toBe(
+      "First sentence. Second sentence. Third sentence."
+    );
+    expect(
+      screen.getByTestId("findings-summary").querySelectorAll("p")
+    ).toHaveLength(0);
+  });
+
+  it("does not leave a gap where an empty sentence was", () => {
+    // Neither composer emits one today. This is what lets them never have to
+    // promise not to — a blank string joined naively reads as a typo.
+    render(
+      <FindingsSummaryCard
+        sessionCount={1}
+        summary={["The discovery stage broke.", "   ", "", "Maya left lost."]}
+        footnotes={[]}
+      />
+    );
+    expect(screen.getByTestId("findings-headline").textContent).toBe(
+      "The discovery stage broke. Maya left lost."
+    );
+  });
+
+  it("still names the session count and the footnotes", () => {
+    render(
+      <FindingsSummaryCard
+        sessionCount={1}
+        summary={["Nothing graded yet."]}
+        footnotes={["Rubric findings only"]}
+      />
+    );
+    // Singular, because one session is one session.
+    expect(screen.getByTestId("findings-summary-card").textContent).toContain(
+      "Finding summary · 1 session"
+    );
+    expect(screen.getByTestId("findings-footnotes").textContent).toContain(
+      "Rubric findings only"
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-findings-tab.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-findings-tab.test.tsx
@@ -518,14 +518,21 @@ describe("SwarmFindingsTab", () => {
         personas={personas}
       />
     );
-    // The lead names the goal, the stage and the persona; the supporting
-    // lines carry the cause and the feeling.
-    expect(screen.getByTestId("findings-headline").textContent).toBe(
-      '"Export the board" broke at discovery for Maya Chen.'
+    // ONE paragraph, in ONE element. The composer still answers the four
+    // questions as separate sentences — goal, cause, persona, feeling — and
+    // the card joins them, so the exact text is pinned here rather than in
+    // fragments: a sentence that stopped being joined would still satisfy
+    // every `toContain` while rendering as a stacked line again.
+    const headline = screen.getByTestId("findings-headline");
+    expect(headline.textContent).toBe(
+      '"Export the board" broke at discovery for Maya Chen. Agents invented a tool named "listSkills" in 2 sessions. Maya Chen left lost.'
     );
-    const summary = screen.getByTestId("findings-summary").textContent ?? "";
-    expect(summary).toContain("Maya Chen left lost.");
-    expect(summary).not.toContain("No findings yet");
+    // The supporting sentences used to render as siblings BELOW the headline.
+    // Asserting on the card's text would pass either way, so the check is that
+    // the summary block holds nothing but that one heading.
+    const summary = screen.getByTestId("findings-summary");
+    expect(summary.querySelectorAll("p")).toHaveLength(0);
+    expect(summary.textContent).not.toContain("No findings yet");
     expect(screen.getByText(/Choose a persona/i)).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/swarms/findings/findings-headline.ts
+++ b/mcpjam-inspector/client/src/components/swarms/findings/findings-headline.ts
@@ -1,11 +1,14 @@
 /**
- * Deterministic multi-line summary + honesty footnotes for the Findings card.
+ * Deterministic summary sentences + honesty footnotes for the Findings card.
  *
  * The summary answers four questions in the reader's order — which goal broke,
- * for whom, where in the value chain, and how it felt. A finished run that
- * opens on "No findings yet" reads as a broken product rather than an honest
- * one, so the terminal branch states what the run actually established instead
- * of shrugging. Templates only: the LLM headline (`SwarmWaveInsights.summary`)
+ * for whom, where in the value chain, and how it felt. Each answer is returned
+ * as its OWN sentence, so each can be asserted on its own; the card joins them
+ * into one paragraph at render.
+ *
+ * A finished run that opens on "No findings yet" reads as a broken product
+ * rather than an honest one, so the terminal branch states what the run
+ * actually established instead of shrugging. Templates only: the LLM headline (`SwarmWaveInsights.summary`)
  * is a later iteration, and nothing here may claim more than the counts
  * support.
  *
@@ -68,7 +71,11 @@ export function countWords(text: string): number {
     .filter(Boolean).length;
 }
 
-/** Per-line cap — the card holds a few short lines, not a paragraph. */
+/**
+ * Per-SENTENCE cap. The card joins these into a paragraph, so this no longer
+ * keeps a line from wrapping — it keeps each answer short enough that four of
+ * them still read as a summary rather than a report.
+ */
 export function limitWords(text: string, max = LINE_MAX_WORDS): string {
   const words = text
     .trim()
@@ -97,7 +104,7 @@ function firstSentence(text: string): string {
   return end === -1 ? trimmed : trimmed.slice(0, end + 1);
 }
 
-/** Detector sentences do not all ship a full stop; the card's lines do. */
+/** Detector sentences do not all ship a full stop; the card's do. */
 function endWithStop(text: string): string {
   return /[.!?…]$/.test(text) ? text : `${text}.`;
 }
@@ -142,8 +149,8 @@ export function composeFindingsSummary(
    * "finished" nor "still running" can be claimed. */
   opts: { terminal: boolean | null }
 ): string[] {
-  // The cap is applied in one place so no branch can smuggle a long line past
-  // it — an interpolated persona name does that as easily as a goal title.
+  // The cap is applied in one place so no branch can smuggle a long sentence
+  // past it — an interpolated persona name does that as easily as a goal title.
   return composeLines(model, opts).map((line) => limitWords(line));
 }
 

--- a/mcpjam-inspector/client/src/components/swarms/findings/findings-summary-card.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/findings/findings-summary-card.tsx
@@ -4,9 +4,14 @@
  * — a light card with accent orbs on the right. The orbs use the `primary`
  * role token; literal hex is forbidden by AGENTS.md.
  *
- * The summary arrives as lines, not one headline: the reader needs the goal,
- * the persona, the stage and the feeling, and that does not fit on one line.
- * The first line leads at display size; the rest support it.
+ * The summary arrives as SENTENCES and renders as ONE PARAGRAPH.
+ *
+ * It still needs to name the goal, the persona, the stage and the feeling, so
+ * the composers keep producing those as separate strings — each one is tested
+ * on its own, and a joined blob would be far harder to assert against. The
+ * joining happens here, at the presentation layer, because that is what it is:
+ * Vignesh asked for one flowing paragraph rather than the stacked lines this
+ * card used to render (standup, 2026-09-12).
  */
 
 export function FindingsSummaryCard({
@@ -15,11 +20,17 @@ export function FindingsSummaryCard({
   footnotes,
 }: {
   sessionCount: number;
-  /** 1–4 short lines. The first is the lead. */
+  /** 1–4 sentences, joined into one paragraph here. */
   summary: readonly string[];
   footnotes: readonly string[];
 }) {
-  const [lead, ...rest] = summary;
+  // Filtered before joining so an empty or whitespace-only sentence cannot
+  // leave a double space mid-paragraph. The composers do not emit one today;
+  // this costs nothing and means they never have to promise not to.
+  const paragraph = summary
+    .map((sentence) => sentence.trim())
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <section
@@ -46,20 +57,8 @@ export function FindingsSummaryCard({
             className="mt-1.5 text-pretty text-2xl font-semibold leading-[1.25] tracking-[-0.02em] text-foreground"
             data-testid="findings-headline"
           >
-            {lead}
+            {paragraph}
           </h2>
-          {rest.length > 0 ? (
-            <div className="mt-2 space-y-1">
-              {rest.map((line) => (
-                <p
-                  key={line}
-                  className="text-pretty text-base leading-snug text-muted-foreground"
-                >
-                  {line}
-                </p>
-              ))}
-            </div>
-          ) : null}
         </div>
         {footnotes.length > 0 ? (
           <div


### PR DESCRIPTION
## What

The Findings summary card renders its summary as **one flowing paragraph** instead of a headline with stacked supporting lines beneath it.

Before / after, same fixture:

> **Before**
> `"Export the board" broke at discovery for Maya Chen.`
> `Agents invented a tool named "listSkills" in 2 sessions.`
> `Maya Chen left lost.`

> **After**
> `"Export the board" broke at discovery for Maya Chen. Agents invented a tool named "listSkills" in 2 sessions. Maya Chen left lost.`

## Why

Vignesh raised this at standup on 2026-09-12 and confirmed on follow-up: one flowing paragraph is what he asked for, and the stacked lines the card renders today were never it.

## How

The composers keep producing **sentences**, and that is deliberate. The summary still has to answer four questions in the reader's order — which goal broke, for whom, where in the value chain, and how it felt — and each answer is asserted on its own today. A composer that emitted one joined blob would be markedly harder to test. So the joining moves to the presentation layer, which is what it is: the card's `<h2>` now holds the whole paragraph, and the sibling `<p>` block is gone.

Sentences are trimmed and empty ones dropped before joining. Neither composer emits a blank one today; it costs nothing and means they never have to promise not to.

Comments in both composers that described the output as "lines" are corrected to say sentences. That includes the per-sentence word cap, whose stated reason ("keeps a line from wrapping") is no longer the real one — it now keeps each answer short enough that four of them still read as a summary rather than a report. Behaviour there is unchanged.

## Scope note for reviewers

`FindingsSummaryCard` is **shared**, so this lands on both surfaces:

- the swarm run's Findings tab
- the User Testing study's Findings tab (the BB-146 landing tab)

Both are covered below. Nothing else reads these testids.

## Tests

- New `findings-summary-card.test.tsx` — unit tests on the card: the join, the gap where a blank sentence was, and that the summary block contains exactly one element rather than siblings.
- `swarm-findings-tab.test.tsx` — the headline assertion moves from the lead sentence to the full paragraph, and adds a structural check that no `<p>` siblings remain. A bare `toContain` would have passed either way, which is the failure mode this is guarding.
- Mutation-verified. Three mutants all fail the suite: dropping `.filter(Boolean)`, joining with `""`, and rendering only `summary[0]`.
- `client/src/components/swarms` + `client/src/components/scenarios`: 805 passing, 1 failing — `ScenarioOutcomeCalibration > qualifies its rates when the scan was truncated`, which is already red on `main` (a bare `toLocaleString()` producing `2.000` under this locale) and untouched here.
- Typecheck clean; eslint clean (5 warnings, 0 errors).

Files are left un-prettier'd on purpose: `main` is not prettier-clean and there is no format check in CI, so running it here added ~40 lines of unrelated churn.

Part of BB-146. Split out as its own PR because it is a copy fix on a shared card, independent of the stage-to-session work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the shared `FindingsSummaryCard` for BB-146 so Findings summaries on the swarm and User Testing tabs render as one flowing paragraph instead of stacked lines, and labels the card's accessible region with its kicker instead of the full summary.

- Composers still return separate sentences; the card trims, drops empty ones, and joins them with single spaces.
- The summary is now a `<p>` rather than an `<h2>`.
- Footnotes and session-count labeling are unchanged.
- Adds card and swarm-tab tests for joining, blank-sentence gaps, single-element structure, footnotes, and region naming.

<sup>Written for commit 32952a9b4f2c854ea3b82a34d7e7c699d516d99e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

