### PR TITLE
Stop the Add Server dialog crashing on translated pages

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
@@ -357,7 +357,10 @@ export function AddServerModal({
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent
-        className="max-w-2xl max-h-[90vh] overflow-y-auto"
+        // Browser translators rewrite text nodes in-place. React then cannot
+        // safely remove this portaled dialog after its close animation.
+        translate="no"
+        className="notranslate max-w-2xl max-h-[90vh] overflow-y-auto"
         onPointerDownOutside={(e) => e.preventDefault()}
         onInteractOutside={(e) => e.preventDefault()}
       >

--- a/mcpjam-inspector/client/src/components/connection/__tests__/AddServerModal.translation.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/AddServerModal.translation.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AddServerModal } from "../AddServerModal";
+
+// AddServerModal reaches for auth, app-readiness and analytics at render time;
+// stub them so the modal mounts standalone.
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: null }),
+}));
+vi.mock("@/hooks/use-app-ready", () => ({
+  useAppReady: () => ({ status: "ready" }),
+  useAppReadyMessage: () => null,
+}));
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
+describe("AddServerModal — browser translation", () => {
+  // Regression: on a Chrome-translated page, cancelling this modal threw
+  // NotFoundError from `removeChild` once the close animation unmounted the
+  // portal. The translator had swapped the dialog's text nodes for `<font>`
+  // wrappers, so the nodes React held references to were no longer children
+  // of their parents.
+  it("prevents browser translation from rewriting the portaled dialog", () => {
+    render(
+      <AddServerModal isOpen onClose={vi.fn()} onSubmit={vi.fn()} />,
+    );
+
+    expect(screen.getByRole("dialog")).toHaveAttribute("translate", "no");
+    expect(screen.getByRole("dialog")).toHaveClass("notranslate");
+  });
+});


### PR DESCRIPTION
- On a Chrome-translated page (seen in production in Korean), opening the **Add Server** dialog and hitting Cancel threw a `NotFoundError` from `removeChild`.
- Chrome's translation replaces each text node with a `<font>` wrapper. React still holds the original nodes, so tearing the dialog down after its close animation tries to remove nodes that are no longer there.
- Fix marks the dialog `translate="no"` / `notranslate`, so Chrome leaves it alone. `ServerDetailModal` already had this exact guard from #4056 — this just mirrors it.
- Added a regression test matching the one that ships with `ServerDetailModal`.
- Longer term we could put this on the shared `DialogContent` (or the whole app) instead of one dialog at a time — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Add Server dialog crashing when canceled on a Chrome-translated page. Chrome's translation rewrites the dialog's text nodes in place, so React can't remove them after the close animation and throws `NotFoundError`; the dialog is now excluded from translation entirely.

**Bug Fixes**
- Marks the dialog `translate="no"` and `notranslate` so Chrome leaves it alone, mirroring the existing guard on `ServerDetailModal`.
- Adds a regression test asserting the dialog carries both attributes.

<sup>Written for commit fa102a135111f221e5717ef50aa155f3a7e3f65a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/5008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

