### PR TITLE
Show one Expected Outcome per case, after the last action, marked as the judge's

### DIFF
--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/case-spine.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/case-spine.test.tsx
@@ -254,6 +254,29 @@ describe("the spine", () => {
     expect(screen.queryByText("Steps")).toBeNull();
   });
 
+  it("keeps one Expected Outcome for the whole case, after the last action, marked as the judge's", async () => {
+    await openSpine({ steps: twoTurn });
+    const outcome = screen.getByLabelText("Expected Outcome");
+    const section = screen.getByTestId("spine-expected-outcome-section");
+    expect(section).toContainElement(outcome);
+    // Not inside any prompt row: under prompt 1 it read as that prompt's
+    // outcome, and prompt 2 then looked broken for having none.
+    for (const row of screen.getAllByTestId("spine-action-row")) {
+      expect(row).not.toContainElement(outcome);
+    }
+    const actions = screen.getByTestId("spine-actions");
+    expect(
+      actions.compareDocumentPosition(section) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      within(section).getByText("Judge").getAttribute("data-provenance"),
+    ).toBe("judge");
+    // The chip is beside the label, not inside it, so the field's name stays
+    // "Expected Outcome".
+    expect(screen.getByLabelText("Expected Outcome")).toBe(outcome);
+  });
+
   it("nests each check under the action it follows", async () => {
     await openSpine({ steps: withClick });
     const [prompt, click] = screen.getAllByTestId("spine-action-row");

--- a/mcpjam-inspector/client/src/components/evaluate/case-spine/case-spine.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/case-spine/case-spine.tsx
@@ -8,6 +8,7 @@ import {
 } from "../case-scorecard/trial-results";
 import { TrialScorecardRow } from "../case-scorecard/trial-scorecard-row";
 import { ScorecardRowView } from "../case-scorecard/scorecard-row";
+import { ProvenanceChip } from "../case-scorecard/provenance-chip";
 import { afterTheRunRows } from "./case-spine-model";
 /**
  * The case, as one list.
@@ -484,33 +485,6 @@ export function CaseSpine({
               onSelectStep ? () => onSelectStep(action.step.id) : undefined
             }
           >
-            {action.ordinal === 1 ? (
-              <section className="space-y-2">
-                <Label
-                  className="text-lg font-semibold text-info"
-                  htmlFor="spine-expected-outcome"
-                >
-                  <Target className="size-4" aria-hidden="true" />
-                  Expected Outcome
-                </Label>
-                <Textarea
-                  id="spine-expected-outcome"
-                  ref={outcomeRef}
-                  value={expectedOutput ?? ""}
-                  onChange={(event) =>
-                    onExpectedOutputChange(event.target.value)
-                  }
-                  rows={3}
-                  readOnly={readOnly}
-                  placeholder={
-                    readOnly
-                      ? "No expected outcome captured"
-                      : "States the signed-in account's email address."
-                  }
-                  className={cnBorder(undefined)}
-                />
-              </section>
-            ) : null}
             {readOnly ? null : (
               <EvalAddDrawer
                 className="w-full"
@@ -636,6 +610,41 @@ export function CaseSpine({
           </ActionRow>
         ))}
       </ul>
+
+      {/* One outcome for the whole case, not one per prompt. It sits AFTER
+          the last action because the judge grades the end state of the run:
+          rendering it under prompt 1 read as "prompt 1's outcome", and a
+          second prompt then looked broken for having none. Per-step
+          expectations are the checks under each action. */}
+      <section
+        className="space-y-2"
+        data-testid="spine-expected-outcome-section"
+      >
+        <div className="flex items-center gap-2">
+          <Label
+            className="text-lg font-semibold text-info"
+            htmlFor="spine-expected-outcome"
+          >
+            <Target className="size-4" aria-hidden="true" />
+            Expected Outcome
+          </Label>
+          <ProvenanceChip provenance="judge" />
+        </div>
+        <Textarea
+          id="spine-expected-outcome"
+          ref={outcomeRef}
+          value={expectedOutput ?? ""}
+          onChange={(event) => onExpectedOutputChange(event.target.value)}
+          rows={3}
+          readOnly={readOnly}
+          placeholder={
+            readOnly
+              ? "No expected outcome captured"
+              : "States the signed-in account's email address."
+          }
+          className={cnBorder(undefined)}
+        />
+      </section>
 
       {wholeCaseRows.length > 0 && (
         <section className="space-y-2" aria-label="Whole-case assertions">


### PR DESCRIPTION
## What

Moves the Evaluate case spine's **Expected Outcome** out of the first prompt row into its own section after the last action, and puts the existing **Judge** provenance chip beside the label.

## Why (EBB-43)

The textarea rendered inside prompt 1, so it read as *prompt 1's* outcome, and adding a second User Prompt looked broken because no outcome field appeared under it. The case model has exactly one case-level outcome and the judge grades the end state of the whole run (every turn is already sent to it, anchored on this one rubric), so the UI now says that: one outcome, for the whole case, graded by the judge. Per-step expectations stay the checks under each action. This matches how LangSmith (one reference `outputs` per example) and promptfoo (one `trajectory:goal-success` goal plus deterministic per-step trace asserts) model agent evals.

## Notes

- No model, wire, or backend change. Field id, label text and the drawer's focus-outcome path are unchanged.
- The chip sits next to the `<Label>`, not inside it, so the field's accessible name stays "Expected Outcome" (every existing test keyed on that still passes).
- New test pins: outcome is outside every action row, after the actions list, and carries `data-provenance="judge"`.

## Verification

- `client/src/components/evaluate` + `client/src/components/evals`: 288 files, 3087 tests pass.
- `tsc` on client: same 816 pre-existing errors as main, none in the touched lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLTYxHQmQE46MACZVMDmvg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only layout and provenance labeling in the evaluate editor; no model, API, or persistence changes.
> 
> **Overview**
> The case spine no longer renders **Expected Outcome** inside the first prompt row. It now appears in a dedicated section **after the last action**, reflecting one case-level rubric for the judge rather than a per-prompt field.
> 
> A **Judge** `ProvenanceChip` sits next to the label (not inside it) so the textarea’s accessible name stays **Expected Outcome**. Behavior is unchanged: same field id, drawer focus path, and data model—layout and labeling only.
> 
> A new test asserts the outcome section is outside every action row, follows the actions list, and exposes `data-provenance="judge"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02794a80dfc5423b2cc2b7811d9a48b6b986f403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relocates the Expected Outcome field in the Evaluate case spine from inside the first prompt row to its own section after the last action, and adds the Judge provenance chip beside the label. Previously the outcome read as prompt 1's outcome and a second prompt appeared broken; now it's clear there's one case-level outcome graded by the judge (EBB-43). No model, wire, or backend changes. The chip sits outside the label so the field's accessible name stays "Expected Outcome" and existing tests pass.

<sup>Written for commit 02794a80dfc5423b2cc2b7811d9a48b6b986f403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/5005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

