### PR TITLE
Answer every reason the backend gives for withholding an OAuth token

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
@@ -645,6 +645,132 @@ describe("web auth manager batching", () => {
     });
   });
 
+  // Every reason the backend names for a withheld token needs its own branch.
+  // Without one it falls through to the refusal above and tells the user to
+  // complete an OAuth flow — wrong for an authorization server that never
+  // answered, wrong for a refresh already in flight, and silent about the
+  // repointed URL that is what actually invalidated the credential.
+  function batchWithOAuthUnavailableReason(
+    reason: string,
+    extra: Record<string, unknown> = {}
+  ): typeof fetch {
+    return vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            results: {
+              "server-1": {
+                ok: true,
+                role: "member",
+                accessLevel: "project_member",
+                permissions: { chatOnly: false },
+                oauthUnavailableReason: reason,
+                ...extra,
+                serverConfig: {
+                  transportType: "http",
+                  url: "https://server-1.example.com/mcp",
+                  headers: {},
+                  useOAuth: true,
+                },
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+    ) as typeof fetch;
+  }
+
+  async function captureConnectError(): Promise<WebRouteError> {
+    try {
+      await createAuthorizedManager(
+        callerContextFromHono(mockContext),
+        "bearer-token",
+        "project-1",
+        ["server-1"],
+        10_000,
+        undefined,
+        undefined,
+        { serverNames: ["Asana"] }
+      );
+    } catch (error) {
+      return error as WebRouteError;
+    }
+    throw new Error("expected createAuthorizedManager to reject");
+  }
+
+  it("tells the user the destination changed when the credential origin no longer matches", async () => {
+    global.fetch = batchWithOAuthUnavailableReason(
+      "credential_origin_mismatch"
+    );
+
+    const error = await captureConnectError();
+
+    expect(error).toMatchObject({
+      status: 401,
+      code: "UNAUTHORIZED",
+      message:
+        'Server "Asana" now points at a different destination, so its saved credentials no longer apply. Authorize it again for the new destination.',
+      details: {
+        oauthRequired: true,
+        serverId: "server-1",
+        serverName: "Asana",
+        serverUrl: "https://server-1.example.com/mcp",
+      },
+    });
+    expect(error.message).not.toContain("complete the OAuth flow first");
+  });
+
+  it("reports an unreachable authorization server as retryable, not as a missing authorization", async () => {
+    global.fetch = batchWithOAuthUnavailableReason(
+      "authorization_server_unreachable"
+    );
+
+    const error = await captureConnectError();
+
+    expect(error).toMatchObject({
+      status: 503,
+      code: "SERVER_UNREACHABLE",
+      message:
+        'The authorization server for "Asana" did not respond, so its access token could not be refreshed. Authorizing again will not change that. Try again shortly.',
+      details: {
+        serverId: "server-1",
+        serverName: "Asana",
+        serverUrl: "https://server-1.example.com/mcp",
+      },
+    });
+    expect(error.message).not.toContain("complete the OAuth flow first");
+    expect(error.details?.oauthRequired).toBeUndefined();
+  });
+
+  it("turns an in-flight refresh into a retry carrying the backend's oauthRetryAfterMs", async () => {
+    global.fetch = batchWithOAuthUnavailableReason("refresh_in_progress", {
+      oauthRetryAfterMs: 4200,
+    });
+
+    const error = await captureConnectError();
+
+    expect(error).toMatchObject({
+      status: 429,
+      code: "RATE_LIMITED",
+      message:
+        'Credentials for "Asana" are being refreshed by another request. Try again in 5 seconds.',
+    });
+    expect(error.headers).toEqual({ "Retry-After": "5" });
+    expect(error.message).not.toContain("complete the OAuth flow first");
+  });
+
+  it("omits the retry delay when the backend sends no oauthRetryAfterMs", async () => {
+    global.fetch = batchWithOAuthUnavailableReason("refresh_in_progress");
+
+    const error = await captureConnectError();
+
+    expect(error.status).toBe(429);
+    expect(error.message).toBe(
+      'Credentials for "Asana" are being refreshed by another request. Try again shortly.'
+    );
+    expect(error.headers).toBeUndefined();
+  });
+
   it("connects a tokenless auto (discover) server unauthenticated and tags a live 401", async () => {
     global.fetch = vi.fn(async () => {
       return new Response(

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -468,18 +468,43 @@ export type ConvexBatchAuthorizeFailure = {
   message: string;
 };
 
+/**
+ * Why there is no `oauthAccessToken`, when the reason is actionable rather
+ * than "nothing stored". Mirrored by hand from the backend
+ * (`BatchAuthorizeSuccess.oauthUnavailableReason` in convex/http.ts); absent
+ * on older backends, which is why every read treats absence as "no idea".
+ *
+ * Each member has its own branch in PASS 1 below. A reason with no branch
+ * falls through to the explicit-OAuth refusal and tells the user to complete
+ * an OAuth flow, which is wrong for every reason here except the credential
+ * that really was cleared — so widening this union without widening that
+ * dispatch is a silent regression.
+ */
+export type ConvexOAuthUnavailableReason =
+  /** The credential is fine; only this machine can reach its authorization server. */
+  | "private_authorization_server"
+  /** The credential is fine; the authorization server never answered usably. */
+  | "authorization_server_unreachable"
+  /** Another refresh holds the lease. Retry after `oauthRetryAfterMs`. */
+  | "refresh_in_progress"
+  /**
+   * The server's URL was repointed, so the backend refuses to hand a
+   * credential bound to the old destination to the new one.
+   */
+  | "credential_origin_mismatch";
+
 export type ConvexBatchAuthorizeSuccess = {
   ok: true;
   role: "owner" | "admin" | "member";
   accessLevel: "project_member" | "shared_chat";
   oauthAccessToken?: string | null;
+  oauthUnavailableReason?: ConvexOAuthUnavailableReason;
   /**
-   * Why there is no `oauthAccessToken`, when the reason is actionable rather
-   * than "nothing stored". Mirrored by hand from the backend
-   * (`BatchAuthorizeSuccess.oauthUnavailableReason` in convex/http.ts); absent
-   * on older backends, which is why every read treats absence as "no idea".
+   * How long to wait before retrying, when the reason is transient. Sent with
+   * `refresh_in_progress` — the lease the other refresh holds expires after
+   * roughly this long.
    */
-  oauthUnavailableReason?: "private_authorization_server";
+  oauthRetryAfterMs?: number | null;
   permissions: {
     chatOnly: boolean;
   };
@@ -1479,21 +1504,76 @@ export async function createAuthorizedManager(
     // Explicit-OAuth server with no stored token: also a synchronous verdict,
     // so it belongs here — leaving it in the concurrent pass let a configured
     // XAA sibling start minting a real token while this one rejected.
+    //
+    // When the backend named a reason for withholding the token, that reason
+    // decides the answer. Only `credential_origin_mismatch` is about the
+    // user's authorization; the default would send the other two off to
+    // complete an OAuth flow that was never the problem.
     if (
       effectiveAuth === "oauth" &&
       !(auth.oauthAccessToken ?? oauthTokens?.[serverId])
     ) {
-      throw new WebRouteError(
-        401,
-        ErrorCode.UNAUTHORIZED,
-        `Server "${displayServerName}" requires OAuth authentication. Please complete the OAuth flow first.`,
-        {
-          oauthRequired: true,
-          serverId,
-          serverName: serverNamesById?.[serverId] ?? null,
-          serverUrl: auth.serverConfig.url,
-        },
-      );
+      const errorDetails = {
+        serverId,
+        serverName: serverNamesById?.[serverId] ?? null,
+        serverUrl: auth.serverConfig.url,
+      };
+      switch (auth.oauthUnavailableReason) {
+        // The server's URL was repointed. The stored credential belongs to the
+        // old destination, so the backend refuses to send it to the new one —
+        // a real reauthorize, but the user has to be told which destination
+        // they are authorizing and why the old grant stopped counting.
+        case "credential_origin_mismatch":
+          throw new WebRouteError(
+            401,
+            ErrorCode.UNAUTHORIZED,
+            `Server "${displayServerName}" now points at a different destination, so its saved credentials no longer apply. Authorize it again for the new destination.`,
+            { oauthRequired: true, ...errorDetails },
+          );
+        // The credential is intact; the authorization server never answered.
+        // Authorizing again means talking to the same unreachable host, so
+        // saying "reconnect" would send the user in a circle.
+        case "authorization_server_unreachable":
+          throw new WebRouteError(
+            503,
+            ErrorCode.SERVER_UNREACHABLE,
+            `The authorization server for "${displayServerName}" did not respond, so its access token could not be refreshed. Authorizing again will not change that. Try again shortly.`,
+            errorDetails,
+          );
+        // Another refresh holds the lease. Refusing here would be a regression
+        // from a retry: the token this connect wants is being minted right
+        // now, and the backend says how long that takes.
+        case "refresh_in_progress": {
+          const retryAfterMs =
+            typeof auth.oauthRetryAfterMs === "number" &&
+            Number.isFinite(auth.oauthRetryAfterMs) &&
+            auth.oauthRetryAfterMs > 0
+              ? auth.oauthRetryAfterMs
+              : null;
+          const retryAfterSeconds =
+            retryAfterMs === null ? null : Math.ceil(retryAfterMs / 1000);
+          const error = new WebRouteError(
+            429,
+            ErrorCode.RATE_LIMITED,
+            `Credentials for "${displayServerName}" are being refreshed by another request.${
+              retryAfterSeconds === null
+                ? " Try again shortly."
+                : ` Try again in ${retryAfterSeconds} second${retryAfterSeconds === 1 ? "" : "s"}.`
+            }`,
+            errorDetails,
+          );
+          throw retryAfterSeconds === null
+            ? error
+            : error.withHeaders({ "Retry-After": String(retryAfterSeconds) });
+        }
+        default:
+          throw new WebRouteError(
+            401,
+            ErrorCode.UNAUTHORIZED,
+            `Server "${displayServerName}" requires OAuth authentication. Please complete the OAuth flow first.`,
+            { oauthRequired: true, ...errorDetails },
+          );
+      }
     }
   }
 


### PR DESCRIPTION
## What this unblocks

- **Unblocks the deploy of MCPJam/mcpjam-backend#1152.** That PR adds `authorization_server_unreachable` and `refresh_in_progress` to the reasons `/web/authorize-batch` can send. Without this change, an authorization-server outage tells the user to complete an OAuth flow that was never the problem, and `refresh_in_progress` lands as a worse experience than today's 500 — the inspector treats it as non-recoverable in `isUninformativeBackendFailure` (`server/utils/hosted-oauth-refresh.ts`).
- **Makes the merged MJ-003 backend refusal visible to users.** `credential_origin_mismatch` already ships in mcpjam-backend (`convex/hostedOAuthCredentialsNode.ts`): when a server's URL is repointed, the backend refuses to hand over the credential bound to the old destination. The inspector had no branch for it, so the user got the generic "complete the OAuth flow first" with no mention of the destination change. This does not close MJ-003 — PR #4989 (server enforcement) deliberately does not gate OAuth inspector-side, because the backfill never writes a binding for OAuth-only rows. The backend refusal is the enforcement; this branch is how it reaches the user.

## The problem

`ConvexBatchAuthorizeSuccess.oauthUnavailableReason` was a closed literal with exactly one member, `private_authorization_server`. The only read was an exact-equality comparison routing it into `privateAuthorizationServerRecoveries`. Every other value fell through to the explicit-OAuth refusal:

> Server "X" requires OAuth authentication. Please complete the OAuth flow first.

`oauthRetryAfterMs` was sent by the backend and had zero consumers anywhere in the inspector (`server`, `client`, `cli`, `chat-ui`).

## The change

The union is now a named `ConvexOAuthUnavailableReason` with four members, and the refusal became the `default` arm of a switch, so a reason added without a branch is visible in one place. Each new reason gets its own answer:

| Reason | Status | Copy |
| --- | --- | --- |
| `credential_origin_mismatch` | 401, `oauthRequired: true` | `Server "X" now points at a different destination, so its saved credentials no longer apply. Authorize it again for the new destination.` |
| `authorization_server_unreachable` | 503 `SERVER_UNREACHABLE` | `The authorization server for "X" did not respond, so its access token could not be refreshed. Authorizing again will not change that. Try again shortly.` |
| `refresh_in_progress` | 429 `RATE_LIMITED` + `Retry-After` | `Credentials for "X" are being refreshed by another request. Try again in N seconds.` (`Try again shortly.` when the backend sends no delay) |

`refresh_in_progress` reads `oauthRetryAfterMs`, rejecting a non-finite or non-positive value, and renders it both in the message and as a `Retry-After` header in seconds.

`credential_origin_mismatch` is the one real reauthorize here, and it keeps `oauthRequired: true` so the existing reconnect affordance still fires — the message says *why* the old grant stopped counting rather than just asking for a flow.

The `private_authorization_server` path is untouched: it still `continue`s to the PASS 1b recovery above this block.

### Scope

- Server only. Nothing under `client/**` changed; no type had to move.
- Scoped to `effectiveAuth === "oauth"` — the population that reaches the refusal at all. A `discover` server still connects unauthenticated and escalates on a live 401, as before.
- **The type was not mirrored inside this repo.** The reported `BatchAuthorizeSuccessLocal` copy does not exist here; `LocalAuthorizeBatchSuccess` in `server/utils/local-server-resolver.ts` carries no `oauthUnavailableReason` at all, so there was nothing to widen. The only mirror is the backend's `BatchAuthorizeSuccess` in `convex/http.ts`, which the doc comment already names. A shared type would have to cross the repo boundary, so the hand-mirror stays — with the "add a branch when you add a member" contract now written on the type.
- Does not touch #4989 (MJ-003 server enforcement) or #4990 (client warnings).

## Tests

Four new cases in `server/routes/web/__tests__/auth-manager.test.ts`, each asserting the response does **not** carry `complete the OAuth flow first`:

- `credential_origin_mismatch` → 401 with the destination-change copy and `oauthRequired: true`
- `authorization_server_unreachable` → 503, no `oauthRequired`
- `refresh_in_progress` with `oauthRetryAfterMs: 4200` → 429, `Retry-After: 5`, delay in the message
- `refresh_in_progress` with no delay → 429, no `Retry-After`

All four fail against the unfixed code with `401 / UNAUTHORIZED / "requires OAuth authentication. Please complete the OAuth flow first."`, and pass with it.

## Verification

```
npx tsc --noEmit -p mcpjam-inspector/server/tsconfig.json
  main:   296 errors
  branch: 296 errors
  error sets identical (line-number agnostic diff is empty)

npm run typecheck:client -w @mcpjam/inspector      exit 0
npm run typecheck                                  exit 0
npm run docs:check-tokens                          exit 0
npm run test:checks                                exit 0   (rg 14.1.1 on PATH)
npm run build:inspector                            exit 0

vitest --project server routes/web/__tests__/ utils/__tests__/local-server-resolver utils/__tests__/hosted-oauth-refresh
  Test Files  88 passed (88)
       Tests  1251 passed (1251)
```

`npm run test -w @mcpjam/inspector` (full) is red locally on 21 files / 95 tests, all POSIX-bound on this Windows host (symlinks, process-group kills, file modes, the harness's own `not available on win32` refusal). The identical set fails on clean `main` — verified by re-running exactly those paths against the stashed baseline: 22 files / 101 tests. `@mcpjam/sdk` (2 files), `@mcpjam/cli`, and `@mcpjam/discord-app` are likewise red on clean `main` with the same failures. `main`'s own `test.yml` run at the merge base (`0be63d5a6`) is already `failure`. None of the failing files touch `routes/web`.

Playwright e2e skipped: the diff touches no routing, app boot, or the OAuth debugger.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The web auth manager no longer treats every missing OAuth token as a request to complete OAuth. It now distinguishes backend reasons: destination changes return 401 with reauthorization, authorization-server outages return 503, and concurrent refreshes return 429 with `Retry-After` when available.

- `credential_origin_mismatch` keeps `oauthRequired: true` so the existing reconnect UI remains available.
- Missing or invalid `oauthRetryAfterMs` produces “Try again shortly” without a retry header.
- The `private_authorization_server` recovery remains unchanged, and unknown reasons use the existing OAuth refusal.
- The change is limited to servers using `effectiveAuth === "oauth"`.

**Tests**

- Adds route tests for all three reasons, including retry-delay rounding and header behavior.

<sup>Written for commit ca7a9399a41555637e2108025e815c56cd552b2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/5003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

