### PR TITLE
Add hosted evals GitHub Action

### DIFF
--- a/.github/workflows/evals-action-smoke.yml
+++ b/.github/workflows/evals-action-smoke.yml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
       - name: Verify pinned CLI is published

--- a/.github/workflows/evals-action-smoke.yml
+++ b/.github/workflows/evals-action-smoke.yml
@@ -1,0 +1,42 @@
+name: Evals action live smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      project:
+        description: Existing MCPJam project name or ID
+        required: true
+        type: string
+      suite:
+        description: Existing hosted suite to run (uses eval credits)
+        required: true
+        type: string
+      gate:
+        description: Also evaluate gates
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - name: Verify pinned CLI is published
+        run: npm view @mcpjam/cli@5.7.1 version
+      - name: Test the action helpers
+        run: node --test actions/evals/*.test.mjs
+      - name: Run hosted suite with the local action
+        uses: ./actions/evals
+        with:
+          # Set this secret before manually starting the live smoke test.
+          api-key: ${{ secrets.MCPJAM_API_KEY }}
+          project: ${{ inputs.project }}
+          suite: ${{ inputs.suite }}
+          gate: ${{ inputs.gate }}

--- a/.github/workflows/evals-action-test.yml
+++ b/.github/workflows/evals-action-test.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: "24"

--- a/.github/workflows/evals-action-test.yml
+++ b/.github/workflows/evals-action-test.yml
@@ -1,0 +1,25 @@
+name: Evals action tests
+
+on:
+  pull_request:
+    paths:
+      - "actions/evals/**"
+      - ".github/workflows/evals-action-*.yml"
+  push:
+    branches: [main]
+    paths:
+      - "actions/evals/**"
+      - ".github/workflows/evals-action-*.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - run: node --test actions/evals/*.test.mjs

--- a/actions/evals/README.md
+++ b/actions/evals/README.md
@@ -1,0 +1,133 @@
+# MCPJam evals action
+
+Run an existing hosted eval suite, wait for its result, and save reports as a
+GitHub Actions artifact. Optional gates can apply thresholds, compare a baseline,
+and honor existing run waivers. The action does not create waivers.
+
+This action supports GitHub.com and Ubuntu runners. It tests the suite's saved
+server; it does **not** build or deploy the code in a pull request. Use MCPJam's
+GitHub App integration for builds from PR source.
+
+## Setup
+
+1. Create an API key in MCPJam Settings → API keys.
+2. In your GitHub repository, open Settings → Secrets and variables → Actions.
+   Add a repository secret named `MCPJAM_API_KEY` containing the key.
+3. Copy [mcpjam.yml](./mcpjam.yml) to `.github/workflows/mcpjam.yml` in your repo.
+   Replace the project and suite placeholders. Names and IDs are both supported.
+
+The workflow references the secret; never paste the key into YAML. No checkout or
+Node setup step is required when using the published action.
+
+```yaml
+- uses: MCPJam/inspector/actions/evals@evals-v1
+  with:
+    # Add the real API key to GitHub Actions secrets, not this file.
+    api-key: ${{ secrets.MCPJAM_API_KEY }}
+    project: "My project"
+    suite: "My eval suite"
+```
+
+**Release status:** `evals-v1` becomes usable only after the release procedure
+below succeeds and the tag is published. Until then, test with a checkout and
+`uses: ./actions/evals`, as the live smoke workflow does.
+
+## Optional gates
+
+```yaml
+- uses: MCPJam/inspector/actions/evals@evals-v1
+  with:
+    api-key: ${{ secrets.MCPJAM_API_KEY }}
+    project: "My project"
+    suite: "My eval suite"
+    gate: true
+    min-pass-rate-percent: 95
+    # Optional: a commit SHA already stored on a completed baseline run.
+    # baseline-sha: '0123456789abcdef0123456789abcdef01234567'
+```
+
+Without gates, only run exit code `0` passes. With gates, each completed run's
+gate must return `0` (passed or waived), and every launched run must have complete
+results and reports. Gate success can clear a measured eval failure; it cannot
+clear a failed launch, missing result, or reporting error. Existing suite policies
+remain enabled: a run waiver does not override a separate suite-policy failure.
+
+Waiver details remain in the CLI's JUnit report, including skipped cases. An
+expired waiver or an unresolved baseline remains blocking according to the CLI's
+gate result. The action delegates these rules to the CLI rather than calculating
+its own thresholds or deciding whether a waiver is active.
+
+## Inputs
+
+| Input                   | Default     | Meaning                                                                      |
+| ----------------------- | ----------- | ---------------------------------------------------------------------------- |
+| `api-key`               | Required    | API key from GitHub Actions secrets.                                         |
+| `project`               | Required    | Existing project name or ID.                                                 |
+| `suite`                 | Required    | Existing hosted suite name or ID.                                            |
+| `gate`                  | `false`     | Let `eval gate` decide the result.                                           |
+| `min-pass-rate-percent` | CLI default | Gate threshold, 0–100; requires `gate: true`.                                |
+| `baseline-run`          | None        | Baseline run ID; requires gates.                                             |
+| `baseline-sha`          | None        | Stored baseline commit SHA; requires gates. Cannot accompany `baseline-run`. |
+| `wait-timeout-ms`       | CLI default | Positive integer; applied to run and gate waits.                             |
+| `cli-version`           | `5.7.1`     | Exact published version, not `latest` or a URL.                              |
+| `idempotency-key`       | Derived     | Optional stable retry key, at most 256 characters.                           |
+
+The CLI's default wait is 10 minutes, with its existing grading extension when
+no explicit limit is supplied. The example workflow sets a 60-minute job limit.
+Large suites or several targets may need a longer GitHub job timeout.
+
+There are no automatic retries. The default retry key includes repository,
+workflow run, job, matrix cell, action invocation, project and suite, but excludes
+the workflow attempt. Re-running the same job therefore reuses the paid run.
+Starting a new workflow run produces a new key. A custom key is useful if you
+need to preserve identity across changes to the workflow's step layout.
+
+## Reports and outputs
+
+The action saves `eval-report.json`, one `gate-N.xml` per attempted gate when
+enabled, and `action-result.json`. It uploads them before the final failure step,
+using a unique artifact name per invocation. Reports use the CLI's redaction, with
+an additional literal API-key scrub. Raw CLI stdout and stderr are not uploaded.
+
+| Output            | Format                                                            |
+| ----------------- | ----------------------------------------------------------------- |
+| `run-ids`         | JSON array, including runs that launched but did not finish.      |
+| `run-exit-code`   | Original CLI exit code; empty if the CLI could not start.         |
+| `gate-exit-codes` | JSON object mapping each attempted run ID to its gate exit code.  |
+| `report-path`     | Local report directory; empty if it could not be safely prepared. |
+| `artifact-url`    | GitHub URL returned by the successful artifact upload.            |
+
+Run exit codes: `0` passed, `1` measured eval failure, `2` usage, `3` auth,
+`4` setup/connection/report write, `5` no valid verdict. Gate codes retain their
+separate contract: `0` passed/waived, `1` failed, `2` usage, `3` incomplete.
+GitHub displays success or failure; the outputs retain the more precise codes.
+An upload failure also fails the action, even if evaluation passed. Cancellation
+or a runner shutdown can prevent report upload.
+
+## Tests and release
+
+Run the tests without installing workspace dependencies:
+
+```sh
+node --test actions/evals/*.test.mjs
+```
+
+The `Evals action tests` workflow runs these checks on action changes. Before
+releasing, run `Evals action live smoke` manually against the candidate commit,
+supplying an existing project and suite and setting `MCPJAM_API_KEY` in the repo's
+Actions secrets. This spends eval credits. Test both gate settings before the
+first release. The smoke workflow verifies the pinned CLI is published, runs
+the helper tests, executes the local action, and uploads real reports.
+
+Publish only a commit with a successful live smoke run. The release guard checks
+the run's repository, workflow, event, conclusion and exact commit:
+
+```sh
+node actions/evals/check-release.mjs <successful-smoke-run-id> <full-commit-sha>
+```
+
+After that check passes, maintainers can tag that exact commit `evals-v1.0.0`
+and create the moving `evals-v1` tag pointing at it. For later releases, repeat the
+smoke check for the new commit, create a new immutable version tag, then update
+`evals-v1`. These tags are separate from Inspector's application releases. Do not
+publish a tag or describe the action as released before the live check passes.

--- a/actions/evals/action.yml
+++ b/actions/evals/action.yml
@@ -1,0 +1,84 @@
+name: MCPJam evals
+description: Run a hosted MCPJam eval suite, optionally gate it, and save reports.
+inputs:
+  api-key:
+    description: MCPJam API key, supplied from GitHub Actions secrets.
+    required: true
+  project:
+    description: Existing project name or ID.
+    required: true
+  suite:
+    description: Existing eval suite name or ID.
+    required: true
+  gate:
+    description: Use the gate result, including existing waivers, to decide success.
+    default: "false"
+  min-pass-rate-percent:
+    description: Optional gate pass threshold between 0 and 100. Requires gate.
+  baseline-run:
+    description: Baseline run ID. Requires gate; cannot accompany baseline-sha.
+  baseline-sha:
+    description: Commit SHA with a saved baseline run. Requires gate; cannot accompany baseline-run.
+  wait-timeout-ms:
+    description: Positive wait limit in milliseconds. Omit to retain CLI defaults.
+  cli-version:
+    description: Exact published CLI version.
+    default: "5.7.1"
+  idempotency-key:
+    description: Optional retry key, at most 256 characters. Otherwise derived from the workflow invocation.
+outputs:
+  run-ids:
+    description: JSON array of all launched run IDs, including runs that did not finish.
+    value: ${{ steps.evaluate.outputs.run-ids }}
+  run-exit-code:
+    description: Original CLI run exit code, or empty if it could not start.
+    value: ${{ steps.evaluate.outputs.run-exit-code }}
+  gate-exit-codes:
+    description: JSON object mapping run IDs to their gate exit codes.
+    value: ${{ steps.evaluate.outputs.gate-exit-codes }}
+  report-path:
+    description: Local directory containing reports and the action result.
+    value: ${{ steps.evaluate.outputs.report-path }}
+  artifact-url:
+    description: GitHub URL for the uploaded reports.
+    value: ${{ steps.upload.outputs.artifact-url }}
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "24"
+    - name: Run evals and optional gates
+      id: evaluate
+      shell: bash
+      env:
+        MCPJAM_ACTION_PATH: ${{ github.action_path }}
+        MCPJAM_API_KEY: ${{ inputs.api-key }}
+        MCPJAM_ACTION_PROJECT: ${{ inputs.project }}
+        MCPJAM_ACTION_SUITE: ${{ inputs.suite }}
+        MCPJAM_ACTION_GATE: ${{ inputs.gate }}
+        MCPJAM_ACTION_MIN_PASS_RATE: ${{ inputs.min-pass-rate-percent }}
+        MCPJAM_ACTION_BASELINE_RUN: ${{ inputs.baseline-run }}
+        MCPJAM_ACTION_BASELINE_SHA: ${{ inputs.baseline-sha }}
+        MCPJAM_ACTION_WAIT_TIMEOUT: ${{ inputs.wait-timeout-ms }}
+        MCPJAM_ACTION_CLI_VERSION: ${{ inputs.cli-version }}
+        MCPJAM_ACTION_IDEMPOTENCY_KEY: ${{ inputs.idempotency-key }}
+        MCPJAM_ACTION_INVOCATION: ${{ github.action }}
+        MCPJAM_ACTION_MATRIX: ${{ toJSON(matrix) }}
+      run: node "$MCPJAM_ACTION_PATH/run.mjs"
+    - name: Save eval reports
+      id: upload
+      if: ${{ always() && steps.evaluate.outputs.report-path != '' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.evaluate.outputs.artifact-name }}
+        path: ${{ steps.evaluate.outputs.report-path }}
+        if-no-files-found: error
+    - name: Report final result
+      if: ${{ always() }}
+      shell: bash
+      env:
+        MCPJAM_ACTION_PATH: ${{ github.action_path }}
+        MCPJAM_ACTION_RESULT: ${{ steps.evaluate.outputs.result }}
+        MCPJAM_ACTION_UPLOAD_OUTCOME: ${{ steps.upload.outcome }}
+      run: node "$MCPJAM_ACTION_PATH/run.mjs" finalize

--- a/actions/evals/action.yml
+++ b/actions/evals/action.yml
@@ -45,7 +45,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: "24"
     - name: Run evals and optional gates
@@ -69,7 +69,7 @@ runs:
     - name: Save eval reports
       id: upload
       if: ${{ always() && steps.evaluate.outputs.report-path != '' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ steps.evaluate.outputs.artifact-name }}
         path: ${{ steps.evaluate.outputs.report-path }}

--- a/actions/evals/check-release.mjs
+++ b/actions/evals/check-release.mjs
@@ -1,0 +1,46 @@
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+export function checkSmokeRun(run, sha) {
+  if (!/^[a-f0-9]{40}$/.test(sha ?? ""))
+    throw new Error("A full commit SHA is required.");
+  if (
+    run.repository?.full_name !== "MCPJam/inspector" ||
+    run.path?.split("@")[0] !== ".github/workflows/evals-action-smoke.yml" ||
+    run.event !== "workflow_dispatch" ||
+    run.status !== "completed" ||
+    run.conclusion !== "success" ||
+    run.head_sha !== sha
+  ) {
+    throw new Error(
+      "Release requires a successful live smoke run for this exact Inspector commit.",
+    );
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    const [runId, sha] = process.argv.slice(2);
+    if (!/^\d+$/.test(runId ?? ""))
+      throw new Error("A numeric GitHub smoke run ID is required.");
+    const run = JSON.parse(
+      execFileSync(
+        "gh",
+        ["api", `repos/MCPJam/inspector/actions/runs/${runId}`],
+        { encoding: "utf8" },
+      ),
+    );
+    checkSmokeRun(run, sha);
+    process.stdout.write(
+      `Live smoke verified for ${sha}. This command does not publish tags.\n`,
+    );
+  } catch {
+    process.stderr.write(
+      "Release check failed: verify gh authentication, the smoke run ID, and the exact commit SHA.\n",
+    );
+    process.exitCode = 1;
+  }
+}

--- a/actions/evals/check-release.test.mjs
+++ b/actions/evals/check-release.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { checkSmokeRun } from "./check-release.mjs";
+
+const sha = "a".repeat(40);
+const successful = {
+  repository: { full_name: "MCPJam/inspector" },
+  path: ".github/workflows/evals-action-smoke.yml",
+  head_sha: sha,
+  status: "completed",
+  conclusion: "success",
+  event: "workflow_dispatch",
+};
+
+test("release requires a successful live smoke for the exact commit", () => {
+  assert.doesNotThrow(() => checkSmokeRun(successful, sha));
+  for (const change of [
+    { head_sha: "b".repeat(40) },
+    { conclusion: "failure" },
+    { conclusion: "cancelled" },
+    { status: "in_progress" },
+    { event: "pull_request" },
+    { repository: { full_name: "someone/inspector" } },
+    { path: ".github/workflows/evals-action-test.yml" },
+  ])
+    assert.throws(() => checkSmokeRun({ ...successful, ...change }, sha));
+  assert.throws(() => checkSmokeRun(successful, "main"));
+});

--- a/actions/evals/mcpjam.yml
+++ b/actions/evals/mcpjam.yml
@@ -1,0 +1,27 @@
+name: MCPJam evals
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  evals:
+    # Fork PRs do not receive this repo's secrets.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: MCPJam/inspector/actions/evals@evals-v1
+        with:
+          # Add your API key as MCPJAM_API_KEY in GitHub Actions secrets.
+          api-key: ${{ secrets.MCPJAM_API_KEY }}
+          project: "My project"
+          suite: "My eval suite"
+
+          # Optional: let the gate decide pass or fail.
+          # gate: true
+          # min-pass-rate-percent: 95
+          # baseline-sha: '<commit with an existing eval run>'

--- a/actions/evals/run.mjs
+++ b/actions/evals/run.mjs
@@ -1,0 +1,402 @@
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  appendFile,
+  mkdtemp,
+  readFile,
+  readdir,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const validId = (value) =>
+  typeof value === "string" && /^[a-zA-Z0-9_-]+$/.test(value);
+const escapeCommand = (value) =>
+  value.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+
+export function parseInputs(env) {
+  const get = (name) => (env[`MCPJAM_ACTION_${name}`] ?? "").trim();
+  const inputs = {
+    apiKey: (env.MCPJAM_API_KEY ?? "").trim(),
+    project: get("PROJECT"),
+    suite: get("SUITE"),
+    gate: get("GATE") || "false",
+    minPassRate: get("MIN_PASS_RATE"),
+    baselineRun: get("BASELINE_RUN"),
+    baselineSha: get("BASELINE_SHA"),
+    waitTimeout: get("WAIT_TIMEOUT"),
+    cliVersion: get("CLI_VERSION") || "5.7.1",
+    idempotencyKey: get("IDEMPOTENCY_KEY"),
+  };
+  for (const key of ["apiKey", "project", "suite"]) {
+    if (!inputs[key])
+      throw new Error(
+        `Missing required input: ${key === "apiKey" ? "api-key (add MCPJAM_API_KEY to GitHub Actions secrets)" : key}.`,
+      );
+  }
+  if (!["true", "false"].includes(inputs.gate))
+    throw new Error("gate must be true or false.");
+  inputs.gate = inputs.gate === "true";
+  if (
+    !inputs.gate &&
+    (inputs.minPassRate || inputs.baselineRun || inputs.baselineSha)
+  ) {
+    throw new Error("Gate settings require gate: true.");
+  }
+  if (inputs.baselineRun && inputs.baselineSha)
+    throw new Error("Use baseline-run or baseline-sha, not both.");
+  if (inputs.baselineRun && !validId(inputs.baselineRun))
+    throw new Error("baseline-run must be a run ID.");
+  if (inputs.baselineSha && !/^[a-fA-F0-9]{7,64}$/.test(inputs.baselineSha))
+    throw new Error("baseline-sha must be a commit SHA.");
+  if (
+    inputs.minPassRate &&
+    (!/^\d+(?:\.\d+)?$/.test(inputs.minPassRate) ||
+      Number(inputs.minPassRate) > 100)
+  ) {
+    throw new Error("min-pass-rate-percent must be between 0 and 100.");
+  }
+  if (
+    inputs.waitTimeout &&
+    (!/^\d+$/.test(inputs.waitTimeout) ||
+      !Number.isSafeInteger(Number(inputs.waitTimeout)) ||
+      Number(inputs.waitTimeout) <= 0)
+  ) {
+    throw new Error("wait-timeout-ms must be a positive safe integer.");
+  }
+  // No npm tags, URLs, paths or shell fragments in the package selector.
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(inputs.cliVersion))
+    throw new Error("cli-version must be an exact version, such as 5.7.1.");
+  if (inputs.idempotencyKey.length > 256)
+    throw new Error("idempotency-key must be at most 256 characters.");
+  if (!inputs.idempotencyKey)
+    inputs.idempotencyKey = deriveIdempotencyKey(env, inputs);
+  return inputs;
+}
+
+export function deriveIdempotencyKey(env, inputs) {
+  // run_attempt is deliberately excluded: a rerun must observe the paid run
+  // already launched by this job, rather than purchase a duplicate.
+  const identity = [
+    env.GITHUB_SERVER_URL,
+    env.GITHUB_REPOSITORY,
+    env.GITHUB_WORKFLOW,
+    env.GITHUB_RUN_ID,
+    env.GITHUB_JOB,
+    env.MCPJAM_ACTION_INVOCATION,
+    env.MCPJAM_ACTION_MATRIX,
+    inputs.project,
+    inputs.suite,
+  ];
+  if (!env.GITHUB_RUN_ID || !env.GITHUB_JOB || !env.MCPJAM_ACTION_INVOCATION) {
+    throw new Error("Cannot derive retry identity; provide idempotency-key.");
+  }
+  return `github-evals:${createHash("sha256").update(JSON.stringify(identity)).digest("hex")}`;
+}
+
+// The CLI renderers redact reports. Also remove the supplied key literally,
+// including its JSON/XML encodings, before any file is uploaded.
+export function redactSecret(text, key) {
+  if (!key) return text;
+  const xml = key
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+  const forms = [...new Set([key, JSON.stringify(key).slice(1, -1), xml])].sort(
+    (a, b) => b.length - a.length,
+  );
+  return forms.reduce(
+    (value, form) => value.replaceAll(form, "[REDACTED]"),
+    text,
+  );
+}
+
+export function invokeCli(args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("npx", args, {
+      env,
+      shell: false,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const chunks = [];
+    let size = 0;
+    let tooLarge = false;
+    child.stdout.on("data", (chunk) => {
+      size += chunk.length;
+      if (size > 64 * 1024 * 1024) {
+        tooLarge = true;
+        child.kill("SIGTERM");
+      } else chunks.push(chunk);
+    });
+    child.on("error", () =>
+      reject(new Error("Could not start the MCPJam CLI.")),
+    );
+    child.on("close", (code) => {
+      if (tooLarge) reject(new Error("CLI receipt exceeded the size limit."));
+      else
+        resolve({
+          code: code ?? 5,
+          stdout: Buffer.concat(chunks).toString("utf8"),
+        });
+    });
+  });
+}
+
+function parseReceipt(stdout) {
+  let receipt;
+  try {
+    receipt = JSON.parse(stdout);
+  } catch {
+    throw new Error("CLI did not return a valid JSON receipt.");
+  }
+  const targets = receipt?.launch?.targets;
+  if (
+    !Array.isArray(targets) ||
+    targets.length === 0 ||
+    !Array.isArray(receipt.runs) ||
+    !["started", "partial", "failed"].includes(receipt.launch.outcome) ||
+    targets.some(
+      (target) =>
+        !["started", "failed"].includes(target.status) ||
+        (target.status === "started" && !validId(target.runId)),
+    ) ||
+    receipt.runs.some((run) => !validId(run.id))
+  ) {
+    throw new Error("CLI receipt has an unsupported shape.");
+  }
+  const ids = targets
+    .filter((target) => target.status === "started")
+    .map((target) => target.runId);
+  if (
+    new Set(ids).size !== ids.length ||
+    new Set(receipt.runs.map((run) => run.id)).size !== receipt.runs.length ||
+    receipt.runs.some((run) => !ids.includes(run.id))
+  )
+    throw new Error("CLI receipt contains inconsistent run IDs.");
+  return { receipt, ids };
+}
+
+function completeEvidence(report, receipt, ids) {
+  const rows = report?.metadata?.runs;
+  return (
+    report?.schemaVersion === 1 &&
+    report.kind === "eval-run" &&
+    Array.isArray(report.cases) &&
+    report.cases.every(
+      (entry) =>
+        typeof entry.passed === "boolean" &&
+        !(["reporting", "launch"].includes(entry.category) && !entry.passed),
+    ) &&
+    ids.length > 0 &&
+    receipt.launch.outcome === "started" &&
+    receipt.launch.targets.every((target) => target.status === "started") &&
+    receipt.runs.length === ids.length &&
+    receipt.runs.every(
+      (run) =>
+        run.status === "completed" && ["passed", "failed"].includes(run.result),
+    ) &&
+    Array.isArray(rows) &&
+    rows.length === ids.length &&
+    new Set(rows.map((row) => row.id)).size === ids.length &&
+    rows.every(
+      (row) =>
+        ids.includes(row.id) &&
+        row.iterationsComplete === true &&
+        row.status === "completed" &&
+        row.result === receipt.runs.find((run) => run.id === row.id)?.result,
+    )
+  );
+}
+
+async function output(env, values, apiKey) {
+  if (!env.GITHUB_OUTPUT) return;
+  for (const [key, value] of Object.entries(values)) {
+    const delimiter = `mcpjam_${randomUUID()}`;
+    await appendFile(
+      env.GITHUB_OUTPUT,
+      `${key}<<${delimiter}\n${redactSecret(String(value), apiKey)}\n${delimiter}\n`,
+    );
+  }
+}
+
+export async function runAction(
+  env = process.env,
+  invoke = invokeCli,
+  log = (message) => process.stdout.write(`${message}\n`),
+) {
+  const state = {
+    result: "failed",
+    runIds: [],
+    runExitCode: "",
+    gateExitCodes: {},
+    message: "Evaluation did not complete.",
+  };
+  const key = (env.MCPJAM_API_KEY ?? "").trim();
+  if (key) log(`::add-mask::${escapeCommand(key)}`);
+  let directory;
+  try {
+    const inputs = parseInputs(env);
+    directory = await mkdtemp(
+      join(env.RUNNER_TEMP || tmpdir(), "mcpjam-evals-"),
+    );
+    const prefix = [
+      "--yes",
+      `@mcpjam/cli@${inputs.cliVersion}`,
+      "cloud",
+      "eval",
+    ];
+    const reportPath = join(directory, "eval-report.json");
+    const args = [
+      ...prefix,
+      "run",
+      `--project=${inputs.project}`,
+      `--suite=${inputs.suite}`,
+      "--wait",
+      `--out=${reportPath}`,
+      "--format=json",
+      `--idempotency-key=${inputs.idempotencyKey}`,
+    ];
+    if (inputs.waitTimeout) args.push(`--wait-timeout=${inputs.waitTimeout}`);
+    const cliEnv = { ...env, MCPJAM_API_KEY: inputs.apiKey };
+    const run = await invoke(args, cliEnv);
+    state.runExitCode = run.code;
+    const { receipt, ids } = parseReceipt(run.stdout);
+    state.runIds = ids;
+    let report;
+    try {
+      report = JSON.parse(await readFile(reportPath, "utf8"));
+    } catch {
+      /* Missing evidence cannot pass. */
+    }
+    let safeToPass =
+      [0, 1].includes(run.code) && completeEvidence(report, receipt, ids);
+    if (inputs.gate) {
+      for (const [index, row] of receipt.runs.entries()) {
+        if (row.status !== "completed") continue;
+        const gatePath = join(directory, `gate-${index + 1}.xml`);
+        const gateArgs = [
+          ...prefix,
+          "gate",
+          `--project=${receipt.launch.project?.id || inputs.project}`,
+          `--run=${row.id}`,
+          "--wait",
+          "--reporter=junit-xml",
+          `--out=${gatePath}`,
+        ];
+        if (inputs.minPassRate)
+          gateArgs.push(`--min-pass-rate-percent=${inputs.minPassRate}`);
+        if (inputs.baselineRun)
+          gateArgs.push(`--baseline=${inputs.baselineRun}`);
+        if (inputs.baselineSha)
+          gateArgs.push(`--baseline-sha=${inputs.baselineSha}`);
+        if (inputs.waitTimeout)
+          gateArgs.push(`--wait-timeout=${inputs.waitTimeout}`);
+        let gate;
+        try {
+          gate = await invoke(gateArgs, cliEnv);
+        } catch {
+          state.gateExitCodes[row.id] = 3;
+          safeToPass = false;
+          continue;
+        }
+        state.gateExitCodes[row.id] = gate.code;
+        let xml = "";
+        try {
+          xml = await readFile(gatePath, "utf8");
+        } catch {
+          /* A missing gate report fails the action. */
+        }
+        safeToPass &&=
+          gate.code === 0 &&
+          xml.includes("<testsuites ") &&
+          xml.includes("</testsuites>");
+      }
+      safeToPass &&= Object.keys(state.gateExitCodes).length === ids.length;
+    } else {
+      safeToPass &&=
+        run.code === 0 && receipt.runs.every((row) => row.result === "passed");
+    }
+    state.result = safeToPass ? "passed" : "failed";
+    state.message = safeToPass
+      ? inputs.gate
+        ? "All gates passed or were waived."
+        : "All eval runs passed."
+      : "Eval, gate, or reporting failed or was incomplete. See the reports and exit codes.";
+  } catch (error) {
+    // Only validation errors are echoed; unexpected filesystem/process errors
+    // can contain credentials or other data from the environment.
+    state.message = directory
+      ? "Could not finish the eval action. Check the reports and CLI exit code."
+      : redactSecret(error.message, key);
+  }
+  if (directory) {
+    try {
+      // Only known, renderer-produced report files are uploaded. Raw stdout
+      // receipts and stderr are deliberately kept out of artifacts and logs.
+      for (const file of await readdir(directory)) {
+        const path = join(directory, file);
+        await writeFile(path, redactSecret(await readFile(path, "utf8"), key));
+      }
+      await writeFile(
+        join(directory, "action-result.json"),
+        redactSecret(JSON.stringify(state, null, 2), key),
+      );
+    } catch {
+      // Do not upload any directory whose final redaction could not finish.
+      directory = undefined;
+      state.result = "failed";
+      state.message = "Could not safely write the eval reports.";
+    }
+  }
+  if (env.GITHUB_STEP_SUMMARY) {
+    await appendFile(
+      env.GITHUB_STEP_SUMMARY,
+      redactSecret(
+        `### MCPJam evals: ${state.result}\n\n${state.message}\n\nRun exit code: ${state.runExitCode === "" ? "not started" : state.runExitCode}\n\nRuns: ${state.runIds.join(", ") || "none"}\n\nGate exit codes: ${JSON.stringify(state.gateExitCodes)}\n`,
+        key,
+      ),
+    );
+  }
+  await output(
+    env,
+    {
+      "run-ids": JSON.stringify(state.runIds),
+      "run-exit-code": state.runExitCode,
+      "gate-exit-codes": JSON.stringify(state.gateExitCodes),
+      "report-path": directory || "",
+      "artifact-name": `mcpjam-evals-${randomUUID()}`,
+      result: state.result,
+    },
+    key,
+  );
+  if (state.result !== "passed")
+    log(`::error::${escapeCommand(state.message)}`);
+  return state;
+}
+
+export function finalExitCode(env) {
+  return env.MCPJAM_ACTION_RESULT === "passed" &&
+    env.MCPJAM_ACTION_UPLOAD_OUTCOME === "success"
+    ? 0
+    : 1;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  if (process.argv[2] === "finalize") {
+    process.exitCode = finalExitCode(process.env);
+    if (process.exitCode)
+      process.stdout.write(
+        "::error::MCPJam evals or report upload did not pass.\n",
+      );
+  } else {
+    // The final composite step fails AFTER reports have been uploaded.
+    await runAction();
+  }
+}

--- a/actions/evals/run.test.mjs
+++ b/actions/evals/run.test.mjs
@@ -1,0 +1,549 @@
+import assert from "node:assert/strict";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, delimiter } from "node:path";
+import { test } from "node:test";
+import {
+  finalExitCode,
+  invokeCli,
+  parseInputs,
+  redactSecret,
+  runAction,
+} from "./run.mjs";
+
+async function fixture(t, overrides = {}) {
+  const root = await mkdtemp(join(tmpdir(), "eval-action-test-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const env = {
+    MCPJAM_API_KEY: "sk-test-secret",
+    MCPJAM_ACTION_PROJECT: "Project",
+    MCPJAM_ACTION_SUITE: "Suite",
+    MCPJAM_ACTION_INVOCATION: "MCPJaminspectoractions-evals",
+    MCPJAM_ACTION_MATRIX: '{"os":"ubuntu"}',
+    GITHUB_RUN_ID: "123",
+    GITHUB_JOB: "evals",
+    GITHUB_REPOSITORY: "example/repo",
+    GITHUB_RUN_ATTEMPT: "1",
+    RUNNER_TEMP: root,
+    GITHUB_OUTPUT: join(root, "outputs"),
+    GITHUB_STEP_SUMMARY: join(root, "summary"),
+    ...overrides,
+  };
+  const calls = [];
+  const logs = [];
+  const rows = [{ id: "run1", status: "completed", result: "passed" }];
+  const receipt = {
+    launch: {
+      project: { id: "project1" },
+      outcome: "started",
+      targets: [{ status: "started", runId: "run1" }],
+    },
+    runs: rows,
+  };
+  const report = {
+    schemaVersion: 1,
+    kind: "eval-run",
+    cases: [],
+    metadata: {
+      runs: rows.map((row) => ({ ...row, iterationsComplete: true })),
+    },
+  };
+  const behavior = {
+    runCode: 0,
+    receipt,
+    report,
+    gateCodes: {},
+    gateXml: {},
+    noGateReport: false,
+  };
+  const invoke = async (args, childEnv) => {
+    calls.push({ args, env: childEnv });
+    const path = args.find((arg) => arg.startsWith("--out=")).slice(6);
+    if (args.includes("run")) {
+      if (behavior.report)
+        await writeFile(path, JSON.stringify(behavior.report));
+      return {
+        code: behavior.runCode,
+        stdout: behavior.stdout ?? JSON.stringify(behavior.receipt),
+      };
+    }
+    const id = args.find((arg) => arg.startsWith("--run=")).slice(6);
+    if (!behavior.noGateReport)
+      await writeFile(
+        path,
+        behavior.gateXml[id] ??
+          '<testsuites name="eval-gate" tests="1" failures="0"></testsuites>',
+      );
+    return { code: behavior.gateCodes[id] ?? 0, stdout: "never logged" };
+  };
+  const run = () => runAction(env, invoke, (line) => logs.push(line));
+  return { root, env, calls, logs, behavior, run };
+}
+
+test("runs a suite, retains CI metadata, publishes output IDs and a report directory", async (t) => {
+  const f = await fixture(t);
+  const result = await f.run();
+  assert.equal(result.result, "passed");
+  assert.deepEqual(result.runIds, ["run1"]);
+  assert.equal(f.calls.length, 1);
+  assert.equal(f.calls[0].env.GITHUB_RUN_ATTEMPT, "1");
+  assert.ok(f.calls[0].args.includes("@mcpjam/cli@5.7.1"));
+  assert.ok(f.calls[0].args.includes("--wait"));
+  assert.ok(!f.calls[0].args.some((arg) => arg.includes("wait-timeout")));
+  assert.match(
+    await readFile(f.env.GITHUB_OUTPUT, "utf8"),
+    /run-ids<<.*\n\["run1"\]/,
+  );
+  assert.match(
+    await readFile(f.env.GITHUB_STEP_SUMMARY, "utf8"),
+    /Run exit code: 0/,
+  );
+});
+
+for (const [name, overrides] of Object.entries({
+  "missing key": { MCPJAM_API_KEY: "" },
+  "missing project": { MCPJAM_ACTION_PROJECT: "" },
+  "missing suite": { MCPJAM_ACTION_SUITE: "" },
+  "bad boolean": { MCPJAM_ACTION_GATE: "yes" },
+  "gate disabled": { MCPJAM_ACTION_MIN_PASS_RATE: "95" },
+  "conflicting baselines": {
+    MCPJAM_ACTION_GATE: "true",
+    MCPJAM_ACTION_BASELINE_RUN: "base1",
+    MCPJAM_ACTION_BASELINE_SHA: "abcdef1",
+  },
+  "bad threshold": {
+    MCPJAM_ACTION_GATE: "true",
+    MCPJAM_ACTION_MIN_PASS_RATE: "101",
+  },
+  "negative threshold": {
+    MCPJAM_ACTION_GATE: "true",
+    MCPJAM_ACTION_MIN_PASS_RATE: "-1",
+  },
+  "bad SHA": {
+    MCPJAM_ACTION_GATE: "true",
+    MCPJAM_ACTION_BASELINE_SHA: "not-a-sha",
+  },
+  "bad run ID": {
+    MCPJAM_ACTION_GATE: "true",
+    MCPJAM_ACTION_BASELINE_RUN: "../base",
+  },
+  "zero timeout": { MCPJAM_ACTION_WAIT_TIMEOUT: "0" },
+  "fraction timeout": { MCPJAM_ACTION_WAIT_TIMEOUT: "1.5" },
+  "version URL": { MCPJAM_ACTION_CLI_VERSION: "https://example.org/cli" },
+  "version tag": { MCPJAM_ACTION_CLI_VERSION: "latest" },
+  "long retry key": { MCPJAM_ACTION_IDEMPOTENCY_KEY: "x".repeat(257) },
+  "missing retry identity": { GITHUB_RUN_ID: "" },
+})) {
+  test(`rejects ${name} before launching`, async (t) => {
+    const f = await fixture(t, overrides);
+    assert.equal((await f.run()).result, "failed");
+    assert.equal(f.calls.length, 0);
+  });
+}
+
+for (const code of [1, 2, 3, 4, 5, 127]) {
+  test(`preserves run exit ${code} and fails without gates`, async (t) => {
+    const f = await fixture(t);
+    f.behavior.runCode = code;
+    if (code === 1) {
+      f.behavior.receipt.runs[0].result = "failed";
+      f.behavior.report.metadata.runs[0].result = "failed";
+    }
+    const result = await f.run();
+    assert.equal(result.result, "failed");
+    assert.equal(result.runExitCode, code);
+    assert.equal(f.calls.length, 1, "never automatically retries");
+  });
+}
+
+for (const scenario of ["waiver", "lower threshold"]) {
+  test(`${scenario} can pass a failed eval through the gate`, async (t) => {
+    const f = await fixture(t, {
+      MCPJAM_ACTION_GATE: "true",
+      MCPJAM_ACTION_MIN_PASS_RATE: "95",
+    });
+    f.behavior.runCode = 1;
+    f.behavior.receipt.runs[0].result = "failed";
+    f.behavior.report.metadata.runs[0].result = "failed";
+    f.behavior.report.cases = [{ category: "eval", passed: false }];
+    if (scenario === "waiver")
+      f.behavior.gateXml.run1 =
+        '<testsuites name="gate" skipped="1"><testcase><skipped message="Gate WAIVED"/></testcase></testsuites>';
+    const result = await f.run();
+    assert.equal(result.result, "passed");
+    assert.equal(result.runExitCode, 1);
+    assert.deepEqual(result.gateExitCodes, { run1: 0 });
+    assert.ok(f.calls[1].args.includes("--min-pass-rate-percent=95"));
+    assert.ok(!f.calls[1].args.includes("--no-suite-policy"));
+  });
+}
+
+for (const [name, code] of [
+  ["expired waiver", 1],
+  ["suite policy failure despite waiver", 1],
+  ["missing baseline", 3],
+  ["unknown scorer", 2],
+]) {
+  test(`gate ${name} remains blocking`, async (t) => {
+    const f = await fixture(t, { MCPJAM_ACTION_GATE: "true" });
+    f.behavior.gateCodes.run1 = code;
+    const result = await f.run();
+    assert.equal(result.result, "failed");
+    assert.equal(result.gateExitCodes.run1, code);
+  });
+}
+
+test("gates all completed runs and requires every gate to pass", async (t) => {
+  const f = await fixture(t, { MCPJAM_ACTION_GATE: "true" });
+  f.behavior.receipt.launch.targets.push({ status: "started", runId: "run2" });
+  f.behavior.receipt.runs.push({
+    id: "run2",
+    status: "completed",
+    result: "passed",
+  });
+  f.behavior.report.metadata.runs.push({
+    id: "run2",
+    status: "completed",
+    result: "passed",
+    iterationsComplete: true,
+  });
+  f.behavior.gateCodes.run1 = 1;
+  assert.equal((await f.run()).result, "failed");
+  assert.equal(f.calls.length, 3);
+});
+
+test("multiple completed runs can all pass and receive separate gate reports", async (t) => {
+  const f = await fixture(t, {
+    MCPJAM_ACTION_GATE: "true",
+    MCPJAM_ACTION_BASELINE_RUN: "base1",
+  });
+  f.behavior.receipt.launch.targets.push({ status: "started", runId: "run2" });
+  f.behavior.receipt.runs.push({
+    id: "run2",
+    status: "completed",
+    result: "passed",
+  });
+  f.behavior.report.metadata.runs.push({
+    id: "run2",
+    status: "completed",
+    result: "passed",
+    iterationsComplete: true,
+  });
+  assert.equal((await f.run()).result, "passed");
+  assert.ok(f.calls[1].args.includes("--baseline=base1"));
+  const paths = f.calls
+    .slice(1)
+    .map((call) => call.args.find((arg) => arg.startsWith("--out=")));
+  assert.equal(new Set(paths).size, 2);
+});
+
+test("a gate process failure does not prevent checking the next run", async (t) => {
+  const f = await fixture(t, { MCPJAM_ACTION_GATE: "true" });
+  f.behavior.receipt.launch.targets.push({ status: "started", runId: "run2" });
+  f.behavior.receipt.runs.push({
+    id: "run2",
+    status: "completed",
+    result: "passed",
+  });
+  const gated = [];
+  const result = await runAction(
+    f.env,
+    async (args) => {
+      if (args.includes("run"))
+        return { code: 0, stdout: JSON.stringify(f.behavior.receipt) };
+      gated.push(args.find((arg) => arg.startsWith("--run=")));
+      throw new Error("process failed");
+    },
+    () => {},
+  );
+  assert.equal(result.result, "failed");
+  assert.deepEqual(gated, ["--run=run1", "--run=run2"]);
+  assert.deepEqual(result.gateExitCodes, { run1: 3, run2: 3 });
+});
+
+test("report sanitization failure suppresses the upload directory", async (t) => {
+  const f = await fixture(t);
+  const result = await runAction(
+    f.env,
+    async (args) => {
+      const path = args.find((arg) => arg.startsWith("--out=")).slice(6);
+      await mkdir(path);
+      return { code: 0, stdout: JSON.stringify(f.behavior.receipt) };
+    },
+    () => {},
+  );
+  assert.equal(result.result, "failed");
+  assert.match(
+    await readFile(f.env.GITHUB_OUTPUT, "utf8"),
+    /report-path<<[^\n]+\n\n/,
+  );
+});
+
+for (const [name, mutate] of [
+  [
+    "partial launch hidden by verdict exit 1",
+    (b) => {
+      b.runCode = 1;
+      b.receipt.launch.outcome = "partial";
+      b.receipt.launch.targets.push({ status: "failed" });
+    },
+  ],
+  [
+    "timeout",
+    (b) => {
+      b.runCode = 5;
+      b.receipt.runs = [];
+    },
+  ],
+  [
+    "inconclusive result",
+    (b) => {
+      b.receipt.runs[0].result = "inconclusive";
+    },
+  ],
+  [
+    "failed execution",
+    (b) => {
+      b.receipt.runs[0].status = "failed";
+    },
+  ],
+  [
+    "grading",
+    (b) => {
+      b.receipt.runs[0].status = "grading";
+    },
+  ],
+  [
+    "missing JSON report",
+    (b) => {
+      b.report = null;
+    },
+  ],
+  [
+    "malformed report",
+    (b) => {
+      b.report = {};
+    },
+  ],
+  [
+    "reporting failure hidden by verdict exit 1",
+    (b) => {
+      b.runCode = 1;
+      b.report.cases.push({ category: "reporting", passed: false });
+    },
+  ],
+  [
+    "partial iteration fetch",
+    (b) => {
+      b.report.metadata.runs[0].iterationsComplete = false;
+    },
+  ],
+  [
+    "missing target completion",
+    (b) => {
+      b.receipt.launch.targets.push({ status: "started", runId: "run2" });
+    },
+  ],
+  [
+    "duplicate report rows",
+    (b) => {
+      b.report.metadata.runs.push(b.report.metadata.runs[0]);
+    },
+  ],
+  [
+    "missing gate report",
+    (b) => {
+      b.noGateReport = true;
+    },
+  ],
+  [
+    "malformed gate report",
+    (b) => {
+      b.gateXml.run1 = "not XML";
+    },
+  ],
+  [
+    "invalid JSON receipt",
+    (b) => {
+      b.stdout = "not JSON";
+    },
+  ],
+  [
+    "unexpected receipt",
+    (b) => {
+      b.stdout = "{}";
+    },
+  ],
+  [
+    "unknown completed run",
+    (b) => {
+      b.receipt.runs[0].id = "unrelated";
+    },
+  ],
+  [
+    "duplicate target",
+    (b) => {
+      b.receipt.launch.targets.push(b.receipt.launch.targets[0]);
+    },
+  ],
+]) {
+  test(`gate success cannot hide ${name}`, async (t) => {
+    const f = await fixture(t, { MCPJAM_ACTION_GATE: "true" });
+    mutate(f.behavior);
+    assert.equal((await f.run()).result, "failed");
+  });
+}
+
+test("run IDs survive timeout and are not replaced by an empty completion list", async (t) => {
+  const f = await fixture(t);
+  f.behavior.runCode = 5;
+  f.behavior.receipt.runs = [];
+  assert.deepEqual((await f.run()).runIds, ["run1"]);
+});
+
+test("passes baseline and explicit wait settings literally, including zero threshold", async (t) => {
+  const f = await fixture(t, {
+    MCPJAM_ACTION_GATE: "true",
+    MCPJAM_ACTION_MIN_PASS_RATE: "0",
+    MCPJAM_ACTION_BASELINE_SHA: "abcdef123",
+    MCPJAM_ACTION_WAIT_TIMEOUT: "42000",
+  });
+  await f.run();
+  assert.ok(f.calls[0].args.includes("--wait-timeout=42000"));
+  assert.ok(f.calls[1].args.includes("--wait-timeout=42000"));
+  assert.ok(f.calls[1].args.includes("--baseline-sha=abcdef123"));
+  assert.ok(f.calls[1].args.includes("--min-pass-rate-percent=0"));
+});
+
+test("retry identity is stable across attempts and distinct across jobs, matrices and invocations", async (t) => {
+  const f = await fixture(t);
+  const key = parseInputs(f.env).idempotencyKey;
+  assert.equal(
+    parseInputs({ ...f.env, GITHUB_RUN_ATTEMPT: "2" }).idempotencyKey,
+    key,
+  );
+  for (const field of [
+    "GITHUB_RUN_ID",
+    "GITHUB_JOB",
+    "GITHUB_REPOSITORY",
+    "MCPJAM_ACTION_MATRIX",
+    "MCPJAM_ACTION_INVOCATION",
+    "MCPJAM_ACTION_SUITE",
+  ]) {
+    assert.notEqual(
+      parseInputs({ ...f.env, [field]: "different" }).idempotencyKey,
+      key,
+      field,
+    );
+  }
+  assert.equal(
+    parseInputs({ ...f.env, MCPJAM_ACTION_IDEMPOTENCY_KEY: "custom" })
+      .idempotencyKey,
+    "custom",
+  );
+});
+
+test("artifacts and logs never include the key or raw CLI output", async (t) => {
+  const f = await fixture(t, { MCPJAM_ACTION_GATE: "true" });
+  f.behavior.report.secret = f.env.MCPJAM_API_KEY;
+  f.behavior.gateXml.run1 = `<testsuites name="gate"><system-out>${f.env.MCPJAM_API_KEY}</system-out></testsuites>`;
+  await f.run();
+  const dir = (await readdir(f.root)).find((name) =>
+    name.startsWith("mcpjam-evals-"),
+  );
+  for (const file of await readdir(join(f.root, dir))) {
+    assert.ok(
+      !(await readFile(join(f.root, dir, file), "utf8")).includes(
+        f.env.MCPJAM_API_KEY,
+      ),
+    );
+  }
+  assert.ok(
+    !f.logs
+      .filter((line) => !line.startsWith("::add-mask::"))
+      .join("\n")
+      .includes(f.env.MCPJAM_API_KEY),
+  );
+  assert.ok(!f.logs.join("\n").includes("never logged"));
+  assert.ok(
+    !f.calls
+      .flatMap((call) => call.args)
+      .join("\n")
+      .includes(f.env.MCPJAM_API_KEY),
+  );
+  assert.equal(redactSecret("a&lt;&amp;&quot;", '<&"'), "a[REDACTED]");
+});
+
+test("process invocation preserves special characters and never executes a shell", async (t) => {
+  const f = await fixture(t, {
+    MCPJAM_ACTION_PROJECT: "--version",
+    MCPJAM_ACTION_SUITE: 'Suite " $(touch unsafe) `id`\nsecond line',
+  });
+  await f.run();
+  assert.ok(f.calls[0].args.includes(`--suite=${f.env.MCPJAM_ACTION_SUITE}`));
+  assert.ok(f.calls[0].args.includes("--project=--version"));
+  const executable = join(f.root, "npx");
+  await writeFile(
+    executable,
+    `#!${process.execPath}\nprocess.stdout.write(JSON.stringify(process.argv.slice(2)));\n`,
+  );
+  await chmod(executable, 0o755);
+  const args = ["$(touch unsafe)", "with spaces", "`id`", "line\nbreak"];
+  const result = await invokeCli(args, {
+    ...process.env,
+    PATH: `${f.root}${delimiter}${process.env.PATH}`,
+  });
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout), args);
+});
+
+test("process failure and unsafe report write cannot produce success", async (t) => {
+  const f = await fixture(t);
+  const result = await runAction(
+    f.env,
+    async () => {
+      throw new Error(f.env.MCPJAM_API_KEY);
+    },
+    () => {},
+  );
+  assert.equal(result.result, "failed");
+  assert.ok(!result.message.includes(f.env.MCPJAM_API_KEY));
+  const broken = await fixture(t);
+  await runAction(
+    broken.env,
+    async (args) => {
+      const out = args.find((arg) => arg.startsWith("--out=")).slice(6);
+      await writeFile(out, Buffer.from([0xff]));
+      return { code: 0, stdout: JSON.stringify(broken.behavior.receipt) };
+    },
+    () => {},
+  ).then((state) => assert.equal(state.result, "failed"));
+});
+
+test("final step only passes after both evaluation and upload succeed", () => {
+  for (const result of ["passed", "failed", "", undefined]) {
+    for (const upload of [
+      "success",
+      "failure",
+      "skipped",
+      "cancelled",
+      undefined,
+    ]) {
+      assert.equal(
+        finalExitCode({
+          MCPJAM_ACTION_RESULT: result,
+          MCPJAM_ACTION_UPLOAD_OUTCOME: upload,
+        }),
+        result === "passed" && upload === "success" ? 0 : 1,
+      );
+    }
+  }
+});

--- a/docs/cli/ci.mdx
+++ b/docs/cli/ci.mdx
@@ -360,7 +360,72 @@ See [OAuth Conformance](/cli/oauth-conformance) for details on the config file f
 
 There are two ways to wire MCPJam evals into a pipeline: trigger a **hosted eval run** with the CLI, or run evals **locally with the SDK** and upload the results. Both authenticate with an MCPJam API key (`sk_…`) from **Settings → API keys**.
 
-### Trigger a hosted eval suite
+### GitHub Action for hosted evals
+
+The MCPJam evals action runs an existing hosted suite, waits for its result, and
+uploads reports to GitHub. It sets up Node automatically. It tests the suite's
+saved server; it does not build or deploy your PR's source code.
+
+<Note>
+The action's `evals-v1` tag must be published after its live smoke test passes
+before the example below can be used. The direct CLI integration in the next
+section remains available independently.
+</Note>
+
+Save this as `.github/workflows/mcpjam.yml`, then replace the project and suite:
+
+```yaml
+name: MCPJam evals
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  evals:
+    # Fork PRs do not receive this repo's secrets.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: MCPJam/inspector/actions/evals@evals-v1
+        with:
+          # Add your API key as MCPJAM_API_KEY in GitHub Actions secrets.
+          api-key: ${{ secrets.MCPJAM_API_KEY }}
+          project: 'My project'
+          suite: 'My eval suite'
+
+          # Optional: let the gate decide pass or fail.
+          # gate: true
+          # min-pass-rate-percent: 95
+          # baseline-sha: '<commit with an existing eval run>'
+```
+
+Create the `MCPJAM_API_KEY` repository secret under GitHub **Settings → Secrets and
+variables → Actions**. The YAML contains only a reference to it, never the key.
+
+Without `gate: true`, the run itself must pass. With gates enabled, each gate
+must pass or be waived; a lower threshold or existing waiver can clear an eval
+failure. Failed launches, incomplete runs, missing reports, and upload failures
+remain blocking. A run waiver does not clear a separate suite-policy failure.
+
+Use `baseline-run` instead of `baseline-sha` to name a baseline by run ID; never
+provide both. Optional `wait-timeout-ms` replaces the CLI wait default. The CLI
+version is pinned to `5.7.1`, with an exact-version override via `cli-version`.
+There are no automatic retries, and the generated idempotency key reuses launched
+runs when the same workflow job is retried.
+
+The action exposes `run-ids`, `run-exit-code`, `gate-exit-codes`, `report-path`,
+and `artifact-url`. It saves the eval JSON report and optional gate JUnit reports
+before reporting failure. See the
+[action README](https://github.com/MCPJam/inspector/blob/main/actions/evals/README.md)
+for all inputs, outputs, retry details, and release status. GitHub.com with Ubuntu
+runners is supported in this first version.
+
+### Trigger a hosted eval suite with the CLI
 
 `mcpjam cloud eval run` starts an asynchronous run of a suite that lives in your MCPJam project. Without `--wait`, it prints a launch receipt and returns immediately. In CI, add `--wait` and `--out` to write a structured JSON report after every launched run reaches a terminal state.
 


### PR DESCRIPTION
## Problem

Users currently have to write every MCPJam CLI, gate, retry, and report-upload step themselves to run an existing hosted suite in GitHub Actions.

## Before

```yaml
- name: Run MCPJam evals
  env:
    MCPJAM_API_KEY: ${{ secrets.MCPJAM_API_KEY }}
  run: |
    npx -y @mcpjam/cli@latest cloud eval run \
      --project "My project" \
      --suite "My eval suite" \
      --wait \
      --idempotency-key "${{ github.run_id }}-${{ github.job }}" \
      --out eval-report.json \
      --format json > eval-result.json

- name: Gate the eval
  if: always()
  env:
    MCPJAM_API_KEY: ${{ secrets.MCPJAM_API_KEY }}
  run: |
    RUN_ID=$(jq -r '.runs[0].id' eval-result.json)
    npx -y @mcpjam/cli@latest cloud eval gate \
      --project "My project" \
      --run "$RUN_ID" \
      --wait \
      --min-pass-rate-percent 95 \
      --reporter junit-xml \
      --out eval-gate.xml

- name: Upload reports
  if: always()
  uses: actions/upload-artifact@v4
  with:
    name: mcpjam-evals
    path: |
      eval-report.json
      eval-result.json
      eval-gate.xml
```

## After

```yaml
- uses: MCPJam/inspector/actions/evals@evals-v1
  with:
    # Add the real key as MCPJAM_API_KEY in GitHub Actions secrets.
    api-key: ${{ secrets.MCPJAM_API_KEY }}
    project: "My project"
    suite: "My eval suite"

    # Optional:
    gate: true
    min-pass-rate-percent: 95
```

The action wraps the same CLI. It handles Node setup, CLI execution, run IDs, report upload, exit codes, and stable retry keys. Existing YAML workflows keep working unchanged.

Optional inputs also support a baseline run/SHA, wait timeout, exact CLI version, and custom idempotency key.

## Validation

- 58 action tests pass on Node 24.
- New workflows and the copy-ready template pass actionlint.
- `@mcpjam/cli@5.7.1` is published and supports Node 20+.
- Gates preserve existing waiver and suite-policy behavior.

## Rollout

Run **Evals action live smoke** with an existing project, suite, and the `MCPJAM_API_KEY` repository secret. Only after it passes for the exact commit, create `evals-v1.0.0` and point `evals-v1` at it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hosted evals GitHub Action so teams can run an existing MCPJam suite from one YAML step instead of hand-writing the CLI run, gate, retry, and report-upload steps. The action wraps `@mcpjam/cli`, preserves existing waiver and suite-policy gate behavior, and existing direct CLI workflows keep working unchanged.

**New Features**
- New `actions/evals` composite action handles Node setup, CLI execution, run IDs, retry keys, exit codes, and artifact upload.
- Supports optional gates, baseline run/SHA, wait timeout, exact CLI version, and custom idempotency keys.
- Adds a copy-ready workflow template that pins the action to an immutable commit SHA, plus action docs and test and live-smoke workflows; 58 tests pass on Node 24 and the workflows pass actionlint.
- There are no automatic retries; rerunning the same job reuses the paid run, while a new workflow run gets a new retry key.
- The first version supports GitHub.com and Ubuntu runners.

**Rollout**
- `evals-v1` stays unusable until a live smoke run passes for the exact commit, then tag `evals-v1.0.0` and point `evals-v1` at it.
- `@mcpjam/cli@5.7.1` is already published and supports Node 20+.

<sup>Written for commit 0dc374e904fa86e03f302a40817cc00903245403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/5011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

